### PR TITLE
feat: 重设计导入窗口，支持每张卡片的精细控制

### DIFF
--- a/importer.py
+++ b/importer.py
@@ -73,12 +73,13 @@ def import_yaml_file(filepath: str, deck_path: list[str]) -> dict:
 
 def import_yaml_content(content: str, parent_deck_id: int,
                         resolutions: dict | None = None,
-                        card_configs: dict | None = None) -> dict:
+                        card_configs: dict | None = None,
+                        custom_fields: dict | None = None) -> dict:
     """Import YAML from a string into an existing parent deck.
 
-    resolutions:  {word_zh: "keep"|"update"} for component word conflicts.
-    card_configs: {word_zh: {include, deck_path, suspended, ai_fill}}
-                  Per-card overrides; omitted keys fall back to defaults.
+    resolutions:   {word_zh: "keep"|"update"|"custom"} for component word conflicts.
+    card_configs:  {word_zh: {include, deck_path, suspended, ai_fill}}
+    custom_fields: {word_zh: {pinyin, definition, traditional}} merged values for "custom" resolutions.
     """
     try:
         data = yaml.safe_load(content)
@@ -94,7 +95,8 @@ def import_yaml_content(content: str, parent_deck_id: int,
     source = leaf_parent.lower()
     return _import_entries(entries, default_deck_ids, source, label="<upload>",
                            resolutions=resolutions or {},
-                           card_configs=card_configs or {})
+                           card_configs=card_configs or {},
+                           custom_fields=custom_fields or {})
 
 
 def preview_yaml_content(content: str) -> dict:
@@ -131,6 +133,8 @@ def preview_yaml_content(content: str) -> dict:
             word_zh = entry.get("simplified", "").strip() or "(no simplified)"
             result_entries.append({
                 "simplified": word_zh, "note_type": yaml_type or "(none)",
+                "english": entry.get("english", ""),
+                "hsk": str(entry.get("hsk", "") or ""),
                 "status": "invalid", "reason": f"unknown type: {yaml_type!r}",
                 "raw_yaml": yaml.dump(entry, allow_unicode=True, default_flow_style=False, sort_keys=False).strip(),
             })
@@ -141,6 +145,7 @@ def preview_yaml_content(content: str) -> dict:
             summary["invalid"] += 1
             result_entries.append({
                 "simplified": "(empty)", "note_type": note_type,
+                "english": "",
                 "status": "invalid", "reason": "missing simplified field",
             })
             continue
@@ -150,11 +155,14 @@ def preview_yaml_content(content: str) -> dict:
             logger.warning("STRIP preview: ellipsis stripped from %r → %r", word_zh, stripped)
             word_zh = stripped
 
+        english = entry.get("english", "")
+        hsk = str(entry.get("hsk", "") or "")
         warning = _validate_entry(word_zh, note_type)
         if warning:
             summary["invalid"] += 1
             result_entries.append({
                 "simplified": word_zh, "note_type": note_type,
+                "english": english, "hsk": hsk,
                 "status": "invalid", "reason": warning,
                 "raw_yaml": yaml.dump(entry, allow_unicode=True, default_flow_style=False, sort_keys=False).strip(),
             })
@@ -166,6 +174,7 @@ def preview_yaml_content(content: str) -> dict:
             summary["duplicate"] += 1
             result_entries.append({
                 "simplified": word_zh, "note_type": note_type,
+                "english": english, "hsk": hsk,
                 "status": "duplicate", "reason": None,
                 "raw_yaml": raw,
             })
@@ -173,6 +182,7 @@ def preview_yaml_content(content: str) -> dict:
             summary["ok"] += 1
             result_entries.append({
                 "simplified": word_zh, "note_type": note_type,
+                "english": english, "hsk": hsk,
                 "status": "ok", "reason": None,
                 "raw_yaml": raw,
             })
@@ -304,7 +314,8 @@ def _process_char_only_component(analysis: dict, note_word_id: int,
 
 
 def _process_component(analysis: dict, note_word_id: int, position: int,
-                       source: str, resolutions: dict) -> None:
+                       source: str, resolutions: dict,
+                       custom_fields: dict | None = None) -> None:
     """Store a word_analyses component word and link it to its parent note."""
     comp_zh = analysis.get("simplified", "").strip()
     if not comp_zh:
