### PR TITLE
feat: Browse redesign — word list, search, word detail, card actions

### DIFF
--- a/database.py
+++ b/database.py
@@ -844,6 +844,132 @@ def unsuspend_card(card_id: int) -> None:
     conn.close()
 
 
+def get_words_for_browse() -> list[dict]:
+    """Return all words that have cards, with embedded card states per category."""
+    sql = """
+        SELECT w.id, w.word_zh, w.pinyin, w.definition, w.pos, w.hsk_level,
+               c.id as card_id, c.category, c.state, c.interval, c.ease,
+               c.due, c.lapses, c.step_index, c.deck_id,
+               d.name as deck_name
+        FROM words w
+        JOIN cards c ON c.word_id = w.id
+        JOIN decks d ON d.id = c.deck_id
+        ORDER BY w.word_zh, c.category
+    """
+    conn = get_db()
+    rows = conn.execute(sql).fetchall()
+    conn.close()
+    words: dict = {}
+    for r in rows:
+        r = dict(r)
+        wid = r["id"]
+        if wid not in words:
+            words[wid] = {
+                "id": wid,
+                "word_zh": r["word_zh"],
+                "pinyin": r["pinyin"],
+                "definition": r["definition"],
+                "pos": r["pos"],
+                "hsk_level": r["hsk_level"],
+                "cards": [],
+            }
+        words[wid]["cards"].append({
+            "id": r["card_id"],
+            "category": r["category"],
+            "state": r["state"],
+            "interval": r["interval"],
+            "ease": r["ease"],
+            "due": r["due"],
+            "lapses": r["lapses"],
+            "step_index": r["step_index"],
+            "deck_id": r["deck_id"],
+            "deck_name": r["deck_name"],
+        })
+    return list(words.values())
+
+
+def search_words(q: str) -> dict:
+    """Return word IDs split into primary (word/def match) and secondary (example/notes match)."""
+    like = f"%{q}%"
+    conn = get_db()
+    primary_ids = {r["id"] for r in conn.execute(
+        """SELECT DISTINCT w.id FROM words w
+           JOIN cards c ON c.word_id = w.id
+           WHERE w.word_zh LIKE ? OR w.pinyin LIKE ?
+              OR w.definition LIKE ? OR w.definition_zh LIKE ?""",
+        (like, like, like, like),
+    ).fetchall()}
+    secondary_ids = {r["id"] for r in conn.execute(
+        """SELECT DISTINCT w.id FROM words w
+           JOIN cards c ON c.word_id = w.id
+           LEFT JOIN word_examples we ON we.word_id = w.id
+           WHERE we.example_zh LIKE ? OR we.example_de LIKE ? OR w.notes LIKE ?""",
+        (like, like, like),
+    ).fetchall()} - primary_ids
+    conn.close()
+    return {"primary": list(primary_ids), "secondary": list(secondary_ids)}
+
+
+def get_cards_for_word(word_id: int) -> list[dict]:
+    """Return all cards for a word with full deck path (parent › child)."""
+    conn = get_db()
+    rows = conn.execute(
+        """SELECT c.*, d.name as deck_name, p.name as parent_deck_name
+           FROM cards c
+           JOIN decks d ON d.id = c.deck_id
+           LEFT JOIN decks p ON p.id = d.parent_id
+           WHERE c.word_id = ? ORDER BY c.category""",
+        (word_id,),
+    ).fetchall()
+    conn.close()
+    result = []
+    for r in rows:
+        r = dict(r)
+        if r.get("parent_deck_name"):
+            r["deck_path"] = f"{r['parent_deck_name']} › {r['deck_name']}"
+        else:
+            r["deck_path"] = r["deck_name"]
+        result.append(r)
+    return result
+
+
+def suspend_card(card_id: int) -> dict:
+    """Toggle a card between suspended and new."""
+    conn = get_db()
+    cur = conn.execute("SELECT state FROM cards WHERE id=?", (card_id,)).fetchone()
+    new_state = "new" if cur and cur["state"] == "suspended" else "suspended"
+    conn.execute("UPDATE cards SET state=? WHERE id=?", (new_state, card_id))
+    conn.commit()
+    conn.close()
+    return get_card(card_id)
+
+
+def reset_card(card_id: int) -> dict:
+    """Reset a card to new state with default scheduling values."""
+    conn = get_db()
+    conn.execute(
+        """UPDATE cards SET state='new', step_index=0, interval=1,
+                            ease=2.5, lapses=0, due=date('now'), buried_until=NULL
+           WHERE id=?""",
+        (card_id,),
+    )
+    conn.commit()
+    conn.close()
+    return get_card(card_id)
+
+
+def bury_card_until_tomorrow(card_id: int) -> dict:
+    """Bury a card until tomorrow."""
+    conn = get_db()
+    conn.execute(
+        "UPDATE cards SET buried_until=date('now', '+1 day') WHERE id=?",
+        (card_id,),
+    )
+    conn.commit()
+    conn.close()
+    return get_card(card_id)
+
+
 def get_all_cards_for_browse(filters: dict | None = None) -> list[dict]:
     """Browse view. Supports filters: deck_id, category, state, search_text."""
     where = ["1=1"]

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -13,13 +13,46 @@ def trigger_import():
 
 @router.get("/api/word/{word_id}")
 def get_word_detail(word_id: int):
