### PR TITLE
feat: 故事生成弹窗添加语法点聚焦字段

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -84,14 +84,18 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str) -> str:
 
 def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2,
                    model: str = DEFAULT_MODEL,
-                   progress_key: str | None = None) -> tuple[list[dict], str]:
+                   progress_key: str | None = None,
+                   grammar_focus: str | None = None,
+                   grammar_pct: int = 50) -> tuple[list[dict], str]:
     """
     Generate a short Mandarin story, one sentence per card.
 
-    cards:   list of dicts with keys word_id, word_zh, pinyin, definition, pos
-    topic:   optional theme/setting to guide the story
-    max_hsk: maximum HSK level for non-target background vocabulary (1-6)
-    model:   model ID to use for generation
+    cards:         list of dicts with keys word_id, word_zh, pinyin, definition, pos
+    topic:         optional theme/setting to guide the story
+    max_hsk:       maximum HSK level for non-target background vocabulary (1-6)
+    model:         model ID to use for generation
+    grammar_focus: optional grammar pattern to encourage (e.g. "把字句")
+    grammar_pct:   approximate percentage of sentences that should use the grammar (0-100)
     Returns: (sentences, prompt_text)
       sentences: list of {word_id, sentence_zh, sentence_en} — same length as cards.
       prompt_text: the full prompt string sent to the AI.
@@ -126,6 +130,15 @@ def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2
     word_list = "\n".join(word_list_lines)
 
     topic_line = f"- The story should be set around this topic or theme: {topic}\n" if topic else ""
+    if grammar_focus:
+        n_sentences = max(1, round(len(cards) * grammar_pct / 100))
+        grammar_line = (
+            f"- Grammar focus: try to use the pattern 「{grammar_focus}」 in roughly "
+            f"{n_sentences} of the {len(cards)} sentences (about {grammar_pct}%). "
+            f"You decide which sentences to apply it to — it does not need to be forced.\n"
+        )
+    else:
+        grammar_line = ""
 
     prompt = f"""Write a short Mandarin Chinese story to help an HSK 4-5 learner review vocabulary.
 
@@ -138,7 +151,7 @@ Rules:
 - For all other items: write a sentence that naturally contains the target word
 - Use proper Chinese punctuation — include commas（，）where natural pauses occur
 - Use only HSK 1-{max_hsk} vocabulary for non-target words
