### PR TITLE
feat: 为预设添加按类别的调度选项覆盖

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -113,6 +113,7 @@ def get_card(card_id: int) -> dict | None:
                     (SELECT group_concat(name, ' › ')
                      FROM (SELECT name FROM ancestors ORDER BY depth DESC))
                   END AS deck_path,
+                  p.id AS preset_id,
                   p.learning_steps, p.graduating_interval, p.easy_interval,
                   p.relearning_steps, p.minimum_interval,
                   p.leech_threshold, p.leech_action,
@@ -124,8 +125,24 @@ def get_card(card_id: int) -> dict | None:
            WHERE c.id = ?""",
         (card_id, card_id),
     ).fetchone()
+    if not row:
+        conn.close()
+        return None
+    card = dict(row)
+    # Apply category-level scheduling overrides on top of the preset defaults
+    category = card.get("category")
+    preset_id = card.get("preset_id")
+    if category and preset_id:
+        override = conn.execute(
+            "SELECT * FROM preset_category_overrides WHERE preset_id = ? AND category = ?",
+            (preset_id, category),
+        ).fetchone()
+        if override:
+            for key, val in dict(override).items():
+                if key not in ("id", "preset_id", "category") and val is not None:
+                    card[key] = val
     conn.close()
-    return dict(row) if row else None
+    return card
 
 
 def _count_new_introduced_today(conn, deck_id: int, category: str, today: str) -> int:
@@ -248,7 +265,7 @@ def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = Fa
     now = datetime.now().isoformat(timespec="seconds")
     conn = get_db()
 
-    preset = get_preset_for_deck(deck_id)
+    preset = get_preset_for_deck(deck_id, category)
     new_limit = preset["new_per_day"]
     new_done_today = _count_new_introduced_today(conn, deck_id, category, today)
     new_remaining = max(0, new_limit - new_done_today)
@@ -395,7 +412,7 @@ def count_due(deck_id: int, category: str) -> dict:
     """Returns {new, learning, review} counts for deck badge display."""
     today = anki_today().isoformat()
     now = datetime.now().isoformat(timespec="seconds")
-    preset = get_preset_for_deck(deck_id)
+    preset = get_preset_for_deck(deck_id, category)
     new_limit = preset["new_per_day"]
 
     conn = get_db()

--- a/database/core.py
+++ b/database/core.py
@@ -212,6 +212,22 @@ def init_db() -> None:
     if "new_review_order_override" not in preset_cols:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN new_review_order_override TEXT")
 
+    conn.execute("""CREATE TABLE IF NOT EXISTS preset_category_overrides (
+        id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+        preset_id           INTEGER NOT NULL REFERENCES deck_presets(id) ON DELETE CASCADE,
+        category            TEXT NOT NULL CHECK(category IN ('listening', 'reading', 'creating')),
+        new_per_day         INTEGER,
+        reviews_per_day     INTEGER,
+        learning_steps      TEXT,
+        graduating_interval INTEGER,
+        easy_interval       INTEGER,
+        relearning_steps    TEXT,
+        minimum_interval    INTEGER,
+        leech_threshold     INTEGER,
+        leech_action        TEXT CHECK(leech_action IN ('suspend', 'tag')),
+        UNIQUE(preset_id, category)
+    )""")
+
     # Normalize legacy due values: learning/relearn cards whose due datetime
     # falls on a future Anki day should store just the date (no time component).
     # This matches the new _smart_due() rule in srs.py.

--- a/database/presets.py
+++ b/database/presets.py
@@ -89,7 +89,7 @@ def get_preset(preset_id: int) -> dict:
     return dict(row) if row else None
 
 
-def get_preset_for_deck(deck_id: int) -> dict:
+def get_preset_for_deck(deck_id: int, category: str | None = None) -> dict:
     conn = get_db()
     row = conn.execute(
         """SELECT p.*,
