### PR TITLE
feat: 导入界面添加 Deck B 快速分配功能及列宽优化

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2986,6 +2986,7 @@ function _importRenderTable() {
     const susp     = cfg.suspended || IMPORT_DEFAULT_SUSPENDED;
     const deckVal  = cfg.deck_path || '';
     const isInvalid = e.status === 'invalid';
+    const isB = deckVal === '__deckB__';
 
     const rowClass = isInvalid ? 'import-row-invalid' : (!include ? 'import-row-excluded' : '');
 
@@ -3018,27 +3019,63 @@ function _importRenderTable() {
           onclick="openYamlEditFromBtn(this)">Edit</button>` : ''}
       </td>
       <td style="color:var(--clr-muted,#888);font-size:11px;max-width:120px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${_ea(e.english || '')}">${e.english || ''}</td>
-      <td style="color:var(--clr-muted,#888);font-size:11px">${NOTE_TYPE_LABEL[e.note_type] || e.note_type}</td>
-      <td style="color:var(--clr-muted,#888);font-size:11px">${e.hsk || ''}</td>
-      <td>${statusSpan}</td>
       <td>${suspBtn('listening')}</td>
       <td>${suspBtn('reading')}</td>
       <td>${suspBtn('creating')}</td>
       <td>
-        <select class="import-row-deck-select"
-          onchange="importSetCardDeck(${_ea(JSON.stringify(e.simplified))}, this.value)"
-          ${(!include || isInvalid) ? 'disabled' : ''}>
-          ${deckOptHtml}
-        </select>
+        <div class="import-deck-cell">
+          <button class="import-deck-b-badge${isB ? ' active' : ''}"
+            onclick="event.stopPropagation();importToggleDeckB(${_ea(JSON.stringify(e.simplified))})"
+            title="${isB ? 'Remove Deck B — use default' : 'Assign to Deck B'}"
+            ${(!include || isInvalid || !_deckBPath) ? 'disabled' : ''}>B</button>
+          <select class="import-row-deck-select"
+            onchange="importSetCardDeck(${_ea(JSON.stringify(e.simplified))}, this.value)"
+            ${(!include || isInvalid || isB) ? 'disabled' : ''}>
+            ${deckOptHtml}
+          </select>
+        </div>
       </td>
+      <td style="color:var(--clr-muted,#888);font-size:11px">${NOTE_TYPE_LABEL[e.note_type] || e.note_type}</td>
+      <td style="color:var(--clr-muted,#888);font-size:11px">${e.hsk || ''}</td>
+      <td>${statusSpan}</td>
     </tr>`;
   }).join('');
 
-  // Set selected deck value for each row's <select>
+  // Set selected deck value for each row's <select> (skip B-assigned rows)
   tbody.querySelectorAll('select.import-row-deck-select').forEach((sel, i) => {
     const e = _previewEntries[i];
     if (!e) return;
-    sel.value = (_cardConfigs[e.simplified] || {}).deck_path || '';
+    const dp = (_cardConfigs[e.simplified] || {}).deck_path || '';
+    sel.value = dp === '__deckB__' ? '' : dp;
+  });
+}
+
+let _resizeHandlesInited = false;
+function _initImportColResize() {
+  if (_resizeHandlesInited) return;
+  _resizeHandlesInited = true;
+  // Remove any leftover handles from a previous open
+  document.querySelectorAll('.import-table .col-resize-handle').forEach(h => h.remove());
+  document.querySelectorAll('.import-table thead th').forEach(th => {
+    const handle = document.createElement('div');
+    handle.className = 'col-resize-handle';
+    th.appendChild(handle);
+    let startX, startW;
+    handle.addEventListener('mousedown', e => {
+      startX = e.pageX;
+      startW = th.offsetWidth;
+      handle.classList.add('resizing');
+      const onMove = e2 => { th.style.minWidth = Math.max(30, startW + e2.pageX - startX) + 'px'; };
+      const onUp = () => {
+        handle.classList.remove('resizing');
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+      };
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+      e.preventDefault();
+      e.stopPropagation();
+    });
   });
 }
 
