### PR TITLE
feat: sentence position counter on review card

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -506,6 +506,15 @@ function loadCard(c, counts) {
   // Find sentence for this card's word in the story
   sentence = story?.sentences?.find(s => s.word_id === card.word_id) || null;
 
+  // Update sentence position counter
+  const counter = document.getElementById('sentence-counter');
+  if (sentence && story?.sentences?.length) {
+    counter.textContent = `Sentence ${sentence.position + 1} / ${story.sentences.length}`;
+    counter.style.display = 'block';
+  } else {
+    counter.style.display = 'none';
+  }
+
   // Preload full word details for the back side (local DB — near-instant)
   fetch(`/api/word/${c.word_id}`)
     .then(r => r.ok ? r.json() : null)

--- a/static/index.html
+++ b/static/index.html
@@ -38,6 +38,9 @@
 
     <div class="review-card" id="review-card">
 
+      <!-- Sentence position indicator -->
+      <div id="sentence-counter" style="display:none"></div>
+
       <!-- Front side (content varies by category) -->
       <div id="side-front">
         <!-- Listening: speaker icon + replay -->

--- a/static/style.css
+++ b/static/style.css
@@ -151,6 +151,14 @@ main {
   gap: 16px;
 }
 
+/* Sentence counter (position indicator) */
+#sentence-counter {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--muted);
+  letter-spacing: 0.4px;
+}
+
 /* Sentence display */
 .sentence {
   font-size: 28px;


### PR DESCRIPTION
## Summary
- Shows "Sentence 4 / 21" left-aligned above the card content during review
- Uses `sentence.position` (already in DB) + `story.sentences.length` (already in memory) — no backend changes
- Hidden in mixed mode and when AI is disabled (no story)

🤖 Generated with [Claude Code](https://claude.com/claude-code)