-{topic_line}- The sentences must form a coherent narrative with the same recurring characters
+{topic_line}{grammar_line}- The sentences must form a coherent narrative with the same recurring characters
 - NEVER use ASCII double-quote characters (") inside Chinese sentences — use 「」or （）instead if quoting is needed
 - Return ONLY valid JSON, no explanation, no markdown:
 [

--- a/ai.py
+++ b/ai.py
@@ -363,13 +363,11 @@ def _fill_translations(sentences: list[dict], progress_key: str | None = None) -
         total = len(texts)
 
         if progress_key and total > 0:
-            # Translate one by one to show per-sentence progress
-            results: list[str] = []
-            for i, text in enumerate(texts):
-                _set_progress(progress_key, phase="translating",
-                              msg=f"Translating… {i + 1}/{total}",
-                              percent=88 + round((i + 1) / total * 4))
-                results.append(_t.translate_zh_en(text))
+            _set_progress(progress_key, phase="translating",
+                          msg=f"Translating… 0/{total}", percent=88)
+            results = _t.translate_batch(texts)
+            _set_progress(progress_key, phase="translating",
+                          msg=f"Translating… {total}/{total}", percent=92)
         else:
             results = _t.translate_batch(texts)
 

--- a/ai.py
+++ b/ai.py
@@ -151,6 +151,7 @@ Rules:
 - For all other items: write a sentence that naturally contains the target word
 - Use proper Chinese punctuation — include commas（，）where natural pauses occur
 - Use only HSK 1-{max_hsk} vocabulary for non-target words
+- Please keep each sentence as short and simple as possible — shorter is better, as long as all other rules are still met
 {topic_line}{grammar_line}- The sentences must form a coherent narrative with the same recurring characters
 - NEVER use ASCII double-quote characters (") inside Chinese sentences — use 「」or （）instead if quoting is needed
 - Return ONLY valid JSON, no explanation, no markdown:

--- a/database/cards.py
+++ b/database/cards.py
@@ -113,6 +113,7 @@ def get_card(card_id: int) -> dict | None:
                     (SELECT group_concat(name, ' › ')
                      FROM (SELECT name FROM ancestors ORDER BY depth DESC))
                   END AS deck_path,
+                  p.id AS preset_id,
                   p.learning_steps, p.graduating_interval, p.easy_interval,
                   p.relearning_steps, p.minimum_interval,
                   p.leech_threshold, p.leech_action,
@@ -124,8 +125,24 @@ def get_card(card_id: int) -> dict | None:
            WHERE c.id = ?""",
         (card_id, card_id),
     ).fetchone()
+    if not row:
+        conn.close()
+        return None
+    card = dict(row)
+    # Apply category-level scheduling overrides on top of the preset defaults
+    category = card.get("category")
+    preset_id = card.get("preset_id")
+    if category and preset_id:
+        override = conn.execute(
+            "SELECT * FROM preset_category_overrides WHERE preset_id = ? AND category = ?",
+            (preset_id, category),
+        ).fetchone()
+        if override:
+            for key, val in dict(override).items():
+                if key not in ("id", "preset_id", "category") and val is not None:
+                    card[key] = val
     conn.close()
-    return dict(row) if row else None
+    return card
 
 
 def _count_new_introduced_today(conn, deck_id: int, category: str, today: str) -> int:
@@ -248,7 +265,7 @@ def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = Fa
     now = datetime.now().isoformat(timespec="seconds")
     conn = get_db()
 
-    preset = get_preset_for_deck(deck_id)
+    preset = get_preset_for_deck(deck_id, category)
     new_limit = preset["new_per_day"]
     new_done_today = _count_new_introduced_today(conn, deck_id, category, today)
     new_remaining = max(0, new_limit - new_done_today)
@@ -395,7 +412,7 @@ def count_due(deck_id: int, category: str) -> dict:
     """Returns {new, learning, review} counts for deck badge display."""
     today = anki_today().isoformat()
     now = datetime.now().isoformat(timespec="seconds")
-    preset = get_preset_for_deck(deck_id)
+    preset = get_preset_for_deck(deck_id, category)
     new_limit = preset["new_per_day"]
 
     conn = get_db()

--- a/database/cards.py
+++ b/database/cards.py
@@ -857,19 +857,23 @@ def get_sibling_cards(card_id: int) -> list[dict]:
     return [dict(r) for r in rows]
 
 
-def apply_sibling_repulsion(card_id: int, new_interval: int, sibling_separation: int) -> None:
-    """Push sibling due dates that fall within sibling_separation days of today.
+def apply_sibling_repulsion(card_id: int, new_interval: int,
+                            sibling_separation: int, sibling_factor: float = 0.2) -> None:
+    """Push sibling due dates that are too close after a review.
 
-    Only applied when the reviewed card's new_interval exceeds sibling_separation,
-    so initial learning (small intervals) is unaffected — the staggered introduction
-    handles that phase.  Only review/new-state siblings are adjusted (learning/relearn
-    cards use datetime-based due values that should not be touched here).
+    effective_separation = max(sibling_separation, floor(new_interval * sibling_factor))
+
+    Only applied when new_interval exceeds sibling_separation so the initial
+    staggered-introduction phase (small intervals) is unaffected.
+    Only review/new-state siblings are adjusted (learning/relearn cards use
+    datetime-based due values that must not be touched here).
     """
     if new_interval <= sibling_separation:
         return
 
+    effective_sep = max(sibling_separation, int(new_interval * sibling_factor))
     today = anki_today()
-    min_due = (today + timedelta(days=sibling_separation)).isoformat()
+    min_due = (today + timedelta(days=effective_sep)).isoformat()
 
     conn = get_db()
     card = conn.execute("SELECT word_id FROM cards WHERE id = ?", (card_id,)).fetchone()

--- a/database/cards.py
+++ b/database/cards.py
@@ -646,7 +646,7 @@ def get_due_cards_multi(deck_ids: list[int], category: str, *, sibling_suppressi
     """Due cards across multiple decks, merged and priority-sorted.
 
     Mirrors the bucket logic of get_due_cards so that new_review_order="mixed"
-    interleaves new cards into the review queue instead of appending them last.
+    interleaves new cards into the full learning+review queue.
     """
     all_cards = []
     for deck_id in deck_ids:
@@ -661,16 +661,22 @@ def get_due_cards_multi(deck_ids: list[int], category: str, *, sibling_suppressi
     # new_cards keep the per-deck gather/sort order from get_due_cards
 
     preset = get_preset_for_deck(deck_ids[0]) if deck_ids else {}
+
+    il_o = preset.get("interday_learning_review_order", "mixed")
+    if il_o == "learning_first":
+        lr = learning_cards + review_cards
+    elif il_o == "reviews_first":
+        lr = review_cards + learning_cards
+    else:  # mixed: merge by due time
+        lr = sorted(learning_cards + review_cards, key=lambda c: c["due"])
+
     nr_o = preset.get("new_review_order_override") or preset.get("new_review_order", "mixed")
-
     if nr_o == "new_first":
-        review_new = new_cards + review_cards
+        return new_cards + lr
     elif nr_o == "reviews_first":
-        review_new = review_cards + new_cards
-    else:  # mixed
-        review_new = _interleave_cards(review_cards, new_cards)
-
-    return learning_cards + review_new
+        return lr + new_cards
+    else:  # mixed: distribute new cards evenly throughout lr
+        return _interleave_cards(lr, new_cards)
 
 
 def get_next_card_multi(deck_ids: list[int], category: str) -> dict | None:

--- a/database/cards.py
+++ b/database/cards.py
@@ -1,8 +1,11 @@
+import logging
 import sqlite3
 from datetime import date, datetime, timedelta
 from .core import get_db, anki_today
 from .presets import get_preset_for_deck
 from .decks import get_deck
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -869,11 +872,21 @@ def apply_sibling_repulsion(card_id: int, new_interval: int,
     datetime-based due values that must not be touched here).
     """
     if new_interval <= sibling_separation:
+        logger.debug(
+            "[sibling_repulsion] card=#%d interval=%d ≤ separation=%d → skipped (initial learning phase)",
+            card_id, new_interval, sibling_separation,
+        )
         return
 
     effective_sep = max(sibling_separation, int(new_interval * sibling_factor))
     today = anki_today()
     min_due = (today + timedelta(days=effective_sep)).isoformat()
+
+    logger.debug(
+        "[sibling_repulsion] card=#%d  interval=%d  sep=%d  factor=%.2f"
+        "  → effective_sep=%d  min_due=%s",
+        card_id, new_interval, sibling_separation, sibling_factor, effective_sep, min_due,
+    )
 
     conn = get_db()
     card = conn.execute("SELECT word_id FROM cards WHERE id = ?", (card_id,)).fetchone()
@@ -882,14 +895,25 @@ def apply_sibling_repulsion(card_id: int, new_interval: int,
         return
 
     siblings = conn.execute(
-        """SELECT id, state, due FROM cards
+        """SELECT id, category, state, due FROM cards
            WHERE word_id = ? AND id != ? AND deleted_at IS NULL AND state NOT IN ('suspended', 'learning', 'relearn')""",
         (card["word_id"], card_id),
     ).fetchall()
 
+    pushed = []
     for s in siblings:
         if s["due"] < min_due:
             conn.execute("UPDATE cards SET due = ? WHERE id = ?", (min_due, s["id"]))
+            pushed.append((s["id"], s["category"], s["due"], min_due))
+
+    if pushed:
+        for sid, cat, old_due, new_due in pushed:
+            logger.debug(
+                "[sibling_repulsion]   pushed sibling #%d (%s): %s → %s",
+                sid, cat, old_due, new_due,
+            )
+    else:
+        logger.debug("[sibling_repulsion]   no siblings needed pushing")
 
     conn.commit()
     conn.close()

--- a/database/cards.py
+++ b/database/cards.py
@@ -645,8 +645,10 @@ def count_due_by_category(root_deck_id: int) -> dict:
 def get_due_cards_multi(deck_ids: list[int], category: str, *, sibling_suppression: bool = False) -> list[dict]:
     """Due cards across multiple decks, merged and priority-sorted.
 
-    Mirrors the bucket logic of get_due_cards so that new_review_order="mixed"
-    interleaves new cards into the full learning+review queue.
+    Learning cards always come first (sorted by due), then review and new cards
+    are combined according to new_review_order: "mixed" interleaves new cards
+    evenly among review cards; "reviews_first" appends new cards after reviews;
+    "new_first" prepends new cards before reviews.
     """
     all_cards = []
     for deck_id in deck_ids:
@@ -661,22 +663,16 @@ def get_due_cards_multi(deck_ids: list[int], category: str, *, sibling_suppressi
     # new_cards keep the per-deck gather/sort order from get_due_cards
 
     preset = get_preset_for_deck(deck_ids[0]) if deck_ids else {}
-
-    il_o = preset.get("interday_learning_review_order", "mixed")
-    if il_o == "learning_first":
-        lr = learning_cards + review_cards
-    elif il_o == "reviews_first":
-        lr = review_cards + learning_cards
-    else:  # mixed: merge by due time
-        lr = sorted(learning_cards + review_cards, key=lambda c: c["due"])
-
     nr_o = preset.get("new_review_order_override") or preset.get("new_review_order", "mixed")
+
     if nr_o == "new_first":
-        return new_cards + lr
+        review_new = new_cards + review_cards
     elif nr_o == "reviews_first":
-        return lr + new_cards
-    else:  # mixed: distribute new cards evenly throughout lr
-        return _interleave_cards(lr, new_cards)
+        review_new = review_cards + new_cards
+    else:  # mixed: interleave new cards evenly among review cards
+        review_new = _interleave_cards(review_cards, new_cards)
+
+    return learning_cards + review_new
 
 
 def get_next_card_multi(deck_ids: list[int], category: str) -> dict | None:

--- a/database/cards.py
+++ b/database/cards.py
@@ -873,7 +873,8 @@ def apply_sibling_repulsion(card_id: int, new_interval: int,
     """
     if new_interval <= sibling_separation:
         logger.debug(
-            "[sibling_repulsion] card=#%d interval=%d ≤ separation=%d → skipped (initial learning phase)",
+            "[SIBLING REPULSION]  card=#%d  interval=%dd  ≤  threshold=%dd"
+            "  →  SKIP (still in early intro phase, repulsion not active yet)",
             card_id, new_interval, sibling_separation,
         )
         return
@@ -882,38 +883,52 @@ def apply_sibling_repulsion(card_id: int, new_interval: int,
     today = anki_today()
     min_due = (today + timedelta(days=effective_sep)).isoformat()
 
-    logger.debug(
-        "[sibling_repulsion] card=#%d  interval=%d  sep=%d  factor=%.2f"
-        "  → effective_sep=%d  min_due=%s",
-        card_id, new_interval, sibling_separation, sibling_factor, effective_sep, min_due,
-    )
-
     conn = get_db()
-    card = conn.execute("SELECT word_id FROM cards WHERE id = ?", (card_id,)).fetchone()
-    if not card:
+    card_row = conn.execute(
+        """SELECT c.category, e.word_zh
+           FROM cards c JOIN entries e ON e.id = c.word_id
+           WHERE c.id = ?""",
+        (card_id,),
+    ).fetchone()
+    if not card_row:
         conn.close()
         return
 
+    cat_label  = card_row["category"]
+    word_label = card_row["word_zh"] or "?"
+    factor_val = int(new_interval * sibling_factor)
+
+    logger.debug(
+        "[SIBLING REPULSION]  #%d %s 「%s」  interval=%dd"
+        "  →  effective_sep = max(%dd, ⌊%d×%.2f⌋=%dd) = %dd  →  min_due=%s",
+        card_id, cat_label, word_label, new_interval,
+        sibling_separation, new_interval, sibling_factor, factor_val,
+        effective_sep, min_due,
+    )
+
     siblings = conn.execute(
         """SELECT id, category, state, due FROM cards
-           WHERE word_id = ? AND id != ? AND deleted_at IS NULL AND state NOT IN ('suspended', 'learning', 'relearn')""",
-        (card["word_id"], card_id),
+           WHERE word_id = (SELECT word_id FROM cards WHERE id = ?)
+             AND id != ? AND deleted_at IS NULL
+             AND state NOT IN ('suspended', 'learning', 'relearn')""",
+        (card_id, card_id),
     ).fetchall()
 
     pushed = []
     for s in siblings:
         if s["due"] < min_due:
             conn.execute("UPDATE cards SET due = ? WHERE id = ?", (min_due, s["id"]))
-            pushed.append((s["id"], s["category"], s["due"], min_due))
+            days_pushed = (date.fromisoformat(min_due) - date.fromisoformat(s["due"])).days
+            pushed.append((s["id"], s["category"], s["due"], min_due, days_pushed))
 
     if pushed:
-        for sid, cat, old_due, new_due in pushed:
+        for sid, cat, old_due, new_due, days_pushed in pushed:
             logger.debug(
-                "[sibling_repulsion]   pushed sibling #%d (%s): %s → %s",
-                sid, cat, old_due, new_due,
+                "  →  pushed  #%d %-10s  %s  →  %s  (+%dd)",
+                sid, cat, old_due, new_due, days_pushed,
             )
     else:
-        logger.debug("[sibling_repulsion]   no siblings needed pushing")
+        logger.debug("  →  all siblings already beyond min_due=%s, no push needed", min_due)
 
     conn.commit()
     conn.close()

--- a/database/cards.py
+++ b/database/cards.py
@@ -373,8 +373,8 @@ def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = Fa
         cards = new_cards + lr
     elif nr_o == "reviews_first":
         cards = lr + new_cards
-    else:  # mixed: distribute new cards evenly throughout lr
-        cards = _interleave_cards(lr, new_cards)
+    else:  # mixed: learning first, then interleave new cards evenly among reviews
+        cards = learning_cards + _interleave_cards(review_cards, new_cards)
 
     # ── 5. Sibling suppression (for story word-list building) ─────────────────
     if sibling_suppression and any(resolve_bury_flags(preset)):

--- a/database/cards.py
+++ b/database/cards.py
@@ -1,5 +1,5 @@
 import sqlite3
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from .core import get_db, anki_today
 from .presets import get_preset_for_deck
 from .decks import get_deck
@@ -10,13 +10,20 @@ from .decks import get_deck
 # ---------------------------------------------------------------------------
 
 def insert_card(word_id: int, category: str, deck_id: int,
-                state: str = "new") -> int:
+                state: str = "new", due: str | None = None) -> int:
     conn = get_db()
-    cur = conn.execute(
-        """INSERT OR IGNORE INTO cards (word_id, deck_id, category, state)
-           VALUES (?, ?, ?, ?)""",
-        (word_id, deck_id, category, state),
-    )
+    if due is not None:
+        conn.execute(
+            """INSERT OR IGNORE INTO cards (word_id, deck_id, category, state, due)
+               VALUES (?, ?, ?, ?, ?)""",
+            (word_id, deck_id, category, state, due),
+        )
+    else:
+        conn.execute(
+            """INSERT OR IGNORE INTO cards (word_id, deck_id, category, state)
+               VALUES (?, ?, ?, ?)""",
+            (word_id, deck_id, category, state),
+        )
     conn.commit()
     row = conn.execute(
         "SELECT id FROM cards WHERE word_id = ? AND category = ?",
@@ -848,6 +855,40 @@ def get_sibling_cards(card_id: int) -> list[dict]:
     ).fetchall()
     conn.close()
     return [dict(r) for r in rows]
+
+
+def apply_sibling_repulsion(card_id: int, new_interval: int, sibling_separation: int) -> None:
+    """Push sibling due dates that fall within sibling_separation days of today.
+
+    Only applied when the reviewed card's new_interval exceeds sibling_separation,
+    so initial learning (small intervals) is unaffected — the staggered introduction
+    handles that phase.  Only review/new-state siblings are adjusted (learning/relearn
+    cards use datetime-based due values that should not be touched here).
+    """
+    if new_interval <= sibling_separation:
+        return
+
+    today = anki_today()
+    min_due = (today + timedelta(days=sibling_separation)).isoformat()
+
+    conn = get_db()
+    card = conn.execute("SELECT word_id FROM cards WHERE id = ?", (card_id,)).fetchone()
+    if not card:
+        conn.close()
+        return
+
+    siblings = conn.execute(
+        """SELECT id, state, due FROM cards
+           WHERE word_id = ? AND id != ? AND deleted_at IS NULL AND state NOT IN ('suspended', 'learning', 'relearn')""",
+        (card["word_id"], card_id),
+    ).fetchall()
+
+    for s in siblings:
+        if s["due"] < min_due:
+            conn.execute("UPDATE cards SET due = ? WHERE id = ?", (min_due, s["id"]))
+
+    conn.commit()
+    conn.close()
 
 
 def get_creating_all_suspended(deck_id: int) -> bool:

--- a/database/core.py
+++ b/database/core.py
@@ -213,6 +213,8 @@ def init_db() -> None:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN new_review_order_override TEXT")
     if "sibling_separation" not in preset_cols:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN sibling_separation INTEGER NOT NULL DEFAULT 3")
+    if "sibling_factor" not in preset_cols:
+        conn.execute("ALTER TABLE deck_presets ADD COLUMN sibling_factor REAL NOT NULL DEFAULT 0.2")
 
     conn.execute("""CREATE TABLE IF NOT EXISTS preset_category_overrides (
         id                  INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/database/core.py
+++ b/database/core.py
@@ -212,6 +212,22 @@ def init_db() -> None:
     if "new_review_order_override" not in preset_cols:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN new_review_order_override TEXT")
 
+    conn.execute("""CREATE TABLE IF NOT EXISTS preset_category_overrides (
+        id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+        preset_id           INTEGER NOT NULL REFERENCES deck_presets(id) ON DELETE CASCADE,
+        category            TEXT NOT NULL CHECK(category IN ('listening', 'reading', 'creating')),
+        new_per_day         INTEGER,
+        reviews_per_day     INTEGER,
+        learning_steps      TEXT,
+        graduating_interval INTEGER,
+        easy_interval       INTEGER,
+        relearning_steps    TEXT,
+        minimum_interval    INTEGER,
+        leech_threshold     INTEGER,
+        leech_action        TEXT CHECK(leech_action IN ('suspend', 'tag')),
+        UNIQUE(preset_id, category)
+    )""")
+
     # Normalize legacy due values: learning/relearn cards whose due datetime
     # falls on a future Anki day should store just the date (no time component).
     # This matches the new _smart_due() rule in srs.py.

--- a/database/core.py
+++ b/database/core.py
@@ -211,6 +211,8 @@ def init_db() -> None:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN category_order TEXT NOT NULL DEFAULT 'listening,reading,creating'")
     if "new_review_order_override" not in preset_cols:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN new_review_order_override TEXT")
+    if "sibling_separation" not in preset_cols:
+        conn.execute("ALTER TABLE deck_presets ADD COLUMN sibling_separation INTEGER NOT NULL DEFAULT 3")
 
     conn.execute("""CREATE TABLE IF NOT EXISTS preset_category_overrides (
         id                  INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/database/presets.py
+++ b/database/presets.py
@@ -89,7 +89,7 @@ def get_preset(preset_id: int) -> dict:
     return dict(row) if row else None
 
 
-def get_preset_for_deck(deck_id: int) -> dict:
+def get_preset_for_deck(deck_id: int, category: str | None = None) -> dict:
     conn = get_db()
     row = conn.execute(
         """SELECT p.*,
@@ -98,8 +98,8 @@ def get_preset_for_deck(deck_id: int) -> dict:
            FROM deck_presets p JOIN decks d ON d.preset_id = p.id WHERE d.id = ?""",
         (deck_id,),
     ).fetchone()
-    conn.close()
     if not row:
+        conn.close()
         return None
     preset = dict(row)
     deck_nro = preset.pop("deck_nro_override", None)
@@ -108,7 +108,87 @@ def get_preset_for_deck(deck_id: int) -> dict:
     deck_bury = preset.pop("deck_bury_quick_mode", None)
     if deck_bury is not None:
         preset["bury_quick_mode"] = deck_bury
+
+    if category:
+        override_row = conn.execute(
+            "SELECT * FROM preset_category_overrides WHERE preset_id = ? AND category = ?",
+            (preset["id"], category),
+        ).fetchone()
+        if override_row:
+            for key, val in dict(override_row).items():
+                if key not in ("id", "preset_id", "category") and val is not None:
+                    preset[key] = val
+
+    conn.close()
     return preset
+
+
+# ---------------------------------------------------------------------------
+# Category overrides
+# ---------------------------------------------------------------------------
+
+_OVERRIDE_FIELDS = {
+    "new_per_day", "reviews_per_day", "learning_steps",
+    "graduating_interval", "easy_interval", "relearning_steps",
+    "minimum_interval", "leech_threshold", "leech_action",
+}
+
+
+def get_category_overrides(preset_id: int) -> dict:
+    """Return {category: {field: value, ...}} for all overrides of a preset."""
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT * FROM preset_category_overrides WHERE preset_id = ?", (preset_id,)
+    ).fetchall()
+    conn.close()
+    result = {}
+    for r in rows:
+        d = dict(r)
+        cat = d.pop("category")
+        d.pop("id", None)
+        d.pop("preset_id", None)
+        result[cat] = {k: v for k, v in d.items() if v is not None}
+    return result
+
+
+def set_category_override(preset_id: int, category: str, fields: dict) -> None:
+    """Upsert category-level scheduling overrides. Pass None values to clear a field."""
+    allowed = {k: fields[k] for k in fields if k in _OVERRIDE_FIELDS}
+    if not allowed:
+        return
+    conn = get_db()
+    existing = conn.execute(
+        "SELECT id FROM preset_category_overrides WHERE preset_id = ? AND category = ?",
+        (preset_id, category),
+    ).fetchone()
+    if existing:
+        set_clause = ", ".join(f"{k} = :{k}" for k in allowed)
+        allowed["_pid"] = preset_id
+        allowed["_cat"] = category
+        conn.execute(
+            f"UPDATE preset_category_overrides SET {set_clause} WHERE preset_id = :_pid AND category = :_cat",
+            allowed,
+        )
+    else:
+        cols = ", ".join(["preset_id", "category"] + list(allowed.keys()))
+        placeholders = ", ".join([":preset_id", ":category"] + [f":{k}" for k in allowed])
+        allowed["preset_id"] = preset_id
+        allowed["category"] = category
+        conn.execute(
+            f"INSERT INTO preset_category_overrides ({cols}) VALUES ({placeholders})", allowed
+        )
+    conn.commit()
+    conn.close()
+
+
+def delete_category_override(preset_id: int, category: str) -> None:
+    conn = get_db()
+    conn.execute(
+        "DELETE FROM preset_category_overrides WHERE preset_id = ? AND category = ?",
+        (preset_id, category),
+    )
+    conn.commit()
+    conn.close()
 
 
 def insert_preset(preset: dict) -> int:

--- a/database/presets.py
+++ b/database/presets.py
@@ -32,6 +32,7 @@ def default_preset() -> dict:
         "bury_quick_mode": "all",
         "category_order": "listening,reading,creating",
         "sibling_separation": 3,
+        "sibling_factor": 0.2,
     }
 
 
@@ -203,7 +204,7 @@ def insert_preset(preset: dict) -> int:
             new_gather_order, new_sort_order, new_review_order,
             interday_learning_review_order, review_sort_order,
             bury_new_siblings, bury_review_siblings, bury_interday_siblings,
-            bury_quick_mode, category_order, sibling_separation)
+            bury_quick_mode, category_order, sibling_separation, sibling_factor)
            VALUES (:name, :new_per_day, :reviews_per_day,
                    :learning_steps, :graduating_interval, :easy_interval,
                    :relearning_steps, :minimum_interval, :insertion_order,
@@ -211,7 +212,7 @@ def insert_preset(preset: dict) -> int:
                    :new_gather_order, :new_sort_order, :new_review_order,
                    :interday_learning_review_order, :review_sort_order,
                    :bury_new_siblings, :bury_review_siblings, :bury_interday_siblings,
-                   :bury_quick_mode, :category_order, :sibling_separation)""",
+                   :bury_quick_mode, :category_order, :sibling_separation, :sibling_factor)""",
         preset,
     )
     conn.commit()
@@ -230,7 +231,7 @@ def update_preset(preset_id: int, fields: dict) -> None:
         "interday_learning_review_order", "review_sort_order",
         "bury_new_siblings", "bury_review_siblings", "bury_interday_siblings",
         "bury_quick_mode", "category_order", "new_review_order_override",
-        "sibling_separation",
+        "sibling_separation", "sibling_factor",
     }
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:

