### PR TITLE
fix: 删除自动导入步骤，imports文件夹不存在时静默跳过

### DIFF
--- a/importer.py
+++ b/importer.py
@@ -60,6 +60,8 @@ def import_all(imports_dir: str = "imports") -> dict:
     total_imported = 0
     total_skipped = 0
     total_invalid = 0
+    if not os.path.isdir(imports_dir):
+        return {"imported": 0, "skipped_duplicate": 0, "skipped_invalid": 0}
     for source_dir in sorted(os.scandir(imports_dir), key=lambda e: e.name):
         if not source_dir.is_dir():
             continue

--- a/run.sh
+++ b/run.sh
@@ -5,5 +5,4 @@ source .env
 # Kill any process already on port 8000
 lsof -ti :8000 | xargs kill -9 2>/dev/null || true
 
-.venv/bin/python main.py import   # import YAML files (skips duplicates if already imported)
 .venv/bin/python main.py          # start the web server


### PR DESCRIPTION
## 变更内容
- 从 run.sh 删除自动 import 步骤
- importer.py：imports 文件夹不存在时静默返回，不报错

## 原因
imports/ 文件夹已不再使用

Closes #75