-    return database.get_word_full(word_id)
+    word = database.get_word_full(word_id)
+    if word:
+        word["cards"] = database.get_cards_for_word(word_id)
+    return word
 
 
 @router.put("/api/word/{word_id}")
 def update_word(word_id: int, body: dict):
     database.update_word(word_id, body)
     return database.get_word_full(word_id)
+
+
+@router.get("/api/browse-words")
+def browse_words():
+    return database.get_words_for_browse()
+
+
+@router.get("/api/search-words")
+def search_words(q: str):
+    return database.search_words(q)
+
+
+@router.get("/api/words/{word_id}/cards")
+def get_word_cards(word_id: int):
+    return database.get_cards_for_word(word_id)
+
+
+@router.post("/api/cards/{card_id}/suspend")
+def toggle_suspend(card_id: int):
+    return database.suspend_card(card_id)
+
+
+@router.post("/api/cards/{card_id}/reset")
+def reset_card_endpoint(card_id: int):
+    return database.reset_card(card_id)
+
+
+@router.post("/api/cards/{card_id}/bury")
+def bury_card_endpoint(card_id: int):
+    return database.bury_card_until_tomorrow(card_id)
 
 
 @router.get("/api/browse")

--- a/static/app.js
+++ b/static/app.js
@@ -9,7 +9,9 @@ let story       = null;   // story dict with sentences[]
 let sentence    = null;   // current sentence from story (may be null)
 let wordDetails = null;   // full word data: examples + characters
 let userInput   = '';     // creating category: what the user typed
-let browseAll    = [];   // all cards from API for client-side filtering
+let browseWords  = [];   // all words from /api/browse-words
+let browseAll    = [];   // kept for legacy (unused by new browse)
+let _browseSort  = 'pinyin-asc';
 let optDeckId    = null; // deck whose options modal is open
 const collapsed  = new Set();  // parent deck IDs that are collapsed
 
