### PR TITLE
feat: 复习界面显示语体标签（口语/书面语等）

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -40,7 +40,7 @@ def get_card(card_id: int) -> dict | None:
            )
            SELECT c.*,
                   w.word_zh, w.pinyin, w.definition, w.pos, w.hsk_level,
-                  w.traditional, w.definition_zh, w.note_type, w.notes, w.definition_de,
+                  w.traditional, w.definition_zh, w.note_type, w.notes, w.definition_de, w.register,
                   d.name AS deck_name,
                   (SELECT group_concat(name, ' › ')
                    FROM (SELECT name FROM ancestors ORDER BY depth DESC)) AS deck_path,
@@ -174,7 +174,7 @@ def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = Fa
     rows = conn.execute(
         """SELECT c.*, w.word_zh, w.pinyin, w.definition, w.pos,
                   w.hsk_level, w.traditional, w.definition_zh,
-                  w.note_type, w.source_sentence, w.notes, w.definition_de
+                  w.note_type, w.source_sentence, w.notes, w.definition_de, w.register
            FROM cards c
            JOIN entries w ON w.id = c.word_id
            WHERE c.deck_id = ?

--- a/static/app.js
+++ b/static/app.js
@@ -2117,6 +2117,19 @@ function revealAnswer() {
   posEl.textContent   = card.pos || '';
   posEl.style.display = card.pos ? 'inline-block' : 'none';
 
+  const regEl = document.getElementById('word-register');
+  const regLabels = {
+    spoken: '口语', written: '书面语', both: '通用',
+    spoken_colloquial: '口语俚语', spoken_neutral: '中性口语',
+    neutral: '通用', formal_written: '正式书面语', literary: '文学语体'
+  };
+  if (card.register) {
+    regEl.textContent = regLabels[card.register] || card.register;
+    regEl.style.display = 'inline-block';
+  } else {
+    regEl.style.display = 'none';
+  }
+
   // Re-enable rating buttons
   document.querySelectorAll('.r-btn').forEach(b => b.disabled = false);
 

--- a/static/index.html
+++ b/static/index.html
@@ -122,7 +122,7 @@
         <div class="vocab-detail">
           <div class="word-big" id="word-zh"></div>
           <div class="word-pin" id="word-pin"></div>
-          <div class="word-pos-row"><span class="word-pos" id="word-pos"></span></div>
+          <div class="word-pos-row"><span class="word-pos" id="word-pos"></span><span class="word-register" id="word-register" style="display:none"></span></div>
           <div class="word-def" id="word-def"></div>
           <div class="word-def-de" id="word-def-de" style="display:none"></div>
           <!-- Notes — populated by JS, hidden when empty -->


### PR DESCRIPTION
## 变更内容

- `database/cards.py`：两处 SELECT 语句加入 `w.register`，卡片数据携带语体信息
- `static/index.html`：`word-pos-row` 行加入 `word-register` span
- `static/app.js`：在词性标签旁填充 register 标签，复用与词语详情页相同的映射逻辑

## 测试方法

- 打开复习界面，翻开带有 register 字段的卡片（口语词汇）
- 确认语体标签（如"口语"）显示在词性标签旁边

Closes #177