### PR TITLE
feat: model selector in story setup

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -16,13 +16,15 @@ import database
 logger = logging.getLogger(__name__)
 
 
-def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2) -> list[dict]:
+def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2,
+                   model: str = "claude-haiku-4-5-20251001") -> list[dict]:
     """
-    Generate a short Mandarin story using Haiku, one sentence per card.
+    Generate a short Mandarin story, one sentence per card.
 
     cards:   list of dicts with keys word_id, word_zh, pinyin, definition, pos
     topic:   optional theme/setting to guide the story
     max_hsk: maximum HSK level for non-target background vocabulary (1-6)
+    model:   Anthropic model ID to use for generation
     Returns: list of {word_id, sentence_zh, sentence_en} — same length as cards.
     Returns [] immediately if cards is empty (no API call made).
     """
@@ -66,7 +68,7 @@ Rules:
     max_tokens = len(cards) * 150 + 200
 
     message = client.messages.create(
-        model="claude-sonnet-4-6",
+        model=model,
         max_tokens=max_tokens,
         messages=[{"role": "user", "content": prompt}],
     )

--- a/routes/story.py
+++ b/routes/story.py
@@ -30,12 +30,27 @@ def _get_cards_for_story(deck_id: int, category: str) -> list:
         else database.get_due_cards(deck_id, category)
 
 
+ALLOWED_MODELS = {
+    "claude-haiku-4-5-20251001",
+    "claude-sonnet-4-6",
+    "claude-opus-4-6",
+}
+DEFAULT_MODEL = "claude-haiku-4-5-20251001"
+
+
+def _validated_model(model: str | None) -> str:
+    if model and model in ALLOWED_MODELS:
+        return model
+    return DEFAULT_MODEL
+
+
 @router.get("/api/story/{deck_id}/{category}")
 def get_story(deck_id: int, category: str,
-              topic: str | None = None, max_hsk: int = 2):
+              topic: str | None = None, max_hsk: int = 2,
+              model: str | None = None):
     today = date.today().isoformat()
     # Only use cached story if no custom options were provided
-    if not topic and max_hsk == 2:
+    if not topic and max_hsk == 2 and not model:
         story = database.get_active_story(today, category, deck_id)
         if story:
             story["sentences"] = database.get_story_sentences(story["id"])
@@ -48,17 +63,19 @@ def get_story(deck_id: int, category: str,
         logger.info("story  DISABLED (DISABLE_AI=1) deck=%d cat=%s", deck_id, category)
         return None
 
+    chosen_model = _validated_model(model)
     story = None
     cards = _get_cards_for_story(deck_id, category)
-    logger.info("story  GENERATE deck=%d cat=%s due_cards=%d topic=%r max_hsk=%d",
-                deck_id, category, len(cards), topic, max_hsk)
+    logger.info("story  GENERATE deck=%d cat=%s due_cards=%d topic=%r max_hsk=%d model=%s",
+                deck_id, category, len(cards), topic, max_hsk, chosen_model)
     if cards:
         try:
             ids = leaf_ids(deck_id, category)
             preset = database.get_preset_for_deck(ids[0] if ids else deck_id)
             if preset.get("randomize_story_order", 1):
                 random.shuffle(cards)
-            sentences = ai.generate_story(cards, topic=topic, max_hsk=max_hsk)
+            sentences = ai.generate_story(cards, topic=topic, max_hsk=max_hsk,
+                                          model=chosen_model)
             for i, s in enumerate(sentences):
                 s["position"] = i
             database.create_story(today, category, deck_id, sentences)
@@ -76,20 +93,23 @@ def get_story(deck_id: int, category: str,
 
 @router.post("/api/story/{deck_id}/{category}/regenerate")
 def regenerate_story(deck_id: int, category: str,
-                     topic: str | None = None, max_hsk: int = 2):
+                     topic: str | None = None, max_hsk: int = 2,
+                     model: str | None = None):
     if DISABLE_AI:
         return None
+    chosen_model = _validated_model(model)
     today = date.today().isoformat()
     cards = _get_cards_for_story(deck_id, category)
-    logger.info("regen  deck=%d cat=%s due_cards=%d topic=%r max_hsk=%d",
-                deck_id, category, len(cards), topic, max_hsk)
+    logger.info("regen  deck=%d cat=%s due_cards=%d topic=%r max_hsk=%d model=%s",
+                deck_id, category, len(cards), topic, max_hsk, chosen_model)
     if not cards:
         return None
     ids = leaf_ids(deck_id, category)
     preset = database.get_preset_for_deck(ids[0] if ids else deck_id)
     if preset.get("randomize_story_order", 1):
         random.shuffle(cards)
-    sentences = ai.generate_story(cards, topic=topic, max_hsk=max_hsk)
+    sentences = ai.generate_story(cards, topic=topic, max_hsk=max_hsk,
+                                  model=chosen_model)
     for i, s in enumerate(sentences):
         s["position"] = i
     database.create_story(today, category, deck_id, sentences)

--- a/static/app.js
+++ b/static/app.js
@@ -723,10 +723,10 @@ async function startReview(id, cat, name) {
   }
 }
 
