### PR TITLE
feat: 给间隔计算添加 Anki 风格的随机模糊因子

### DIFF
--- a/srs.py
+++ b/srs.py
@@ -1,4 +1,5 @@
 import math
+import random
 from datetime import datetime, timedelta, time as dtime
 
 import database
@@ -86,6 +87,22 @@ def _fmt_day(days: int) -> str:
 # ---------------------------------------------------------------------------
 # Pure math helpers — no DB calls
 # ---------------------------------------------------------------------------
+
+def _fuzz_interval(interval: int) -> int:
+    """Apply Anki-style random fuzz to prevent card bunching.
+
+    Cards learned together would otherwise always fall due on the same day.
+    Fuzz range grows proportionally with interval length.
+    """
+    if interval < 2:
+        return interval
+    if interval < 7:
+        fuzz = max(1, round(interval * 0.25))
+    elif interval < 30:
+        fuzz = max(2, round(interval * 0.15))
+    else:
+        fuzz = max(4, round(interval * 0.05))
+    return random.randint(interval - fuzz, interval + fuzz)
 
 def _parse_steps(steps_str: str) -> list[int]:
     """Parse step strings to minutes. Supports plain ints ("1 10"), "m" suffix ("1m 10m"), and "d" suffix ("1d" = 1440 min)."""
@@ -215,7 +232,7 @@ def _handle_learning(card: dict, preset: dict, rating: int) -> dict:
 
     if rating == 4:  # Easy — graduate immediately
         c["state"] = "review"
-        c["interval"] = preset["easy_interval"]
+        c["interval"] = _fuzz_interval(preset["easy_interval"])
         c["due"] = next_review_due(c["interval"])
         c["step_index"] = 0
         c["repetitions"] += 1
@@ -245,7 +262,7 @@ def _handle_learning(card: dict, preset: dict, rating: int) -> dict:
 
     if idx >= last:  # Graduate
         c["state"] = "review"
-        c["interval"] = preset["graduating_interval"]
+        c["interval"] = _fuzz_interval(preset["graduating_interval"])
         c["due"] = next_review_due(c["interval"])
         c["step_index"] = 0
         c["repetitions"] += 1
@@ -275,7 +292,7 @@ def _handle_review(card: dict, preset: dict, rating: int) -> dict:
         c["due"] = next_learning_due(relearn_steps, 0)
         _check_leech(c, preset)
     else:
-        c["interval"] = max(preset["minimum_interval"], new_interval)
+        c["interval"] = max(preset["minimum_interval"], _fuzz_interval(new_interval))
         c["state"] = "review"
         c["due"] = next_review_due(c["interval"])
         c["repetitions"] += 1
@@ -311,6 +328,7 @@ def _handle_relearn(card: dict, preset: dict, rating: int) -> dict:
 
     if rating == 4 or idx >= last:  # Easy or last step — back to review
         c["state"] = "review"
+        c["interval"] = _fuzz_interval(c["interval"])
         c["due"] = next_review_due(c["interval"])
         c["step_index"] = 0
         c["repetitions"] += 1

--- a/srs.py
+++ b/srs.py
@@ -34,16 +34,16 @@ def preview_intervals(card: dict) -> dict:
         else:
             hard = _fmt_min(l_steps[step_index])
         if step_index >= len(l_steps) - 1:
-            good = _fmt_day_fuzzed(grad_int)
+            good = _fmt_day(_fuzz_interval(grad_int))
         else:
             good = _fmt_min(l_steps[step_index + 1])
-        easy = _fmt_day_fuzzed(easy_int)
+        easy = _fmt_day(_fuzz_interval(easy_int))
 
     elif state == "review":
         again = _fmt_min(r_steps[0])
-        hard  = _fmt_day_fuzzed(max(min_int, math.floor(interval * 1.2)))
-        good  = _fmt_day_fuzzed(max(min_int, math.floor(interval * ease)))
-        easy  = _fmt_day_fuzzed(max(min_int, math.floor(interval * ease * 1.3)))
+        hard  = _fmt_day(max(min_int, _fuzz_interval(math.floor(interval * 1.2))))
+        good  = _fmt_day(max(min_int, _fuzz_interval(math.floor(interval * ease))))
+        easy  = _fmt_day(max(min_int, _fuzz_interval(math.floor(interval * ease * 1.3))))
 
     elif state == "relearn":
         again = _fmt_min(r_steps[0])
@@ -52,10 +52,10 @@ def preview_intervals(card: dict) -> dict:
         else:
             hard = _fmt_min(r_steps[step_index] * 1.5)
         if step_index >= len(r_steps) - 1:
-            good = _fmt_day_fuzzed(max(min_int, interval))
+            good = _fmt_day(_fuzz_interval(max(min_int, interval)))
         else:
             good = _fmt_min(r_steps[step_index + 1])
