### PR TITLE
feat: shared presets, generalized deck options, dev environment

### DIFF
--- a/database.py
+++ b/database.py
@@ -3,7 +3,7 @@ import os
 import sqlite3
 from datetime import date, datetime
 
-DB_PATH = "data/srs.db"
+DB_PATH = os.environ.get("DB_PATH", "data/srs.db")
 SCHEMA_PATH = os.path.join(os.path.dirname(__file__), "schema.sql")
 
 
@@ -26,21 +26,45 @@ def init_db() -> None:
     conn.executescript(schema)
     conn.commit()
 
-    # Ensure a default preset + deck exist
-    preset_id = _ensure_default_preset(conn)
+    # Ensure presets + default deck exist
+    _ensure_presets(conn)
+    preset_id = conn.execute("SELECT id FROM deck_presets WHERE is_default = 1 LIMIT 1").fetchone()["id"]
     _ensure_deck(conn, "Default", parent_id=None, preset_id=preset_id)
     conn.commit()
     conn.close()
 
 
+def _ensure_presets(conn: sqlite3.Connection) -> None:
+    """Seed the two built-in presets if they don't exist yet."""
+    existing = {r["name"] for r in conn.execute("SELECT name FROM deck_presets").fetchall()}
+
+    if "Default" not in existing:
+        conn.execute(
+            """INSERT INTO deck_presets (name, is_default) VALUES ('Default', 0)"""
+        )
+
+    if "Anki Default" not in existing:
+        conn.execute(
+            """INSERT INTO deck_presets
+               (name, new_per_day, reviews_per_day,
+                learning_steps, graduating_interval, easy_interval,
+                relearning_steps, minimum_interval, insertion_order,
+                leech_threshold, leech_action, is_default)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)""",
+            ("Anki Default", 9999, 9999, "1m 2d", 4, 9, "10", 1, "sequential", 8, "suspend"),
+        )
+
+    # Guarantee exactly one default
+    if not conn.execute("SELECT id FROM deck_presets WHERE is_default = 1").fetchone():
+        conn.execute("UPDATE deck_presets SET is_default = 1 WHERE name = 'Anki Default'")
+
+
 def _ensure_default_preset(conn: sqlite3.Connection) -> int:
-    row = conn.execute("SELECT id FROM deck_presets WHERE name = 'Default'").fetchone()
+    row = conn.execute("SELECT id FROM deck_presets WHERE is_default = 1 LIMIT 1").fetchone()
     if row:
         return row["id"]
