### PR TITLE
feat: 在数据库和前端加入德语翻译支持

### DIFF
--- a/database.py
+++ b/database.py
@@ -99,6 +99,8 @@ def init_db() -> None:
 
     if "date_yaml" not in cols:
         conn.execute("ALTER TABLE entries ADD COLUMN date_yaml TEXT")
+    if "definition_de" not in cols:
+        conn.execute("ALTER TABLE entries ADD COLUMN definition_de TEXT")
 
     ex_cols = {r["name"] for r in conn.execute("PRAGMA table_info(entry_examples)").fetchall()}
     if "example_type" not in ex_cols:
@@ -709,10 +711,10 @@ def insert_word(word: dict) -> int:
         """INSERT OR IGNORE INTO entries
            (word_zh, pinyin, definition, pos, hsk_level,
             traditional, definition_zh, source, note_type,
-            notes, date_yaml, source_sentence, grammar_notes, register)
+            notes, date_yaml, source_sentence, grammar_notes, register, definition_de)
            VALUES (:word_zh, :pinyin, :definition, :pos, :hsk_level,
                    :traditional, :definition_zh, :source, :note_type,
-                   :notes, :date_yaml, :source_sentence, :grammar_notes, :register)""",
+                   :notes, :date_yaml, :source_sentence, :grammar_notes, :register, :definition_de)""",
         {
             **word,
             "note_type":       word.get("note_type", "vocabulary"),
@@ -721,6 +723,7 @@ def insert_word(word: dict) -> int:
             "source_sentence": word.get("source_sentence"),
             "grammar_notes":   word.get("grammar_notes"),
             "register":        word.get("register"),
+            "definition_de":   word.get("definition_de"),
         },
     )
     # Backfill notes / date_yaml for entries that existed before these fields were added
@@ -796,13 +799,15 @@ def update_word(word_id: int, word: dict) -> None:
         """UPDATE entries SET
                pinyin=:pinyin, definition=:definition, pos=:pos, hsk_level=:hsk_level,
                traditional=:traditional, definition_zh=:definition_zh,
-               source_sentence=:source_sentence, grammar_notes=:grammar_notes
+               source_sentence=:source_sentence, grammar_notes=:grammar_notes,
+               definition_de=:definition_de
            WHERE id=:id""",
         {
             **word,
             "id":              word_id,
             "source_sentence": word.get("source_sentence"),
             "grammar_notes":   word.get("grammar_notes"),
+            "definition_de":   word.get("definition_de"),
         },
     )
     conn.commit()
@@ -1221,7 +1226,7 @@ def get_card(card_id: int) -> dict | None:
     row = conn.execute(
         """SELECT c.*,
                   w.word_zh, w.pinyin, w.definition, w.pos, w.hsk_level,
-                  w.traditional, w.definition_zh, w.note_type, w.notes,
+                  w.traditional, w.definition_zh, w.note_type, w.notes, w.definition_de,
                   p.learning_steps, p.graduating_interval, p.easy_interval,
                   p.relearning_steps, p.minimum_interval,
                   p.leech_threshold, p.leech_action,