@@ -98,8 +98,8 @@ def get_preset_for_deck(deck_id: int) -> dict:
            FROM deck_presets p JOIN decks d ON d.preset_id = p.id WHERE d.id = ?""",
         (deck_id,),
     ).fetchone()
-    conn.close()
     if not row:
+        conn.close()
         return None
     preset = dict(row)
     deck_nro = preset.pop("deck_nro_override", None)
@@ -108,7 +108,87 @@ def get_preset_for_deck(deck_id: int) -> dict:
     deck_bury = preset.pop("deck_bury_quick_mode", None)
     if deck_bury is not None:
         preset["bury_quick_mode"] = deck_bury
+
+    if category:
+        override_row = conn.execute(
+            "SELECT * FROM preset_category_overrides WHERE preset_id = ? AND category = ?",
+            (preset["id"], category),
+        ).fetchone()
+        if override_row:
+            for key, val in dict(override_row).items():
+                if key not in ("id", "preset_id", "category") and val is not None:
+                    preset[key] = val
+
+    conn.close()
     return preset
+
+
+# ---------------------------------------------------------------------------
+# Category overrides
+# ---------------------------------------------------------------------------
+
+_OVERRIDE_FIELDS = {
+    "new_per_day", "reviews_per_day", "learning_steps",
+    "graduating_interval", "easy_interval", "relearning_steps",
+    "minimum_interval", "leech_threshold", "leech_action",
+}
+
+
+def get_category_overrides(preset_id: int) -> dict:
+    """Return {category: {field: value, ...}} for all overrides of a preset."""
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT * FROM preset_category_overrides WHERE preset_id = ?", (preset_id,)
+    ).fetchall()
+    conn.close()
+    result = {}
+    for r in rows:
+        d = dict(r)
+        cat = d.pop("category")
+        d.pop("id", None)
+        d.pop("preset_id", None)
+        result[cat] = {k: v for k, v in d.items() if v is not None}
+    return result
+
+
+def set_category_override(preset_id: int, category: str, fields: dict) -> None:
+    """Upsert category-level scheduling overrides. Pass None values to clear a field."""
+    allowed = {k: fields[k] for k in fields if k in _OVERRIDE_FIELDS}
+    if not allowed:
+        return
+    conn = get_db()
+    existing = conn.execute(
+        "SELECT id FROM preset_category_overrides WHERE preset_id = ? AND category = ?",
+        (preset_id, category),
+    ).fetchone()
+    if existing:
+        set_clause = ", ".join(f"{k} = :{k}" for k in allowed)
+        allowed["_pid"] = preset_id
+        allowed["_cat"] = category
+        conn.execute(
+            f"UPDATE preset_category_overrides SET {set_clause} WHERE preset_id = :_pid AND category = :_cat",
+            allowed,
+        )
+    else:
+        cols = ", ".join(["preset_id", "category"] + list(allowed.keys()))
+        placeholders = ", ".join([":preset_id", ":category"] + [f":{k}" for k in allowed])
+        allowed["preset_id"] = preset_id
+        allowed["category"] = category
+        conn.execute(
+            f"INSERT INTO preset_category_overrides ({cols}) VALUES ({placeholders})", allowed
+        )
+    conn.commit()
+    conn.close()
+
+
+def delete_category_override(preset_id: int, category: str) -> None:
+    conn = get_db()
+    conn.execute(
+        "DELETE FROM preset_category_overrides WHERE preset_id = ? AND category = ?",
+        (preset_id, category),
+    )
+    conn.commit()
+    conn.close()
 
 
 def insert_preset(preset: dict) -> int:

--- a/routes/decks.py
+++ b/routes/decks.py
@@ -206,8 +206,10 @@ def delete_preset(preset_id: int):
 
 
 @router.get("/api/decks/{deck_id}/preset")
-def get_deck_preset(deck_id: int):
-    return database.get_preset_for_deck(deck_id)
+def get_deck_preset(deck_id: int, category: str | None = None):
+    preset = database.get_preset_for_deck(deck_id, category)
+    preset["category_overrides"] = database.get_category_overrides(preset["id"])
+    return preset
 
 
 @router.put("/api/decks/{deck_id}/preset")
@@ -252,3 +254,40 @@ def set_deck_preset_as_default(deck_id: int):
     deck = database.get_deck(deck_id)
     database.set_default_preset(deck["preset_id"])
     return database.get_preset(deck["preset_id"])
+
+
+# ---------------------------------------------------------------------------
+# Category-level scheduling overrides
+# ---------------------------------------------------------------------------
+
+VALID_CATEGORIES = {"listening", "reading", "creating"}
+
+
+@router.get("/api/presets/{preset_id}/categories")
+def get_preset_category_overrides(preset_id: int):
+    return database.get_category_overrides(preset_id)
+
+
+@router.get("/api/presets/{preset_id}/categories/{category}")
+def get_preset_category_override(preset_id: int, category: str):
+    if category not in VALID_CATEGORIES:
+        raise HTTPException(status_code=400, detail="Invalid category")
+    overrides = database.get_category_overrides(preset_id)
+    return overrides.get(category, {})
+
+
+@router.put("/api/presets/{preset_id}/categories/{category}")
+def set_preset_category_override(preset_id: int, category: str, fields: dict):
+    if category not in VALID_CATEGORIES:
+        raise HTTPException(status_code=400, detail="Invalid category")
+    database.set_category_override(preset_id, category, fields)
+    overrides = database.get_category_overrides(preset_id)
+    return overrides.get(category, {})
+
+
+@router.delete("/api/presets/{preset_id}/categories/{category}")
+def delete_preset_category_override(preset_id: int, category: str):
+    if category not in VALID_CATEGORIES:
+        raise HTTPException(status_code=400, detail="Invalid category")
+    database.delete_category_override(preset_id, category)
+    return {"ok": True}

--- a/schema.sql
+++ b/schema.sql
@@ -390,3 +390,24 @@ CREATE TABLE IF NOT EXISTS grammar_expressions (
     meaning     TEXT,
     position    INTEGER NOT NULL DEFAULT 0
 );
+
+-- ---------------------------------------------------------------------------
+-- preset_category_overrides
+-- Per-category scheduling overrides for a preset.
+-- NULL fields mean "use the preset default".
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS preset_category_overrides (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    preset_id           INTEGER NOT NULL REFERENCES deck_presets(id) ON DELETE CASCADE,
+    category            TEXT NOT NULL CHECK(category IN ('listening', 'reading', 'creating')),
+    new_per_day         INTEGER,
+    reviews_per_day     INTEGER,
+    learning_steps      TEXT,
+    graduating_interval INTEGER,
+    easy_interval       INTEGER,
+    relearning_steps    TEXT,
+    minimum_interval    INTEGER,
+    leech_threshold     INTEGER,
+    leech_action        TEXT CHECK(leech_action IN ('suspend', 'tag')),
+    UNIQUE(preset_id, category)
+);

--- a/static/app.js
+++ b/static/app.js
@@ -1861,7 +1861,10 @@ function _getCategoryOrderUI() {
   return [...list.children].map(el => el.dataset.cat).join(',');
 }
 
+let currentPresetId = null;
+
 function loadPresetFields(preset) {
+  currentPresetId = preset.id;
   document.getElementById('opt-new-per-day').value     = preset.new_per_day;
   document.getElementById('opt-reviews-per-day').value = preset.reviews_per_day;
   document.getElementById('opt-learn-steps').value     = preset.learning_steps;
@@ -1886,6 +1889,50 @@ function loadPresetFields(preset) {
   btnDef.disabled = !!preset.is_default;
   const btnDel = document.getElementById('btn-delete-preset');
   btnDel.disabled = allPresets.length <= 1;
+
+  // Category overrides
+  _loadCategoryOverrides(preset.category_overrides || {});
+}
+
+const _CAT_OVERRIDE_FIELDS = [
+  'new_per_day', 'reviews_per_day', 'learning_steps',
+  'graduating_interval', 'easy_interval', 'relearning_steps',
+];
+
+function _loadCategoryOverrides(overrides) {
+  for (const details of document.querySelectorAll('.cat-override-details')) {
+    const cat = details.dataset.cat;
+    const catOverrides = overrides[cat] || {};
+    let hasAny = false;
+    for (const input of details.querySelectorAll('input[data-field]')) {
+      const val = catOverrides[input.dataset.field];
+      input.value = val != null ? val : '';
+      if (val != null) hasAny = true;
+    }
+    if (hasAny) {
+      details.setAttribute('data-has-overrides', '');
+      details.open = true;
+    } else {
+      details.removeAttribute('data-has-overrides');
+      details.open = false;
+    }
+  }
+}
+
+function _collectCategoryOverrides() {
+  const result = {};
+  for (const details of document.querySelectorAll('.cat-override-details')) {
+    const cat = details.dataset.cat;
+    const fields = {};
+    for (const input of details.querySelectorAll('input[data-field]')) {
+      const raw = input.value.trim();
+      if (raw !== '') {
+        fields[input.dataset.field] = input.type === 'number' ? Number(raw) : raw;
+      }
+    }
+    if (Object.keys(fields).length > 0) result[cat] = fields;
+  }
+  return result;
 }
 
 function renderPresetSelect(selectedId) {
@@ -1915,7 +1962,7 @@ async function switchPreset(presetId) {
   presetId = parseInt(presetId);
   try {
     await api('PUT', `/api/decks/${optDeckId}/preset/assign?preset_id=${presetId}`);
-    const preset = allPresets.find(p => p.id === presetId);
+    const preset = await api('GET', `/api/decks/${optDeckId}/preset`);
     loadPresetFields(preset);
   } catch (e) {
     showError('Failed to switch preset: ' + e.message);
@@ -1999,7 +2046,20 @@ async function saveOptions() {
     if (!ok) return;
   }
   try {
-    await api('PUT', `/api/decks/${optDeckId}/preset`, fields);
+    const [savedPreset] = await Promise.all([
+      api('PUT', `/api/decks/${optDeckId}/preset`, fields),
+    ]);
+    const presetId = currentPresetId;
+    // Save category overrides
+    const catOverrides = _collectCategoryOverrides();
+    const cats = ['listening', 'reading', 'creating'];
+    await Promise.all(cats.map(cat => {
+      if (catOverrides[cat]) {
+        return api('PUT', `/api/presets/${presetId}/categories/${cat}`, catOverrides[cat]);
+      } else {
+        return api('DELETE', `/api/presets/${presetId}/categories/${cat}`).catch(() => {});
+      }
+    }));
     closeModal();
     loadDecks();
   } catch (e) {

--- a/static/index.html
+++ b/static/index.html
@@ -327,6 +327,48 @@
     </div>
 
     <div class="opt-group">
+      <div class="opt-group-label">Category Overrides <span style="font-weight:400;font-size:11px;color:var(--muted)">— leave blank to use preset default</span></div>
+      <div id="cat-overrides-container">
+        <!-- Listening -->
+        <details class="cat-override-details" data-cat="listening">
+          <summary class="cat-override-summary">Listening</summary>
+          <div class="cat-override-fields">
+            <div class="opt-row"><span class="opt-label">New / day</span>              <input class="opt-input" data-field="new_per_day"         type="number" min="0" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Reviews / day</span>          <input class="opt-input" data-field="reviews_per_day"     type="number" min="0" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Steps (min)</span>            <input class="opt-input wide" data-field="learning_steps" type="text"   placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Graduating interval (days)</span><input class="opt-input" data-field="graduating_interval" type="number" min="1" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Easy interval (days)</span>  <input class="opt-input" data-field="easy_interval"        type="number" min="1" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Relearning steps (min)</span><input class="opt-input wide" data-field="relearning_steps" type="text"  placeholder="default"></div>
+          </div>
+        </details>
+        <!-- Reading -->
+        <details class="cat-override-details" data-cat="reading">
+          <summary class="cat-override-summary">Reading</summary>
+          <div class="cat-override-fields">
+            <div class="opt-row"><span class="opt-label">New / day</span>              <input class="opt-input" data-field="new_per_day"         type="number" min="0" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Reviews / day</span>          <input class="opt-input" data-field="reviews_per_day"     type="number" min="0" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Steps (min)</span>            <input class="opt-input wide" data-field="learning_steps" type="text"   placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Graduating interval (days)</span><input class="opt-input" data-field="graduating_interval" type="number" min="1" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Easy interval (days)</span>  <input class="opt-input" data-field="easy_interval"        type="number" min="1" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Relearning steps (min)</span><input class="opt-input wide" data-field="relearning_steps" type="text"  placeholder="default"></div>
+          </div>
+        </details>
+        <!-- Creating -->
+        <details class="cat-override-details" data-cat="creating">
+          <summary class="cat-override-summary">Creating</summary>
+          <div class="cat-override-fields">
+            <div class="opt-row"><span class="opt-label">New / day</span>              <input class="opt-input" data-field="new_per_day"         type="number" min="0" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Reviews / day</span>          <input class="opt-input" data-field="reviews_per_day"     type="number" min="0" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Steps (min)</span>            <input class="opt-input wide" data-field="learning_steps" type="text"   placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Graduating interval (days)</span><input class="opt-input" data-field="graduating_interval" type="number" min="1" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Easy interval (days)</span>  <input class="opt-input" data-field="easy_interval"        type="number" min="1" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Relearning steps (min)</span><input class="opt-input wide" data-field="relearning_steps" type="text"  placeholder="default"></div>
+          </div>
+        </details>
+      </div>
+    </div>
+
+    <div class="opt-group">
       <div class="opt-group-label">Display Order</div>
       <div class="opt-row"><span class="opt-label">New card gather order</span>
         <select class="opt-input" id="opt-new-gather-order">

--- a/static/style.css
+++ b/static/style.css
@@ -2947,6 +2947,39 @@ select.opt-input {
 .cat-order-btns button:hover:not(:disabled) { background: var(--hover); color: var(--text); }
 .cat-order-btns button:disabled { opacity: 0.3; cursor: default; }
 
+/* ── Category overrides ───────────────────────────────────────────────────── */
+.cat-override-details {
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  margin-bottom: 4px;
+  overflow: hidden;
+}
+.cat-override-summary {
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  background: var(--card-bg);
+  user-select: none;
+  list-style: none;
+}
+.cat-override-summary::-webkit-details-marker { display: none; }
+.cat-override-summary::before { content: '▶ '; font-size: 9px; }
+details[open] .cat-override-summary::before { content: '▼ '; }
+.cat-override-details[data-has-overrides] .cat-override-summary {
+  color: var(--text);
+}
+.cat-override-details[data-has-overrides] .cat-override-summary::after {
+  content: ' ●';
+  color: #4a9eff;
+  font-size: 9px;
+}
+.cat-override-fields {
+  padding: 4px 8px 8px;
+  background: var(--bg);
+}
+
 /* ── Clapping animation on review completion ─────────────────────────────── */
 .clap-particle {
   position: fixed;


### PR DESCRIPTION
## 变更内容

- **数据库**：新增 `preset_category_overrides` 表，每个预设可为 listening/reading/creating 三个类别单独覆盖调度参数（`new_per_day`、`reviews_per_day`、`learning_steps`、`graduating_interval`、`easy_interval`、`relearning_steps`）
- **后端**：`get_preset_for_deck(deck_id, category=None)` 传入类别时自动合并覆盖字段；`get_card()` 在 SQL JOIN 后再叠加类别覆盖；`get_due_cards()` 和 `count_due()` 均传入 category
- **API**：新增 `GET/PUT/DELETE /api/presets/{id}/categories/{cat}` 端点；`GET /api/decks/{id}/preset` 返回 `category_overrides` 字典
- **前端**：Options 弹窗新增 "Category Overrides" 区域，三个可折叠面板（Listening/Reading/Creating），各字段留空 = 使用预设默认值，有覆盖时标题显示蓝点提示

## 测试方法

1. 启动服务器，打开任意牌组的 Options（⚙ 按钮）
2. 展开 "Category Overrides" → Listening，设置 "New / day" = 3，保存
3. 重新打开 Options，确认 Listening 面板仍显示 3，且有蓝点标记
4. 把字段清空再保存，确认蓝点消失
5. 验证调度：听力牌组每天最多出 3 张新卡，其他类别不受影响

Closes #233