-async function _doStartReview(topic, maxHsk) {
+async function _doStartReview(topic, maxHsk, model) {
   setLoading('Generating your story…');
   try {
-    const storyUrl = `/api/story/${deckId}/${category}` + _storyParams(topic, maxHsk);
+    const storyUrl = `/api/story/${deckId}/${category}` + _storyParams(topic, maxHsk, model);
     const [todayData, storyData] = await Promise.all([
       api('GET', `/api/today/${deckId}/${category}`),
       api('GET', storyUrl),
@@ -752,10 +752,11 @@ async function _doStartReview(topic, maxHsk) {
   }
 }
 
-function _storyParams(topic, maxHsk) {
+function _storyParams(topic, maxHsk, model) {
   const p = new URLSearchParams();
-  if (topic)        p.set('topic', topic);
-  if (maxHsk !== 2) p.set('max_hsk', maxHsk);
+  if (topic)                              p.set('topic', topic);
+  if (maxHsk !== 2)                       p.set('max_hsk', maxHsk);
+  if (model && model !== 'claude-haiku-4-5-20251001') p.set('model', model);
   const s = p.toString();
   return s ? '?' + s : '';
 }
@@ -1153,11 +1154,12 @@ function updateHskLabel() {
 function confirmStorySetup() {
   const topic  = document.getElementById('setup-topic').value.trim() || null;
   const maxHsk = parseInt(document.getElementById('setup-hsk-slider').value, 10);
+  const model  = document.getElementById('setup-model').value;
   _closeSetupModal();
   if (_setupIsRegen) {
-    _doRegenerateStory(topic, maxHsk);
+    _doRegenerateStory(topic, maxHsk, model);
   } else {
-    _doStartReview(topic, maxHsk);
+    _doStartReview(topic, maxHsk, model);
   }
 }
 
@@ -1332,10 +1334,10 @@ async function regenerateStory() {
   }
 }
 
-async function _doRegenerateStory(topic, maxHsk) {
+async function _doRegenerateStory(topic, maxHsk, model) {
   setLoading('Regenerating story…');
   try {
-    story = await api('POST', `/api/story/${deckId}/${category}/regenerate` + _storyParams(topic, maxHsk));
+    story = await api('POST', `/api/story/${deckId}/${category}/regenerate` + _storyParams(topic, maxHsk, model));
     sentence = story?.sentences?.find(s => s.word_id === card.word_id) || null;
     try {
       await fetch(`/api/preload-session/${deckId}/${category}`, { method: 'POST' });

--- a/static/index.html
+++ b/static/index.html
@@ -265,6 +265,13 @@
     <label class="edit-label">Topic <span style="font-weight:400;text-transform:none">(optional)</span>
       <input class="edit-input" id="setup-topic" type="text" placeholder="e.g. a day at a coffee shop" onkeydown="if(event.key==='Enter')confirmStorySetup()">
     </label>
+    <label class="edit-label">Model
+      <select class="edit-input" id="setup-model">
+        <option value="claude-haiku-4-5-20251001" selected>Haiku — fast &amp; cheap</option>
+        <option value="claude-sonnet-4-6">Sonnet — balanced</option>
+        <option value="claude-opus-4-6">Opus — best quality</option>
+      </select>
+    </label>
     <label class="edit-label">
       Max HSK level for background vocabulary
       <div class="setup-slider-row">


### PR DESCRIPTION
## Summary
- Added Haiku / Sonnet / Opus dropdown to the story setup modal
- Haiku is now the default (cheaper, faster) instead of Sonnet
- Model is threaded through `_storyParams` → route query param → `ai.generate_story()`
- Route validates model against an allowlist before use
- Chosen model is captured in the API cost log via `message.model`

🤖 Generated with [Claude Code](https://claude.com/claude-code)