### PR TITLE
feat: API cost history

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -11,6 +11,7 @@ import logging
 import re
 
 import anthropic
+import database
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +69,13 @@ Rules:
         model="claude-sonnet-4-6",
         max_tokens=max_tokens,
         messages=[{"role": "user", "content": prompt}],
+    )
+
+    database.log_api_call(
+        model=message.model,
+        input_tokens=message.usage.input_tokens,
+        output_tokens=message.usage.output_tokens,
+        purpose="story",
     )
 
     raw = message.content[0].text.strip()

--- a/database.py
+++ b/database.py
@@ -30,6 +30,14 @@ def init_db() -> None:
     cols = {r["name"] for r in conn.execute("PRAGMA table_info(words)").fetchall()}
     if "notes" not in cols:
         conn.execute("ALTER TABLE words ADD COLUMN notes TEXT")
+    conn.execute("""CREATE TABLE IF NOT EXISTS api_call_log (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        called_at     TEXT NOT NULL DEFAULT (datetime('now')),
+        model         TEXT NOT NULL,
+        input_tokens  INTEGER NOT NULL,
+        output_tokens INTEGER NOT NULL,
+        purpose       TEXT NOT NULL DEFAULT 'story'
+    )""")
     conn.commit()
 
     # Ensure presets + default deck exist
@@ -1146,6 +1154,50 @@ def get_stats(deck_id: int | None = None) -> dict:
         "reviews_by_day": reviews_by_day,
         "state_counts": state_counts,
     }
+
+
+# ---------------------------------------------------------------------------
+# API cost tracking
+# ---------------------------------------------------------------------------
+
+# Prices per million tokens (USD) as of 2025
+_MODEL_PRICING: dict[str, dict[str, float]] = {
+    "claude-haiku-4-5-20251001": {"input": 0.80,  "output": 4.00},
+    "claude-sonnet-4-6":         {"input": 3.00,  "output": 15.00},
+    "claude-opus-4-6":           {"input": 15.00, "output": 75.00},
+}
+
+
+def log_api_call(model: str, input_tokens: int, output_tokens: int,
+                 purpose: str = "story") -> None:
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO api_call_log (model, input_tokens, output_tokens, purpose) VALUES (?, ?, ?, ?)",
+        (model, input_tokens, output_tokens, purpose),
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_api_costs() -> dict:
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT * FROM api_call_log ORDER BY called_at DESC"
+    ).fetchall()
+    conn.close()
+
+    calls = []
+    total_cost = 0.0
+    for r in rows:
+        r = dict(r)
+        pricing = _MODEL_PRICING.get(r["model"], {"input": 0.0, "output": 0.0})
+        cost = (r["input_tokens"] * pricing["input"] +
+                r["output_tokens"] * pricing["output"]) / 1_000_000
+        r["cost"] = round(cost, 6)
+        total_cost += cost
+        calls.append(r)
+
+    return {"calls": calls, "total_cost": round(total_cost, 6)}
 
 
 def _calc_streak(conn: sqlite3.Connection, deck_id: int | None) -> int:

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -71,6 +71,11 @@ def get_stats(deck_id: int | None = None):
     return database.get_stats(deck_id)
 
 
+@router.get("/api/costs")
+def get_api_costs():
+    return database.get_api_costs()
+
+
 @router.get("/api/pinyin")
 def get_pinyin(text: str):
     syllables = [item[0] for item in _pinyin(text, style=Style.TONE)]

--- a/schema.sql
+++ b/schema.sql
@@ -180,6 +180,18 @@ CREATE TABLE IF NOT EXISTS sentences (
 );
 
 -- ---------------------------------------------------------------------------
