### PR TITLE
fix: 混合复习时按 category_order 设置决定第一张卡片的类别

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -450,6 +450,11 @@ def get_next_card_any_cat(root_deck_id: int) -> dict | None:
     if not all_cards:
         return None
 
+    # Build category order index from root deck's preset
+    preset = get_preset_for_deck(root_deck_id)
+    order_str = preset.get("category_order", "listening,reading,creating")
+    cat_order = {c.strip(): i for i, c in enumerate(order_str.split(","))}
+
     # Reorder by story sentence position (same as get_next_card for single-cat)
     today = anki_today().isoformat()
     from .stories import get_active_story, get_story_sentences
@@ -464,6 +469,7 @@ def get_next_card_any_cat(root_deck_id: int) -> dict | None:
     all_cards.sort(key=lambda c: (
         0 if c["state"] in ("learning", "relearn") else
         1 if c["state"] == "review" else 2,
+        cat_order.get(c["category"], 99),
         story_pos.get(c["word_id"], NO_POS),
         c["due"],
     ))

--- a/static/app.js
+++ b/static/app.js
@@ -1741,7 +1741,10 @@ async function _doStartReviewMixed(topic, maxHsk, model, noStory = false) {
       } catch (_) {}
       // Fire story generation for the other categories in the background,
       // then preload TTS so audio is ready when the category switches.
-      for (const cat of ['listening', 'reading', 'creating'].filter(c => c !== category)) {
+      // Use the deck's configured category_order so preloading follows the same priority.
+      const _deckForOrder = (() => { const flat = []; const w = ns => ns.forEach(n => { flat.push(n); w(n.children || []); }); if (_cachedDecks) w(_cachedDecks); return flat.find(d => d.id === rootDeckId); })();
+      const _catOrder = (_deckForOrder?.category_order || 'listening,reading,creating').split(',').map(s => s.trim());
+      for (const cat of _catOrder.filter(c => c !== category)) {
         fetch(`/api/story/${rootDeckId}/${cat}` + _storyParams(topic, maxHsk, model))
           .then(() => fetch(`/api/preload-session/${rootDeckId}/${cat}`, { method: 'POST' }))
           .catch(() => {});


### PR DESCRIPTION
## 变更内容

- `database/cards.py`：`get_next_card_any_cat` 排序键加入类别顺序索引，从根牌组预设的 `category_order` 字段读取（默认 `listening,reading,creating`）
- `static/app.js`：`_doStartReviewMixed` 后台预加载故事时，改用牌组的 `category_order` 替换硬编码的 `['listening','reading','creating']`

## 问题根因

议题 #168 只更新了牌组列表中 L/R/C 药片的显示顺序，没有修复 `get_next_card_any_cat` 的排序逻辑。该函数决定混合复习时第一张卡片的类别，但它完全忽略了 `category_order` 设置。

## 排序优先级

1. 状态优先级（learning/relearn > review > new）—— 保持不变
2. **类别顺序**（新增）—— 按 `category_order` 配置
3. 故事句子位置
4. 到期日期

## 测试方法

1. 将牌组设置的类别顺序改为 R → L → C
2. 向该牌组导入一个新词
3. 点击牌组名称进入混合复习
4. 确认第一张卡片为阅读（R）类别

Closes #173