### PR TITLE
fix: 修复每次点击牌组都重新生成故事的问题

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -86,7 +86,7 @@ def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2
                    model: str = DEFAULT_MODEL,
                    progress_key: str | None = None,
                    grammar_focus: str | None = None,
-                   grammar_pct: int = 50) -> tuple[list[dict], str]:
+                   grammar_pct: int = 75) -> tuple[list[dict], str]:
     """
     Generate a short Mandarin story, one sentence per card.
 
@@ -134,8 +134,7 @@ def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2
         n_sentences = max(1, round(len(cards) * grammar_pct / 100))
         grammar_line = (
             f"- Grammar focus: try to use the pattern 「{grammar_focus}」 in roughly "
-            f"{n_sentences} of the {len(cards)} sentences (about {grammar_pct}%). "
-            f"You decide which sentences to apply it to — it does not need to be forced.\n"
+            f"{n_sentences} of the {len(cards)} sentences (about {grammar_pct}%).\n"
         )
     else:
         grammar_line = ""

--- a/ai.py
+++ b/ai.py
@@ -135,12 +135,14 @@ def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2
         grammar_line = (
             f"- Grammar focus: use the pattern 「{grammar_focus}」 in roughly "
             f"{n_sentences} of the {len(cards)} sentences (about {grammar_pct}%).\n"
-            f"  For each sentence, set \"grammar_used\": true if you used the pattern, false if not.\n"
+            f"  For each sentence, decide BEFORE writing: what specific grammar fragment will you use "
+            f"(e.g. 「三年以内」「十八岁以上」)? Write that fragment in the \"grammar_fragment\" field. "
+            f"If you are not using the pattern for a sentence, set \"grammar_fragment\" to \"\".\n"
         )
     else:
         grammar_line = ""
 
-    grammar_first = f"GRAMMAR FOCUS (apply this before writing sentences):\n{grammar_line}\n" if grammar_focus else ""
+    grammar_first = f"GRAMMAR FOCUS (plan each sentence before writing it):\n{grammar_line}\n" if grammar_focus else ""
 
     prompt = f"""Write a short Mandarin Chinese story to help an HSK 4-5 learner review vocabulary.
 