--- a/database/presets.py
+++ b/database/presets.py
@@ -31,6 +31,7 @@ def default_preset() -> dict:
         "bury_interday_siblings": 0,
         "bury_quick_mode": "all",
         "category_order": "listening,reading,creating",
+        "sibling_separation": 3,
     }
 
 
@@ -202,7 +203,7 @@ def insert_preset(preset: dict) -> int:
             new_gather_order, new_sort_order, new_review_order,
             interday_learning_review_order, review_sort_order,
             bury_new_siblings, bury_review_siblings, bury_interday_siblings,
-            bury_quick_mode, category_order)
+            bury_quick_mode, category_order, sibling_separation)
            VALUES (:name, :new_per_day, :reviews_per_day,
                    :learning_steps, :graduating_interval, :easy_interval,
                    :relearning_steps, :minimum_interval, :insertion_order,
@@ -210,7 +211,7 @@ def insert_preset(preset: dict) -> int:
                    :new_gather_order, :new_sort_order, :new_review_order,
                    :interday_learning_review_order, :review_sort_order,
                    :bury_new_siblings, :bury_review_siblings, :bury_interday_siblings,
-                   :bury_quick_mode, :category_order)""",
+                   :bury_quick_mode, :category_order, :sibling_separation)""",
         preset,
     )
     conn.commit()
@@ -229,6 +230,7 @@ def update_preset(preset_id: int, fields: dict) -> None:
         "interday_learning_review_order", "review_sort_order",
         "bury_new_siblings", "bury_review_siblings", "bury_interday_siblings",
         "bury_quick_mode", "category_order", "new_review_order_override",
+        "sibling_separation",
     }
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:

