### PR TITLE
feat: 复习完成时触发鼓掌动画

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -44,6 +44,7 @@ let sentence    = null;   // current sentence from story (may be null)
 let wordDetails = null;   // full word data: examples + characters
 let _currentWordId = null; // word ID open in word-detail view
 let _prevView = null;      // view we came from before opening word-detail
+let _sessionReviewedCount = 0; // cards rated this session (for clap animation)
 let userInput   = '';     // creating category: what the user typed
 let browseWords  = [];   // all words from /api/browse-words
 let browseAll    = [];   // kept for legacy (unused by new browse)
@@ -131,7 +132,27 @@ async function api(method, path, body) {
 }
 
 // ── View switcher ──────────────────────────────────────────────────────────
+function _triggerClapAnimation() {
+  const emojis = ['👏', '👏', '👏', '⭐', '✨', '🌟'];
+  const count = 18;
+  for (let i = 0; i < count; i++) {
+    setTimeout(() => {
+      const el = document.createElement('span');
+      el.className = 'clap-particle';
+      el.textContent = emojis[Math.floor(Math.random() * emojis.length)];
+      const x = 5 + Math.random() * 90;
+      const rise = 55 + Math.random() * 35;
+      const dur = 1.4 + Math.random() * 0.8;
+      const tilt = (Math.random() - 0.5) * 30;
+      el.style.cssText = `left:${x}vw;--rise:-${rise}vh;--dur:${dur}s;--tilt:${tilt}deg`;
+      document.body.appendChild(el);
+      el.addEventListener('animationend', () => el.remove());
+    }, i * 80);
+  }
+}
+
 function showView(name) {
+  if (name === 'done' && _sessionReviewedCount > 0) _triggerClapAnimation();
   ['loading', 'decks', 'review', 'done', 'browse', 'word-detail', 'hanzi-detail', 'stats'].forEach(v => {
     document.getElementById(`view-${v}`).style.display = 'none';
   });
@@ -1631,6 +1652,7 @@ async function startReview(id, cat, name, noStory = false) {
   deckId   = id;
   category = cat;
   deckName = name;
+  _sessionReviewedCount = 0;
 
   try {
     if (noStory) {
@@ -1705,6 +1727,7 @@ async function startReviewMixed(id, name, noStory = false) {
   deckId     = id;
   deckName   = name;
   story      = null;
+  _sessionReviewedCount = 0;
   try {
     const todayData = await api('GET', `/api/today-mixed/${id}`);
     if (!todayData.card) {
@@ -1785,6 +1808,7 @@ async function _doStartReviewMixed(topic, maxHsk, model, noStory = false) {
 async function startReviewUnfinished() {
   deckName = 'Unfinished Cards';
   story    = null;
+  _sessionReviewedCount = 0;
   try {
     const counts = await api('GET', '/api/today-unfinished');
     if (!counts.card) {
@@ -2447,6 +2471,7 @@ async function rate(rating) {
     else if (rootDeckId) url += `&root_deck_id=${rootDeckId}`;
     else if (deckId) url += `&parent_deck_id=${deckId}`;
     const result = await api('POST', url);
+    _sessionReviewedCount++;
     if (!result.next_card) {
       rootDeckId = null;
       unfinishedMode = false;
@@ -2977,7 +3002,7 @@ function goBack() {
     return;
   }
   card = null; story = null; sentence = null; wordDetails = null; userInput = '';
-  rootDeckId = null; unfinishedMode = false;
+  rootDeckId = null; unfinishedMode = false; _sessionReviewedCount = 0;
   browseWords = []; browseAll = []; _browseSelected.clear();
   loadDecks();
 }

--- a/static/style.css
+++ b/static/style.css
@@ -2659,3 +2659,18 @@ select.opt-input {
 }
 .cat-order-btns button:hover:not(:disabled) { background: var(--hover); color: var(--text); }
 .cat-order-btns button:disabled { opacity: 0.3; cursor: default; }
+
+/* ── Clapping animation on review completion ─────────────────────────────── */
+.clap-particle {
+  position: fixed;
+  bottom: -60px;
+  font-size: 2rem;
+  pointer-events: none;
+  z-index: 9999;
+  animation: clap-rise var(--dur, 1.8s) ease-out forwards;
+}
+@keyframes clap-rise {
+  0%   { transform: translateY(0) scale(0.6) rotate(var(--tilt, 0deg)); opacity: 1; }
+  60%  { opacity: 1; }
+  100% { transform: translateY(var(--rise, -80vh)) scale(1.1) rotate(var(--tilt, 0deg)); opacity: 0; }
+}


### PR DESCRIPTION
## 变更内容
- 新增 `_triggerClapAnimation()` 函数：生成 18 个 👏/✨/⭐ 粒子从屏幕底部随机位置飘上来并淡出
- 新增 `_sessionReviewedCount` 变量追踪本次复习环节的评分次数，在每次 `startReview*` 开始时归零
- 每次 `rate()` 成功后递增计数器
- `showView('done')` 时，若本次有实际复习（计数 > 0），自动触发动画
- CSS `@keyframes clap-rise` 控制上升、缩放和透明度变化

## 测试方法
1. 用 `bash run.dev.sh` 启动开发模式
2. 进入复习流程，评分至少一张卡片直到"全部完成"
3. 确认鼓掌动画出现（多个表情从底部飘上）
4. 点击 Back to Decks 再重新进入，确认动画只在完成复习后出现，不在未复习就到达 done 页面时出现

Closes #191