### PR TITLE
feat: 故事生成缺词容忍机制——缺少<3%则用原句填充

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -138,6 +138,7 @@ Rules:
         max_tokens = min(max_tokens, 8192)
 
     missing_hint = ""
+    last_partial: tuple | None = None  # (result, missing_pairs) from best attempt
     for attempt in range(3):
         full_prompt = prompt + missing_hint
         raw = _call_api(model, [{"role": "user", "content": full_prompt}], max_tokens,
@@ -158,20 +159,22 @@ Rules:
                 for item, card in zip(result, cards):
                     item["word_id"] = card["word_id"]
                 if len(result) == len(cards):
-                    missing = [
-                        card["word_zh"]
+                    missing_pairs = [
+                        (item, card)
                         for item, card in zip(result, cards)
                         if not _is_sentence(card["word_zh"])
                         and card["word_zh"] not in item.get("sentence_zh", "")
                     ]
-                    if missing:
+                    if missing_pairs:
+                        last_partial = (result, missing_pairs)
+                        missing_words = [card["word_zh"] for _, card in missing_pairs]
                         logger.warning(
                             "generate_story: attempt %d — words missing from sentences: %s",
-                            attempt + 1, missing,
+                            attempt + 1, missing_words,
                         )
                         missing_hint = (
                             f"\n\nIMPORTANT: Your previous attempt was missing these words "
-                            f"— each MUST appear verbatim in its sentence: {', '.join(missing)}"
+                            f"— each MUST appear verbatim in its sentence: {', '.join(missing_words)}"
                         )
                         continue
                     logger.info("generate_story: success — %d sentences (attempt %d)",
@@ -184,6 +187,22 @@ Rules:
                                    len(result), len(cards))
         except (json.JSONDecodeError, TypeError, KeyError) as e:
             logger.error("generate_story: JSON parse error: %s", e)
+
+    # If the best attempt had < 3% missing words, accept it and patch with source sentences
+    if last_partial is not None:
+        result, missing_pairs = last_partial
+        missing_ratio = len(missing_pairs) / len(cards)
+        if missing_ratio < 0.03:
+            missing_words = [card["word_zh"] for _, card in missing_pairs]
+            logger.info(
+                "generate_story: accepting partial result (%.1f%% missing) — "
+                "patching %d word(s) with source sentence: %s",
+                missing_ratio * 100, len(missing_pairs), missing_words,
+            )
+            for item, card in missing_pairs:
+                item["sentence_zh"] = card.get("source_sentence") or f"我学了{card['word_zh']}这个词。"
+            _fill_translations(result)
+            return result, prompt
 
     logger.warning("generate_story: falling back to placeholder sentences")
     return _fallback_sentences(cards), prompt


### PR DESCRIPTION
## 变更内容

- 在 `generate_story` 3次重试失败后，新增容忍检查：
  - 若缺词比例 **< 3%**：接受故事，用 `source_sentence`（YAML原句）替换缺失词的句子
  - 若缺词比例 **>= 3%**：行为不变，回退到占位符句子

## 为什么

之前只缺1-2个词时，整个故事所有句子都变成「我学了X这个词。」。现在只有真正缺失的词才用原句替换，其余AI生成的句子保留。

## 日志示例

```
generate_story: accepting partial result (1.0% missing) — patching 1 word(s) with source sentence: ['某词']
```

## 测试方法

- 正常生成故事，观察日志是否有 `patching` 记录
- 缺词时确认只有那几个词用原句，其余句子正常

Closes #209