--- a/importer.py
+++ b/importer.py
@@ -752,13 +752,17 @@ def _create_cards(word_id: int, deck_ids: dict,
     if suspended_states is None:
         suspended_states = _DEFAULT_SUSPENDED
     today = database.anki_today()
+    from datetime import timedelta
     for category, deck_id in deck_ids.items():
         is_suspended = suspended_states.get(category,
                                             _DEFAULT_SUSPENDED.get(category, False))
         state = "suspended" if is_suspended else "new"
         offset = _CATEGORY_DUE_OFFSET.get(category, 0)
-        from datetime import timedelta
         due = (today + timedelta(days=offset)).isoformat() if not is_suspended else None
+        logger.debug(
+            "[stagger_intro] word_id=%d  category=%s  state=%s  due=%s (offset=+%d)",
+            word_id, category, state, due or "default", offset,
+        )
         database.insert_card(word_id, category, deck_id, state=state, due=due)
 
 

--- a/importer.py
+++ b/importer.py
@@ -740,15 +740,26 @@ _DEFAULT_SUSPENDED: dict[str, bool] = {
 }
 
 
+_CATEGORY_DUE_OFFSET: dict[str, int] = {
+    "reading": 0,
+    "listening": 1,
+    "creating": 2,
+}
+
+
 def _create_cards(word_id: int, deck_ids: dict,
                   suspended_states: dict[str, bool] | None = None) -> None:
     if suspended_states is None:
         suspended_states = _DEFAULT_SUSPENDED
+    today = database.anki_today()
     for category, deck_id in deck_ids.items():
         is_suspended = suspended_states.get(category,
                                             _DEFAULT_SUSPENDED.get(category, False))
         state = "suspended" if is_suspended else "new"
-        database.insert_card(word_id, category, deck_id, state=state)
+        offset = _CATEGORY_DUE_OFFSET.get(category, 0)
+        from datetime import timedelta
+        due = (today + timedelta(days=offset)).isoformat() if not is_suspended else None
+        database.insert_card(word_id, category, deck_id, state=state, due=due)
 
 
 def _hsk_to_int(hsk_str: str) -> int | None:

--- a/importer.py
+++ b/importer.py
@@ -711,7 +711,7 @@ def _import_entries(entries: list, deck_ids: dict, source: str, label: str,
             logger.info("CATEGORIES %s: %r active=%r", label, word_zh, list(active))
         else:
             suspended_states = card_cfg.get("suspended") or None
-        _create_cards(word_id, target_deck_ids, suspended_states)
+        _create_cards(word_id, target_deck_ids, suspended_states, word_zh=word_zh)
         imported += 1
 
     return {"imported": imported, "skipped_duplicate": skipped_duplicate,
@@ -748,22 +748,26 @@ _CATEGORY_DUE_OFFSET: dict[str, int] = {
 
 
 def _create_cards(word_id: int, deck_ids: dict,
-                  suspended_states: dict[str, bool] | None = None) -> None:
+                  suspended_states: dict[str, bool] | None = None,
+                  word_zh: str = "") -> None:
     if suspended_states is None:
         suspended_states = _DEFAULT_SUSPENDED
     today = database.anki_today()
     from datetime import timedelta
+    lines = []
     for category, deck_id in deck_ids.items():
         is_suspended = suspended_states.get(category,
                                             _DEFAULT_SUSPENDED.get(category, False))
         state = "suspended" if is_suspended else "new"
         offset = _CATEGORY_DUE_OFFSET.get(category, 0)
         due = (today + timedelta(days=offset)).isoformat() if not is_suspended else None
-        logger.debug(
-            "[stagger_intro] word_id=%d  category=%s  state=%s  due=%s (offset=+%d)",
-            word_id, category, state, due or "default", offset,
-        )
+        tag = "  [SUSPENDED]" if is_suspended else ""
+        lines.append(f"  {category:<10}  due={due or '(none)'}  (+{offset}d){tag}")
         database.insert_card(word_id, category, deck_id, state=state, due=due)
+    logger.debug(
+        "[STAGGER INTRO]  「%s」 (word_id=%d)\n%s",
+        word_zh or "?", word_id, "\n".join(lines),
+    )
 
 
 def _hsk_to_int(hsk_str: str) -> int | None:

--- a/routes/decks.py
+++ b/routes/decks.py
@@ -206,8 +206,10 @@ def delete_preset(preset_id: int):
 
 
 @router.get("/api/decks/{deck_id}/preset")
-def get_deck_preset(deck_id: int):
-    return database.get_preset_for_deck(deck_id)
+def get_deck_preset(deck_id: int, category: str | None = None):
+    preset = database.get_preset_for_deck(deck_id, category)
+    preset["category_overrides"] = database.get_category_overrides(preset["id"])
+    return preset
 
 
 @router.put("/api/decks/{deck_id}/preset")
@@ -252,3 +254,40 @@ def set_deck_preset_as_default(deck_id: int):
     deck = database.get_deck(deck_id)
     database.set_default_preset(deck["preset_id"])
     return database.get_preset(deck["preset_id"])
+
+
+# ---------------------------------------------------------------------------
+# Category-level scheduling overrides
+# ---------------------------------------------------------------------------
+
+VALID_CATEGORIES = {"listening", "reading", "creating"}
+
+
+@router.get("/api/presets/{preset_id}/categories")
+def get_preset_category_overrides(preset_id: int):
+    return database.get_category_overrides(preset_id)
+
+
+@router.get("/api/presets/{preset_id}/categories/{category}")
+def get_preset_category_override(preset_id: int, category: str):
+    if category not in VALID_CATEGORIES:
+        raise HTTPException(status_code=400, detail="Invalid category")
+    overrides = database.get_category_overrides(preset_id)
+    return overrides.get(category, {})
+
+
+@router.put("/api/presets/{preset_id}/categories/{category}")
+def set_preset_category_override(preset_id: int, category: str, fields: dict):
+    if category not in VALID_CATEGORIES:
+        raise HTTPException(status_code=400, detail="Invalid category")
+    database.set_category_override(preset_id, category, fields)
+    overrides = database.get_category_overrides(preset_id)
+    return overrides.get(category, {})
+
+
+@router.delete("/api/presets/{preset_id}/categories/{category}")
+def delete_preset_category_override(preset_id: int, category: str):
+    if category not in VALID_CATEGORIES:
+        raise HTTPException(status_code=400, detail="Invalid category")
+    database.delete_category_override(preset_id, category)
+    return {"ok": True}

--- a/routes/review.py
+++ b/routes/review.py
@@ -107,8 +107,9 @@ def submit_review(card_id: int, rating: int, user_response: str | None = None,
     # Only kicks in when the reviewed card has a long enough interval (> sibling_separation),
     # leaving the initial staggered-introduction phase unaffected.
     preset = database.get_preset_for_deck(deck_id)
-    sibling_sep = preset.get("sibling_separation", 3)
-    database.apply_sibling_repulsion(card_id, updated.get("interval", 0), sibling_sep)
+    sibling_sep    = preset.get("sibling_separation", 3)
+    sibling_factor = preset.get("sibling_factor", 0.2)
+    database.apply_sibling_repulsion(card_id, updated.get("interval", 0), sibling_sep, sibling_factor)
 
     # Snapshot sibling buried_until values BEFORE burying so undo can restore them
     siblings_before = database.get_sibling_cards(card_id)

--- a/routes/review.py
+++ b/routes/review.py
@@ -103,6 +103,13 @@ def submit_review(card_id: int, rating: int, user_response: str | None = None,
     deck_id = updated["deck_id"]
     cat     = updated["category"]
 
+    # Apply sibling repulsion: push sibling due dates that are too close to today.
+    # Only kicks in when the reviewed card has a long enough interval (> sibling_separation),
+    # leaving the initial staggered-introduction phase unaffected.
+    preset = database.get_preset_for_deck(deck_id)
+    sibling_sep = preset.get("sibling_separation", 3)
+    database.apply_sibling_repulsion(card_id, updated.get("interval", 0), sibling_sep)
+
     # Snapshot sibling buried_until values BEFORE burying so undo can restore them
     siblings_before = database.get_sibling_cards(card_id)
     siblings_snapshot = [
@@ -110,7 +117,6 @@ def submit_review(card_id: int, rating: int, user_response: str | None = None,
         for s in siblings_before
     ]
 
-    preset = database.get_preset_for_deck(deck_id)
     bury_new, bury_review, bury_learning = database.resolve_bury_flags(preset)
     logger.debug(
         "[preset] deck=%d  bury_quick_mode=%s → new=%s review=%s learning=%s\n"

--- a/routes/review.py
+++ b/routes/review.py
@@ -109,7 +109,12 @@ def submit_review(card_id: int, rating: int, user_response: str | None = None,
     preset = database.get_preset_for_deck(deck_id)
     sibling_sep    = preset.get("sibling_separation", 3)
     sibling_factor = preset.get("sibling_factor", 0.2)
-    database.apply_sibling_repulsion(card_id, updated.get("interval", 0), sibling_sep, sibling_factor)
+    new_interval   = updated.get("interval", 0)
+    logger.debug(
+        "[sibling_repulsion] triggering for card=#%d  new_interval=%d  sep=%d  factor=%.2f",
+        card_id, new_interval, sibling_sep, sibling_factor,
+    )
+    database.apply_sibling_repulsion(card_id, new_interval, sibling_sep, sibling_factor)
 
     # Snapshot sibling buried_until values BEFORE burying so undo can restore them
     siblings_before = database.get_sibling_cards(card_id)

--- a/routes/story.py
+++ b/routes/story.py
@@ -1,5 +1,6 @@
 import logging
 
+import jieba
 import database
 import ai
 import tts
@@ -7,6 +8,17 @@ from fastapi import APIRouter
 from fastapi.responses import FileResponse
 
 from .utils import DISABLE_AI, leaf_ids
+
+# Suppress jieba's startup log messages
+jieba.setLogLevel(logging.ERROR)
+
+
+def _add_tokens(sentences: list[dict]) -> list[dict]:
+    """Add jieba word segmentation tokens to each story sentence."""
+    for s in sentences:
+        zh = s.get("sentence_zh") or ""
+        s["tokens"] = jieba.lcut(zh) if zh else []
+    return sentences
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -81,7 +93,7 @@ def get_story(deck_id: int, category: str,
     if not topic and max_hsk == 2 and not model:
         story = database.get_active_story(today, category, deck_id)
         if story:
-            story["sentences"] = database.get_story_sentences(story["id"])
+            story["sentences"] = _add_tokens(database.get_story_sentences(story["id"]))
             logger.info("story  CACHED  deck=%d cat=%s sentences=%d story_id=%d",
                         deck_id, category, len(story["sentences"]), story["id"])
             _log_story(story)
@@ -122,7 +134,7 @@ def get_story(deck_id: int, category: str,
             }
 
     if story:
-        story["sentences"] = database.get_story_sentences(story["id"])
+        story["sentences"] = _add_tokens(database.get_story_sentences(story["id"]))
         logger.info("story  SAVED   deck=%d cat=%s sentences=%d",
                     deck_id, category, len(story["sentences"]))
         _log_story(story)
@@ -168,7 +180,7 @@ def regenerate_story(deck_id: int, category: str,
             "has_history": database.has_story_history(deck_id, category),
         }
     if story:
-        story["sentences"] = database.get_story_sentences(story["id"])
+        story["sentences"] = _add_tokens(database.get_story_sentences(story["id"]))
         logger.info("regen  SAVED sentences=%d", len(story["sentences"]))
         _log_story(story)
     return story
@@ -179,7 +191,7 @@ def get_history_story(deck_id: int, category: str):
     """Return the most recent story for this deck+category, regardless of date."""
     story = database.get_latest_story(deck_id, category)
     if story:
-        story["sentences"] = database.get_story_sentences(story["id"])
+        story["sentences"] = _add_tokens(database.get_story_sentences(story["id"]))
     return story
 
 
@@ -249,7 +261,7 @@ async def preload_session(deck_id: int, category: str):
     story = database.get_active_story(today, category, deck_id)
     progress_key = f"{deck_id}/{category}"
     if story:
-        sentences = database.get_story_sentences(story["id"])
+        sentences = _add_tokens(database.get_story_sentences(story["id"]))
         texts = [s["sentence_zh"] for s in sentences if s.get("sentence_zh")]
         logger.info("tts  preloading %d sentences", len(texts))
         try:

--- a/routes/story.py
+++ b/routes/story.py
@@ -72,13 +72,14 @@ def _validated_model(model: str | None) -> str:
 @router.get("/api/story/{deck_id}/{category}")
 def get_story(deck_id: int, category: str,
               topic: str | None = None, max_hsk: int = 2,
-              model: str | None = None):
+              model: str | None = None,
+              grammar_focus: str | None = None, grammar_pct: int = 50):
     if database.is_sentences_deck(deck_id):
         return None
 
     today = database.anki_today().isoformat()
     # Only use cached story if no custom options were provided
-    if not topic and max_hsk == 2 and not model:
+    if not topic and max_hsk == 2 and not model and not grammar_focus:
         story = database.get_active_story(today, category, deck_id)
         if story:
             story["sentences"] = database.get_story_sentences(story["id"])
@@ -103,7 +104,9 @@ def get_story(deck_id: int, category: str,
         try:
             sentences, prompt_text = ai.generate_story(cards, topic=topic, max_hsk=max_hsk,
                                                        model=chosen_model,
-                                                       progress_key=progress_key)
+                                                       progress_key=progress_key,
+                                                       grammar_focus=grammar_focus,
+                                                       grammar_pct=grammar_pct)
             for i, s in enumerate(sentences):
                 s["position"] = i
             database.create_story(today, category, deck_id, sentences, prompt_text, topic)
@@ -132,7 +135,8 @@ def get_story(deck_id: int, category: str,
 @router.post("/api/story/{deck_id}/{category}/regenerate")
 def regenerate_story(deck_id: int, category: str,
                      topic: str | None = None, max_hsk: int = 2,
-                     model: str | None = None):
+                     model: str | None = None,
+                     grammar_focus: str | None = None, grammar_pct: int = 50):
     if database.is_sentences_deck(deck_id):
         return None
     if DISABLE_AI:
@@ -150,7 +154,9 @@ def regenerate_story(deck_id: int, category: str,
     try:
         sentences, prompt_text = ai.generate_story(cards, topic=topic, max_hsk=max_hsk,
                                                    model=chosen_model,
-                                                   progress_key=progress_key)
+                                                   progress_key=progress_key,
+                                                   grammar_focus=grammar_focus,
+                                                   grammar_pct=grammar_pct)
         for i, s in enumerate(sentences):
             s["position"] = i
         database.create_story(today, category, deck_id, sentences, prompt_text, topic)

--- a/schema.sql
+++ b/schema.sql
@@ -88,7 +88,11 @@ CREATE TABLE IF NOT EXISTS deck_presets (
     category_order          TEXT NOT NULL DEFAULT 'listening,reading,creating',
 
     -- Minimum days between sibling card reviews (R/T/C of the same word)
-    sibling_separation      INTEGER NOT NULL DEFAULT 3
+    sibling_separation      INTEGER NOT NULL DEFAULT 3,
+
+    -- Fraction of current interval applied as additional sibling separation
+    -- effective_separation = max(sibling_separation, floor(interval * sibling_factor))
+    sibling_factor          REAL NOT NULL DEFAULT 0.2
 );
 
 -- ---------------------------------------------------------------------------

--- a/schema.sql
+++ b/schema.sql
@@ -85,7 +85,10 @@ CREATE TABLE IF NOT EXISTS deck_presets (
                                 CHECK(bury_quick_mode IN ('all', 'none', 'custom')),
 
     -- Order of L/R/C category pills shown in the deck list
-    category_order          TEXT NOT NULL DEFAULT 'listening,reading,creating'
+    category_order          TEXT NOT NULL DEFAULT 'listening,reading,creating',
+
+    -- Minimum days between sibling card reviews (R/T/C of the same word)
+    sibling_separation      INTEGER NOT NULL DEFAULT 3
 );
 
 -- ---------------------------------------------------------------------------

--- a/schema.sql
+++ b/schema.sql
@@ -390,3 +390,24 @@ CREATE TABLE IF NOT EXISTS grammar_expressions (
     meaning     TEXT,
     position    INTEGER NOT NULL DEFAULT 0
 );
+
+-- ---------------------------------------------------------------------------
+-- preset_category_overrides
+-- Per-category scheduling overrides for a preset.
+-- NULL fields mean "use the preset default".
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS preset_category_overrides (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    preset_id           INTEGER NOT NULL REFERENCES deck_presets(id) ON DELETE CASCADE,
+    category            TEXT NOT NULL CHECK(category IN ('listening', 'reading', 'creating')),
+    new_per_day         INTEGER,
+    reviews_per_day     INTEGER,
+    learning_steps      TEXT,
+    graduating_interval INTEGER,
+    easy_interval       INTEGER,
+    relearning_steps    TEXT,
+    minimum_interval    INTEGER,
+    leech_threshold     INTEGER,
+    leech_action        TEXT CHECK(leech_action IN ('suspend', 'tag')),
+    UNIQUE(preset_id, category)
+);

--- a/static/app.js
+++ b/static/app.js
@@ -2052,7 +2052,7 @@ async function startReview(id, cat, name, noStory = false) {
   }
 }
 
-async function _doStartReview(topic, maxHsk, model) {
+async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct) {
   setLoading('Generating story…', true);
   setLoadingStep(10, null, 'Sending request to AI…');
   _startFakeProgress(10, 55, 45000);
@@ -2060,7 +2060,7 @@ async function _doStartReview(topic, maxHsk, model) {
     const storyDeckId = rootDeckId || deckId;
     const storyCategory = rootDeckId ? 'unified' : category;
     _startStoryProgressPoll(storyDeckId, storyCategory);
-    const storyUrl = `/api/story/${storyDeckId}/${storyCategory}` + _storyParams(topic, maxHsk, model);
+    const storyUrl = `/api/story/${storyDeckId}/${storyCategory}` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct);
     let todayData, storyData;
     try {
       [todayData, storyData] = await Promise.all([
@@ -2078,7 +2078,7 @@ async function _doStartReview(topic, maxHsk, model) {
 
     _stopFakeProgress(); _stopStoryProgressPoll();
     setLoadingStep(65, null, 'Story received, processing…');
-    story = await _resolveStory(storyData, storyDeckId, storyCategory, topic, maxHsk);
+    story = await _resolveStory(storyData, storyDeckId, storyCategory, topic, maxHsk, grammarFocus, grammarPct);
 
     if (!todayData.card) {
       showView('done');
@@ -2106,11 +2106,13 @@ async function _doStartReview(topic, maxHsk, model) {
   }
 }
 
-function _storyParams(topic, maxHsk, model) {
+function _storyParams(topic, maxHsk, model, grammarFocus, grammarPct) {
   const p = new URLSearchParams();
   if (topic)                              p.set('topic', topic);
   if (maxHsk !== 2)                       p.set('max_hsk', maxHsk);
   if (model && model !== 'deepseek-chat') p.set('model', model);
+  if (grammarFocus)                       p.set('grammar_focus', grammarFocus);
+  if (grammarFocus && grammarPct !== 50)  p.set('grammar_pct', grammarPct);
   const s = p.toString();
   return s ? '?' + s : '';
 }
@@ -2131,7 +2133,7 @@ async function startReviewMixed(id, name, noStory = false) {
       return;
     }
     if (noStory) {
-      await _doStartReviewMixed(null, 2, null, true);
+      await _doStartReviewMixed(null, 2, null, null, 50, true);
       return;
     }
     const c = todayData.counts;
@@ -2140,7 +2142,7 @@ async function startReviewMixed(id, name, noStory = false) {
     const firstCat = todayData.card.category;
     const { has_story, estimated_tokens } = await api('GET', `/api/story/${id}/unified/count`);
     if (has_story) {
-      await _doStartReviewMixed(null, 2);
+      await _doStartReviewMixed(null, 2, null, null, 50);
     } else {
       openStorySetup(total, { isMixed: true, learningCount: learning, estimatedTokens: estimated_tokens });
     }
@@ -2151,7 +2153,7 @@ async function startReviewMixed(id, name, noStory = false) {
   }
 }
 
-async function _doStartReviewMixed(topic, maxHsk, model, noStory = false) {
+async function _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPct, noStory = false) {
   setLoading(noStory ? 'Loading…' : 'Generating stories…', !noStory);
   if (!noStory) {
     setLoadingStep(10, null, 'Sending request to AI…');
@@ -2171,7 +2173,7 @@ async function _doStartReviewMixed(topic, maxHsk, model, noStory = false) {
     if (!noStory) {
       // Load a single unified story covering all categories (1 AI call instead of 3)
       try {
-        story = await api('GET', `/api/story/${rootDeckId}/unified` + _storyParams(topic, maxHsk, model));
+        story = await api('GET', `/api/story/${rootDeckId}/unified` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct));
       } catch (e) {
         _stopFakeProgress(); _stopStoryProgressPoll();
         _showLoadingError('AI request failed', e.message);
@@ -2230,7 +2232,7 @@ async function startReviewUnfinished() {
   }
 }
 
-async function _doStartReviewUnfinished(topic, maxHsk, model) {
+async function _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, grammarPct) {
   unfinishedMode = true;
   setLoading('Loading cards…');
   try {
@@ -2247,7 +2249,7 @@ async function _doStartReviewUnfinished(topic, maxHsk, model) {
     const firstDeckId = todayData.card.deck_id;
     // Load a single unified story for the first card's deck
     try {
-      story = await api('GET', `/api/story/${firstDeckId}/unified` + _storyParams(topic, maxHsk, model));
+      story = await api('GET', `/api/story/${firstDeckId}/unified` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct));
     } catch (_) {}
     fetch(`/api/preload-session/${firstDeckId}/unified`, { method: 'POST' }).catch(() => {});
     showView('review');
@@ -3081,7 +3083,7 @@ function storyErrorUseHistory() {
   if (_storyErrorResolve) { _storyErrorResolve({ action: 'history' }); _storyErrorResolve = null; }
 }
 
-async function _resolveStory(storyData, resolvedeckId, resolveCat, topic, maxHsk) {
+async function _resolveStory(storyData, resolvedeckId, resolveCat, topic, maxHsk, grammarFocus, grammarPct) {
   if (!storyData?.error) return storyData;
   const choice = await _openStoryErrorModal(storyData);
   if (choice.action === 'skip') return null;
@@ -3096,12 +3098,12 @@ async function _resolveStory(storyData, resolvedeckId, resolveCat, topic, maxHsk
   _startStoryProgressPoll(resolvedeckId, resolveCat);
   let newData;
   try {
-    newData = await api('GET', `/api/story/${resolvedeckId}/${resolveCat}` + _storyParams(topic, maxHsk, choice.model));
+    newData = await api('GET', `/api/story/${resolvedeckId}/${resolveCat}` + _storyParams(topic, maxHsk, choice.model, grammarFocus, grammarPct));
   } catch (e) {
     newData = { error: true, reason: e.message, model: choice.model, has_history: storyData.has_history };
   }
   _stopFakeProgress(); _stopStoryProgressPoll();
-  return _resolveStory(newData, resolvedeckId, resolveCat, topic, maxHsk);
+  return _resolveStory(newData, resolvedeckId, resolveCat, topic, maxHsk, grammarFocus, grammarPct);
 }
 
 // ── Story setup modal ────────────────────────────────────────────────────────
@@ -3136,6 +3138,8 @@ function openStorySetup(sentenceCount, { isMixed = false, isUnfinished = false, 
     }
   }
   document.getElementById('setup-topic').value = '';
+  document.getElementById('setup-grammar').value = '';
+  document.getElementById('setup-grammar-pct').value = 50;
   document.getElementById('setup-hsk-slider').value = 2;
   updateHskLabel();
   document.getElementById('setup-modal-overlay').style.display = 'block';
@@ -3157,20 +3161,22 @@ function updateHskLabel() {
 }
 
 function confirmStorySetup() {
-  const topic  = document.getElementById('setup-topic').value.trim() || null;
-  const maxHsk = parseInt(document.getElementById('setup-hsk-slider').value, 10);
-  const model  = document.getElementById('setup-model').value;
+  const topic       = document.getElementById('setup-topic').value.trim() || null;
+  const maxHsk      = parseInt(document.getElementById('setup-hsk-slider').value, 10);
+  const model       = document.getElementById('setup-model').value;
+  const grammarFocus = document.getElementById('setup-grammar').value.trim() || null;
+  const grammarPct  = parseInt(document.getElementById('setup-grammar-pct').value, 10) || 50;
   _closeSetupModal();
   if (_setupIsDeckListRegen) {
-    _doRegenStoryForDeckList(_deckListRegenId, topic, maxHsk, model);
+    _doRegenStoryForDeckList(_deckListRegenId, topic, maxHsk, model, grammarFocus, grammarPct);
   } else if (_setupIsRegen) {
-    _doRegenerateStory(topic, maxHsk, model);
+    _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct);
   } else if (_setupIsUnfinished) {
-    _doStartReviewUnfinished(topic, maxHsk, model);
+    _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, grammarPct);
   } else if (_setupIsMixed) {
-    _doStartReviewMixed(topic, maxHsk, model);
+    _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPct);
   } else {
-    _doStartReview(topic, maxHsk, model);
+    _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct);
   }
 }
 
@@ -3556,7 +3562,7 @@ async function regenerateStory() {
   }
 }
 
-async function _doRegenerateStory(topic, maxHsk, model) {
+async function _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct) {
   setLoading('Regenerating story…', true);
   setLoadingStep(10, null, 'Sending request to AI…');
   _startFakeProgress(10, 55, 45000);
@@ -3566,7 +3572,7 @@ async function _doRegenerateStory(topic, maxHsk, model) {
     _startStoryProgressPoll(storyDeckId, storyCategory);
     let storyData;
     try {
-      storyData = await api('POST', `/api/story/${storyDeckId}/${storyCategory}/regenerate` + _storyParams(topic, maxHsk, model));
+      storyData = await api('POST', `/api/story/${storyDeckId}/${storyCategory}/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct));
     } catch (e) {
       _stopFakeProgress(); _stopStoryProgressPoll();
       _showLoadingError('AI request failed', e.message);
@@ -3577,7 +3583,7 @@ async function _doRegenerateStory(topic, maxHsk, model) {
     }
     _stopFakeProgress(); _stopStoryProgressPoll();
     setLoadingStep(65, null, 'Story received, processing…');
-    story = await _resolveStory(storyData, storyDeckId, storyCategory, topic, maxHsk);
+    story = await _resolveStory(storyData, storyDeckId, storyCategory, topic, maxHsk, grammarFocus, grammarPct);
     sentence = story?.sentences?.find(s => s.word_id === card.word_id) || null;
     _updateStoryInfoRow();
 
@@ -3619,6 +3625,8 @@ async function regenerateStoryFromList(deckId) {
   const tokenWarn = document.getElementById('setup-token-warning');
   if (tokenWarn) tokenWarn.style.display = 'none';
   document.getElementById('setup-topic').value = '';
+  document.getElementById('setup-grammar').value = '';
+  document.getElementById('setup-grammar-pct').value = 50;
   document.getElementById('setup-hsk-slider').value = 2;
   updateHskLabel();
   document.getElementById('setup-modal-overlay').style.display = 'block';
@@ -3626,7 +3634,7 @@ async function regenerateStoryFromList(deckId) {
   document.getElementById('setup-topic').focus();
 }
 
-async function _doRegenStoryForDeckList(deckId, topic, maxHsk, model) {
+async function _doRegenStoryForDeckList(deckId, topic, maxHsk, model, grammarFocus, grammarPct) {
   setLoading('Regenerating story…', true);
   setLoadingStep(10, null, 'Sending request to AI…');
   _startFakeProgress(10, 55, 45000);
@@ -3634,7 +3642,7 @@ async function _doRegenStoryForDeckList(deckId, topic, maxHsk, model) {
   try {
     let storyData;
     try {
-      storyData = await api('POST', `/api/story/${deckId}/unified/regenerate` + _storyParams(topic, maxHsk, model));
+      storyData = await api('POST', `/api/story/${deckId}/unified/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct));
     } catch (e) {
       _stopFakeProgress(); _stopStoryProgressPoll();
       _showLoadingError('AI request failed', e.message);

--- a/static/app.js
+++ b/static/app.js
@@ -2882,8 +2882,11 @@ function renderWordAnalysis(container, wordData) {
   let wordGroups = [];
   if (isMultiWord) {
     wordGroups = wd?.components || [];
+  } else if (wd?.components?.length > 0) {
+    // New-format vocabulary: word_analyses stored as components (each with own characters)
+    wordGroups = wd.components;
   } else if (wd) {
-    // Single word: one group = the word itself
+    // Old-format vocabulary: characters linked directly to the entry
     wordGroups = [{
       id: wd.id,
       word_zh:       wd.word_zh    || card?.word_zh,

--- a/static/app.js
+++ b/static/app.js
@@ -1881,6 +1881,7 @@ function loadPresetFields(preset) {
   document.getElementById('opt-bury-review').checked   = !!preset.bury_review_siblings;
   document.getElementById('opt-bury-interday').checked = !!preset.bury_interday_siblings;
   document.getElementById('opt-sibling-sep').value     = preset.sibling_separation ?? 3;
+  document.getElementById('opt-sibling-factor').value  = preset.sibling_factor ?? 0.2;
 
   // Category order
   const order = (preset.category_order || 'listening,reading,creating').split(',').map(s => s.trim());
@@ -2040,6 +2041,7 @@ async function saveOptions() {
     bury_review_siblings:   document.getElementById('opt-bury-review').checked   ? 1 : 0,
     bury_interday_siblings: document.getElementById('opt-bury-interday').checked ? 1 : 0,
     sibling_separation:     parseInt(document.getElementById('opt-sibling-sep').value) || 3,
+    sibling_factor:         parseFloat(document.getElementById('opt-sibling-factor').value) || 0.2,
     category_order: _getCategoryOrderUI(),
   };
   // Warn if a story for today already exists — order settings change would cause mismatch

--- a/static/app.js
+++ b/static/app.js
@@ -1861,7 +1861,10 @@ function _getCategoryOrderUI() {
   return [...list.children].map(el => el.dataset.cat).join(',');
 }
 
+let currentPresetId = null;
+
 function loadPresetFields(preset) {
+  currentPresetId = preset.id;
   document.getElementById('opt-new-per-day').value     = preset.new_per_day;
   document.getElementById('opt-reviews-per-day').value = preset.reviews_per_day;
   document.getElementById('opt-learn-steps').value     = preset.learning_steps;
@@ -1886,6 +1889,50 @@ function loadPresetFields(preset) {
   btnDef.disabled = !!preset.is_default;
   const btnDel = document.getElementById('btn-delete-preset');
   btnDel.disabled = allPresets.length <= 1;
+
+  // Category overrides
+  _loadCategoryOverrides(preset.category_overrides || {});
+}
+
+const _CAT_OVERRIDE_FIELDS = [
+  'new_per_day', 'reviews_per_day', 'learning_steps',
+  'graduating_interval', 'easy_interval', 'relearning_steps',
+];
+
+function _loadCategoryOverrides(overrides) {
+  for (const details of document.querySelectorAll('.cat-override-details')) {
+    const cat = details.dataset.cat;
+    const catOverrides = overrides[cat] || {};
+    let hasAny = false;
+    for (const input of details.querySelectorAll('input[data-field]')) {
+      const val = catOverrides[input.dataset.field];
+      input.value = val != null ? val : '';
+      if (val != null) hasAny = true;
+    }
+    if (hasAny) {
+      details.setAttribute('data-has-overrides', '');
+      details.open = true;
+    } else {
+      details.removeAttribute('data-has-overrides');
+      details.open = false;
+    }
+  }
+}
+
+function _collectCategoryOverrides() {
+  const result = {};
+  for (const details of document.querySelectorAll('.cat-override-details')) {
+    const cat = details.dataset.cat;
+    const fields = {};
+    for (const input of details.querySelectorAll('input[data-field]')) {
+      const raw = input.value.trim();
+      if (raw !== '') {
+        fields[input.dataset.field] = input.type === 'number' ? Number(raw) : raw;
+      }
+    }
+    if (Object.keys(fields).length > 0) result[cat] = fields;
+  }
+  return result;
 }
 
 function renderPresetSelect(selectedId) {
@@ -1915,7 +1962,7 @@ async function switchPreset(presetId) {
   presetId = parseInt(presetId);
   try {
     await api('PUT', `/api/decks/${optDeckId}/preset/assign?preset_id=${presetId}`);
-    const preset = allPresets.find(p => p.id === presetId);
+    const preset = await api('GET', `/api/decks/${optDeckId}/preset`);
     loadPresetFields(preset);
   } catch (e) {
     showError('Failed to switch preset: ' + e.message);
@@ -1999,7 +2046,20 @@ async function saveOptions() {
     if (!ok) return;
   }
   try {
-    await api('PUT', `/api/decks/${optDeckId}/preset`, fields);
+    const [savedPreset] = await Promise.all([
+      api('PUT', `/api/decks/${optDeckId}/preset`, fields),
+    ]);
+    const presetId = currentPresetId;
+    // Save category overrides
+    const catOverrides = _collectCategoryOverrides();
+    const cats = ['listening', 'reading', 'creating'];
+    await Promise.all(cats.map(cat => {
+      if (catOverrides[cat]) {
+        return api('PUT', `/api/presets/${presetId}/categories/${cat}`, catOverrides[cat]);
+      } else {
+        return api('DELETE', `/api/presets/${presetId}/categories/${cat}`).catch(() => {});
+      }
+    }));
     closeModal();
     loadDecks();
   } catch (e) {

--- a/static/app.js
+++ b/static/app.js
@@ -3123,9 +3123,11 @@ function updateWordBankPreview(text) {
   const parts = _parseWordBankInput(text);
   el.textContent = parts.length ? parts.join('') : '…';
 
-  // Grey out tokens whose number has been typed
+  // Grey out tokens whose number has been typed OR whose char appears in typed CJK text
+  const isCjk = ch => /[\u3000-\u9FFF\uF900-\uFAFF]/.test(ch);
   const usedNums = new Set();
   const chars = [...text.replace(/\s+/g, '')];
+  const cjkText = chars.filter(isCjk).join('');
   let i = 0;
   while (i < chars.length) {
     if (/\d/.test(chars[i])) {
@@ -3137,6 +3139,7 @@ function updateWordBankPreview(text) {
       i++;
     } else { i++; }
   }
+  wordBankTokens.forEach(t => { if (cjkText.includes(t.char)) usedNums.add(t.num); });
   document.querySelectorAll('.wb-token-btn').forEach(btn => {
     const num = parseInt(btn.querySelector('.wb-num').textContent, 10);
     btn.classList.toggle('wb-used', usedNums.has(num));

--- a/static/app.js
+++ b/static/app.js
@@ -47,6 +47,8 @@ let _prevView = null;      // view we came from before opening word-detail
 let _sessionReviewedCount = 0; // cards rated this session (for clap animation)
 let userInput   = '';     // creating category: what the user typed
 let clozeExtraWord = ''; // extra word blanked in cloze front (revealed on back)
+let wordBankTokens = [];  // [{char, num}] shuffled non-target tokens
+let wordBankOrder  = [];  // [{type:'char'|'target', char?, word?, num?}] original order
 let browseWords  = [];   // all words from /api/browse-words
 let browseAll    = [];   // kept for legacy (unused by new browse)
 let _browseSort  = 'pinyin-asc';
@@ -2400,11 +2402,13 @@ function loadCard(c, counts) {
               const sentFront = document.getElementById('sentence-front');
               if (sentFront.style.display !== 'none') sentFront.innerHTML = renderSentence();
             } else if (isCloze) {
-              // Cloze: update sentence-front with blanked Chinese + show English hint
-              document.getElementById('sentence-front').innerHTML = renderClozeSentence();
+              // Word bank: sentence just loaded — update hint and rebuild token bank
               const enFront = document.getElementById('sentence-en-front');
               enFront.style.display = 'flex';
               enFront.textContent = sentence.sentence_en || '';
+              if (document.getElementById('word-bank-wrap').style.display !== 'none') {
+                renderWordBankUI();
+              }
             } else if (isCreating && isSentenceNt) {
               // Sentence notes: update English prompt
               const inp = document.getElementById('sentence-en-front');
@@ -2516,22 +2520,19 @@ function showFront() {
   _listenCount = 0;
   _updateListenCounters();
 
-  // Cloze mode: creating category for non-sentence notes → show sentence with blank
+  // Word bank mode: creating category for non-sentence notes
   const isCloze = isCreating && !isSentence;
 
-  // Reading / Cloze: Chinese sentence on front
+  // Reading only: Chinese sentence on front
   const sentFront = document.getElementById('sentence-front');
-  sentFront.style.display = (!isListening && (!isCreating || isCloze)) ? 'flex' : 'none';
-  if (!isListening && !isCreating) {
-    sentFront.innerHTML = renderSentence();
-  } else if (isCloze) {
-    sentFront.innerHTML = renderClozeSentence();
-  }
+  sentFront.style.display = !isListening && !isCreating ? 'flex' : 'none';
+  if (!isListening && !isCreating) sentFront.innerHTML = renderSentence();
 
-  // Creating: show sentence-en-front for both cloze and sentence notes
+  // Creating: show English hint + appropriate input
   document.getElementById('sentence-en-front').style.display   = isCreating ? 'flex' : 'none';
-  // Cloze mode uses inline input inside the sentence; sentence notes use the box below
   document.getElementById('creating-input-wrap').style.display = (isCreating && !isCloze) ? 'flex' : 'none';
+  document.getElementById('word-bank-wrap').style.display      = isCloze ? 'flex' : 'none';
+
   if (isCreating) {
     if (isSentence) {
       // Sentence notes: show the German/English source as prompt
@@ -2544,11 +2545,10 @@ function showFront() {
       userInput = '';
       setTimeout(() => inp.focus(), 80);
     } else {
-      // Cloze: show English translation as context hint; input is inline in the sentence
+      // Word bank mode: English translation as hint; word bank renders below
       document.getElementById('sentence-en-front').textContent = sentence?.sentence_en || '';
       userInput = '';
-      // Focus the inline input that was just rendered inside the sentence
-      setTimeout(() => document.getElementById('cloze-inline-input')?.focus(), 80);
+      renderWordBankUI();
     }
   }
 
@@ -2595,8 +2595,13 @@ function revealAnswer() {
   // Capture user input before hiding front
   if (isCreating) {
     const isClozeMode = card.note_type !== 'sentence';
-    const inlineEl = isClozeMode ? document.getElementById('cloze-inline-input') : null;
-    userInput = (inlineEl ?? document.getElementById('creating-input')).value.trim();
+    if (isClozeMode) {
+      // Word bank mode: parse number sequence into reconstructed sentence
+      const wbRaw = document.getElementById('word-bank-input').value.trim();
+      userInput = _parseWordBankInput(wbRaw).join('');
+    } else {
+      userInput = document.getElementById('creating-input').value.trim();
+    }
   }
 
   document.getElementById('side-front').style.display = 'none';
@@ -2619,9 +2624,19 @@ function revealAnswer() {
     const matchBar = document.getElementById('answer-match-bar');
 
     if (!isSentenceNote) {
-      // ── Cloze mode: compare only the target word ─────────────────────────
-      const { html: userHtml, pct } = diffClozeAnswer(userInput, card.word_zh);
+      // ── Word bank mode: compare reconstructed sentence ────────────────────
+      const correctZh = sentence?.sentence_zh || card.word_zh;
+      const userChars  = [...userInput];
+      const corrChars  = [...correctZh];
+      const matched = userChars.filter((ch, i) => ch === corrChars[i]).length;
+      const pct = corrChars.length > 0 ? Math.round((matched / corrChars.length) * 100) : 0;
+
+      // Highlight target word in user's answer
+      const userHtml = userInput
+        ? userInput.replace(card.word_zh, `<span class="ch-target">${card.word_zh}</span>`)
+        : '<span class="ch-miss">(no answer)</span>';
       document.getElementById('user-answer-text').innerHTML = userHtml;
+
       if (userInput) {
         const filled = Math.round(pct / 10);
         const bar = '▓'.repeat(filled) + '░'.repeat(10 - filled);
@@ -3011,6 +3026,90 @@ function pickExtraBlankWord(zh, excludeWord) {
   if (!candidates.length) return '';
   const idx = candidates[Math.floor(Math.random() * candidates.length)];
   return zh.slice(idx, idx + 2);
+}
+
+// ── Word bank (creating mode, non-sentence notes) ─────────────────────────
+function _buildWordBank() {
+  const zh = sentence?.sentence_zh;
+  if (!zh || !card?.word_zh) return;
+  const target = card.word_zh;
+
+  // Use jieba tokens from backend if available, otherwise fall back to char-by-char
+  let rawTokens;
+  if (sentence.tokens && sentence.tokens.length) {
+    rawTokens = sentence.tokens;
+  } else {
+    // Fallback: split by target word boundary, then individual chars
+    rawTokens = [];
+    let i = 0;
+    const tIdx = zh.indexOf(target);
+    while (i < zh.length) {
+      if (tIdx >= 0 && i === tIdx) { rawTokens.push(target); i += target.length; }
+      else { rawTokens.push(zh[i]); i++; }
+    }
+  }
+
+  // Build ordered sequence, marking which token is the target
+  const order = rawTokens.map(tok =>
+    tok === target
+      ? { type: 'target', word: target }
+      : { type: 'char', char: tok }
+  );
+  // If target wasn't found in tokens, append it
+  if (!order.some(it => it.type === 'target')) order.push({ type: 'target', word: target });
+
+  const chars    = order.filter(it => it.type === 'char');
+  const shuffled = [...chars].sort(() => Math.random() - 0.5);
+  shuffled.forEach((item, n) => { item.num = n + 1; });
+
+  wordBankOrder  = order;
+  wordBankTokens = shuffled;
+}
+
+function _parseWordBankInput(text) {
+  // Auto-split by token type: runs of digits OR runs of CJK chars (spaces optional)
+  const tokens = text.match(/\d+|[\u3000-\u9FFF\uF900-\uFAFF]+/g) || [];
+  return tokens.map(part => {
+    if (/^\d+$/.test(part)) {
+      const tok = wordBankTokens.find(t => t.num === parseInt(part, 10));
+      return tok ? tok.char : '?';
+    }
+    return part; // Chinese characters = target word
+  });
+}
+
+function updateWordBankPreview(text) {
+  const el = document.getElementById('word-bank-preview');
+  const parts = _parseWordBankInput(text);
+  el.textContent = parts.length ? parts.join('') : '…';
+}
+
+function wordBankAddToken(num) {
+  const inp = document.getElementById('word-bank-input');
+  const cur = inp.value.trim();
+  inp.value = cur ? cur + ' ' + num : String(num);
+  updateWordBankPreview(inp.value);
+  inp.focus();
+}
+
+function renderWordBankUI() {
+  _buildWordBank();
+  if (!wordBankTokens.length) return; // sentence not loaded yet
+
+  document.getElementById('word-bank-preview').textContent = '…';
+
+  const tokensEl = document.getElementById('word-bank-tokens');
+  tokensEl.innerHTML = wordBankTokens.map(tok =>
+    `<button class="wb-token-btn" onclick="wordBankAddToken(${tok.num})">`
+    + `<span class="wb-num">${tok.num}</span>`
+    + `<span class="wb-char">${tok.char}</span>`
+    + `</button>`
+  ).join('');
+
+  const inp = document.getElementById('word-bank-input');
+  inp.value = '';
+  userInput = '';
+  setTimeout(() => inp.focus(), 80);
 }
 
 // ── Cloze sentence (creating category, non-sentence notes) ──────────────────

--- a/static/app.js
+++ b/static/app.js
@@ -3122,6 +3122,25 @@ function updateWordBankPreview(text) {
   const el = document.getElementById('word-bank-preview');
   const parts = _parseWordBankInput(text);
   el.textContent = parts.length ? parts.join('') : '…';
+
+  // Grey out tokens whose number has been typed
+  const usedNums = new Set();
+  const chars = [...text.replace(/\s+/g, '')];
+  let i = 0;
+  while (i < chars.length) {
+    if (/\d/.test(chars[i])) {
+      if (i + 1 < chars.length && /\d/.test(chars[i + 1])) {
+        const two = parseInt(chars[i] + chars[i + 1], 10);
+        if (wordBankTokens.some(t => t.num === two)) { usedNums.add(two); i += 2; continue; }
+      }
+      usedNums.add(parseInt(chars[i], 10));
+      i++;
+    } else { i++; }
+  }
+  document.querySelectorAll('.wb-token-btn').forEach(btn => {
+    const num = parseInt(btn.querySelector('.wb-num').textContent, 10);
+    btn.classList.toggle('wb-used', usedNums.has(num));
+  });
 }
 
 function wordBankAddToken(num) {

--- a/static/app.js
+++ b/static/app.js
@@ -1880,6 +1880,7 @@ function loadPresetFields(preset) {
   document.getElementById('opt-bury-new').checked      = !!preset.bury_new_siblings;
   document.getElementById('opt-bury-review').checked   = !!preset.bury_review_siblings;
   document.getElementById('opt-bury-interday').checked = !!preset.bury_interday_siblings;
+  document.getElementById('opt-sibling-sep').value     = preset.sibling_separation ?? 3;
 
   // Category order
   const order = (preset.category_order || 'listening,reading,creating').split(',').map(s => s.trim());
@@ -2038,6 +2039,7 @@ async function saveOptions() {
     bury_new_siblings:      document.getElementById('opt-bury-new').checked      ? 1 : 0,
     bury_review_siblings:   document.getElementById('opt-bury-review').checked   ? 1 : 0,
     bury_interday_siblings: document.getElementById('opt-bury-interday').checked ? 1 : 0,
+    sibling_separation:     parseInt(document.getElementById('opt-sibling-sep').value) || 3,
     category_order: _getCategoryOrderUI(),
   };
   // Warn if a story for today already exists — order settings change would cause mismatch

--- a/static/app.js
+++ b/static/app.js
@@ -46,6 +46,7 @@ let _currentWordId = null; // word ID open in word-detail view
 let _prevView = null;      // view we came from before opening word-detail
 let _sessionReviewedCount = 0; // cards rated this session (for clap animation)
 let userInput   = '';     // creating category: what the user typed
+let clozeExtraWord = ''; // extra word blanked in cloze front (revealed on back)
 let browseWords  = [];   // all words from /api/browse-words
 let browseAll    = [];   // kept for legacy (unused by new browse)
 let _browseSort  = 'pinyin-asc';
@@ -2994,17 +2995,45 @@ function renderSentence() {
   return `<span>${inner}</span>`;
 }
 
+// ── Pick a random 2-char CJK word that doesn't overlap with excludeWord ─────
+function pickExtraBlankWord(zh, excludeWord) {
+  const excludeIdx = zh.indexOf(excludeWord);
+  const excludeEnd = excludeIdx >= 0 ? excludeIdx + excludeWord.length : -1;
+  const isCjk = ch => ch >= '\u4E00' && ch <= '\u9FFF';
+  const candidates = [];
+  for (let i = 0; i < zh.length - 1; i++) {
+    if (excludeIdx >= 0 && i < excludeEnd && i + 2 > excludeIdx) continue;
+    if (isCjk(zh[i]) && isCjk(zh[i + 1])) candidates.push(i);
+  }
+  if (!candidates.length) return '';
+  const idx = candidates[Math.floor(Math.random() * candidates.length)];
+  return zh.slice(idx, idx + 2);
+}
+
 // ── Cloze sentence (creating category, non-sentence notes) ──────────────────
 function renderClozeSentence() {
-  const len  = sentence ? [...card.word_zh].length : 2;
   const inputEl = `<input class="cloze-inline-input" id="cloze-inline-input" type="text"`
     + ` autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"`
     + ` style="width:5.8em"`
     + ` onkeydown="if(event.key==='Enter')revealAnswer()">`;
   if (!sentence) return `<span>${inputEl}</span>`;
   const zh = sentence.sentence_zh;
-  const blanked = zh.includes(card.word_zh) ? zh.replace(card.word_zh, inputEl) : `${zh} ${inputEl}`;
-  return `<span>${blanked}</span>`;
+
+  // Pick an extra word to blank out (chosen before any replacements)
+  clozeExtraWord = pickExtraBlankWord(zh, card.word_zh);
+
+  // Use a temporary placeholder so the two replacements don't interfere
+  let text = zh.includes(card.word_zh)
+    ? zh.replace(card.word_zh, '\x00T\x00')
+    : `${zh} \x00T\x00`;
+
+  if (clozeExtraWord && text.includes(clozeExtraWord)) {
+    const blank = `<span class="cloze-blank">${'＿'.repeat(clozeExtraWord.length)}</span>`;
+    text = text.replace(clozeExtraWord, blank);
+  }
+
+  text = text.replace('\x00T\x00', inputEl);
+  return `<span>${text}</span>`;
 }
 
 // ── Cloze answer diff ────────────────────────────────────────────────────────

--- a/static/app.js
+++ b/static/app.js
@@ -2626,21 +2626,40 @@ function revealAnswer() {
     if (!isSentenceNote) {
       // ── Word bank mode: compare reconstructed sentence ────────────────────
       const correctZh = sentence?.sentence_zh || card.word_zh;
-      const userChars  = [...userInput];
-      const corrChars  = [...correctZh];
-      const matched = userChars.filter((ch, i) => ch === corrChars[i]).length;
-      const pct = corrChars.length > 0 ? Math.round((matched / corrChars.length) * 100) : 0;
 
-      // Highlight target word in user's answer
-      const userHtml = userInput
-        ? userInput.replace(card.word_zh, `<span class="ch-target">${card.word_zh}</span>`)
-        : '<span class="ch-miss">(no answer)</span>';
+      // LCS-based match percentage (handles missing/extra words gracefully)
+      const ua = [...userInput], ca = [...correctZh];
+      const dp = Array(ua.length + 1).fill(null).map(() => Array(ca.length + 1).fill(0));
+      for (let i = 1; i <= ua.length; i++)
+        for (let j = 1; j <= ca.length; j++)
+          dp[i][j] = ua[i-1] === ca[j-1] ? dp[i-1][j-1] + 1 : Math.max(dp[i-1][j], dp[i][j-1]);
+      const lcs = dp[ua.length][ca.length];
+      const pct = ca.length > 0 ? Math.round((lcs / ca.length) * 100) : 0;
+
+      // Per-character coloring: target word = blue, others green/red by presence
+      const corrSet = new Set(ca);
+      const hanzi = /[\u4E00-\u9FFF]/;
+      const targetIdx = userInput.indexOf(card.word_zh);
+      const targetLen = [...card.word_zh].length;
+      let userHtml;
+      if (!userInput) {
+        userHtml = '<span class="ch-miss">(no answer)</span>';
+      } else {
+        const chars = [...userInput];
+        const tStart = targetIdx >= 0 ? [...userInput.slice(0, targetIdx)].length : -1;
+        userHtml = chars.map((ch, i) => {
+          if (tStart >= 0 && i >= tStart && i < tStart + targetLen)
+            return `<span class="ch-target">${ch}</span>`;
+          if (hanzi.test(ch) && corrSet.has(ch)) return `<span class="ch-match">${ch}</span>`;
+          return `<span class="ch-miss">${ch}</span>`;
+        }).join('');
+      }
       document.getElementById('user-answer-text').innerHTML = userHtml;
 
       if (userInput) {
         const filled = Math.round(pct / 10);
         const bar = '▓'.repeat(filled) + '░'.repeat(10 - filled);
-        const color = pct >= 100 ? 'var(--good)' : pct >= 50 ? 'var(--hard)' : 'var(--again)';
+        const color = pct >= 100 ? 'var(--good)' : pct >= 60 ? 'var(--hard)' : 'var(--again)';
         matchBar.innerHTML = `<span class="match-bar" style="color:${color}">${bar} ${pct}%</span>`;
         matchBar.style.display = 'block';
       } else {

--- a/static/app.js
+++ b/static/app.js
@@ -3086,14 +3086,35 @@ function _buildWordBank() {
 }
 
 function _parseWordBankInput(text) {
-  // Auto-split by token type: runs of digits OR runs of CJK chars (spaces optional)
-  const tokens = text.match(/\d+|[\u3000-\u9FFF\uF900-\uFAFF]+/g) || [];
-  return tokens.map(part => {
+  // Segment into tokens without requiring spaces:
+  // - CJK runs → one token (target word)
+  // - Digits: greedy 2-digit if it's a valid token number, else single digit
+  const isCjk = ch => /[\u3000-\u9FFF\uF900-\uFAFF]/.test(ch);
+  const chars = [...text.replace(/\s+/g, '')];
+  const raw = [];
+  let i = 0;
+  while (i < chars.length) {
+    if (isCjk(chars[i])) {
+      let s = chars[i++];
+      while (i < chars.length && isCjk(chars[i])) s += chars[i++];
+      raw.push(s);
+    } else if (/\d/.test(chars[i])) {
+      // Try 2-digit match first
+      if (i + 1 < chars.length && /\d/.test(chars[i + 1])) {
+        const two = parseInt(chars[i] + chars[i + 1], 10);
+        if (wordBankTokens.some(t => t.num === two)) { raw.push(String(two)); i += 2; continue; }
+      }
+      raw.push(chars[i++]);
+    } else {
+      i++; // skip spaces / punctuation typed by mistake
+    }
+  }
+  return raw.map(part => {
     if (/^\d+$/.test(part)) {
       const tok = wordBankTokens.find(t => t.num === parseInt(part, 10));
       return tok ? tok.char : '?';
     }
-    return part; // Chinese characters = target word
+    return part;
   });
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -4940,6 +4940,9 @@ document.addEventListener('keydown', async e => {
     } else if (e.key === 'D') {
       e.preventDefault();
       if (await showConfirm('Delete this card?')) reviewCardAction('delete');
+    } else if (e.key === 'o') {
+      e.preventDefault();
+      if (deckId) openOptions(deckId);
     }
     return;
   }

--- a/static/index.html
+++ b/static/index.html
@@ -454,6 +454,13 @@
     <label class="edit-label">Topic <span style="font-weight:400;text-transform:none">(optional)</span>
       <input class="edit-input" id="setup-topic" type="text" placeholder="e.g. a day at a coffee shop" onkeydown="if(event.key==='Enter')confirmStorySetup()">
     </label>
+    <label class="edit-label">Grammar focus <span style="font-weight:400;text-transform:none">(optional)</span>
+      <div style="display:flex;gap:8px;align-items:center">
+        <input class="edit-input" id="setup-grammar" type="text" placeholder="e.g. 把字句, 是...的结构" style="flex:1" onkeydown="if(event.key==='Enter')confirmStorySetup()">
+        <input class="edit-input" id="setup-grammar-pct" type="number" min="0" max="100" value="50" style="width:64px;text-align:center" title="% of sentences">
+        <span style="font-size:13px;color:var(--muted,#888);white-space:nowrap">%</span>
+      </div>
+    </label>
     <label class="edit-label">
       <span style="display:flex;align-items:center;gap:6px">
         Model

--- a/static/index.html
+++ b/static/index.html
@@ -115,6 +115,17 @@
                  autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
                  onkeydown="if(event.key==='Enter')revealAnswer()">
         </div>
+        <!-- Word bank (creating mode, non-sentence notes) -->
+        <div id="word-bank-wrap" style="display:none">
+          <div class="input-label">Reconstruct the sentence</div>
+          <div class="word-bank-preview" id="word-bank-preview">…</div>
+          <div class="word-bank-tokens" id="word-bank-tokens"></div>
+          <input type="text" id="word-bank-input"
+                 autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
+                 placeholder="Type numbers + target word (e.g. 3 1 学校 2 4)"
+                 oninput="updateWordBankPreview(this.value)"
+                 onkeydown="if(event.key==='Enter')revealAnswer()">
+        </div>
         <button class="reveal-btn" id="reveal-btn" onclick="revealAnswer()">Show Answer</button>
       </div>
 

--- a/static/index.html
+++ b/static/index.html
@@ -435,6 +435,7 @@
         <span class="opt-label">Bury interday learning siblings</span>
         <input type="checkbox" id="opt-bury-interday" style="width:18px;height:18px;cursor:pointer">
       </div>
+      <div class="opt-row"><span class="opt-label">Sibling separation (days)</span><input class="opt-input" id="opt-sibling-sep" type="number" min="1" title="Min days between R/T/C reviews of the same word once established"></div>
     </div>
 
     <div class="modal-footer">

--- a/static/index.html
+++ b/static/index.html
@@ -436,6 +436,7 @@
         <input type="checkbox" id="opt-bury-interday" style="width:18px;height:18px;cursor:pointer">
       </div>
       <div class="opt-row"><span class="opt-label">Sibling separation (days)</span><input class="opt-input" id="opt-sibling-sep" type="number" min="1" title="Min days between R/T/C reviews of the same word once established"></div>
+      <div class="opt-row"><span class="opt-label">Sibling factor (× interval)</span><input class="opt-input" id="opt-sibling-factor" type="number" min="0" max="1" step="0.05" title="Fraction of interval used as additional separation. Effective = max(separation, interval × factor)"></div>
     </div>
 
     <div class="modal-footer">

--- a/static/index.html
+++ b/static/index.html
@@ -327,6 +327,48 @@
     </div>
 
     <div class="opt-group">
+      <div class="opt-group-label">Category Overrides <span style="font-weight:400;font-size:11px;color:var(--muted)">— leave blank to use preset default</span></div>
+      <div id="cat-overrides-container">
+        <!-- Listening -->
+        <details class="cat-override-details" data-cat="listening">
+          <summary class="cat-override-summary">Listening</summary>
+          <div class="cat-override-fields">
+            <div class="opt-row"><span class="opt-label">New / day</span>              <input class="opt-input" data-field="new_per_day"         type="number" min="0" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Reviews / day</span>          <input class="opt-input" data-field="reviews_per_day"     type="number" min="0" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Steps (min)</span>            <input class="opt-input wide" data-field="learning_steps" type="text"   placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Graduating interval (days)</span><input class="opt-input" data-field="graduating_interval" type="number" min="1" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Easy interval (days)</span>  <input class="opt-input" data-field="easy_interval"        type="number" min="1" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Relearning steps (min)</span><input class="opt-input wide" data-field="relearning_steps" type="text"  placeholder="default"></div>
+          </div>
+        </details>
+        <!-- Reading -->
+        <details class="cat-override-details" data-cat="reading">
+          <summary class="cat-override-summary">Reading</summary>
+          <div class="cat-override-fields">
+            <div class="opt-row"><span class="opt-label">New / day</span>              <input class="opt-input" data-field="new_per_day"         type="number" min="0" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Reviews / day</span>          <input class="opt-input" data-field="reviews_per_day"     type="number" min="0" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Steps (min)</span>            <input class="opt-input wide" data-field="learning_steps" type="text"   placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Graduating interval (days)</span><input class="opt-input" data-field="graduating_interval" type="number" min="1" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Easy interval (days)</span>  <input class="opt-input" data-field="easy_interval"        type="number" min="1" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Relearning steps (min)</span><input class="opt-input wide" data-field="relearning_steps" type="text"  placeholder="default"></div>
+          </div>
+        </details>
+        <!-- Creating -->
+        <details class="cat-override-details" data-cat="creating">
+          <summary class="cat-override-summary">Creating</summary>
+          <div class="cat-override-fields">
+            <div class="opt-row"><span class="opt-label">New / day</span>              <input class="opt-input" data-field="new_per_day"         type="number" min="0" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Reviews / day</span>          <input class="opt-input" data-field="reviews_per_day"     type="number" min="0" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Steps (min)</span>            <input class="opt-input wide" data-field="learning_steps" type="text"   placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Graduating interval (days)</span><input class="opt-input" data-field="graduating_interval" type="number" min="1" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Easy interval (days)</span>  <input class="opt-input" data-field="easy_interval"        type="number" min="1" placeholder="default"></div>
+            <div class="opt-row"><span class="opt-label">Relearning steps (min)</span><input class="opt-input wide" data-field="relearning_steps" type="text"  placeholder="default"></div>
+          </div>
+        </details>
+      </div>
+    </div>
+
+    <div class="opt-group">
       <div class="opt-group-label">Display Order</div>
       <div class="opt-row"><span class="opt-label">New card gather order</span>
         <select class="opt-input" id="opt-new-gather-order">

--- a/static/style.css
+++ b/static/style.css
@@ -1235,6 +1235,7 @@ main.browse-open {
   gap: 2px;
 }
 .wb-token-btn:hover { background: var(--bg); border-color: var(--primary); }
+.wb-token-btn.wb-used { opacity: 0.3; pointer-events: none; }
 .wb-num { font-size: 10px; font-weight: 700; color: var(--muted); line-height: 1; }
 .wb-char { font-size: 20px; color: var(--text); line-height: 1; }
 #word-bank-input {

--- a/static/style.css
+++ b/static/style.css
@@ -1200,6 +1200,58 @@ main.browse-open {
 }
 .match-bar { font-size: 13px; font-weight: 700; margin-top: 8px; display: block; letter-spacing: 1px; }
 
+/* ── Word bank (creating mode) ──────────────────────────────── */
+#word-bank-wrap {
+  flex-direction: column;
+  gap: 10px;
+}
+.word-bank-preview {
+  min-height: 52px;
+  padding: 10px 14px;
+  border: 2px dashed var(--border);
+  border-radius: 10px;
+  font-size: 24px;
+  color: var(--text);
+  line-height: 1.4;
+  background: var(--bg);
+  letter-spacing: 1px;
+}
+.word-bank-tokens {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.wb-token-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 6px 10px;
+  border: 1.5px solid var(--border);
+  border-radius: 8px;
+  background: var(--card);
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s, opacity 0.12s;
+  font-family: inherit;
+  gap: 2px;
+}
+.wb-token-btn:hover { background: var(--bg); border-color: var(--primary); }
+.wb-num { font-size: 10px; font-weight: 700; color: var(--muted); line-height: 1; }
+.wb-char { font-size: 20px; color: var(--text); line-height: 1; }
+#word-bank-input {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  font-size: 18px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.15s;
+  background: var(--card);
+  color: var(--text);
+  box-sizing: border-box;
+}
+#word-bank-input:focus { border-color: var(--primary); }
+
 /* ── Deck tree ───────────────────────────────────────────── */
 .tree-row {
   display: flex;

--- a/static/style.css
+++ b/static/style.css
@@ -2947,6 +2947,39 @@ select.opt-input {
 .cat-order-btns button:hover:not(:disabled) { background: var(--hover); color: var(--text); }
 .cat-order-btns button:disabled { opacity: 0.3; cursor: default; }
 
+/* ── Category overrides ───────────────────────────────────────────────────── */
+.cat-override-details {
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  margin-bottom: 4px;
+  overflow: hidden;
+}
+.cat-override-summary {
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  background: var(--card-bg);
+  user-select: none;
+  list-style: none;
+}
+.cat-override-summary::-webkit-details-marker { display: none; }
+.cat-override-summary::before { content: '▶ '; font-size: 9px; }
+details[open] .cat-override-summary::before { content: '▼ '; }
+.cat-override-details[data-has-overrides] .cat-override-summary {
+  color: var(--text);
+}
+.cat-override-details[data-has-overrides] .cat-override-summary::after {
+  content: ' ●';
+  color: #4a9eff;
+  font-size: 9px;
+}
+.cat-override-fields {
+  padding: 4px 8px 8px;
+  background: var(--bg);
+}
+
 /* ── Clapping animation on review completion ─────────────────────────────── */
 .clap-particle {
   position: fixed;

--- a/translator.py
+++ b/translator.py
@@ -37,14 +37,25 @@ def translate_zh_en(text: str) -> str:
 
 
 def translate_batch(texts: list[str]) -> list[str]:
-    """Translate a list of Chinese strings to English."""
+    """Translate a list of Chinese strings to English in a single HTTP request."""
     _load()
     if _translator is None:
         return texts
+    if not texts:
+        return texts
+
+    # Join with newline — Google Translate preserves \n, so one request suffices.
+    sep = "\n"
+    combined = sep.join(t.strip() or " " for t in texts)
     try:
-        from deep_translator import GoogleTranslator
-        results = GoogleTranslator(source="zh-CN", target="en").translate_batch(texts)
-        return [r or t for r, t in zip(results, texts)]
+        translated = _translator.translate(combined) or combined
+        parts = translated.split(sep)
+        # If split count matches, return aligned results; otherwise fall back.
+        if len(parts) == len(texts):
+            return [p.strip() or t for p, t in zip(parts, texts)]
+        logger.warning("translator: split count mismatch (%d vs %d), falling back", len(parts), len(texts))
     except Exception as e:
         logger.warning("translator: batch error — %s", e)
-        return [translate_zh_en(t) for t in texts]
+
+    # Fallback: translate one by one
+    return [translate_zh_en(t) for t in texts]


### PR DESCRIPTION
## 变更内容

在"Story setup"弹窗中新增两个可选字段：

- **语法字段**：文本输入框，输入想练习的语法点（如"把字句"、"是...的结构"）
- **百分比字段**：数字输入框（0–100），指定 AI 在多少比例的句子中尝试使用该语法（默认 50%）

AI 自由决定在哪些句子使用语法，复习时不测试语法正确性。不填语法字段时行为与之前完全一致。

## 受影响文件

- `ai.py`：`generate_story()` 新增 `grammar_focus`、`grammar_pct` 参数；在 prompt 中注入语法指令行
- `routes/story.py`：GET 和 POST（regenerate）接口新增 `grammar_focus`、`grammar_pct` 查询参数
- `static/index.html`：Story setup 弹窗新增两个字段
- `static/app.js`：`_storyParams()`、`confirmStorySetup()` 及所有 `_do*` 函数透传新参数

## 测试方法

1. 启动服务器，打开任意牌组
2. 点击开始复习，在弹窗中填写语法字段（如"把字句"）和百分比（如 70）
3. 生成故事后检查故事句子是否有"把"字结构出现
4. 不填语法字段时确认行为与之前一致

Closes #235