@@ -313,9 +324,12 @@ def _process_component(analysis: dict, note_word_id: int, position: int,
     comp_word = _build_word_dict(analysis, source=source, note_type="vocabulary")
     comp_word_id = database.insert_word(comp_word)  # INSERT OR IGNORE
 
-    # Apply conflict resolution: "update" overwrites existing data
-    if resolutions.get(comp_zh, "keep") == "update":
+    resolution = resolutions.get(comp_zh, "keep")
+    if resolution == "update":
         database.update_word(comp_word_id, comp_word)
+    elif resolution == "custom" and custom_fields and comp_zh in custom_fields:
+        merged = {**comp_word, **(custom_fields[comp_zh] or {})}
+        database.update_word(comp_word_id, merged)
 
     _process_characters(analysis, comp_word_id)
 
@@ -344,11 +358,14 @@ def _get_sentences_deck_ids() -> dict:
 
 def _import_entries(entries: list, deck_ids: dict, source: str, label: str,
                     resolutions: dict | None = None,
-                    card_configs: dict | None = None) -> dict:
+                    card_configs: dict | None = None,
+                    custom_fields: dict | None = None) -> dict:
     if resolutions is None:
         resolutions = {}
     if card_configs is None:
         card_configs = {}
+    if custom_fields is None:
+        custom_fields = {}
 
     imported = 0
     skipped_duplicate = 0
