### PR TITLE
feat: bury siblings via buried_until field

### DIFF
--- a/database.py
+++ b/database.py
@@ -532,6 +532,7 @@ def get_due_cards(deck_id: int, category: str) -> list[dict]:
            WHERE c.deck_id = ?
              AND c.category = ?
              AND c.state != 'suspended'
+             AND (c.buried_until IS NULL OR c.buried_until < ?)
              AND (
                (c.state IN ('learning', 'relearn') AND c.due <= ?)
                OR (c.state = 'review' AND c.due <= ?)
@@ -544,21 +545,8 @@ def get_due_cards(deck_id: int, category: str) -> list[dict]:
                ELSE 2
              END,
              c.due""",
-        (deck_id, category, now, today, today),
+        (deck_id, category, today, now, today, today),
     ).fetchall()
-
-    # Bury siblings: exclude cards whose word was already reviewed today in another category
-    if preset.get("bury_siblings", 1):
-        buried_word_ids = {
-            r[0] for r in conn.execute(
-                """SELECT DISTINCT c.word_id FROM cards c
-                   JOIN review_log rl ON rl.card_id = c.id
-                   WHERE c.category != ?
-                     AND date(rl.reviewed_at) = ?""",
-                (category, today),
-            ).fetchall()
-        }
-        rows = [r for r in rows if r["word_id"] not in buried_word_ids]
 
     conn.close()
 
@@ -601,25 +589,30 @@ def count_due(deck_id: int, category: str) -> dict:
     new_done_today = _count_new_introduced_today(conn, deck_id, category, today)
     new_remaining = max(0, new_limit - new_done_today)
 
+    buried_filter = "AND (c.buried_until IS NULL OR c.buried_until < ?)"
+
     learning = conn.execute(
-        """SELECT COUNT(*) FROM cards c
+        f"""SELECT COUNT(*) FROM cards c
            WHERE c.deck_id = ? AND c.category = ?
-             AND c.state IN ('learning', 'relearn') AND c.due <= ?""",
-        (deck_id, category, now),
+             AND c.state IN ('learning', 'relearn') AND c.due <= ?
+             {buried_filter}""",
+        (deck_id, category, now, today),
     ).fetchone()[0]
 
     review = conn.execute(
-        """SELECT COUNT(*) FROM cards c
+        f"""SELECT COUNT(*) FROM cards c
            WHERE c.deck_id = ? AND c.category = ?
-             AND c.state = 'review' AND c.due <= ?""",
-        (deck_id, category, today),
+             AND c.state = 'review' AND c.due <= ?
+             {buried_filter}""",
+        (deck_id, category, today, today),
     ).fetchone()[0]
 
     new_available = conn.execute(
-        """SELECT COUNT(*) FROM cards c
+        f"""SELECT COUNT(*) FROM cards c
            WHERE c.deck_id = ? AND c.category = ?
-             AND c.state = 'new' AND c.due <= ?""",
-        (deck_id, category, today),
+             AND c.state = 'new' AND c.due <= ?
+             {buried_filter}""",
+        (deck_id, category, today, today),
     ).fetchone()[0]
 
     conn.close()
@@ -639,6 +632,35 @@ def update_card(card_id: int, *, state: str, due: str,
                             ease=?, repetitions=?, lapses=?
            WHERE id=?""",
         (state, due, step_index, interval, ease, repetitions, lapses, card_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+def bury_card(card_id: int) -> None:
+    """Bury a card until tomorrow (hidden for the rest of today)."""
+    today = date.today().isoformat()
+    conn = get_db()
+    conn.execute("UPDATE cards SET buried_until = ? WHERE id = ?", (today, card_id))
+    conn.commit()
+    conn.close()
+
+
+def unbury_card(card_id: int) -> None:
+    """Remove burial — card becomes available immediately."""
+    conn = get_db()
+    conn.execute("UPDATE cards SET buried_until = NULL WHERE id = ?", (card_id,))
+    conn.commit()
+    conn.close()
+
+
+def bury_siblings(word_id: int, reviewed_category: str) -> None:
+    """Bury all other-category cards for this word for the rest of today."""
+    today = date.today().isoformat()
+    conn = get_db()
+    conn.execute(
+        "UPDATE cards SET buried_until = ? WHERE word_id = ? AND category != ?",
+        (today, word_id, reviewed_category),
     )
     conn.commit()
     conn.close()

--- a/main.py
+++ b/main.py
@@ -282,6 +282,9 @@ try:
         updated = srs.apply_review(card_id, rating, user_response=user_response)
         deck_id = updated["deck_id"]
         cat = updated["category"]
+        preset = database.get_preset_for_deck(deck_id)
+        if preset.get("bury_siblings", 1):
+            database.bury_siblings(updated["word_id"], cat)
         next_card = database.get_next_card(deck_id, cat)
         if next_card:
             next_card = database.get_card(next_card["id"])
@@ -293,6 +296,16 @@ try:
                     updated["due"], next_card["word_zh"] if next_card else "—",
                     counts["learning"], counts["review"], counts["new"])
         return {"next_card": next_card, "counts": counts}
+
+    @app.post("/api/cards/{card_id}/bury")
+    def bury_card(card_id: int):
+        database.bury_card(card_id)
+        return {"ok": True}
+
+    @app.post("/api/cards/{card_id}/unbury")
+    def unbury_card(card_id: int):
+        database.unbury_card(card_id)
+        return {"ok": True}
 
     @app.post("/api/speak")
     def speak(text: str):

--- a/schema.sql
+++ b/schema.sql
@@ -131,6 +131,9 @@ CREATE TABLE IF NOT EXISTS cards (
     repetitions INTEGER NOT NULL DEFAULT 0,
     lapses      INTEGER NOT NULL DEFAULT 0,
 
+    -- Temporary burial: card is hidden until this date (resets automatically next day)
+    buried_until TEXT,
+
     UNIQUE(word_id, category)
 );
 


### PR DESCRIPTION
## Summary
- Adds `buried_until TEXT` column to `cards` table
- `get_due_cards()` and `count_due()` filter out cards where `buried_until >= today`
- `POST /api/review` calls `bury_siblings()` when `preset.bury_siblings` is enabled (default on)
- New `POST /api/cards/{id}/bury` and `/unbury` endpoints for manual burial

## Test plan
- [ ] Review a listening card → reading/creating cards for same word should not appear today
- [ ] Counts in deck list should not include buried cards
- [ ] Bury siblings off (preset) → sibling cards still appear
- [ ] Manual bury/unbury endpoints respond `{"ok": true}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)