@@ -1352,7 +1357,7 @@ def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = Fa
     rows = conn.execute(
         """SELECT c.*, w.word_zh, w.pinyin, w.definition, w.pos,
                   w.hsk_level, w.traditional, w.definition_zh,
-                  w.note_type, w.source_sentence, w.notes
+                  w.note_type, w.source_sentence, w.notes, w.definition_de
            FROM cards c
            JOIN entries w ON w.id = c.word_id
            WHERE c.deck_id = ?
@@ -1523,7 +1528,7 @@ def count_due(deck_id: int, category: str) -> dict:
 
 
 def update_word(word_id: int, fields: dict) -> None:
-    allowed = {"word_zh", "pinyin", "definition", "pos", "traditional", "definition_zh", "notes", "hsk_level"}
+    allowed = {"word_zh", "pinyin", "definition", "pos", "traditional", "definition_zh", "notes", "hsk_level", "definition_de"}
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:
         return
@@ -2048,7 +2053,7 @@ def toggle_deck_all_suspension(deck_id: int) -> dict:
 def get_words_for_browse() -> list[dict]:
     """Return all entries (with or without cards), with embedded card states per category."""
     sql = """
-        SELECT w.id, w.word_zh, w.pinyin, w.definition, w.pos, w.hsk_level, w.note_type,
+        SELECT w.id, w.word_zh, w.pinyin, w.definition, w.definition_de, w.pos, w.hsk_level, w.note_type,
                c.id as card_id, c.category, c.state, c.interval, c.ease,
                c.due, c.lapses, c.step_index, c.deck_id,
                d.name as deck_name
@@ -2070,6 +2075,7 @@ def get_words_for_browse() -> list[dict]:
                 "word_zh": r["word_zh"],
                 "pinyin": r["pinyin"],
                 "definition": r["definition"],
+                "definition_de": r["definition_de"],
                 "pos": r["pos"],
                 "hsk_level": r["hsk_level"],
                 "note_type": r["note_type"],
@@ -2099,8 +2105,9 @@ def search_words(q: str) -> dict:
     primary_ids = {r["id"] for r in conn.execute(
         """SELECT DISTINCT w.id FROM entries w
            WHERE (w.word_zh LIKE ? OR w.pinyin LIKE ?
-              OR w.definition LIKE ? OR w.definition_zh LIKE ?)""",
-        (like, like, like, like),
+              OR w.definition LIKE ? OR w.definition_zh LIKE ?
+              OR w.definition_de LIKE ?)""",
+        (like, like, like, like, like),
     ).fetchall()}
     secondary_ids = {r["id"] for r in conn.execute(
         """SELECT DISTINCT w.id FROM entries w
@@ -2330,7 +2337,7 @@ def get_all_cards_for_browse(filters: dict | None = None) -> list[dict]:
             q = f"%{filters['search_text']}%"
             params.extend([q, q, q])
 
-    sql = f"""SELECT c.*, w.word_zh, w.pinyin, w.definition, w.pos,
+    sql = f"""SELECT c.*, w.word_zh, w.pinyin, w.definition, w.definition_de, w.pos,
                      w.hsk_level, d.name as deck_name
               FROM cards c
               JOIN entries w ON w.id = c.word_id

--- a/de-dict-yaml.md
+++ b/de-dict-yaml.md
@@ -121,6 +121,7 @@ Append entries using the schema below. Field names, indentation, and block scala
     traditional: 一流                      # omit if identical to simplified
     pinyin: yī liú
     english: first-class / top-notch
+    german: erstklassig / spitzenklasse   # German translation (optional)
     hsk: "5-6"                            # always a string
     note: |                               # optional, for usage notes
       ...
@@ -188,6 +189,7 @@ Append entries using the schema below. Field names, indentation, and block scala
 | `traditional` | Omit from character block if identical to simplified |
 | `etymology` | Always `|` block scalar, prose only — no bullet points inside |
 | `note` | Add for important usage/register notes |
+| `german` | German translation / definition (vocabulary and sentence entries) |
 | `grammar_de` | Sentences only, always `|` block scalar, always in German |
 
 ---

--- a/importer.py
+++ b/importer.py
@@ -302,6 +302,7 @@ def _build_word_dict(entry: dict, source: str, note_type: str = "vocabulary") ->
         "word_zh":         _strip_ellipsis(entry.get("simplified", "").strip()),
         "pinyin":          entry.get("pinyin"),
         "definition":      entry.get("english"),
+        "definition_de":   entry.get("german"),
         "pos":             entry.get("pos"),
         "hsk_level":       _hsk_to_int(str(entry.get("hsk", ""))),
         "traditional":     entry.get("traditional"),

--- a/schema.sql
+++ b/schema.sql
@@ -118,6 +118,7 @@ CREATE TABLE IF NOT EXISTS entries (
     notes           TEXT,           -- usage notes / explanations from YAML `note` field
     source_sentence TEXT,           -- original source-language sentence (e.g. German) for sentence notes
     grammar_notes   TEXT,           -- grammar explanation (e.g. grammar_de from YAML)
+    definition_de   TEXT,           -- German translation / definition
     note_type       TEXT NOT NULL DEFAULT 'vocabulary',
                         -- vocabulary | sentence | chengyu | expression | grammar
     register        TEXT CHECK(register IN ('spoken', 'written', 'both', 'spoken_colloquial', 'spoken_neutral', 'neutral', 'formal_written', 'literary'))

--- a/static/app.js
+++ b/static/app.js
@@ -954,6 +954,9 @@ function renderWordDetail(word) {
   const defZhEl = document.getElementById('wd-def-zh');
   defZhEl.textContent = word.definition_zh || '';
   defZhEl.style.display = word.definition_zh ? 'block' : 'none';
+  const defDeEl = document.getElementById('wd-def-de');
+  defDeEl.textContent = word.definition_de ? `🇩🇪 ${word.definition_de}` : '';
+  defDeEl.style.display = word.definition_de ? 'block' : 'none';
 
   // Characters section — each hanzi is clickable
   const charsEl = document.getElementById('wd-chars-section');
@@ -2023,6 +2026,9 @@ function revealAnswer() {
   wordPinEl.textContent = isSentenceNote ? '' : (card.pinyin || '');
   wordPinEl.style.display = isSentenceNote ? 'none' : '';
   document.getElementById('word-def').textContent = card.definition || '';
+  const wordDefDeEl = document.getElementById('word-def-de');
+  wordDefDeEl.textContent = card.definition_de ? `🇩🇪 ${card.definition_de}` : '';
+  wordDefDeEl.style.display = card.definition_de ? 'block' : 'none';
 
   const posEl = document.getElementById('word-pos');
   posEl.textContent   = card.pos || '';
@@ -2607,6 +2613,7 @@ function _openEditModal(wordObj) {
   document.getElementById('edit-pos').value           = wordObj.pos           || '';
   document.getElementById('edit-traditional').value   = wordObj.traditional   || '';
   document.getElementById('edit-definition-zh').value = wordObj.definition_zh || '';
+  document.getElementById('edit-definition-de').value = wordObj.definition_de || '';
   document.getElementById('edit-notes').value         = wordObj.notes         || '';
   // Show card action menu only when opened during active review
   const menuWrap = document.getElementById('edit-card-menu-wrap');
@@ -2727,6 +2734,7 @@ async function saveEditCard() {
     pos:           document.getElementById('edit-pos').value.trim(),
     traditional:   document.getElementById('edit-traditional').value.trim(),
     definition_zh: document.getElementById('edit-definition-zh').value.trim(),
+    definition_de: document.getElementById('edit-definition-de').value.trim(),
     notes:         document.getElementById('edit-notes').value.trim(),
   };
   try {
@@ -2740,11 +2748,15 @@ async function saveEditCard() {
         word_zh: updated.word_zh, pinyin: updated.pinyin,
         definition: updated.definition, pos: updated.pos,
         traditional: updated.traditional, definition_zh: updated.definition_zh,
+        definition_de: updated.definition_de,
         notes: updated.notes,
       });
       document.getElementById('word-zh').textContent  = updated.word_zh || '';
       document.getElementById('word-pin').textContent = updated.pinyin  || '';
       document.getElementById('word-def').textContent = updated.definition || '';
+      const wordDefDeEl2 = document.getElementById('word-def-de');
+      wordDefDeEl2.textContent = updated.definition_de ? `🇩🇪 ${updated.definition_de}` : '';
+      wordDefDeEl2.style.display = updated.definition_de ? 'block' : 'none';
       const posEl = document.getElementById('word-pos');
       posEl.textContent   = updated.pos || '';
       posEl.style.display = updated.pos ? 'inline-block' : 'none';

--- a/static/index.html
+++ b/static/index.html
@@ -124,6 +124,7 @@
           <div class="word-pin" id="word-pin"></div>
           <div class="word-pos-row"><span class="word-pos" id="word-pos"></span></div>
           <div class="word-def" id="word-def"></div>
+          <div class="word-def-de" id="word-def-de" style="display:none"></div>
           <!-- Notes — populated by JS, hidden when empty -->
           <div id="notes-section"></div>
           <!-- Example sentences — populated by JS -->
@@ -217,6 +218,7 @@
         <span class="wd-def" id="wd-def"></span>
       </div>
       <div class="wd-def-zh" id="wd-def-zh" style="display:none"></div>
+      <div class="wd-def-de" id="wd-def-de" style="display:none"></div>
       <button class="wd-edit-btn" id="wd-edit-btn">Edit</button>
       <button class="wd-back-review-btn" id="wd-back-review-btn" style="display:none" onclick="goBack()">← Review</button>
     </div>
@@ -388,6 +390,7 @@
     <label class="edit-label">Part of speech<input class="edit-input" id="edit-pos" type="text"></label>
     <label class="edit-label">Traditional<input class="edit-input" id="edit-traditional" type="text" lang="zh"></label>
     <label class="edit-label">Chinese definition<input class="edit-input" id="edit-definition-zh" type="text" lang="zh"></label>
+    <label class="edit-label">German definition<input class="edit-input" id="edit-definition-de" type="text"></label>
     <label class="edit-label">Notes<textarea class="edit-input edit-notes" id="edit-notes" rows="3"></textarea></label>
   </div>
   <div class="edit-card-actions">

--- a/static/style.css
+++ b/static/style.css
@@ -398,6 +398,7 @@ main.browse-open {
 }
 .word-pos-row { text-align: center; margin: 2px 0; }
 .word-def  { font-size: 16px; color: var(--text); text-align: center; margin-bottom: 4px; }
+.word-def-de { font-size: 14px; color: var(--muted); text-align: center; margin-bottom: 4px; }
 
 /* ── Edit card ───────────────────────────────────────── */
 .edit-card-btn {
@@ -1667,6 +1668,7 @@ main.browse-open {
 }
 .wd-def    { font-size: 16px; color: var(--text); }
 .wd-def-zh { font-size: 14px; color: var(--muted); margin-top: 4px; }
+.wd-def-de { font-size: 14px; color: var(--muted); margin-top: 2px; }
 .word-register {
   display: inline-block;
   font-size: 11px;


### PR DESCRIPTION
## 变更内容

- **数据库**：`entries` 表新增 `definition_de TEXT` 字段；添加列迁移逻辑，兼容旧数据库
- **导入**：`importer.py` 的 `_build_word_dict()` 将 YAML `german:` 字段映射到 `definition_de`
- **查询**：所有涉及词条的 SQL 查询（复习卡片、浏览、搜索）均包含 `definition_de`
- **搜索**：`search_words()` 新增对 `definition_de` 的全文搜索
- **前端**：
  - 词汇详情视图（Word Detail）在中文释义下方显示德语翻译（带 🇩🇪 标记）
  - 复习卡片背面的词汇信息区域显示德语翻译
  - 编辑卡片模态框新增"German definition"输入框
- **样式**：新增 `.wd-def-de` 和 `.word-def-de` CSS 类
- **YAML 规范**：`de-dict-yaml.md` 更新说明 `german:` 字段的用法

## 测试方法

1. 在 YAML 文件中为一个词条添加 `german: deine Übersetzung`，执行导入
2. 打开浏览页面，确认词条详情中显示 🇩🇪 德语翻译
3. 进入复习，翻转卡片，确认词汇信息区域显示德语翻译
4. 通过编辑模态框手动填写德语翻译，保存后确认实时刷新
5. 在浏览搜索框中输入德文关键词，确认可搜索到对应词条

Closes #155