### PR TITLE
fix: 修复卡片编辑弹窗保存功能

### DIFF
--- a/database.py
+++ b/database.py
@@ -1027,7 +1027,7 @@ def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = Fa
     rows = conn.execute(
         """SELECT c.*, w.word_zh, w.pinyin, w.definition, w.pos,
                   w.hsk_level, w.traditional, w.definition_zh,
-                  w.note_type, w.source_sentence
+                  w.note_type, w.source_sentence, w.notes
            FROM cards c
            JOIN words w ON w.id = c.word_id
            WHERE c.deck_id = ?

--- a/static/app.js
+++ b/static/app.js
@@ -2293,7 +2293,7 @@ let _editWordId   = null;   // word ID being edited
 let _editFromWord = false;  // true when opened from word-detail view
 
 function _openEditModal(wordObj) {
-  _editWordId = wordObj.id || wordObj.word_id;
+  _editWordId = wordObj.word_id || wordObj.id;
   document.getElementById('edit-word-zh').value       = wordObj.word_zh       || '';
   document.getElementById('edit-pinyin').value        = wordObj.pinyin        || '';
   document.getElementById('edit-definition').value    = wordObj.definition    || '';
@@ -2385,17 +2385,9 @@ async function saveEditCard() {
   };
   try {
     const updated = await api('PUT', `/api/word/${_editWordId}`, body);
+    closeEditCard();
     if (_editFromWord) {
-      // Refresh word-detail header in place
-      document.getElementById('wd-hanzi').textContent  = updated.word_zh || '';
-      document.getElementById('wd-pinyin').textContent = updated.pinyin  || '';
-      document.getElementById('wd-def').textContent    = updated.definition || '';
-      const posEl = document.getElementById('wd-pos');
-      posEl.textContent = updated.pos || '';
-      posEl.style.display = updated.pos ? 'inline-block' : 'none';
-      const defZhEl = document.getElementById('wd-def-zh');
-      defZhEl.textContent    = updated.definition_zh || '';
-      defZhEl.style.display  = updated.definition_zh ? 'block' : 'none';
+      await openWordDetail(_editWordId);
     } else {
       // Refresh review card in place
       Object.assign(card, {
@@ -2412,7 +2404,6 @@ async function saveEditCard() {
       posEl.style.display = updated.pos ? 'inline-block' : 'none';
       renderNotesSection();
     }
-    closeEditCard();
   } catch (e) {
     showError('Save failed: ' + e.message);
   }


### PR DESCRIPTION
## 变更内容

修复了卡片编辑弹窗（Edit card modal）在复习和Browse页面的三个bug：

### Bug 1：`_editWordId` 赋值错误（复习模式）
- `_openEditModal` 中原来是 `wordObj.id || wordObj.word_id`
- 复习时传入的是 `card` 对象，`card.id` 是**卡片ID**而非词汇ID
- 修复：改为 `wordObj.word_id || wordObj.id`（词汇对象只有 `id`，卡片对象有 `word_id`）

### Bug 2：Browse保存后重开弹窗显示旧数据
- `openWordEditModal(word)` 是在 `renderWordDetail` 中通过闭包绑定的，`word` 对象在word-detail首次加载时确定
- 保存后虽然服务器数据已更新，但闭包持有旧的 `word` 对象，第二次打开弹窗时显示旧数据
- 修复：`saveEditCard` 的 `_editFromWord` 分支改为 `await openWordDetail(_editWordId)`，重新加载整个word-detail

### Bug 3：复习模式下编辑弹窗notes字段为空
- `get_due_cards` 的SQL查询没有包含 `w.notes`
- 导致复习时打开编辑弹窗，notes字段永远显示为空，保存后会清空原有笔记
- 修复：在 `get_due_cards` 的 `SELECT` 中加入 `w.notes`

## 测试方法
1. 在复习页面点击Edit card → 修改任意字段 → Save → 确认改动已保存且notes未被清空
2. 在Browse打开word-detail → 点击Edit → 修改内容 → Save → 再次打开Edit → 确认显示新内容
3. 刷新页面后重复上述操作，确认数据持久化到数据库

Closes #90
Closes #94