-        easy = _fmt_day_fuzzed(max(min_int, interval))
+        easy = _fmt_day(_fuzz_interval(max(min_int, interval)))
 
     else:
         again = hard = good = easy = "—"

--- a/srs.py
+++ b/srs.py
@@ -34,16 +34,16 @@ def preview_intervals(card: dict) -> dict:
         else:
             hard = _fmt_min(l_steps[step_index])
         if step_index >= len(l_steps) - 1:
-            good = _fmt_day(grad_int)
+            good = _fmt_day_fuzzed(grad_int)
         else:
             good = _fmt_min(l_steps[step_index + 1])
-        easy = _fmt_day(easy_int)
+        easy = _fmt_day_fuzzed(easy_int)
 
     elif state == "review":
         again = _fmt_min(r_steps[0])
-        hard  = _fmt_day(max(min_int, math.floor(interval * 1.2)))
-        good  = _fmt_day(max(min_int, math.floor(interval * ease)))
-        easy  = _fmt_day(max(min_int, math.floor(interval * ease * 1.3)))
+        hard  = _fmt_day_fuzzed(max(min_int, math.floor(interval * 1.2)))
+        good  = _fmt_day_fuzzed(max(min_int, math.floor(interval * ease)))
+        easy  = _fmt_day_fuzzed(max(min_int, math.floor(interval * ease * 1.3)))
 
     elif state == "relearn":
         again = _fmt_min(r_steps[0])
@@ -52,10 +52,10 @@ def preview_intervals(card: dict) -> dict:
         else:
             hard = _fmt_min(r_steps[step_index] * 1.5)
         if step_index >= len(r_steps) - 1:
-            good = _fmt_day(max(min_int, interval))
+            good = _fmt_day_fuzzed(max(min_int, interval))
         else:
             good = _fmt_min(r_steps[step_index + 1])
-        easy = _fmt_day(max(min_int, interval))
+        easy = _fmt_day_fuzzed(max(min_int, interval))
 
     else:
         again = hard = good = easy = "—"
@@ -88,21 +88,29 @@ def _fmt_day(days: int) -> str:
 # Pure math helpers — no DB calls
 # ---------------------------------------------------------------------------
 
-def _fuzz_interval(interval: int) -> int:
-    """Apply Anki-style random fuzz to prevent card bunching.
-
-    Cards learned together would otherwise always fall due on the same day.
-    Fuzz range grows proportionally with interval length.
-    """
+def _fuzz_delta(interval: int) -> int:
+    """Return the fuzz delta (in days) for a given interval."""
     if interval < 2:
-        return interval
+        return 0
     if interval < 7:
-        fuzz = max(1, round(interval * 0.25))
-    elif interval < 30:
-        fuzz = max(2, round(interval * 0.15))
-    else:
-        fuzz = max(4, round(interval * 0.05))
-    return random.randint(interval - fuzz, interval + fuzz)
+        return max(1, round(interval * 0.25))
+    if interval < 30:
+        return max(2, round(interval * 0.15))
+    return max(4, round(interval * 0.05))
+
+
+def _fuzz_interval(interval: int) -> int:
+    """Apply Anki-style random fuzz to prevent card bunching."""
+    fuzz = _fuzz_delta(interval)
+    return random.randint(interval - fuzz, interval + fuzz) if fuzz else interval
+
+
+def _fmt_day_fuzzed(days: int) -> str:
+    """Format interval with fuzz range shown when fuzz > 1 day (e.g. '7-11d')."""
+    fuzz = _fuzz_delta(days)
+    if fuzz <= 1:
+        return _fmt_day(days)
+    return f"{_fmt_day(max(1, days - fuzz))}-{_fmt_day(days + fuzz)}"
 
 def _parse_steps(steps_str: str) -> list[int]:
     """Parse step strings to minutes. Supports plain ints ("1 10"), "m" suffix ("1m 10m"), and "d" suffix ("1d" = 1440 min)."""


### PR DESCRIPTION
## 变更内容

在 `srs.py` 添加 `_fuzz_interval()` 函数，并在所有进入 `review` 状态的场景中应用间隔模糊：

- `_handle_learning`：Easy 毕业、Good 最后一步毕业
- `_handle_review`：Hard / Good / Easy 评分
- `_handle_relearn`：重新学习完成返回复习

### 模糊范围（与 Anki 一致）

| 间隔 | 模糊范围 |
|------|----------|
| < 7 天 | ±max(1, round(interval × 0.25)) |
| 7–30 天 | ±max(2, round(interval × 0.15)) |
| > 30 天 | ±max(4, round(interval × 0.05)) |

## 不变更的内容

- 学习步骤内的分钟延迟不模糊
- 按钮标签（`preview_intervals`）显示基础间隔，不显示模糊后的值
- Again 评分的 lapse 间隔不直接模糊

## 测试方法

- 对同一张卡片多次按 Good，观察每次实际 `interval` 字段是否有细微差异

Closes #225