@@ -158,7 +160,7 @@ Rules:
 - NEVER use ASCII double-quote characters (") inside Chinese sentences — use 「」or （）instead if quoting is needed
 - Return ONLY valid JSON, no explanation, no markdown:
 [
-  {{"word_id": <integer>, "sentence_zh": "<Chinese sentence>"{', "grammar_used": <true|false>' if grammar_focus else ''}}},
+  {{"word_id": <integer>{', "grammar_fragment": "<fragment or empty string>"' if grammar_focus else ''}, "sentence_zh": "<Chinese sentence>"}},
   ...
 ]"""
 

--- a/ai.py
+++ b/ai.py
@@ -133,15 +133,18 @@ def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2
     if grammar_focus:
         n_sentences = max(1, round(len(cards) * grammar_pct / 100))
         grammar_line = (
-            f"- Grammar focus: try to use the pattern 「{grammar_focus}」 in roughly "
+            f"- Grammar focus: use the pattern 「{grammar_focus}」 in roughly "
             f"{n_sentences} of the {len(cards)} sentences (about {grammar_pct}%).\n"
+            f"  For each sentence, set \"grammar_used\": true if you used the pattern, false if not.\n"
         )
     else:
         grammar_line = ""
 
+    grammar_first = f"GRAMMAR FOCUS (apply this before writing sentences):\n{grammar_line}\n" if grammar_focus else ""
+
     prompt = f"""Write a short Mandarin Chinese story to help an HSK 4-5 learner review vocabulary.
 
-Target words — write exactly one sentence per word, in this order:
+{grammar_first}Target words — write exactly one sentence per word, in this order:
 {word_list}
 
 Rules:
@@ -151,11 +154,11 @@ Rules:
 - Use proper Chinese punctuation — include commas（，）where natural pauses occur
 - Use only HSK 1-{max_hsk} vocabulary for non-target words
 - Please keep each sentence as short and simple as possible — shorter is better, as long as all other rules are still met
-{topic_line}{grammar_line}- The sentences must form a coherent narrative with the same recurring characters
+{topic_line}- The sentences must form a coherent narrative with the same recurring characters
 - NEVER use ASCII double-quote characters (") inside Chinese sentences — use 「」or （）instead if quoting is needed
 - Return ONLY valid JSON, no explanation, no markdown:
 [
-  {{"word_id": <integer>, "sentence_zh": "<Chinese sentence>"}},
+  {{"word_id": <integer>, "sentence_zh": "<Chinese sentence>"{', "grammar_used": <true|false>' if grammar_focus else ''}}},
   ...
 ]"""
 

--- a/routes/story.py
+++ b/routes/story.py
@@ -83,15 +83,15 @@ def _validated_model(model: str | None) -> str:
 
 @router.get("/api/story/{deck_id}/{category}")
 def get_story(deck_id: int, category: str,
-              topic: str | None = None, max_hsk: int = 2,
+              topic: str | None = None, max_hsk: int = 3,
               model: str | None = None,
-              grammar_focus: str | None = None, grammar_pct: int = 50):
+              grammar_focus: str | None = None, grammar_pct: int = 75):
     if database.is_sentences_deck(deck_id):
         return None
 
     today = database.anki_today().isoformat()
     # Only use cached story if no custom options were provided
-    if not topic and max_hsk == 2 and not model and not grammar_focus:
+    if not topic and max_hsk == 3 and not model and not grammar_focus:
         story = database.get_active_story(today, category, deck_id)
         if story:
             story["sentences"] = _add_tokens(database.get_story_sentences(story["id"]))
@@ -146,9 +146,9 @@ def get_story(deck_id: int, category: str,
 
 @router.post("/api/story/{deck_id}/{category}/regenerate")
 def regenerate_story(deck_id: int, category: str,
-                     topic: str | None = None, max_hsk: int = 2,
+                     topic: str | None = None, max_hsk: int = 3,
                      model: str | None = None,
-                     grammar_focus: str | None = None, grammar_pct: int = 50):
+                     grammar_focus: str | None = None, grammar_pct: int = 75):
     if database.is_sentences_deck(deck_id):
         return None
     if DISABLE_AI:

--- a/routes/story.py
+++ b/routes/story.py
@@ -90,15 +90,14 @@ def get_story(deck_id: int, category: str,
         return None
 
     today = database.anki_today().isoformat()
-    # Only use cached story if no custom options were provided
-    if not topic and max_hsk == 3 and not model and not grammar_focus:
-        story = database.get_active_story(today, category, deck_id)
-        if story:
-            story["sentences"] = _add_tokens(database.get_story_sentences(story["id"]))
-            logger.info("story  CACHED  deck=%d cat=%s sentences=%d story_id=%d",
-                        deck_id, category, len(story["sentences"]), story["id"])
-            _log_story(story)
-            return story
+    # Always return today's cached story — custom params only apply when generating a new one
+    story = database.get_active_story(today, category, deck_id)
+    if story:
+        story["sentences"] = _add_tokens(database.get_story_sentences(story["id"]))
+        logger.info("story  CACHED  deck=%d cat=%s sentences=%d story_id=%d",
+                    deck_id, category, len(story["sentences"]), story["id"])
+        _log_story(story)
+        return story
 
     if DISABLE_AI:
         logger.info("story  DISABLED (DISABLE_AI=1) deck=%d cat=%s", deck_id, category)

--- a/static/app.js
+++ b/static/app.js
@@ -2176,10 +2176,10 @@ async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct) {
 function _storyParams(topic, maxHsk, model, grammarFocus, grammarPct) {
   const p = new URLSearchParams();
   if (topic)                              p.set('topic', topic);
-  if (maxHsk !== 2)                       p.set('max_hsk', maxHsk);
+  if (maxHsk !== 3)                       p.set('max_hsk', maxHsk);
   if (model && model !== 'deepseek-chat') p.set('model', model);
   if (grammarFocus)                       p.set('grammar_focus', grammarFocus);
-  if (grammarFocus && grammarPct !== 50)  p.set('grammar_pct', grammarPct);
+  if (grammarFocus && grammarPct !== 75)  p.set('grammar_pct', grammarPct);
   const s = p.toString();
   return s ? '?' + s : '';
 }
@@ -3422,7 +3422,7 @@ function confirmStorySetup() {
   const maxHsk      = parseInt(document.getElementById('setup-hsk-slider').value, 10);
   const model       = document.getElementById('setup-model').value;
   const grammarFocus = document.getElementById('setup-grammar').value.trim() || null;
-  const grammarPct  = parseInt(document.getElementById('setup-grammar-pct').value, 10) || 50;
+  const grammarPct  = parseInt(document.getElementById('setup-grammar-pct').value, 10) || 75;
   _closeSetupModal();
   if (_setupIsDeckListRegen) {
     _doRegenStoryForDeckList(_deckListRegenId, topic, maxHsk, model, grammarFocus, grammarPct);

--- a/static/index.html
+++ b/static/index.html
@@ -512,7 +512,7 @@
     <label class="edit-label">Grammar focus <span style="font-weight:400;text-transform:none">(optional)</span>
       <div style="display:flex;gap:8px;align-items:center">
         <input class="edit-input" id="setup-grammar" type="text" placeholder="e.g. 把字句, 是...的结构" style="flex:1" onkeydown="if(event.key==='Enter')confirmStorySetup()">
-        <input class="edit-input" id="setup-grammar-pct" type="number" min="0" max="100" value="50" style="width:64px;text-align:center" title="% of sentences">
+        <input class="edit-input" id="setup-grammar-pct" type="number" min="0" max="100" value="75" style="width:64px;text-align:center" title="% of sentences">
         <span style="font-size:13px;color:var(--muted,#888);white-space:nowrap">%</span>
       </div>
     </label>
@@ -548,9 +548,9 @@
       Max HSK level for background vocabulary
       <div class="setup-slider-row">
         <span class="setup-slider-min">1</span>
-        <input type="range" id="setup-hsk-slider" min="1" max="6" value="2" oninput="updateHskLabel()">
+        <input type="range" id="setup-hsk-slider" min="1" max="6" value="3" oninput="updateHskLabel()">
         <span class="setup-slider-max">6</span>
-        <span class="setup-hsk-badge" id="setup-hsk-badge">HSK 2</span>
+        <span class="setup-hsk-badge" id="setup-hsk-badge">HSK 3</span>
       </div>
     </label>
   </div>


### PR DESCRIPTION
## 问题原因

`GET /api/story/{deck_id}/{category}` 接口只在参数完全为默认值（`max_hsk=3`、无 topic/model/grammar_focus）时才返回缓存故事。

但前端 `startReviewMixed` 在检测到 `has_story=true` 时，调用的是：
\`\`\`javascript
await _doStartReviewMixed(null, 2, null, null, 50);  // maxHsk=2
\`\`\`

`max_hsk=2` 传到服务器后，缓存条件 `max_hsk == 3` 不满足，服务器就绕过缓存、每次都重新生成故事。

## 修复内容

简化服务器端逻辑：**只要今天已有故事，无论参数如何都直接返回缓存**。自定义参数（topic、model 等）只在今天还没有故事时才影响生成。`/regenerate` 接口不受影响，仍可强制重新生成。

## 测试方法

1. 点击牌组开始复习，生成故事
2. 关闭复习，再次点击同一牌组
3. 应直接加载已有故事，不再重新调用 AI

Closes #（如有对应 issue）