-    cur = conn.execute(
-        """INSERT INTO deck_presets (name, is_default) VALUES ('Default', 1)"""
-    )
-    return cur.lastrowid
+    _ensure_presets(conn)
+    return conn.execute("SELECT id FROM deck_presets WHERE is_default = 1 LIMIT 1").fetchone()["id"]
 
 
 def _ensure_deck(conn: sqlite3.Connection, name: str,
@@ -63,12 +87,8 @@ def _ensure_deck(conn: sqlite3.Connection, name: str,
 def default_preset() -> dict:
     return {
         "name": "Default",
-        "listening_new_per_day": 20,
-        "listening_reviews_per_day": 100,
-        "reading_new_per_day": 20,
-        "reading_reviews_per_day": 100,
-        "creating_new_per_day": 10,
-        "creating_reviews_per_day": 50,
+        "new_per_day": 20,
+        "reviews_per_day": 100,
         "learning_steps": "1 10",
         "graduating_interval": 1,
         "easy_interval": 4,
@@ -95,6 +115,39 @@ def set_default_preset(preset_id: int) -> None:
     conn.close()
 
 
+def list_presets() -> list[dict]:
+    conn = get_db()
+    rows = conn.execute(
+        """SELECT p.*, COUNT(d.id) AS deck_count
+           FROM deck_presets p
+           LEFT JOIN decks d ON d.preset_id = p.id
+           GROUP BY p.id
+           ORDER BY p.is_default DESC, p.name"""
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def delete_preset(preset_id: int) -> None:
+    conn = get_db()
+    in_use = conn.execute(
+        "SELECT COUNT(*) FROM decks WHERE preset_id = ?", (preset_id,)
+    ).fetchone()[0]
+    if in_use:
+        conn.close()
+        raise ValueError("Preset is still assigned to one or more decks")
+    conn.execute("DELETE FROM deck_presets WHERE id = ?", (preset_id,))
+    conn.commit()
+    conn.close()
+
+
+def assign_preset_to_deck(deck_id: int, preset_id: int) -> None:
+    conn = get_db()
+    conn.execute("UPDATE decks SET preset_id = ? WHERE id = ?", (preset_id, deck_id))
+    conn.commit()
+    conn.close()
+
+
 def get_preset(preset_id: int) -> dict:
     conn = get_db()
     row = conn.execute("SELECT * FROM deck_presets WHERE id = ?", (preset_id,)).fetchone()
@@ -116,15 +169,11 @@ def insert_preset(preset: dict) -> int:
     conn = get_db()
     cur = conn.execute(
         """INSERT INTO deck_presets
-           (name, listening_new_per_day, listening_reviews_per_day,
-            reading_new_per_day, reading_reviews_per_day,
-            creating_new_per_day, creating_reviews_per_day,
+           (name, new_per_day, reviews_per_day,
             learning_steps, graduating_interval, easy_interval,
             relearning_steps, minimum_interval, insertion_order,
             leech_threshold, leech_action)
-           VALUES (:name, :listening_new_per_day, :listening_reviews_per_day,
-                   :reading_new_per_day, :reading_reviews_per_day,
-                   :creating_new_per_day, :creating_reviews_per_day,
+           VALUES (:name, :new_per_day, :reviews_per_day,
                    :learning_steps, :graduating_interval, :easy_interval,
                    :relearning_steps, :minimum_interval, :insertion_order,
                    :leech_threshold, :leech_action)""",
@@ -138,9 +187,7 @@ def insert_preset(preset: dict) -> int:
 
 def update_preset(preset_id: int, fields: dict) -> None:
     allowed = {
-        "name", "listening_new_per_day", "listening_reviews_per_day",
-        "reading_new_per_day", "reading_reviews_per_day",
-        "creating_new_per_day", "creating_reviews_per_day",
+        "name", "new_per_day", "reviews_per_day",
         "learning_steps", "graduating_interval", "easy_interval",
         "relearning_steps", "minimum_interval", "insertion_order",
         "leech_threshold", "leech_action",
@@ -230,37 +277,13 @@ def get_default_deck_id() -> int:
 
 def get_or_create_deck(name: str, parent_id: int | None = None,
                        category: str | None = None) -> int:
-    """Get deck id by name, creating it (cloning the default preset) if it doesn't exist."""
+    """Get deck id by name, creating it (sharing the default preset) if it doesn't exist."""
     conn = get_db()
     row = conn.execute("SELECT id FROM decks WHERE name = ?", (name,)).fetchone()
     if row:
         conn.close()
         return row["id"]
-    # Clone the active default preset (or fall back to the hardcoded Default)
-    default_row = conn.execute(
-        "SELECT * FROM deck_presets WHERE is_default = 1 LIMIT 1"
-    ).fetchone()
-    if default_row:
-        vals = dict(default_row)
-        cur = conn.execute(
-            """INSERT INTO deck_presets
-               (name, listening_new_per_day, listening_reviews_per_day,
-                reading_new_per_day, reading_reviews_per_day,
-                creating_new_per_day, creating_reviews_per_day,
-                learning_steps, graduating_interval, easy_interval,
-                relearning_steps, minimum_interval, insertion_order,
-                leech_threshold, leech_action)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (name, vals["listening_new_per_day"], vals["listening_reviews_per_day"],
-             vals["reading_new_per_day"], vals["reading_reviews_per_day"],
-             vals["creating_new_per_day"], vals["creating_reviews_per_day"],
-             vals["learning_steps"], vals["graduating_interval"], vals["easy_interval"],
-             vals["relearning_steps"], vals["minimum_interval"], vals["insertion_order"],
-             vals["leech_threshold"], vals["leech_action"]),
-        )
-        preset_id = cur.lastrowid
-    else:
-        preset_id = _ensure_default_preset(conn)
+    preset_id = _ensure_default_preset(conn)
     cur = conn.execute(
         "INSERT INTO decks (name, parent_id, preset_id, category) VALUES (?, ?, ?, ?)",
         (name, parent_id, preset_id, category),
@@ -456,9 +479,7 @@ def get_card(card_id: int) -> dict | None:
                   p.learning_steps, p.graduating_interval, p.easy_interval,
                   p.relearning_steps, p.minimum_interval,
                   p.leech_threshold, p.leech_action,
-                  p.listening_new_per_day, p.listening_reviews_per_day,
-                  p.reading_new_per_day, p.reading_reviews_per_day,
-                  p.creating_new_per_day, p.creating_reviews_per_day
+                  p.new_per_day, p.reviews_per_day
            FROM cards c
            JOIN words w ON w.id = c.word_id
            JOIN decks d ON d.id = c.deck_id
@@ -497,8 +518,7 @@ def get_due_cards(deck_id: int, category: str) -> list[dict]:
     # We track "introduced today" = first-ever review is today, regardless of
     # current state (a card transitions away from 'new' after the first review).
     preset = get_preset_for_deck(deck_id)
-    new_limit_key = f"{category}_new_per_day"
-    new_limit = preset[new_limit_key]
+    new_limit = preset["new_per_day"]
     new_done_today = _count_new_introduced_today(conn, deck_id, category, today)
     new_remaining = max(0, new_limit - new_done_today)
 
@@ -548,7 +568,7 @@ def count_due(deck_id: int, category: str) -> dict:
     today = date.today().isoformat()
     now = datetime.now().isoformat(timespec="seconds")
     preset = get_preset_for_deck(deck_id)
-    new_limit = preset[f"{category}_new_per_day"]
+    new_limit = preset["new_per_day"]
 
     conn = get_db()
     new_done_today = _count_new_introduced_today(conn, deck_id, category, today)

--- a/imports/Zonghe/Chapter 1/deepseek_yaml_20260315_1d0dd3.yaml
+++ b/imports/Zonghe/Chapter 1/deepseek_yaml_20260315_1d0dd3.yaml
@@ -433,7 +433,7 @@ entries:
         etymology: |
           The traditional form 戀 consists of the heart/mind radical 心 at the bottom, and a complex phonetic top (亦 with 言 and 絲) that suggests entanglement or binding. It implies a strong emotional attachment, as if the heart is tied or bound.
       - char: 恋
-        *bereits analysiert*
+        detailed_analysis: false
       - char: 不
         pinyin: bù
         hsk: "1"
@@ -1482,7 +1482,7 @@ entries:
         etymology: |
           The character 邦 in oracle bone script depicted a field (丰) with a tree planted to mark the boundary of a state. It later added the city radical 阝 (right). Its original meaning is a state or nation. In reduplicated form (邦邦) after adjectives, it acts as a suffix to describe the state or appearance, often with an onomatopoeic quality suggesting a "thumping" hardness.
       - char: 邦
-        *bereits analysiert*
+        detailed_analysis: false
 
   - type: vocabulary
     simplified: 简陋

--- a/main.py
+++ b/main.py
@@ -157,6 +157,32 @@ try:
             database.rename_deck(deck_id, name)
         return database.get_deck(deck_id)
 
+    @app.get("/api/presets")
+    def list_presets():
+        return database.list_presets()
+
+    @app.post("/api/presets")
+    def create_preset(name: str, clone_from_id: int | None = None):
+        if clone_from_id:
+            src = database.get_preset(clone_from_id)
+        else:
+            src = database.default_preset()
+        src["name"] = name
+        src.pop("id", None)
+        src.pop("is_default", None)
+        src.pop("deck_count", None)
+        preset_id = database.insert_preset(src)
+        return database.get_preset(preset_id)
+
+    @app.delete("/api/presets/{preset_id}")
+    def delete_preset(preset_id: int):
+        try:
+            database.delete_preset(preset_id)
+            return {"ok": True}
+        except ValueError as e:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=409, detail=str(e))
+
     @app.get("/api/decks/{deck_id}/preset")
     def get_deck_preset(deck_id: int):
         return database.get_preset_for_deck(deck_id)
@@ -166,6 +192,11 @@ try:
         deck = database.get_deck(deck_id)
         database.update_preset(deck["preset_id"], fields)
         return database.get_preset(deck["preset_id"])
+
+    @app.put("/api/decks/{deck_id}/preset/assign")
+    def assign_preset_to_deck(deck_id: int, preset_id: int):
+        database.assign_preset_to_deck(deck_id, preset_id)
+        return database.get_preset(preset_id)
 
     @app.post("/api/decks/{deck_id}/preset/set-default")
     def set_deck_preset_as_default(deck_id: int):

--- a/run.dev.sh
+++ b/run.dev.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+source .env
+DB_PATH=data/dev.db python main.py import
+DB_PATH=data/dev.db python main.py

--- a/schema.sql
+++ b/schema.sql
@@ -9,13 +9,9 @@ CREATE TABLE IF NOT EXISTS deck_presets (
     id                      INTEGER PRIMARY KEY AUTOINCREMENT,
     name                    TEXT NOT NULL,
 
-    -- Per-category daily limits
-    listening_new_per_day   INTEGER NOT NULL DEFAULT 20,
-    listening_reviews_per_day INTEGER NOT NULL DEFAULT 100,
-    reading_new_per_day     INTEGER NOT NULL DEFAULT 20,
-    reading_reviews_per_day INTEGER NOT NULL DEFAULT 100,
-    creating_new_per_day    INTEGER NOT NULL DEFAULT 10,
-    creating_reviews_per_day INTEGER NOT NULL DEFAULT 50,
+    -- Daily limits
+    new_per_day             INTEGER NOT NULL DEFAULT 20,
+    reviews_per_day         INTEGER NOT NULL DEFAULT 100,
 
     -- Learning steps in minutes, space-separated e.g. "1 10"
     learning_steps          TEXT NOT NULL DEFAULT '1 10',

--- a/static/index.html
+++ b/static/index.html
@@ -880,13 +880,19 @@
     <div class="modal-title" id="modal-title">Deck Options</div>
 
     <div class="opt-group">
+      <div class="opt-group-label">Preset</div>
+      <div class="opt-row" style="gap:6px">
+        <select class="opt-input" id="opt-preset-select" style="flex:1" onchange="switchPreset(this.value)"></select>
+        <button class="btn-secondary" style="padding:6px 10px" onclick="addPreset()" title="New preset">+</button>
+        <button class="btn-secondary" style="padding:6px 10px" onclick="renamePreset()" title="Rename">✏</button>
+        <button class="btn-secondary" style="padding:6px 10px;color:#e74c3c" onclick="deletePreset()" title="Delete" id="btn-delete-preset">✕</button>
+      </div>
+    </div>
+
+    <div class="opt-group">
       <div class="opt-group-label">Daily Limits</div>
-      <div class="opt-row"><span class="opt-label">Listening — new / day</span>   <input class="opt-input" id="opt-listening-new"  type="number" min="0"></div>
-      <div class="opt-row"><span class="opt-label">Listening — reviews / day</span><input class="opt-input" id="opt-listening-rev"  type="number" min="0"></div>
-      <div class="opt-row"><span class="opt-label">Reading — new / day</span>      <input class="opt-input" id="opt-reading-new"    type="number" min="0"></div>
-      <div class="opt-row"><span class="opt-label">Reading — reviews / day</span>  <input class="opt-input" id="opt-reading-rev"    type="number" min="0"></div>
-      <div class="opt-row"><span class="opt-label">Creating — new / day</span>     <input class="opt-input" id="opt-creating-new"  type="number" min="0"></div>
-      <div class="opt-row"><span class="opt-label">Creating — reviews / day</span> <input class="opt-input" id="opt-creating-rev"  type="number" min="0"></div>
+      <div class="opt-row"><span class="opt-label">New / day</span>    <input class="opt-input" id="opt-new-per-day"     type="number" min="0"></div>
+      <div class="opt-row"><span class="opt-label">Reviews / day</span><input class="opt-input" id="opt-reviews-per-day" type="number" min="0"></div>
     </div>
 
     <div class="opt-group">
@@ -913,6 +919,7 @@
       <button class="btn-secondary" onclick="closeModal()">Cancel</button>
       <button class="btn-primary"   onclick="saveOptions()">Save</button>
     </div>
+
   </div>
 </div>
 
@@ -931,8 +938,13 @@ let optDeckId    = null; // deck whose options modal is open
 const collapsed  = new Set();  // parent deck IDs that are collapsed
 
 // ── API helper ─────────────────────────────────────────────────────────────
-async function api(method, path) {
-  const r = await fetch(path, { method });
+async function api(method, path, body) {
+  const opts = { method };
+  if (body !== undefined) {
+    opts.headers = { 'Content-Type': 'application/json' };
+    opts.body = JSON.stringify(body);
+  }
+  const r = await fetch(path, opts);
   if (!r.ok) throw new Error(`${method} ${path} → ${r.status}`);
   return r.json();
 }
@@ -1168,29 +1180,101 @@ function renderStats(data) {
 }
 
 // ── Options modal ─────────────────────────────────────────────────────────────
+let allPresets = [];
+
+function loadPresetFields(preset) {
+  document.getElementById('opt-new-per-day').value     = preset.new_per_day;
+  document.getElementById('opt-reviews-per-day').value = preset.reviews_per_day;
+  document.getElementById('opt-learn-steps').value     = preset.learning_steps;
+  document.getElementById('opt-grad-int').value        = preset.graduating_interval;
+  document.getElementById('opt-easy-int').value        = preset.easy_interval;
+  document.getElementById('opt-insertion-order').value = preset.insertion_order || 'sequential';
+  document.getElementById('opt-relearn-steps').value   = preset.relearning_steps;
+  document.getElementById('opt-leech').value           = preset.leech_threshold;
+  const btnDef = document.getElementById('btn-set-default');
+  btnDef.textContent = preset.is_default ? '✓ Already default' : 'Set as default';
+  btnDef.disabled = !!preset.is_default;
+  const btnDel = document.getElementById('btn-delete-preset');
+  btnDel.disabled = allPresets.length <= 1;
+}
+
+function renderPresetSelect(selectedId) {
+  const sel = document.getElementById('opt-preset-select');
+  sel.innerHTML = allPresets.map(p =>
+    `<option value="${p.id}" ${p.id === selectedId ? 'selected' : ''}>${p.name}${p.is_default ? ' ★' : ''}</option>`
+  ).join('');
+}
+
 async function openOptions(deckId) {
   optDeckId = deckId;
   try {
-    const preset = await api('GET', `/api/decks/${deckId}/preset`);
-    document.getElementById('modal-title').textContent = 'Deck Options';
-    document.getElementById('opt-listening-new').value  = preset.listening_new_per_day;
-    document.getElementById('opt-listening-rev').value  = preset.listening_reviews_per_day;
-    document.getElementById('opt-reading-new').value    = preset.reading_new_per_day;
-    document.getElementById('opt-reading-rev').value    = preset.reading_reviews_per_day;
-    document.getElementById('opt-creating-new').value   = preset.creating_new_per_day;
-    document.getElementById('opt-creating-rev').value   = preset.creating_reviews_per_day;
-    document.getElementById('opt-learn-steps').value    = preset.learning_steps;
-    document.getElementById('opt-grad-int').value       = preset.graduating_interval;
-    document.getElementById('opt-easy-int').value       = preset.easy_interval;
-    document.getElementById('opt-insertion-order').value = preset.insertion_order || 'sequential';
-    document.getElementById('opt-relearn-steps').value  = preset.relearning_steps;
-    document.getElementById('opt-leech').value          = preset.leech_threshold;
-    const btn = document.getElementById('btn-set-default');
-    btn.textContent = preset.is_default ? '✓ Already default' : 'Set as default';
-    btn.disabled = !!preset.is_default;
+    const [preset, presets] = await Promise.all([
+      api('GET', `/api/decks/${deckId}/preset`),
+      api('GET', '/api/presets'),
+    ]);
+    allPresets = presets;
+    renderPresetSelect(preset.id);
+    loadPresetFields(preset);
     document.getElementById('modal-overlay').classList.add('open');
   } catch (e) {
     showError('Could not load options: ' + e.message);
+  }
+}
+
+async function switchPreset(presetId) {
+  presetId = parseInt(presetId);
+  try {
+    await api('PUT', `/api/decks/${optDeckId}/preset/assign?preset_id=${presetId}`);
+    const preset = allPresets.find(p => p.id === presetId);
+    loadPresetFields(preset);
+  } catch (e) {
+    showError('Failed to switch preset: ' + e.message);
+  }
+}
+
+async function addPreset() {
+  const name = prompt('Preset name:');
+  if (!name) return;
+  const currentId = parseInt(document.getElementById('opt-preset-select').value);
+  try {
+    const preset = await api('POST', `/api/presets?name=${encodeURIComponent(name)}&clone_from_id=${currentId}`);
+    allPresets = await api('GET', '/api/presets');
+    renderPresetSelect(preset.id);
+    await switchPreset(preset.id);
+  } catch (e) {
+    showError('Failed to create preset: ' + e.message);
+  }
+}
+
+async function renamePreset() {
+  const currentId = parseInt(document.getElementById('opt-preset-select').value);
+  const current = allPresets.find(p => p.id === currentId);
+  const name = prompt('New name:', current?.name || '');
+  if (!name || name === current?.name) return;
+  try {
+    await api('PUT', `/api/decks/${optDeckId}/preset`, { name });
+    allPresets = await api('GET', '/api/presets');
+    renderPresetSelect(currentId);
+  } catch (e) {
+    showError('Failed to rename: ' + e.message);
+  }
+}
+
+async function deletePreset() {
+  if (allPresets.length <= 1) return;
+  const currentId = parseInt(document.getElementById('opt-preset-select').value);
+  const current = allPresets.find(p => p.id === currentId);
+  if (!confirm(`Delete preset "${current?.name}"? Decks using it will be reassigned to the default preset.`)) return;
+  // First reassign all decks using this preset to the default
+  const defaultPreset = allPresets.find(p => p.is_default && p.id !== currentId) || allPresets.find(p => p.id !== currentId);
+  try {
+    await api('PUT', `/api/decks/${optDeckId}/preset/assign?preset_id=${defaultPreset.id}`);
+    await api('DELETE', `/api/presets/${currentId}`);
+    allPresets = await api('GET', '/api/presets');
+    renderPresetSelect(defaultPreset.id);
+    loadPresetFields(defaultPreset);
+  } catch (e) {
+    showError('Delete failed: ' + e.message);
   }
 }
 
@@ -1202,27 +1286,19 @@ function closeModal() {
 async function saveOptions() {
   if (!optDeckId) return;
   const fields = {
-    listening_new_per_day:      parseInt(document.getElementById('opt-listening-new').value),
-    listening_reviews_per_day:  parseInt(document.getElementById('opt-listening-rev').value),
-    reading_new_per_day:        parseInt(document.getElementById('opt-reading-new').value),
-    reading_reviews_per_day:    parseInt(document.getElementById('opt-reading-rev').value),
-    creating_new_per_day:       parseInt(document.getElementById('opt-creating-new').value),
-    creating_reviews_per_day:   parseInt(document.getElementById('opt-creating-rev').value),
-    learning_steps:             document.getElementById('opt-learn-steps').value.trim(),
-    graduating_interval:        parseInt(document.getElementById('opt-grad-int').value),
-    easy_interval:              parseInt(document.getElementById('opt-easy-int').value),
-    relearning_steps:           document.getElementById('opt-relearn-steps').value.trim(),
-    leech_threshold:            parseInt(document.getElementById('opt-leech').value),
-    insertion_order:            document.getElementById('opt-insertion-order').value,
+    new_per_day:         parseInt(document.getElementById('opt-new-per-day').value),
+    reviews_per_day:     parseInt(document.getElementById('opt-reviews-per-day').value),
+    learning_steps:      document.getElementById('opt-learn-steps').value.trim(),
+    graduating_interval: parseInt(document.getElementById('opt-grad-int').value),
+    easy_interval:       parseInt(document.getElementById('opt-easy-int').value),
+    relearning_steps:    document.getElementById('opt-relearn-steps').value.trim(),
+    leech_threshold:     parseInt(document.getElementById('opt-leech').value),
+    insertion_order:     document.getElementById('opt-insertion-order').value,
   };
   try {
-    await fetch(`/api/decks/${optDeckId}/preset`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(fields),
-    });
+    await api('PUT', `/api/decks/${optDeckId}/preset`, fields);
     closeModal();
-    loadDecks(); // refresh counts
+    loadDecks();
   } catch (e) {
     showError('Save failed: ' + e.message);
   }
@@ -1232,10 +1308,12 @@ async function setDefaultPreset() {
   if (!optDeckId) return;
   try {
     await api('POST', `/api/decks/${optDeckId}/preset/set-default`);
+    allPresets = await api('GET', '/api/presets');
+    const currentId = parseInt(document.getElementById('opt-preset-select').value);
+    renderPresetSelect(currentId);
     const btn = document.getElementById('btn-set-default');
-    btn.textContent = '✓ Default set';
+    btn.textContent = '✓ Already default';
     btn.disabled = true;
-    setTimeout(() => { btn.textContent = 'Set as default'; btn.disabled = false; }, 2000);
   } catch (e) {
     showError('Failed: ' + e.message);
   }


### PR DESCRIPTION
## Summary
- Preset profiles are now shared across decks (Anki-style) — no more per-deck cloning
- Two built-in presets seeded on DB init: Default and Anki Default (9999/9999 limits, steps 1m 2d)
- Daily limits generalized: replaced 6 per-category columns with `new_per_day` + `reviews_per_day`
- Options modal: preset dropdown with add/rename/delete/switch support
- `DB_PATH` env var + `run.dev.sh` for isolated dev testing
- Fixed YAML parse errors from DeepSeek artifacts
- Fixed missing `edge-tts` module

## Test plan
- [ ] `rm data/srs.db && ./run.sh` — DB recreates with both presets
- [ ] Import runs cleanly
- [ ] Deck options modal shows preset dropdown
- [ ] Switching preset reassigns deck and loads values
- [ ] Adding/renaming/deleting presets works
- [ ] `./run.dev.sh` uses separate `data/dev.db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)