+-- api_call_log
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS api_call_log (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    called_at       TEXT NOT NULL DEFAULT (datetime('now')),
+    model           TEXT NOT NULL,
+    input_tokens    INTEGER NOT NULL,
+    output_tokens   INTEGER NOT NULL,
+    purpose         TEXT NOT NULL DEFAULT 'story'
+);
+
+-- ---------------------------------------------------------------------------
 -- structures  (future)
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS structures (

--- a/static/app.js
+++ b/static/app.js
@@ -134,6 +134,7 @@ function renderDecks(decks) {
     <div class="nav-row">
       <button class="nav-btn" onclick="openBrowse()">Browse Cards</button>
       <button class="nav-btn" onclick="openStats()">Stats</button>
+      <button class="nav-btn" onclick="openCostModal()">API Costs</button>
     </div>`;
 
   const virtualDecks = decks.filter(d => d.virtual);
@@ -470,6 +471,52 @@ async function openStats() {
     showError('Stats failed: ' + e.message);
     showView('decks');
   }
+}
+
+async function openCostModal() {
+  try {
+    const data = await api('GET', '/api/costs');
+    renderCostModal(data);
+    document.getElementById('cost-modal-overlay').style.display = 'block';
+    document.getElementById('cost-modal').style.display = 'flex';
+  } catch (e) {
+    showError('Failed to load cost data: ' + e.message);
+  }
+}
+
+function closeCostModal() {
+  document.getElementById('cost-modal-overlay').style.display = 'none';
+  document.getElementById('cost-modal').style.display = 'none';
+}
+
+function renderCostModal(data) {
+  const fmt = n => '$' + n.toFixed(4);
+  const fmtFull = n => '$' + n.toFixed(6);
+
+  let html = `<div class="cost-total">Total spent <b>${fmt(data.total_cost)}</b></div>`;
+
+  if (!data.calls.length) {
+    html += '<div class="cost-empty">No API calls logged yet.</div>';
+  } else {
+    html += `<table class="cost-table">
+      <thead><tr>
+        <th>Date</th><th>Model</th><th>Tokens in / out</th>
+        <th style="text-align:right">Cost</th>
+      </tr></thead><tbody>`;
+    for (const c of data.calls) {
+      const dt = c.called_at.slice(0, 16).replace('T', ' ');
+      const model = c.model.replace('claude-', '').replace('-20251001', '');
+      html += `<tr>
+        <td style="color:var(--muted);font-size:12px;white-space:nowrap">${dt}</td>
+        <td><span class="cost-model">${model}</span></td>
+        <td class="cost-num" style="color:var(--muted)">${c.input_tokens.toLocaleString()} / ${c.output_tokens.toLocaleString()}</td>
+        <td class="cost-num cost-value">${fmtFull(c.cost)}</td>
+      </tr>`;
+    }
+    html += '</tbody></table>';
+  }
+
+  document.getElementById('cost-modal-body').innerHTML = html;
 }
 
 function renderStats(data) {
@@ -1070,7 +1117,7 @@ async function togglePinyin() {
   const chars = [...text];
   const wordStart = text.indexOf(card.word_zh);
   const wordEnd = wordStart + [...card.word_zh].length;
-  row.innerHTML = chars.map((ch, i) => {
+  row.innerHTML = chars.map((_ch, i) => {
     const py = syllables[i] || '';
     const isTarget = wordStart >= 0 && i >= wordStart && i < wordEnd;
     return `<span class="py-char${isTarget ? ' py-target' : ''}">`+
@@ -1095,7 +1142,7 @@ function openStorySetup(sentenceCount) {
   document.getElementById('setup-modal-overlay').style.display = 'block';
   document.getElementById('setup-modal').style.display        = 'flex';
   document.getElementById('setup-topic').focus();
-  return new Promise((resolve, reject) => { _setupResolve = resolve; });
+  return new Promise(resolve => { _setupResolve = resolve; });
 }
 
 function updateHskLabel() {

--- a/static/index.html
+++ b/static/index.html
@@ -281,6 +281,16 @@
   </div>
 </div>
 
+<!-- Cost modal -->
+<div id="cost-modal-overlay" onclick="closeCostModal()" style="display:none"></div>
+<div id="cost-modal" style="display:none">
+  <div class="edit-modal-header">
+    <span class="edit-modal-title">API Cost History</span>
+    <button class="edit-modal-close" onclick="closeCostModal()">✕</button>
+  </div>
+  <div id="cost-modal-body"></div>
+</div>
+
 <!-- Story modal -->
 <div id="story-modal-overlay" onclick="closeStoryModal()" style="display:none"></div>
 <div id="story-modal" style="display:none">

--- a/static/style.css
+++ b/static/style.css
@@ -1323,3 +1323,88 @@ main {
   cursor: pointer;
 }
 .btn-primary:hover { opacity: 0.85; }
+
+/* ── Cost modal ──────────────────────────────────────── */
+#cost-modal-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.45);
+  z-index: 200;
+}
+#cost-modal {
+  position: fixed;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(92vw, 700px);
+  max-height: 82vh;
+  background: var(--card);
+  border-radius: 18px;
+  box-shadow: 0 12px 48px rgba(0,0,0,0.22);
+  z-index: 201;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+#cost-modal .edit-modal-header {
+  padding: 18px 20px 16px;
+  border-bottom: 1.5px solid var(--border);
+  flex-shrink: 0;
+}
+#cost-modal-body {
+  overflow-y: auto;
+  padding: 16px 20px 24px;
+}
+.cost-total {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--muted);
+  margin-bottom: 18px;
+  padding: 14px 18px;
+  background: var(--bg);
+  border-radius: 10px;
+}
+.cost-total b { color: var(--primary); font-size: 22px; font-weight: 700; }
+.cost-empty {
+  color: var(--muted);
+  font-size: 14px;
+  padding: 24px 0;
+  text-align: center;
+}
+.cost-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13.5px;
+}
+.cost-table th {
+  text-align: left;
+  padding: 9px 12px;
+  background: var(--bg);
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+}
+.cost-table th:first-child { border-radius: 8px 0 0 8px; }
+.cost-table th:last-child  { border-radius: 0 8px 8px 0; }
+.cost-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  vertical-align: middle;
+}
+.cost-table tbody tr:last-child td { border-bottom: none; }
+.cost-table tbody tr:hover td { background: var(--bg); }
+.cost-model {
+  font-family: monospace;
+  font-size: 12px;
+  color: var(--muted);
+  background: var(--border);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+.cost-num { text-align: right; font-variant-numeric: tabular-nums; }
+.cost-value { color: var(--primary); font-weight: 600; }
+


### PR DESCRIPTION
## Summary
- New `api_call_log` table records every Anthropic API call (model, tokens in/out, purpose, timestamp)
- `ai.py` logs each story generation call using the actual usage from the API response
- `GET /api/costs` endpoint returns all calls with computed costs (hardcoded pricing: Sonnet $3/$15, Haiku $0.80/$4, Opus $15/$75 per MTok)
- "API Costs" button on the deck list opens a modal showing total spent + per-call table (date, model badge, tokens in/out, cost)

## Test plan
- [ ] Generate a story, then open API Costs — entry should appear with correct token counts
- [ ] Total updates correctly across multiple calls
- [ ] Modal fits without horizontal scroll on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)