@@ -424,7 +441,7 @@ def _import_entries(entries: list, deck_ids: dict, source: str, label: str,
                 if analysis.get("char_only"):
                     _process_char_only_component(analysis, word_id, pos, source)
                 elif analysis.get("type") in NOTE_TYPE_MAP:
-                    _process_component(analysis, word_id, pos, source, resolutions)
+                    _process_component(analysis, word_id, pos, source, resolutions, custom_fields)
             continue
 
         # Examples

--- a/routes/imports.py
+++ b/routes/imports.py
@@ -22,8 +22,9 @@ async def upload_import(
     deck_id: int | None = Form(None),
     deck_path: str | None = Form(None),
     deck_name: str | None = Form(None),
-    resolutions: str | None = Form(None),    # JSON: {"word_zh": "keep"|"update"}
+    resolutions: str | None = Form(None),    # JSON: {"word_zh": "keep"|"update"|"custom"}
     card_configs: str | None = Form(None),   # JSON: {word_zh: {include, deck_path, suspended, ai_fill}}
+    custom_fields: str | None = Form(None),  # JSON: {word_zh: {pinyin, definition, traditional}}
 ):
     """Import a YAML file into a deck.
 
@@ -65,9 +66,17 @@ async def upload_import(
         except json.JSONDecodeError:
             raise HTTPException(status_code=400, detail="card_configs must be valid JSON")
 
+    custom_fields_map: dict = {}
+    if custom_fields:
+        try:
+            custom_fields_map = json.loads(custom_fields)
+        except json.JSONDecodeError:
+            raise HTTPException(status_code=400, detail="custom_fields must be valid JSON")
+
     result = importer.import_yaml_content(
         content, deck_id,
         resolutions=resolution_map,
         card_configs=card_configs_map,
+        custom_fields=custom_fields_map,
     )
     return {"deck_id": deck_id, **result}

--- a/static/app.js
+++ b/static/app.js
@@ -2467,10 +2467,13 @@ function goBack() {
 
 // ── Import modal ─────────────────────────────────────────────────────────────
 
-let importResolutions = {};  // {word_zh: "keep"|"update"}
-let _previewEntries = [];    // full entry list from last preview (with raw_yaml)
-let _cardConfigs = {};       // {word_zh: {include, deck_path, suspended:{reading,listening,creating}}}
-let _importDeckOptions = []; // flat list of deck paths for per-card dropdowns
+let importResolutions = {};    // {word_zh: "keep"|"update"|"custom"}
+let _previewEntries = [];      // full entry list from last preview (with raw_yaml)
+let _cardConfigs = {};         // {word_zh: {include, deck_path, suspended:{reading,listening,creating}}}
+let _importDeckOptions = [];   // flat list of deck paths for per-card dropdowns
+let _conflictData = [];        // full conflict list from last preview
+let _conflictEdits = {};       // {word_zh: {field: value}} custom edits
+let _conflictSelections = {};  // {word_zh: "keep"|"update"}
 
 // Default per-category suspension states (creating active, others suspended)
 const IMPORT_DEFAULT_SUSPENDED = { reading: false, listening: false, creating: true };
@@ -2533,10 +2536,12 @@ function _importRenderTable() {
           data-word="${_ea(e.simplified)}" data-yaml="${_ea(e.raw_yaml)}" data-deck="" data-idx="${idx}"
           onclick="openYamlEditFromBtn(this)">Edit</button>` : ''}
       </td>
+      <td style="color:var(--clr-muted,#888);font-size:11px;max-width:120px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${_ea(e.english || '')}">${e.english || ''}</td>
       <td style="color:var(--clr-muted,#888);font-size:11px">${NOTE_TYPE_LABEL[e.note_type] || e.note_type}</td>
+      <td style="color:var(--clr-muted,#888);font-size:11px">${e.hsk || ''}</td>
       <td>${statusSpan}</td>
-      <td>${suspBtn('reading')}</td>
       <td>${suspBtn('listening')}</td>
+      <td>${suspBtn('reading')}</td>
       <td>${suspBtn('creating')}</td>
       <td>
         <select class="import-row-deck-select"
@@ -2605,14 +2610,14 @@ async function openImportModal() {
   importResolutions = {};
   _previewEntries = [];
   _cardConfigs = {};
+  _conflictData = [];
+  _conflictEdits = {};
+  _conflictSelections = {};
   document.getElementById('import-file').value = '';
   document.getElementById('import-preview').style.display = 'none';
   document.getElementById('import-conflicts-section').style.display = 'none';
   document.getElementById('import-deck-section').style.display = 'none';
   document.getElementById('import-result').style.display = 'none';
-  document.getElementById('import-preview-btn').style.display = '';
-  document.getElementById('import-preview-btn').disabled = false;
-  document.getElementById('import-preview-btn').textContent = 'Preview';
   document.getElementById('import-submit-btn').style.display = 'none';
   document.getElementById('import-deck-path').value = '';
   document.getElementById('deck-picker-new-badge').style.display = 'none';
@@ -2637,8 +2642,8 @@ async function openImportModal() {
   }
   addDeckSuggestions(decks, '');
 
-  document.getElementById('import-modal-overlay').style.display = 'block';
-  document.getElementById('import-modal').style.display = 'flex';
+  // Open file picker directly — modal opens after file is selected
+  document.getElementById('import-file').click();
 }
 
 function closeImportModal() {
@@ -2649,17 +2654,27 @@ function closeImportModal() {
 }
 
 function onImportFileChange() {
+  const fileInput = document.getElementById('import-file');
+  if (!fileInput.files.length) return;  // user cancelled picker
+
   importResolutions = {};
   _previewEntries = [];
   _cardConfigs = {};
+  _conflictData = [];
+  _conflictEdits = {};
+  _conflictSelections = {};
   document.getElementById('import-preview').style.display = 'none';
   document.getElementById('import-conflicts-section').style.display = 'none';
   document.getElementById('import-deck-section').style.display = 'none';
   document.getElementById('import-submit-btn').style.display = 'none';
-  document.getElementById('import-preview-btn').style.display = '';
-  document.getElementById('import-preview-btn').disabled = false;
-  document.getElementById('import-preview-btn').textContent = 'Preview';
   document.getElementById('import-result').style.display = 'none';
+
+  // Open modal now that a file has been chosen
+  document.getElementById('import-modal-overlay').style.display = 'block';
+  document.getElementById('import-modal').style.display = 'flex';
+
+  // Auto-preview as soon as a file is selected
+  previewImport();
 }
 
 async function previewImport(yamlContent) {
@@ -2705,7 +2720,12 @@ async function previewImport(yamlContent) {
     _cardConfigs = {};
     data.entries.forEach(e => {
       if (prevConfigs[e.simplified]) {
-        _cardConfigs[e.simplified] = prevConfigs[e.simplified];
+        const prev = prevConfigs[e.simplified];
+        // If status changed from invalid → ok/duplicate, reset include to true
+        const wasInvalid = prev.include === false && e.status !== 'invalid';
+        _cardConfigs[e.simplified] = wasInvalid
+          ? { ...prev, include: true }
+          : prev;
       } else {
         _cardConfigs[e.simplified] = {
           include: e.status !== 'invalid',
@@ -2721,25 +2741,14 @@ async function previewImport(yamlContent) {
     // Conflict resolution
     if (data.conflicts && data.conflicts.length > 0) {
       importResolutions = {};
-      const listEl = document.getElementById('import-conflicts-list');
-      listEl.innerHTML = data.conflicts.map(c => `
-        <div class="conflict-card" id="conflict-${c.simplified}" style="border:1px solid var(--clr-border,#333);border-radius:6px;padding:8px 10px;margin-bottom:8px">
-          <div style="font-weight:600;margin-bottom:4px">${c.simplified}</div>
-          <div style="display:grid;grid-template-columns:70px 1fr;gap:2px 8px;font-size:12px">
-            <span style="color:var(--clr-muted,#888)">Existing</span>
-            <span>${_fmtConflictData(c.existing)}</span>
-            <span style="color:#e67e22">Incoming</span>
-            <span>${_fmtConflictData(c.incoming)}</span>
-          </div>
-          <div style="display:flex;gap:6px;margin-top:6px">
-            <button class="edit-cancel-btn" style="flex:1;font-size:12px"
-              onclick="resolveConflict('${c.simplified}','keep',this)">Keep Existing</button>
-            <button class="edit-cancel-btn" style="flex:1;font-size:12px"
-              onclick="resolveConflict('${c.simplified}','update',this)">Use Incoming</button>
-          </div>
-        </div>`).join('');
+      _conflictData = data.conflicts;
+      _conflictSelections = {};
+      _conflictEdits = {};
+      data.conflicts.forEach(c => { _conflictSelections[c.simplified] = 'keep'; });
+      document.getElementById('import-conflicts-count').textContent = data.conflicts.length;
       document.getElementById('import-conflicts-section').style.display = 'block';
     } else {
+      _conflictData = [];
       document.getElementById('import-conflicts-section').style.display = 'none';
     }
 
@@ -2782,6 +2791,19 @@ async function doImport() {
     form.append('resolutions', JSON.stringify(importResolutions));
   }
   form.append('card_configs', JSON.stringify(cardConfigsMap));
+  // Send custom field edits for "custom" resolutions
+  const customFieldsMap = {};
+  _conflictData.forEach(c => {
+    if (importResolutions[c.simplified] === 'custom') {
+      const sel = _conflictSelections[c.simplified] || 'keep';
+      const base = sel === 'keep' ? c.existing : c.incoming;
+      const edits = _conflictEdits[c.simplified] || {};
+      customFieldsMap[c.simplified] = { ...base, ...edits };
+    }
+  });
+  if (Object.keys(customFieldsMap).length > 0) {
+    form.append('custom_fields', JSON.stringify(customFieldsMap));
+  }
 
   try {
     const res = await fetch('/api/import/upload', { method: 'POST', body: form });
@@ -2790,30 +2812,18 @@ async function doImport() {
       throw new Error(err.detail || res.statusText);
     }
     const data = await res.json();
-    resultEl.style.display = 'block';
-
-    const summaryParts = [`<span style="color:${STATUS_COLOR.ok}">Imported ${data.imported} notes.</span>`];
-    if (data.skipped_duplicate) summaryParts.push(`<span style="color:#e67e22">${data.skipped_duplicate} duplicates skipped</span>`);
-    if (data.skipped_invalid)   summaryParts.push(`<span style="color:#e74c3c">${data.skipped_invalid} invalid skipped</span>`);
-    let html = summaryParts.join(' · ');
-
-    if (data.skipped_entries && data.skipped_entries.length) {
-      html += '<div style="margin-top:10px;border-top:1px solid var(--clr-border,#333);padding-top:8px">';
-      html += data.skipped_entries.map(s => `
-        <div style="display:flex;gap:8px;align-items:center;padding:3px 0;font-size:13px">
-          <span style="color:${s.reason === 'already in deck' ? '#e67e22' : '#e74c3c'};flex:0 0 auto">${s.reason === 'already in deck' ? '⚠' : '✕'}</span>
-          <span style="flex:1;font-weight:500">${s.word}</span>
-          <span style="color:var(--clr-muted,#888);font-size:11px">${s.reason}</span>
-          ${s.raw_yaml ? `<button class="edit-cancel-btn" style="font-size:11px;padding:1px 7px" data-word="${_ea(s.word)}" data-yaml="${_ea(s.raw_yaml)}" data-deck="${_ea(deckPath)}" onclick="openYamlEditFromBtn(this)">Edit</button>` : ''}
-        </div>`).join('');
-      html += '</div>';
-    }
-
-    resultEl.innerHTML = html;
-    btn.disabled = false;
-    btn.textContent = 'Done';
-    btn.onclick = closeImportModal;
+    closeImportModal();
     loadDecks();
+
+    const parts = [`✓ Imported ${data.imported}`];
+    if (data.skipped_duplicate) parts.push(`${data.skipped_duplicate} duplicates skipped`);
+    if (data.skipped_invalid)   parts.push(`${data.skipped_invalid} invalid skipped`);
+    const banner = document.getElementById('error-banner');
+    banner.textContent = parts.join(' · ');
+    banner.style.background = data.skipped_invalid ? '#e67e22' : '#27ae60';
+    banner.style.color = '#fff';
+    banner.style.display = 'block';
+    setTimeout(() => { banner.style.display = 'none'; banner.style.background = ''; banner.style.color = ''; }, 4000);
   } catch (e) {
     resultEl.style.display = 'block';
     resultEl.innerHTML = `<span style="color:#e74c3c">Error: ${e.message}</span>`;
@@ -2822,30 +2832,123 @@ async function doImport() {
   }
 }
 
-function _fmtConflictData(obj) {
-  return Object.entries(obj)
-    .filter(([, v]) => v != null)
-    .map(([k, v]) => `<span style="color:var(--clr-muted,#888)">${k}:</span> ${v}`)
-    .join('  ');
+const _CF_FIELD_LABELS = { pinyin: 'Pinyin', definition: 'Definition', traditional: 'Traditional' };
+
+function openConflictModal() {
+  _renderConflictModal();
+  document.getElementById('conflict-modal-overlay').style.display = 'block';
+  document.getElementById('conflict-modal').style.display = 'flex';
 }
 
-function resolveConflict(wordZh, choice, btn) {
-  importResolutions[wordZh] = choice;
-  const card = document.getElementById(`conflict-${wordZh}`);
-  if (card) card.style.opacity = '0.5';
-  btn.style.fontWeight = 'bold';
+function closeConflictModal() {
+  document.getElementById('conflict-modal-overlay').style.display = 'none';
+  document.getElementById('conflict-modal').style.display = 'none';
 }
 
-function resolveAllConflicts(choice) {
-  document.querySelectorAll('[id^="conflict-"]').forEach(card => {
-    const wordZh = card.id.replace('conflict-', '');
-    importResolutions[wordZh] = choice;
-    card.style.opacity = '0.5';
-    const btns = card.querySelectorAll('button');
-    btns.forEach(b => {
-      b.style.fontWeight = b.textContent.toLowerCase().includes(choice === 'keep' ? 'keep' : 'incoming') ? 'bold' : '';
-    });
+function _renderConflictModal() {
+  const body = document.getElementById('conflict-modal-body');
+  body.innerHTML = _conflictData.map((c, idx) => {
+    const sel = _conflictSelections[c.simplified] || 'keep';
+    const edits = _conflictEdits[c.simplified] || {};
+
+    const renderField = (f) => {
+      const existingVal = c.existing[f] || '';
+      const incomingVal = c.incoming[f] || '';
+      const isEdited = edits[f] !== undefined;
+      const isDiff = existingVal !== incomingVal;
+      const currentVal = isEdited ? edits[f] : (sel === 'keep' ? existingVal : incomingVal);
+      return `
+        <div class="cf-field">
+          <div class="cf-field-label">
+            ${_CF_FIELD_LABELS[f]}
+            <span id="cf-badge-${idx}-${f}" class="cf-edited-badge" style="${isEdited ? '' : 'display:none'}">edited</span>
+            ${isDiff && !isEdited ? `<span class="cf-diff-badge">differs</span>` : ''}
+          </div>
+          <div class="cf-field-compare">
+            <span class="cf-compare-val ${sel === 'keep' && !isEdited ? 'cf-active' : ''}"
+              title="Existing: ${_ea(existingVal)}"
+              onclick="conflictLoadField(${idx},'${f}','existing')">${existingVal || '—'}</span>
+            <span style="color:var(--clr-muted,#888)">↔</span>
+            <span class="cf-compare-val ${sel === 'update' && !isEdited ? 'cf-active' : ''}"
+              title="Incoming: ${_ea(incomingVal)}"
+              onclick="conflictLoadField(${idx},'${f}','incoming')">${incomingVal || '—'}</span>
+          </div>
+          <input class="edit-input cf-field-input" value="${_ea(currentVal)}"
+            oninput="conflictEditField(${idx},'${f}',this.value)">
+        </div>`;
+    };
+
+    return `
+      <div class="cf-card">
+        <div class="cf-card-header">
+          <span class="cf-word">${c.simplified}</span>
+          <div class="cf-version-btns">
+            <button class="cf-version-btn ${sel === 'keep' ? 'cf-version-selected' : ''}"
+              onclick="conflictSelectVersion(${idx},'keep')">✓ Existing</button>
+            <button class="cf-version-btn ${sel === 'update' ? 'cf-version-selected' : ''}"
+              onclick="conflictSelectVersion(${idx},'update')">✓ Incoming</button>
+          </div>
+        </div>
+        ${Object.keys(_CF_FIELD_LABELS).map(renderField).join('')}
+      </div>`;
+  }).join('');
+}
+
+function conflictSelectVersion(idx, version) {
+  const c = _conflictData[idx];
+  if (!c) return;
+  _conflictSelections[c.simplified] = version;
+  delete _conflictEdits[c.simplified];
+  _renderConflictModal();
+}
+
+function conflictLoadField(idx, field, source) {
+  const c = _conflictData[idx];
+  if (!c) return;
+  const val = source === 'existing' ? (c.existing[field] || '') : (c.incoming[field] || '');
+  _conflictEdits[c.simplified] = { ...(_conflictEdits[c.simplified] || {}), [field]: val };
+  _renderConflictModal();
+}
+
+function conflictEditField(idx, field, value) {
+  const c = _conflictData[idx];
+  if (!c) return;
+  const edits = { ...(_conflictEdits[c.simplified] || {}) };
+  const sel = _conflictSelections[c.simplified] || 'keep';
+  const baseVal = sel === 'keep' ? (c.existing[field] || '') : (c.incoming[field] || '');
+  if (value !== baseVal) {
+    edits[field] = value;
+  } else {
+    delete edits[field];
+  }
+  _conflictEdits[c.simplified] = Object.keys(edits).length ? edits : undefined;
+  if (!_conflictEdits[c.simplified]) delete _conflictEdits[c.simplified];
+  // Update just the badge without re-rendering (preserve focus)
+  const badgeEl = document.getElementById(`cf-badge-${idx}-${field}`);
+  if (badgeEl) {
+    badgeEl.style.display = edits[field] !== undefined ? '' : 'none';
+  }
+}
+
+function conflictAcceptAll(version) {
+  _conflictData.forEach(c => {
+    _conflictSelections[c.simplified] = version;
+    delete _conflictEdits[c.simplified];
   });
+  _renderConflictModal();
+}
+
+function conflictDone() {
+  importResolutions = {};
+  _conflictData.forEach(c => {
+    const edits = _conflictEdits[c.simplified];
+    if (edits && Object.keys(edits).length > 0) {
+      importResolutions[c.simplified] = 'custom';
+    } else {
+      importResolutions[c.simplified] = _conflictSelections[c.simplified] || 'keep';
+    }
+  });
+  closeConflictModal();
 }
 
 // ── Trash ────────────────────────────────────────────────────────────────────

--- a/static/index.html
+++ b/static/index.html
@@ -465,14 +465,14 @@
         <span style="color:var(--clr-muted,#888)">Select:</span>
         <button class="import-batch-btn" onclick="importSelectAll(true)">All +</button>
         <button class="import-batch-btn" onclick="importSelectAll(false)">All −</button>
-        <span style="color:var(--clr-muted,#888);margin-left:8px">Reading:</span>
-        <button class="import-batch-btn" onclick="importSetAllSuspended('reading',true)" title="Suspend all reading cards">🔒</button>
-        <button class="import-batch-btn" onclick="importSetAllSuspended('reading',false)" title="Unsuspend all reading cards">✓</button>
-        <span style="color:var(--clr-muted,#888);margin-left:4px">Listening:</span>
-        <button class="import-batch-btn" onclick="importSetAllSuspended('listening',true)" title="Suspend all listening cards">🔒</button>
+        <span style="color:var(--clr-muted,#888);margin-left:8px">Listening:</span>
+        <button class="import-batch-btn" onclick="importSetAllSuspended('listening',true)" title="Suspend all listening cards">✕</button>
         <button class="import-batch-btn" onclick="importSetAllSuspended('listening',false)" title="Unsuspend all listening cards">✓</button>
+        <span style="color:var(--clr-muted,#888);margin-left:4px">Reading:</span>
+        <button class="import-batch-btn" onclick="importSetAllSuspended('reading',true)" title="Suspend all reading cards">✕</button>
+        <button class="import-batch-btn" onclick="importSetAllSuspended('reading',false)" title="Unsuspend all reading cards">✓</button>
         <span style="color:var(--clr-muted,#888);margin-left:4px">Creating:</span>
-        <button class="import-batch-btn" onclick="importSetAllSuspended('creating',true)" title="Suspend all creating cards">🔒</button>
+        <button class="import-batch-btn" onclick="importSetAllSuspended('creating',true)" title="Suspend all creating cards">✕</button>
         <button class="import-batch-btn" onclick="importSetAllSuspended('creating',false)" title="Unsuspend all creating cards">✓</button>
       </div>
 
@@ -483,10 +483,12 @@
             <tr>
               <th style="width:36px">+/−</th>
               <th>Word</th>
+              <th>Translation</th>
               <th style="width:56px">Type</th>
+              <th style="width:44px">HSK</th>
               <th style="width:44px">Status</th>
-              <th style="width:44px" title="Reading suspended">Read</th>
               <th style="width:44px" title="Listening suspended">Listen</th>
+              <th style="width:44px" title="Reading suspended">Read</th>
               <th style="width:44px" title="Creating suspended">Create</th>
               <th>Deck</th>
             </tr>
@@ -496,19 +498,12 @@
       </div>
     </div>
 
-    <!-- Conflict resolution (shown only when conflicts exist) -->
-    <div id="import-conflicts-section" style="display:none">
-      <div style="font-weight:600;color:#e67e22;margin-bottom:6px;margin-top:8px">
-        ⚠ Component word conflicts
-      </div>
-      <div style="font-size:12px;color:var(--clr-muted,#888);margin-bottom:8px">
-        These words already exist in the database with different data. Choose per word or use the global buttons.
-      </div>
-      <div id="import-conflicts-list"></div>
-      <div style="display:flex;gap:8px;margin-top:8px">
-        <button class="edit-cancel-btn" style="flex:1" onclick="resolveAllConflicts('keep')">Keep All Existing</button>
-        <button class="edit-cancel-btn" style="flex:1" onclick="resolveAllConflicts('update')">Use All Incoming</button>
-      </div>
+    <!-- Conflict resolution button (shown only when conflicts exist) -->
+    <div id="import-conflicts-section" style="display:none;margin-top:8px">
+      <button onclick="openConflictModal()"
+        style="background:#e67e22;color:#fff;border:1px solid #c0392b;border-radius:4px;padding:6px 14px;font-size:13px;cursor:pointer;font-weight:600;width:100%">
+        ⚠ <span id="import-conflicts-count">0</span> component word conflict(s) — click to resolve →
+      </button>
     </div>
 
     <!-- Global deck selection (shown after preview) -->
@@ -529,9 +524,30 @@
   </div>
   <div class="edit-card-actions">
     <button class="edit-cancel-btn" onclick="closeImportModal()">Cancel</button>
-    <button class="edit-save-btn" id="import-preview-btn" onclick="previewImport()">Preview</button>
+    <button class="edit-save-btn" id="import-preview-btn" onclick="previewImport()" style="display:none">Preview</button>
     <button class="edit-save-btn" id="import-submit-btn" onclick="doImport()"
             style="display:none">Import</button>
+  </div>
+</div>
+
+<!-- Conflict resolution modal -->
+<div id="conflict-modal-overlay" onclick="closeConflictModal()"
+  style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.4);z-index:1100"></div>
+<div id="conflict-modal"
+  style="display:none;position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);width:min(680px,96vw);max-height:88vh;background:var(--card);border:1px solid var(--border);border-radius:8px;z-index:1101;flex-direction:column;overflow:hidden;box-shadow:0 8px 32px rgba(0,0,0,.15)">
+  <div class="edit-modal-header">
+    <span class="edit-modal-title">Resolve Component Word Conflicts</span>
+    <button class="edit-modal-close" onclick="closeConflictModal()">✕</button>
+  </div>
+  <div style="padding:6px 14px;font-size:12px;color:var(--muted);border-bottom:1px solid var(--border)">
+    Select which version to keep, or edit field values directly. Click a value to load it into the input.
+  </div>
+  <div id="conflict-modal-body" style="overflow-y:auto;padding:12px 14px;flex:1;background:var(--bg)"></div>
+  <div style="display:flex;gap:8px;padding:10px 14px;border-top:1px solid var(--border);background:var(--card)">
+    <button class="edit-cancel-btn" onclick="conflictAcceptAll('keep')">Accept All Existing</button>
+    <button class="edit-cancel-btn" onclick="conflictAcceptAll('update')">Accept All Incoming</button>
+    <div style="flex:1"></div>
+    <button class="edit-save-btn" onclick="conflictDone()">Done</button>
   </div>
 </div>
 

--- a/static/style.css
+++ b/static/style.css
@@ -2282,3 +2282,61 @@ select.opt-input {
   padding: 2px 4px;
   max-width: 140px;
 }
+
+/* ── Conflict resolution modal ───────────────────────────────────────── */
+.cf-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin-bottom: 10px;
+}
+.cf-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.cf-word { font-size: 16px; font-weight: 600; }
+.cf-version-btns { display: flex; gap: 6px; }
+.cf-version-btn {
+  padding: 3px 10px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+.cf-version-btn.cf-version-selected { background: #2980b9; color: #fff; border-color: #2980b9; }
+.cf-field { margin-bottom: 6px; }
+.cf-field-label {
+  font-size: 11px;
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 2px;
+}
+.cf-edited-badge {
+  font-size: 9px; padding: 1px 5px;
+  background: #e67e22; color: #fff;
+  border-radius: 3px; text-transform: uppercase; letter-spacing: 0.5px;
+}
+.cf-diff-badge {
+  font-size: 9px; padding: 1px 5px;
+  background: rgba(231,76,60,0.15); color: #e74c3c;
+  border-radius: 3px;
+}
+.cf-field-compare {
+  display: flex; align-items: center; gap: 4px;
+  margin-bottom: 4px; font-size: 11px;
+}
+.cf-compare-val {
+  padding: 1px 6px; border-radius: 3px; border: 1px solid transparent;
+  cursor: pointer; color: var(--muted);
+  max-width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.cf-compare-val:hover { border-color: var(--border); color: var(--text); }
+.cf-compare-val.cf-active { background: rgba(41,128,185,0.15); border-color: #2980b9; color: var(--text); }
+.cf-field-input { width: 100%; box-sizing: border-box; font-size: 12px; }


### PR DESCRIPTION
## 变更内容

- 每张卡片独立控制：包含/排除、目标牌组、各类别暂停状态
- 冲突解决弹窗：点击标题打开独立弹窗，可查看/编辑所有字段，选择 Existing/Incoming，编辑后显示 edited 徽章
- 导入表格新增翻译列、HSK 列；Listening 列移至 Reading 前
- 点击 Import 直接打开文件选择器（无需额外弹窗）
- 导入成功后自动关闭弹窗并显示绿色提示，无需点击 Done
- Unknown type 条目在预览表格中显示
- 默认状态：阅读/听力激活，创建暂停

## 测试方法

- 选择 YAML 文件 → 确认直接打开文件选择器，选择后弹出预览表格
- 调整单张卡片的暂停状态、牌组，确认仅该卡片受影响
- 有冲突时点击橙色按钮 → 弹窗打开，编辑字段后显示 edited 徽章，点击 Done 后返回
- 点击 Import → 弹窗关闭，顶部绿色提示显示导入数量

Closes #58