@@ -27,15 +29,16 @@ async function api(method, path, body) {
 
 // ── View switcher ──────────────────────────────────────────────────────────
 function showView(name) {
-  ['loading', 'decks', 'review', 'done', 'browse', 'stats'].forEach(v => {
+  ['loading', 'decks', 'review', 'done', 'browse', 'word-detail', 'stats'].forEach(v => {
     document.getElementById(`view-${v}`).style.display = 'none';
   });
   document.getElementById(`view-${name}`).style.display = 'block';
   document.getElementById('back-btn').style.display = name === 'decks' ? 'none' : 'block';
   document.getElementById('header-title').textContent =
-    name === 'review' ? `${deckName} · ${cap(category)}` :
-    name === 'browse' ? 'Browse' :
-    name === 'stats'  ? 'Stats'  : 'AnkiAdvanced';
+    name === 'review'      ? `${deckName} · ${cap(category)}` :
+    name === 'browse'      ? 'Browse' :
+    name === 'word-detail' ? 'Word Detail' :
+    name === 'stats'       ? 'Stats' : 'AnkiAdvanced';
 }
 
 function setLoading(msg) {
@@ -218,57 +221,243 @@ function toggleDeck(deckId) {
 }
 
 // ── Browse ───────────────────────────────────────────────────────────────────
+let _browseSearchTimer = null;
+
+function _sortWords(words) {
+  const sorted = [...words];
+  const locale = { sensitivity: 'base' };
+  switch (_browseSort) {
+    case 'pinyin-asc':  sorted.sort((a, b) => (a.pinyin || '').localeCompare(b.pinyin || '', 'en', locale)); break;
+    case 'pinyin-desc': sorted.sort((a, b) => (b.pinyin || '').localeCompare(a.pinyin || '', 'en', locale)); break;
+    case 'hanzi-asc':   sorted.sort((a, b) => (a.word_zh || '').localeCompare(b.word_zh || '', 'zh')); break;
+    case 'hanzi-desc':  sorted.sort((a, b) => (b.word_zh || '').localeCompare(a.word_zh || '', 'zh')); break;
+    case 'newest':      sorted.sort((a, b) => b.id - a.id); break;
+  }
+  return sorted;
+}
+
+function onBrowseSort(val) {
+  _browseSort = val;
+  // Re-run current search or re-render full list
+  const q = document.getElementById('browse-search').value.trim();
+  if (q) onBrowseSearch(q); else renderBrowseWords(browseWords);
+}
+
 async function openBrowse() {
-  setLoading('Loading cards…');
+  setLoading('Loading words…');
   try {
-    browseAll = await api('GET', '/api/browse');
+    browseWords = await api('GET', '/api/browse-words');
     showView('browse');
-    applyFilters();
+    document.getElementById('browse-search').value = '';
+    document.getElementById('browse-sort').value = _browseSort;
+    renderBrowseWords(browseWords);
   } catch (e) {
     showError('Browse failed: ' + e.message);
     showView('decks');
   }
 }
 
-function applyFilters() {
-  const q     = document.getElementById('f-search').value.toLowerCase();
-  const state = document.getElementById('f-state').value;
-  const cat   = document.getElementById('f-cat').value;
-  const filtered = browseAll.filter(c => {
-    if (state && c.state !== state) return false;
-    if (cat   && c.category !== cat) return false;
-    if (q && !c.word_zh?.toLowerCase().includes(q)
-           && !c.definition?.toLowerCase().includes(q)
-           && !c.pinyin?.toLowerCase().includes(q)) return false;
-    return true;
-  });
-  renderBrowse(filtered);
+function onBrowseSearch(val) {
+  clearTimeout(_browseSearchTimer);
+  const q = val.trim();
+  if (!q) { renderBrowseWords(browseWords); return; }
+  _browseSearchTimer = setTimeout(async () => {
+    try {
+      const result = await api('GET', `/api/search-words?q=${encodeURIComponent(q)}`);
+      const primarySet   = new Set(result.primary);
+      const secondarySet = new Set(result.secondary);
+      const primary   = browseWords.filter(w => primarySet.has(w.id));
+      const secondary = browseWords.filter(w => secondarySet.has(w.id));
+      renderBrowseSearchResults(primary, secondary, q);
+    } catch (e) { showError('Search failed: ' + e.message); }
+  }, 250);
 }
 
-function renderBrowse(cards) {
+function _wordRow(w) {
+  const dots = ['listening', 'reading', 'creating'].map(cat => {
+    const c = w.cards.find(c => c.category === cat);
+    return c
+      ? `<span class="bw-dot bw-dot-${c.state}" title="${cat}: ${c.state}"></span>`
+      : `<span class="bw-dot bw-dot-none" title="${cat}: —"></span>`;
+  }).join('');
+  const def = (w.definition || '').slice(0, 60) + ((w.definition || '').length > 60 ? '…' : '');
+  return `
+    <div class="bw-row" onclick="openWordDetail(${w.id})">
+      <div class="bw-left">
+        <span class="bw-hanzi">${w.word_zh}</span>
+        <span class="bw-pinyin">${w.pinyin || ''}</span>
+      </div>
+      <div class="bw-mid">
+        <span class="bw-def">${def}</span>
+      </div>
+      <div class="bw-right">${dots}</div>
+    </div>`;
+}
+
+function renderBrowseWords(words) {
   const list = document.getElementById('browse-list');
-  if (!cards.length) {
-    list.innerHTML = '<div style="text-align:center;color:var(--muted);padding:40px 0">No cards found</div>';
+  if (!words.length) {
+    list.innerHTML = '<div class="browse-empty">No words found</div>';
     return;
   }
-  list.innerHTML = cards.map(c => {
-    const def = (c.definition || '').slice(0, 48) + ((c.definition || '').length > 48 ? '…' : '');
-    const due = c.due ? c.due.slice(0, 10) : '';
-    const intv = c.interval > 0 ? `${c.interval}d` : '';
+  list.innerHTML = `<div class="bw-list">${_sortWords(words).map(_wordRow).join('')}</div>`;
+}
+
+function renderBrowseSearchResults(primary, secondary, q) {
+  const list = document.getElementById('browse-list');
+  if (!primary.length && !secondary.length) {
+    list.innerHTML = '<div class="browse-empty">No results for "' + q + '"</div>';
+    return;
+  }
+  let html = '';
+  if (primary.length) {
+    html += `<div class="browse-section-label">Words (${primary.length})</div>
+             <div class="bw-list">${_sortWords(primary).map(_wordRow).join('')}</div>`;
+  }
+  if (secondary.length) {
+    html += `<div class="browse-section-label">Found in examples / notes (${secondary.length})</div>
+             <div class="bw-list">${_sortWords(secondary).map(_wordRow).join('')}</div>`;
+  }
+  list.innerHTML = html;
+}
+
+// ── Word Detail ───────────────────────────────────────────────────────────────
+async function openWordDetail(wordId) {
+  setLoading('Loading word…');
+  try {
+    const word = await api('GET', `/api/word/${wordId}`);
+    renderWordDetail(word);
+    showView('word-detail');
+  } catch (e) {
+    showError('Failed to load word: ' + e.message);
+    showView('browse');
+  }
+}
+
+function renderWordDetail(word) {
+  document.getElementById('wd-edit-btn').onclick = () => openEditCardFromDetail(word.id);
+  document.getElementById('wd-hanzi').textContent = word.word_zh || '';
+  document.getElementById('wd-pinyin').textContent = word.pinyin || '';
+  document.getElementById('wd-def').textContent = word.definition || '';
+  const posEl = document.getElementById('wd-pos');
+  posEl.textContent = word.pos || '';
+  posEl.style.display = word.pos ? 'inline-block' : 'none';
+  const defZhEl = document.getElementById('wd-def-zh');
+  defZhEl.textContent = word.definition_zh || '';
+  defZhEl.style.display = word.definition_zh ? 'block' : 'none';
+
+  // Characters section
+  const charsEl = document.getElementById('wd-chars-section');
+  if (word.characters?.length) {
+    const rows = word.characters.map(wc => {
+      const c = wc.character || wc;
+      const char = wc.char || c.char || '';
+      const pin  = wc.pinyin || c.pinyin || '';
+      const ctx  = wc.meaning_in_context ? `<span class="wd-ctx">${wc.meaning_in_context}</span>` : '';
+      const etym = c.etymology ? `<div class="wd-etym">${c.etymology}</div>` : '';
+      return `<div class="wd-char-row">
+        <span class="wd-char-zh">${char}</span>
+        <span class="wd-char-pin">${pin}</span>
+        ${ctx}${etym}
+      </div>`;
+    }).join('');
+    charsEl.innerHTML =
+      `<div class="wd-section-head section-toggle" onclick="toggleSection('wd-chars-body')">` +
+        `<span id="wd-chars-body-arrow">▶</span> Characters</div>` +
+      `<div id="wd-chars-body" class="wd-section-body" style="display:none">${rows}</div>`;
+  } else {
+    charsEl.innerHTML = '';
+  }
+
+  // Examples section
+  const exEl = document.getElementById('wd-examples-section');
+  if (word.examples?.length) {
+    const rows = word.examples.map(ex => `
+      <div class="wd-example-row">
+        <div class="wd-ex-zh">${ex.example_zh || ''}</div>
+        ${ex.example_pinyin ? `<div class="wd-ex-pin">${ex.example_pinyin}</div>` : ''}
+        ${ex.example_de ? `<div class="wd-ex-de">${ex.example_de}</div>` : ''}
+      </div>`).join('');
+    exEl.innerHTML =
+      `<div class="wd-section-head section-toggle" onclick="toggleSection('wd-examples-body')">` +
+        `<span id="wd-examples-body-arrow">▶</span> Examples</div>` +
+      `<div id="wd-examples-body" class="wd-section-body" style="display:none">${rows}</div>`;
+  } else {
+    exEl.innerHTML = '';
+  }
+
+  // Cards section
+  renderWordDetailCards(word.cards || [], word.id);
+}
+
+function renderWordDetailCards(cards, wordId) {
+  const el = document.getElementById('wd-cards-section');
+  if (!cards.length) { el.innerHTML = ''; return; }
+  const CAT_FULL = { listening: 'Listening', reading: 'Reading', creating: 'Creating' };
+  const rows = cards.map(c => {
+    const isSuspended = c.state === 'suspended';
+    const intv  = c.interval > 0 ? `${c.interval}d` : '—';
+    const ease  = c.ease ? `${Math.round(c.ease * 100)}%` : '—';
+    const due   = c.due ? c.due.slice(0, 10) : '—';
+    const isBuried = c.buried_until && c.buried_until >= new Date().toISOString().slice(0, 10);
     return `
-      <div class="browse-item">
-        <div class="browse-top">
-          <div class="browse-word">${c.word_zh}</div>
-          <div class="browse-badges">
-            <span class="badge badge-${c.category}">${c.category.slice(0,1).toUpperCase()}</span>
-            <span class="badge badge-${c.state}">${c.state}</span>
+      <div class="wd-card-block" id="wd-card-${c.id}">
+        <div class="wd-card-head">
+          <span class="wd-cat-label">${CAT_FULL[c.category] || c.category}</span>
+          <span class="badge badge-${c.state}">${c.state}</span>
+          ${isBuried ? '<span class="badge badge-buried">buried</span>' : ''}
+          <div class="wd-card-menu-wrap">
+            <button class="wd-menu-btn" onclick="toggleCardMenu(${c.id}, event)">⋯</button>
+            <div class="wd-card-menu" id="wd-menu-${c.id}" style="display:none">
+              <button class="wd-menu-item" onclick="cardAction(${c.id}, 'bury', ${wordId})">Bury until tomorrow</button>
+              <button class="wd-menu-item ${isSuspended ? 'wd-menu-item-active' : ''}"
+                      onclick="cardAction(${c.id}, 'suspend', ${wordId})">
+                ${isSuspended ? 'Unsuspend' : 'Suspend'}
+              </button>
+              <button class="wd-menu-item wd-menu-item-danger"
+                      onclick="cardAction(${c.id}, 'reset', ${wordId})">Reset to new</button>
+            </div>
           </div>
         </div>
-        <div class="browse-def">${def}</div>
-        <div class="browse-meta">${c.pinyin || ''}${due ? ' · due ' + due : ''}${intv ? ' · ' + intv : ''}</div>
+        <div class="wd-card-stats">
+          <span>Deck <b>${c.deck_path || c.deck_name || '—'}</b></span>
+          <span>Interval <b>${intv}</b></span>
+          <span>Due <b>${due}</b></span>
+          <span>Ease <b>${ease}</b></span>
+          <span>Lapses <b>${c.lapses}</b></span>
+        </div>
       </div>`;
   }).join('');
+  el.innerHTML = `<div class="wd-section-head">Cards</div><div class="wd-cards-list">${rows}</div>`;
 }
+
+function toggleCardMenu(cardId, e) {
+  e.stopPropagation();
+  const menu = document.getElementById(`wd-menu-${cardId}`);
+  const isOpen = menu.style.display !== 'none';
+  closeAllCardMenus();
+  if (!isOpen) menu.style.display = 'block';
+}
+
+function closeAllCardMenus() {
+  document.querySelectorAll('.wd-card-menu').forEach(m => m.style.display = 'none');
+}
+
+document.addEventListener('click', closeAllCardMenus);
+
+async function cardAction(cardId, action, wordId) {
+  closeAllCardMenus();
+  try {
+    await api('POST', `/api/cards/${cardId}/${action}`);
+    const word = await api('GET', `/api/word/${wordId}`);
+    renderWordDetailCards(word.cards || [], wordId);
+  } catch (e) {
+    showError(`Action failed: ${e.message}`);
+  }
+}
+
+// ── applyFilters kept for legacy (no longer used by browse) ──────────────────
+function applyFilters() {}
 
 // ── Stats ────────────────────────────────────────────────────────────────────
 async function openStats() {
@@ -997,16 +1186,31 @@ function closeStoryModal() {
 }
 
 // ── Edit card modal ───────────────────────────────────────────────────────────
-function openEditCard() {
-  document.getElementById('edit-word-zh').value       = card.word_zh || '';
-  document.getElementById('edit-pinyin').value        = card.pinyin || '';
-  document.getElementById('edit-definition').value    = card.definition || '';
-  document.getElementById('edit-pos').value           = card.pos || '';
-  document.getElementById('edit-traditional').value   = card.traditional || '';
-  document.getElementById('edit-definition-zh').value = card.definition_zh || '';
-  document.getElementById('edit-notes').value         = card.notes || '';
+let _editWordId   = null;   // word ID being edited
+let _editFromWord = false;  // true when opened from word-detail view
+
+function _openEditModal(wordObj) {
+  _editWordId = wordObj.id || wordObj.word_id;
+  document.getElementById('edit-word-zh').value       = wordObj.word_zh       || '';
+  document.getElementById('edit-pinyin').value        = wordObj.pinyin        || '';
+  document.getElementById('edit-definition').value    = wordObj.definition    || '';
+  document.getElementById('edit-pos').value           = wordObj.pos           || '';
+  document.getElementById('edit-traditional').value   = wordObj.traditional   || '';
+  document.getElementById('edit-definition-zh').value = wordObj.definition_zh || '';
+  document.getElementById('edit-notes').value         = wordObj.notes         || '';
   document.getElementById('edit-modal-overlay').style.display = 'block';
   document.getElementById('edit-modal').style.display         = 'flex';
+}
+
+function openEditCard() {
+  _editFromWord = false;
+  _openEditModal(card);
+}
+
+function openEditCardFromDetail(wordId) {
+  closeAllCardMenus();
+  _editFromWord = true;
+  api('GET', `/api/word/${wordId}`).then(w => _openEditModal(w)).catch(e => showError(e.message));
 }
 
 function closeEditCard() {
@@ -1025,20 +1229,34 @@ async function saveEditCard() {
     notes:         document.getElementById('edit-notes').value.trim(),
   };
   try {
-    const updated = await api('PUT', `/api/word/${card.word_id}`, body);
-    Object.assign(card, {
-      word_zh: updated.word_zh, pinyin: updated.pinyin,
-      definition: updated.definition, pos: updated.pos,
-      traditional: updated.traditional, definition_zh: updated.definition_zh,
-      notes: updated.notes,
-    });
-    document.getElementById('word-zh').textContent  = updated.word_zh || '';
-    document.getElementById('word-pin').textContent = updated.pinyin || '';
-    document.getElementById('word-def').textContent = updated.definition || '';
-    const posEl = document.getElementById('word-pos');
-    posEl.textContent   = updated.pos || '';
-    posEl.style.display = updated.pos ? 'inline-block' : 'none';
-    renderNotesSection();
+    const updated = await api('PUT', `/api/word/${_editWordId}`, body);
+    if (_editFromWord) {
+      // Refresh word-detail header in place
+      document.getElementById('wd-hanzi').textContent  = updated.word_zh || '';
+      document.getElementById('wd-pinyin').textContent = updated.pinyin  || '';
+      document.getElementById('wd-def').textContent    = updated.definition || '';
+      const posEl = document.getElementById('wd-pos');
+      posEl.textContent = updated.pos || '';
+      posEl.style.display = updated.pos ? 'inline-block' : 'none';
+      const defZhEl = document.getElementById('wd-def-zh');
+      defZhEl.textContent    = updated.definition_zh || '';
+      defZhEl.style.display  = updated.definition_zh ? 'block' : 'none';
+    } else {
+      // Refresh review card in place
+      Object.assign(card, {
+        word_zh: updated.word_zh, pinyin: updated.pinyin,
+        definition: updated.definition, pos: updated.pos,
+        traditional: updated.traditional, definition_zh: updated.definition_zh,
+        notes: updated.notes,
+      });
+      document.getElementById('word-zh').textContent  = updated.word_zh || '';
+      document.getElementById('word-pin').textContent = updated.pinyin  || '';
+      document.getElementById('word-def').textContent = updated.definition || '';
+      const posEl = document.getElementById('word-pos');
+      posEl.textContent   = updated.pos || '';
+      posEl.style.display = updated.pos ? 'inline-block' : 'none';
+      renderNotesSection();
+    }
     closeEditCard();
   } catch (e) {
     showError('Save failed: ' + e.message);
@@ -1085,9 +1303,14 @@ async function _doRegenerateStory(topic, maxHsk) {
 
 // ── Back to decks ────────────────────────────────────────────────────────────
 function goBack() {
+  // Word detail → back to browse list
+  if (document.getElementById('view-word-detail').style.display !== 'none') {
+    showView('browse');
+    return;
+  }
   card = null; story = null; sentence = null; wordDetails = null; userInput = '';
   rootDeckId = null; unfinishedMode = false;
-  browseAll = [];
+  browseWords = []; browseAll = [];
   loadDecks();
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -126,24 +126,36 @@
 
   <!-- Browse -->
   <div id="view-browse">
-    <div class="filter-row">
-      <input  id="f-search"   type="text"   placeholder="Search…" oninput="applyFilters()">
-      <select id="f-state"    onchange="applyFilters()">
-        <option value="">All states</option>
-        <option value="new">New</option>
-        <option value="learning">Learning</option>
-        <option value="review">Review</option>
-        <option value="relearn">Relearn</option>
-        <option value="suspended">Suspended</option>
-      </select>
-      <select id="f-cat"      onchange="applyFilters()">
-        <option value="">All categories</option>
-        <option value="listening">Listening</option>
-        <option value="reading">Reading</option>
-        <option value="creating">Creating</option>
+    <div class="browse-search-row">
+      <input id="browse-search" type="text" placeholder="Search words, pinyin, definition…"
+             oninput="onBrowseSearch(this.value)" autocomplete="off"
+             autocorrect="off" autocapitalize="off" spellcheck="false">
+      <select id="browse-sort" onchange="onBrowseSort(this.value)">
+        <option value="pinyin-asc">Pinyin A→Z</option>
+        <option value="pinyin-desc">Pinyin Z→A</option>
+        <option value="hanzi-asc">Hanzi A→Z</option>
+        <option value="hanzi-desc">Hanzi Z→A</option>
+        <option value="newest">Newest first</option>
       </select>
     </div>
-    <div class="browse-list" id="browse-list"></div>
+    <div id="browse-list"></div>
+  </div>
+
+  <!-- Word Detail -->
+  <div id="view-word-detail">
+    <div class="wd-header">
+      <div class="wd-hanzi" id="wd-hanzi"></div>
+      <div class="wd-pinyin" id="wd-pinyin"></div>
+      <div class="wd-pos-def-row">
+        <span class="word-pos" id="wd-pos" style="display:none"></span>
+        <span class="wd-def" id="wd-def"></span>
+      </div>
+      <div class="wd-def-zh" id="wd-def-zh" style="display:none"></div>
+      <button class="wd-edit-btn" id="wd-edit-btn" onclick="openEditCardFromDetail(0)">Edit</button>
+    </div>
+    <div id="wd-chars-section"></div>
+    <div id="wd-examples-section"></div>
+    <div id="wd-cards-section"></div>
   </div>
 
   <!-- Stats -->

--- a/static/style.css
+++ b/static/style.css
@@ -884,48 +884,101 @@ main {
 .gear-btn:hover { background: var(--border); }
 
 /* ── Browse view ─────────────────────────────────────── */
-#view-browse { display: none; }
+#view-browse      { display: none; }
+#view-word-detail { display: none; }
 
-.filter-row {
+.browse-search-row {
   display: flex;
   gap: 8px;
   margin-bottom: 14px;
-  flex-wrap: wrap;
 }
-.filter-row input,
-.filter-row select {
-  padding: 8px 10px;
+.browse-search-row input {
+  flex: 1;
+  padding: 10px 14px;
   border: 1.5px solid var(--border);
-  border-radius: 8px;
-  font-size: 13px;
+  border-radius: 10px;
+  font-size: 15px;
   background: var(--card);
   color: var(--text);
   outline: none;
 }
-.filter-row input { flex: 1; min-width: 120px; }
-.filter-row input:focus,
-.filter-row select:focus { border-color: var(--primary); }
+.browse-search-row input:focus { border-color: var(--primary); }
+.browse-search-row select {
+  padding: 8px 10px;
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  font-size: 13px;
+  background: var(--card);
+  color: var(--text);
+  outline: none;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.browse-search-row select:focus { border-color: var(--primary); }
 
-.browse-list {
+.browse-empty {
+  text-align: center;
+  color: var(--muted);
+  padding: 40px 0;
+  font-size: 14px;
+}
+.browse-section-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.7px;
+  color: var(--muted);
+  padding: 0 4px 6px;
+  margin-top: 10px;
+}
+
+/* ── Word list rows ──────────────────────────────────── */
+.bw-list {
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  margin-bottom: 14px;
+}
+.bw-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.1s;
+  user-select: none;
+}
+.bw-row:last-child { border-bottom: none; }
+.bw-row:hover { background: #f8fafc; }
+.bw-left {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  min-width: 80px;
+  flex-shrink: 0;
 }
-.browse-item {
-  background: var(--card);
-  border-radius: 10px;
-  padding: 12px 14px;
-  box-shadow: var(--shadow);
+.bw-hanzi  { font-size: 19px; font-weight: 700; line-height: 1.2; }
+.bw-pinyin { font-size: 11px; color: var(--muted); margin-top: 1px; }
+.bw-mid  { flex: 1; overflow: hidden; }
+.bw-def  { font-size: 13px; color: var(--text);
+           white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.bw-right { display: flex; gap: 5px; flex-shrink: 0; }
+
+/* Tiny state dots */
+.bw-dot {
+  width: 9px; height: 9px;
+  border-radius: 50%;
+  display: inline-block;
 }
-.browse-top {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 8px;
-  margin-bottom: 4px;
-}
-.browse-word { font-size: 20px; font-weight: 700; }
-.browse-badges { display: flex; gap: 5px; }
+.bw-dot-new       { background: #93c5fd; }
+.bw-dot-learning  { background: #fbbf24; }
+.bw-dot-review    { background: #4ade80; }
+.bw-dot-relearn   { background: #f87171; }
+.bw-dot-suspended { background: #cbd5e1; }
+.bw-dot-none      { background: var(--border); }
+
+/* ── Badge (shared) ──────────────────────────────────── */
 .badge {
   font-size: 10px;
   font-weight: 700;
@@ -939,12 +992,154 @@ main {
 .badge-review   { background: #dcfce7; color: #15803d; }
 .badge-relearn  { background: #fee2e2; color: #b91c1c; }
 .badge-suspended{ background: #f1f5f9; color: #64748b; }
-.badge-listening{ background: #ede9fe; color: #6d28d9; }
-.badge-reading  { background: #dbeafe; color: #1d4ed8; }
-.badge-creating { background: #ccfbf1; color: #0f766e; }
-.browse-meta { font-size: 12px; color: var(--muted); }
-.browse-def  { font-size: 13px; color: var(--text); margin-top: 2px;
-               white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.badge-buried   { background: #e0e7ff; color: #4338ca; }
+
+/* ── Word Detail view ────────────────────────────────── */
+.wd-header {
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 20px 18px 16px;
+  text-align: center;
+  margin-bottom: 12px;
+}
+.wd-edit-btn {
+  margin-top: 12px;
+  padding: 5px 18px;
+  font-size: 12px;
+  font-weight: 600;
+  border: 1.5px solid var(--border);
+  border-radius: 7px;
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+  transition: border-color 0.12s, color 0.12s;
+}
+.wd-edit-btn:hover { border-color: var(--primary); color: var(--primary); }
+.wd-hanzi  { font-size: 44px; font-weight: 700; line-height: 1.1; }
+.wd-pinyin { font-size: 16px; color: var(--muted); margin: 4px 0 8px; }
+.wd-pos-def-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.wd-def    { font-size: 16px; color: var(--text); }
+.wd-def-zh { font-size: 14px; color: var(--muted); margin-top: 4px; }
+
+/* Collapsible sections */
+.wd-section-head {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.7px;
+  color: var(--muted);
+  padding: 10px 4px 6px;
+}
+.wd-section-head.section-toggle { cursor: pointer; user-select: none; }
+.wd-section-body {
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  margin-bottom: 12px;
+}
+
+/* Character rows */
+.wd-char-row {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+.wd-char-row:last-child { border-bottom: none; }
+.wd-char-zh  { font-size: 22px; font-weight: 700; min-width: 28px; }
+.wd-char-pin { font-size: 13px; color: var(--muted); }
+.wd-ctx      { font-size: 13px; color: var(--text); flex: 1; }
+.wd-etym     { width: 100%; font-size: 12px; color: var(--muted); margin-top: 3px; line-height: 1.5; }
+
+/* Example rows */
+.wd-example-row {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.wd-example-row:last-child { border-bottom: none; }
+.wd-ex-zh  { font-size: 16px; line-height: 1.4; }
+.wd-ex-pin { font-size: 12px; color: var(--muted); margin-top: 2px; }
+.wd-ex-de  { font-size: 13px; color: var(--text); margin-top: 2px; }
+
+/* Card blocks */
+.wd-cards-list { display: flex; flex-direction: column; gap: 10px; margin-bottom: 16px; }
+.wd-card-block {
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 14px 16px;
+}
+.wd-card-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.wd-cat-label { font-size: 14px; font-weight: 700; flex: 1; }
+.wd-card-stats {
+  display: flex;
+  gap: 14px;
+  font-size: 13px;
+  color: var(--muted);
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+.wd-card-stats b { color: var(--text); }
+.wd-card-menu-wrap { position: relative; display: inline-block; }
+.wd-menu-btn {
+  padding: 3px 10px;
+  font-size: 16px;
+  font-weight: 700;
+  border: 1.5px solid var(--border);
+  border-radius: 7px;
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+  line-height: 1.2;
+  transition: border-color 0.12s, color 0.12s;
+}
+.wd-menu-btn:hover { border-color: var(--primary); color: var(--primary); }
+.wd-card-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 170px;
+  background: var(--card);
+  border: 1.5px solid var(--border);
+  border-radius: 9px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.12);
+  z-index: 50;
+  overflow: hidden;
+}
+.wd-menu-item {
+  display: block;
+  width: 100%;
+  padding: 10px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  text-align: left;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+.wd-menu-item:last-child { border-bottom: none; }
+.wd-menu-item:hover { background: #f8fafc; }
+.wd-menu-item.wd-menu-item-active { color: var(--primary); font-weight: 600; }
+.wd-menu-item.wd-menu-item-danger { color: #dc2626; }
+.wd-menu-item.wd-menu-item-danger:hover { background: #fef2f2; }
 
 /* ── Stats view ──────────────────────────────────────── */
 #view-stats { display: none; }


### PR DESCRIPTION
## Summary
- Browse shows words (not cards) with hanzi, pinyin, definition, and L/R/C state dots
- Search splits results into **Words** (direct match) and **Found in examples / notes** (secondary match)
- Sort dropdown: Pinyin A→Z (default), Pinyin Z→A, Hanzi A→Z/Z→A, Newest first
- Click any word → **Word Detail** view with collapsible Characters & Examples sections
- Per-category card blocks showing deck path, interval, due, ease, lapses + ⋯ action menu (Bury, Suspend, Reset)
- **Edit** button in word header, shared with the existing review edit modal

## Test plan
- [ ] Browse word list loads and sorts by pinyin by default
- [ ] Search returns correct primary/secondary sections
- [ ] Changing sort re-orders results immediately
- [ ] Clicking a word opens detail with chars/examples/cards
- [ ] Card ⋯ menu actions update card state in place
- [ ] Edit saves and refreshes word header without reload
- [ ] Back from word detail returns to browse list

🤖 Generated with [Claude Code](https://claude.com/claude-code)