### PR TITLE
feat: 将 DeepSeek 设为默认故事生成模型

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1624,7 +1624,7 @@ function _storyParams(topic, maxHsk, model) {
   const p = new URLSearchParams();
   if (topic)                              p.set('topic', topic);
   if (maxHsk !== 2)                       p.set('max_hsk', maxHsk);
-  if (model && model !== 'claude-haiku-4-5-20251001') p.set('model', model);
+  if (model && model !== 'deepseek-chat') p.set('model', model);
   const s = p.toString();
   return s ? '?' + s : '';
 }

--- a/static/index.html
+++ b/static/index.html
@@ -432,9 +432,9 @@
         <p class="price-table-note">Prices per 1M tokens (USD)</p>
       </div>
       <select class="edit-input" id="setup-model">
-        <option value="glm-4-flash" selected>GLM-4-Flash — free, great Chinese</option>
+        <option value="glm-4-flash">GLM-4-Flash — free, great Chinese</option>
         <option value="glm-4-air">GLM-4-Air — paid, higher quality</option>
-        <option value="deepseek-chat">DeepSeek V3 — cheap, reliable</option>
+        <option value="deepseek-chat" selected>DeepSeek V3 — cheap, reliable</option>
         <option value="qwen-turbo">Qwen Turbo — Alibaba, cheap</option>
         <option value="claude-haiku-4-5-20251001">Haiku — Anthropic fast</option>
         <option value="claude-sonnet-4-6">Sonnet — Anthropic balanced</option>


### PR DESCRIPTION
## 变更内容
- `index.html`：`#setup-model` 选择框默认选中 `deepseek-chat`（原为 `glm-4-flash`）
- `app.js`：`_storyParams` 中将默认值判断从 `claude-haiku` 改为 `deepseek-chat`（默认模型不传 `?model=` 参数）

## 原因
后端 `DEFAULT_MODEL = "deepseek-chat"`，但前端默认选中 `glm-4-flash`，造成 UI 与后端不一致。
此 PR 将两者统一。

## 测试方法
- 打开复习界面，点击开始，确认模型选择框默认显示 "DeepSeek V3"
- 生成故事，确认使用 DeepSeek 而不是 GLM-4-Flash

Closes #125