@@ -3135,6 +3172,11 @@ function closeImportModal() {
   document.getElementById('import-modal').style.display = 'none';
   const btn = document.getElementById('import-submit-btn');
   btn.onclick = doImport;
+  _resizeHandlesInited = false;
+  _deckBPath = null;
+  document.getElementById('import-deck-b-path').value = '';
+  document.getElementById('deck-b-new-badge').style.display = 'none';
+  document.getElementById('deck-b-picker-dropdown').style.display = 'none';
 }
 
 function onImportFileChange() {
@@ -3238,6 +3280,7 @@ async function previewImport(yamlContent) {
 
     _importRenderTable();
     document.getElementById('import-preview').style.display = 'block';
+    _initImportColResize();
 
     // Conflict resolution
     if (data.conflicts && data.conflicts.length > 0) {
@@ -3352,7 +3395,12 @@ async function _doUploadImport() {
   const cardConfigsMap = {};
   _previewEntries.forEach(e => {
     const cfg = _cardConfigs[e.simplified];
-    if (cfg) cardConfigsMap[e.simplified] = cfg;
+    if (cfg) {
+      cardConfigsMap[e.simplified] = {
+        ...cfg,
+        deck_path: cfg.deck_path === '__deckB__' ? (_deckBPath || null) : cfg.deck_path
+      };
+    }
   });
 
   const form = new FormData();
@@ -3980,6 +4028,8 @@ document.addEventListener('keydown', e => {
 // ── Deck picker ───────────────────────────────────────────────────────────────
 
 let _deckPickerActiveIdx = -1;
+let _deckBPickerActiveIdx = -1;
+let _deckBPath = null;
 
 function _deckPathHtml(path) {
   return path.split('::').map(s => `<span>${s}</span>`).join('<span class="deck-picker-sep"> :: </span>');
@@ -4076,7 +4126,109 @@ document.addEventListener('click', e => {
   if (picker && dd && !picker.contains(e.target) && !dd.contains(e.target)) {
     dd.style.display = 'none';
   }
+  const pickerB = document.getElementById('deck-b-picker');
+  const ddB = document.getElementById('deck-b-picker-dropdown');
+  if (pickerB && ddB && !pickerB.contains(e.target) && !ddB.contains(e.target)) {
+    ddB.style.display = 'none';
+  }
 });
+
+// ── Deck B picker ─────────────────────────────────────────────────────────────
+
+function _renderDeckBDropdown(suggestions, query) {
+  const dd = document.getElementById('deck-b-picker-dropdown');
+  if (!dd) return;
+  const isNew = !!query && !suggestions.some(s => s.toLowerCase() === query.toLowerCase());
+  document.getElementById('deck-b-new-badge').style.display = (isNew && query) ? '' : 'none';
+  _deckBPickerActiveIdx = -1;
+  let html = suggestions.map((s, i) =>
+    `<div class="deck-picker-option" data-idx="${i}" onclick="deckBPickerSelect('${s.replace(/'/g, "\\'")}')">${_deckPathHtml(s)}</div>`
+  ).join('');
+  if (!html && !isNew) html = '<div class="deck-picker-empty">No existing decks</div>';
+  if (isNew && query) {
+    html += `<div class="deck-picker-create" onclick="deckBPickerSelect('${query.replace(/'/g, "\\'")}')">+ Create ${_deckPathHtml(query)}</div>`;
+  }
+  dd.innerHTML = html;
+  const show = !!(suggestions.length || isNew || !query);
+  dd.style.display = show ? 'block' : 'none';
+  if (show) _positionDeckBDropdown();
+}
+
+function _positionDeckBDropdown() {
+  const input = document.getElementById('import-deck-b-path');
+  const dd = document.getElementById('deck-b-picker-dropdown');
+  if (!input || !dd) return;
+  const r = input.getBoundingClientRect();
+  const ddH = Math.min(220, dd.scrollHeight);
+  const spaceAbove = r.top;
+  const spaceBelow = window.innerHeight - r.bottom;
+  dd.style.width = r.width + 'px';
+  dd.style.left = r.left + 'px';
+  if (spaceAbove >= ddH + 8 || spaceAbove > spaceBelow) {
+    dd.style.bottom = (window.innerHeight - r.top + 4) + 'px';
+    dd.style.top = 'auto';
+  } else {
+    dd.style.top = (r.bottom + 4) + 'px';
+    dd.style.bottom = 'auto';
+  }
+}
+
+function deckBPickerOpen() {
+  const q = document.getElementById('import-deck-b-path').value.trim();
+  const filtered = (window._deckSuggestions || []).filter(s => !q || s.toLowerCase().includes(q.toLowerCase()));
+  _renderDeckBDropdown(filtered, q);
+}
+
+function deckBPickerFilter() {
+  const q = document.getElementById('import-deck-b-path').value.trim();
+  const filtered = (window._deckSuggestions || []).filter(s => !q || s.toLowerCase().includes(q.toLowerCase()));
+  _renderDeckBDropdown(filtered, q);
+}
+
+function deckBPickerSelect(path) {
+  document.getElementById('import-deck-b-path').value = path;
+  document.getElementById('deck-b-picker-dropdown').style.display = 'none';
+  const isNew = !(window._deckSuggestions || []).some(s => s.toLowerCase() === path.toLowerCase());
+  document.getElementById('deck-b-new-badge').style.display = (isNew && path) ? '' : 'none';
+  _deckBPath = path || null;
+  _importRenderTable();
+}
+
+function deckBPickerKey(e) {
+  const dd = document.getElementById('deck-b-picker-dropdown');
+  if (!dd) return;
+  if (dd.style.display === 'none') {
+    if (e.key === 'ArrowDown') { e.preventDefault(); deckBPickerOpen(); }
+    return;
+  }
+  const opts = dd.querySelectorAll('.deck-picker-option, .deck-picker-create');
+  if (e.key === 'Escape') { dd.style.display = 'none'; return; }
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    _deckBPickerActiveIdx = Math.min(_deckBPickerActiveIdx + 1, opts.length - 1);
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    _deckBPickerActiveIdx = Math.max(_deckBPickerActiveIdx - 1, -1);
+  } else if (e.key === 'Enter' && _deckBPickerActiveIdx >= 0) {
+    e.preventDefault();
+    opts[_deckBPickerActiveIdx].click();
+    return;
+  } else { return; }
+  opts.forEach((o, i) => o.classList.toggle('active', i === _deckBPickerActiveIdx));
+  if (_deckBPickerActiveIdx >= 0) opts[_deckBPickerActiveIdx].scrollIntoView({ block: 'nearest' });
+}
+
+function importApplyDeckB() {
+  _deckBPath = document.getElementById('import-deck-b-path').value.trim() || null;
+  _importRenderTable();
+}
+
+function importToggleDeckB(wordZh) {
+  const cfg = _cardConfigs[wordZh] || {};
+  const isB = cfg.deck_path === '__deckB__';
+  _cardConfigs[wordZh] = { ...cfg, deck_path: isB ? null : '__deckB__' };
+  _importRenderTable();
+}
 
 // ── Boot ─────────────────────────────────────────────────────────────────────
 loadDecks();

--- a/static/index.html
+++ b/static/index.html
@@ -493,6 +493,19 @@
       </div>
     </div>
 
+    <div id="import-deck-b-section">
+      <div class="deck-picker-label">
+        <span>Deck B</span>
+        <span class="deck-picker-new-badge" id="deck-b-new-badge" style="display:none">New</span>
+      </div>
+      <div class="deck-picker" id="deck-b-picker">
+        <input class="edit-input deck-picker-input" id="import-deck-b-path" type="text"
+               placeholder="optional — cards with B badge go here" autocomplete="off"
+               oninput="deckBPickerFilter()" onfocus="deckBPickerOpen()" onkeydown="deckBPickerKey(event)"
+               onchange="importApplyDeckB()">
+      </div>
+    </div>
+
     <!-- Hidden file input kept for YAML-editor preview flow -->
     <input id="import-file" type="file" accept=".yaml,.yml"
            onchange="onImportFileChange()" style="display:none">
@@ -521,15 +534,15 @@
           <thead>
             <tr>
               <th style="width:36px">+/−</th>
-              <th>Word</th>
-              <th>Translation</th>
-              <th style="width:56px">Type</th>
-              <th style="width:44px">HSK</th>
-              <th style="width:44px">Status</th>
+              <th style="width:90px">Word</th>
+              <th style="width:120px">Translation</th>
               <th style="width:44px" title="Listening suspended">Listen</th>
               <th style="width:44px" title="Reading suspended">Read</th>
               <th style="width:44px" title="Creating suspended">Create</th>
-              <th>Deck</th>
+              <th style="width:65px">Deck</th>
+              <th style="width:56px">Type</th>
+              <th style="width:44px">HSK</th>
+              <th style="width:44px">Status</th>
             </tr>
           </thead>
           <tbody id="import-table-body"></tbody>
@@ -720,5 +733,6 @@
 
 <!-- Deck picker dropdown — must be a direct body child to escape modal transform stacking context -->
 <div class="deck-picker-dropdown" id="deck-picker-dropdown" style="display:none"></div>
+<div class="deck-picker-dropdown" id="deck-b-picker-dropdown" style="display:none"></div>
 </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -2443,14 +2443,29 @@ select.opt-input {
 }
 
 /* ── Import modal – wide layout & table ─────────────────────────────────── */
-.import-modal-wide {
+#import-modal.import-modal-wide {
   width: min(1100px, 96vw);
   max-height: 90vh;
+}
+.col-resize-handle {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 5px;
+  cursor: col-resize;
+  user-select: none;
+  z-index: 2;
+}
+.col-resize-handle:hover, .col-resize-handle.resizing {
+  background: var(--primary);
+  opacity: 0.4;
 }
 .import-table {
   width: 100%;
   border-collapse: collapse;
   font-size: 13px;
+  table-layout: fixed;
 }
 .import-table th {
   text-align: left;
@@ -2468,6 +2483,7 @@ select.opt-input {
   padding: 3px 6px;
   border-bottom: 1px solid rgba(255,255,255,0.04);
   vertical-align: middle;
+  overflow: hidden;
 }
 .import-table tr.import-row-excluded td {
   opacity: 0.35;
@@ -2503,14 +2519,43 @@ select.opt-input {
   cursor: pointer;
 }
 .import-batch-btn:hover { background: rgba(255,255,255,0.06); }
+.import-deck-cell {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.import-deck-b-badge {
+  position: absolute;
+  left: 2px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 14px;
+  height: 14px;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 14px;
+  text-align: center;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0;
+  z-index: 1;
+  flex-shrink: 0;
+}
+.import-deck-b-badge:disabled { opacity: 0.25; cursor: default; }
+.import-deck-b-badge.active { background: var(--primary); color: #fff; border-color: var(--primary); }
+.import-deck-b-badge:not(:disabled):not(.active):hover { border-color: var(--primary); color: var(--primary); }
 .import-row-deck-select {
   font-size: 12px;
   background: var(--card);
   color: var(--text);
   border: 1px solid var(--border);
   border-radius: 4px;
-  padding: 2px 4px;
-  max-width: 140px;
+  padding: 2px 4px 2px 20px;
+  width: 100%;
+  max-width: 100%;
 }
 
 /* ── Conflict resolution modal ───────────────────────────────────────── */


### PR DESCRIPTION
## 变更内容

### Deck B 快速分配
- 在 Target Deck 下方新增 **Deck B** 输入框，与 Target Deck 完全一致（自动补全、键盘导航、可创建新牌组）
- 每行 Deck 列左上角添加小 **B 徽章按钮**：
  - 灰色 = 默认（使用 Target Deck 或下拉选择的牌组）
  - 蓝色 = 该卡分配到 Deck B，下拉菜单自动禁用
  - 再点一次 → 取消，恢复下拉菜单
  - Deck B 输入框为空时，B 按钮禁用

### 导入表格优化
- 修复弹窗宽度 CSS 优先级问题（`#import-modal.import-modal-wide`），实际生效 1100px
- 添加列宽拖拽调整（resize handle，拖动列头右边缘）
- 调整列顺序：Listen / Read / Create / Deck → Type / HSK / Status
- 列宽：Translation 120px、Deck 65px、`table-layout: fixed`

## 测试方法
- 打开导入弹窗，确认 Deck B 输入框出现在 Target Deck 下方
- 输入 Deck B 路径（支持自动补全和创建新牌组）
- 点击某行 B 徽章 → 变蓝，下拉菜单禁用
- 再次点击 → 取消，恢复正常
- 导入，确认 B 徽章的卡片进入 Deck B，其余卡片进入 Target Deck

Closes #