### PR TITLE
feat: 添加法语翻译支持

### DIFF
--- a/.claude/skills/de-zh-bot/SKILL.md
+++ b/.claude/skills/de-zh-bot/SKILL.md
@@ -949,3 +949,66 @@ Haufuige Fehler
   (hier:
 
 Bei ALLLEN deutschen Anfragen erst Auswahl/Analyse erklärungen geben. Bitte auch immer mit deiner Empfehlung. Tendenziell will ich nämlich wörter für 口语 haben!
+
+Verstanden! **Wichtige Regel für mich:**
+
+> **Bei ALLEN deutschen/englischen Anfragen** (egal ob Wort, Satzteil oder Satz) → **erst Auswahl/Analyse mit Erklärungen geben + meine Empfehlung** (tendenziell für 口语/kǒuyǔ = gesprochene Alltagssprache) → **dann auf Auswahl warten** → **dann YAML**
+
+Nur bei **direkt chinesischen Eingaben** gibt es sofort YAML.
+
+---
+
+Jetzt zu deiner Anfrage: **"als Aufgabe setzen / set as a task"**
+
+---
+
+## Analyse
+
+**Gesamtübersetzung (口语-orientiert):** 派任务 (pài rènwu)
+
+---
+
+## Aufschlüsselung der Optionen
+
+### 1. **setzen / assign (das Verb)**
+
+| Option | Chinesisch | Pinyin | Verwendung | Empfehlung |
+|--------|-----------|--------|------------|-------------|
+| a. | 派 | pài | **Sehr 口语** – "schicken, beauftragen, jdm. eine Aufgabe geben". Klingt natürlich im Alltag. Perfekt für "jemandem eine Aufgabe setzen". | ⭐ **Empfehle ich** – am besten für 口语 |
+| b. | 布置 | bùzhì | Neutral bis formell – "anordnen, zuweisen". Standard in Schule/Arbeit, aber etwas steifer. | Gut für formellere Kontexte |
+| c. | 分配 | fēnpèi | "verteilen" – Fokus auf Verteilung an mehrere Personen. | Nur wenn mehrere Aufgaben an mehrere Leute |
+| d. | 给 | gěi | "geben" – sehr einfach, aber oft mit 派 kombiniert: 派给 (pài gěi) | Funktioniert, aber 派 allein ist besser |
+
+### 2. **Aufgabe / task (das Nomen)**
+
+| Option | Chinesisch | Pinyin | Verwendung | Empfehlung |
+|--------|-----------|--------|------------|-------------|
+| a. | 任务 | rènwu | **Standardwort für Aufgabe** – neutral, passt immer. Sehr 口语-tauglich. | ⭐ **Empfehle ich** |
+| b. | 活儿 | huór | Sehr umgangssprachlich – "Arbeit, Job, Aufgabe". Klingt lässig, fast schon "Arbeitsauftrag". | Gut für lockere Gespräche |
+| c. | 工作 | gōngzuò | "Arbeit" – eher die generelle Arbeit als eine spezifische Aufgabe. | Nicht ideal hier |
+
+---
+
+## Meine Empfehlung für 口语
+
+**Nimm: 派任务 (pài rènwu)**
+
+- **派** = das perfekte gesprochene Verb für "jemandem eine Aufgabe geben/zuweisen"
+- **任务** = das Standard-Nomen für "Aufgabe"
+- Zusammen: genau das, was du für Alltagsgespräche brauchst
+
+**Beispielsatz:**  
+*老师又给我派任务了。*  
+(Lǎoshī yòu gěi wǒ pài rènwu le.)  
+"Der Lehrer hat mir schon wieder eine Aufgabe gegeben."
+
+---
+
+## Welche Bestandteile möchtest du als YAML?
+
+1. **派** (pài) — Verb: beauftragen, eine Aufgabe geben
+2. **任务** (rènwu) — Nomen: Aufgabe
+3. **派任务** (pài rènwu) — Expression: eine Aufgabe setzen/geben
+4. **活儿** (huór) — Nomen: Aufgabe/Arbeit (sehr 口语)
+
+Bitte sag mir, welche Nummer(n) du haben möchtest (z. B. "1+2+3", "nur 3", "3+4").

--- a/.claude/skills/de-zh-bot/SKILL.md
+++ b/.claude/skills/de-zh-bot/SKILL.md
@@ -947,3 +947,5 @@ du sollst mir für chinesische wörter direkt die YAML geben!!!
 Bitte aufpassen, dass es richtiges YAML ist. Keine falschen Doppelpunkte und Anführungszeichen (vlt alles immer Escapen?)
 Haufuige Fehler
   (hier:
+
+Bei ALLLEN deutschen Anfragen erst Auswahl/Analyse erklärungen geben. Bitte auch immer mit deiner Empfehlung. Tendenziell will ich nämlich wörter für 口语 haben!

--- a/.claude/skills/de-zh-bot/SKILL.md
+++ b/.claude/skills/de-zh-bot/SKILL.md
@@ -771,3 +771,179 @@ Before outputting, verify:
 - [ ] For sentence: `word_analyses` covers the 2–4 most important vocabulary items
 - [ ] No `meaning` field uses double quotes — colons avoided or single-quoted
 - [ ] `synonyms` / `antonyms` included where they add clear value (always for chengyu, optional for others)
+
+
+
+
+Hier ist der **vollständige Prompt** für dieses Verhalten — jetzt mit **Sätzen** integriert:
+
+---
+
+## Verhalten bei deutschen/englischen Eingaben (Wörter, Satzteile, Sätze)
+
+Wenn der Benutzer eine **deutsche oder englische Eingabe** macht, **generiere nicht automatisch YAML**. Stattdessen:
+
+### Fall 1: Eingabe ist ein **vollständiger Satz**
+
+1. **Übersetze den gesamten Satz ins Chinesische** — zeige: Original → Chinesisch (Hanzi) → Pinyin
+
+2. **Gib eine kurze Wort-für-Wort-Aufschlüsselung** (2–5 wichtige Bestandteile mit Bedeutung)
+
+3. **Liste die Bestandteile nummeriert auf** (1., 2., 3., ...) + optional die volle Satzoption
+
+4. **Frage den Benutzer**, welche Bestandteile er als YAML-Einträge haben möchte (z. B. "1+3", "nur 2", "1+2+4")
+
+5. **Generiere für jeden ausgewählten Bestandteil einen eigenen YAML-Eintrag** (`type: word` für einzelne Wörter, `type: expression` für kurze Phrasen, `type: sentence` für den vollen Satz)
+
+---
+
+### Fall 2: Eingabe ist ein **Satzteil / eine Kombination aus zwei oder mehr bedeutungstragenden Bestandteilen** (z. B. Adjektiv + Nomen, Verb + Nomen)
+
+1. **Gib die vollständige Übersetzung des gesamten Ausdrucks** in Hanzi + Pinyin
+
+2. **Liste die einzelnen Bestandteile nummeriert auf** (1., 2., 3., ...)
+   - Für jeden Bestandteil: deutsches/englisches Original + **1–2 chinesische Übersetzungsoptionen** (a., b., ...)
+   - Jede Option erhält eine kurze Erklärung (Verwendung, Kontext, Register)
+
+3. **Frage den Benutzer**, welche Bestandteile er als separate YAML-Einträge haben möchte (z. B. "1a + 2a", "nur 2a", "1b + 2a + 3a")
+
+4. **Generiere für jeden ausgewählten Bestandteil einen eigenen YAML-Eintrag** (`type: word`)
+
+---
+
+### Fall 3: Eingabe ist ein **einzelnes Wort** (Verb, Nomen, Adjektiv)
+
+1. **Wenn eindeutig** (nur eine sinnvolle Übersetzung im gegebenen Kontext) → direkt YAML generieren
+
+2. **Wenn mehrdeutig** (mehrere unterschiedliche Übersetzungen mit verschiedenem Register/Kontext) → nummerierte Liste der Optionen mit:
+   - Chinesisch + Pinyin
+   - Verwendung (1–2 Sätze)
+   - Beispielsatz (Deutsch → Chinesisch)
+   - Dann auf Auswahl warten → YAML generieren
+
+---
+
+### Fall 4: Eingabe ist **direkt Chinesisch**
+
+→ Sofort YAML generieren (keine Auswahl, keine Übersetzung)
+
+---
+
+## Beispiele
+
+### Beispiel 1: Satz — "Wann hast du nächste Woche Zeit?"
+
+**Antwort:**
+
+**Wann hast du nächste Woche Zeit?**
+
+Chinesische Übersetzung: **你下周什么时候有空？**
+Pinyin: *Nǐ xià zhōu shénme shíhou yǒu kòng?*
+
+
+Welche Bestandteile möchtest du als YAML?
+1. 下周 — nächste Woche
+2. 什么时候 — wann
+3. 有空 — Zeit haben
+4. 你下周什么时候有空？ — vollständiger Satz
+
+---
+
+### Beispiel 2: Satzteil — "potenzielle zu interviewende"
+
+**Antwort:**
+
+**Gesamtübersetzung:** 潜在的受访者 (qiánzài de shòufǎngzhě)
+
+**Aufschlüsselung:**
+
+1. **potenziell**
+   - a. 潜在 (qiánzài) — formell, geschrieben (latent, verborgen vorhanden)
+   - b. 可能 (kěnéng) — neutral, alltag (möglich, eventuell)
+
+2. **zu interviewende (Person)**
+   - a. 受访者 (shòufǎngzhě) — formell, allgemein für Befragte (Umfragen, Studien)
+   - b. 面试者 (miànshìzhě) — formell, für Bewerbungsgespräche
+   - c. 访谈对象 (fǎngtán duìxiàng) — formell, für journalistische Interviews
+
+Welche Bestandteile möchtest du als YAML? (z. B. "1a + 2a", "nur 2a", "1b + 2c")
+
+---
+
+### Beispiel 3: Einzelnes Wort (mehrdeutig) — "formulieren"
+
+**Antwort:**
+
+1. 措辞 (cuòcí)
+   - Verwendung: Konkrete Wortwahl, oft mit Bewertung (präzise, höflich, ungeschickt). Formelle Kontexte.
+   - Beispielsatz: Diese Formulierung ist unhöflich. → 这种措辞不礼貌。
+
+2. 表述 (biǎoshù)
+   - Verwendung: Allgemein für das Formulieren einer Idee oder Meinung. Neutral, gesprochen/geschrieben.
+   - Beispielsatz: Kannst du das anders formulieren? → 你能换一种表述吗？
+
+3. 说法 (shuōfǎ)
+   - Verwendung: Umgangssprachlich. Auch "Behauptung" oder "Version einer Geschichte".
+   - Beispielsatz: Das ist eine andere Formulierung. → 这是另一种说法。
+
+Welche Variante möchtest du?
+
+---
+
+### Beispiel 4: Einzelnes Wort (eindeutig) — "生态"
+
+**Antwort:** (sofort YAML, ohne Auswahl)
+
+```yaml
+- type: word
+  ...
+```
+
+---
+
+### Beispiel 5: Satzteil mit drei Bestandteilen — "schnell eine Entscheidung treffen"
+
+**Antwort:**
+
+**Gesamtübersetzung:** 快速做决定 (kuàisù zuò juédìng)
+
+**Aufschlüsselung:**
+
+1. **schnell**
+   - a. 快速 (kuàisù) — neutral, alltag
+   - b. 迅速 (xùnsù) — formeller, schneller
+
+2. **eine Entscheidung**
+   - a. 决定 (juédìng) — Standardwort für Entscheidung
+
+3. **treffen**
+   - a. 做 (zuò) — neutral (machen, treffen)
+   - b. 作出 (zuòchū) — formeller (treffen, fällen)
+
+Welche Bestandteile möchtest du als YAML? (z. B. "1a + 2a + 3a", "nur 2a", "1b + 3b")
+
+---
+
+## Wichtige Regeln
+
+| Eingabetyp | Zuerst Übersetzung? | Dann Aufschlüsselung? | Dann Auswahl? | Dann YAML pro Bestandteil? |
+|------------|---------------------|----------------------|---------------|---------------------------|
+| Ganzer Satz | ✓ | ✓ (Wort-für-Wort) | ✓ | ✓ |
+| Satzteil (2+ Bestandteile) | ✓ (Gesamt) | ✓ (nummeriert) | ✓ | ✓ |
+| Einzelnes Wort (mehrdeutig) | ✗ | ✓ (Optionen) | ✓ | ✓ (ein Eintrag) |
+| Einzelnes Wort (eindeutig) | ✗ | ✗ | ✗ | ✓ (sofort) |
+| Direkt Chinesisch | ✗ | ✗ | ✗ | ✓ (sofort) |
+
+---
+
+**Merke:** Bei **jedem** deutschen/englischen Input, der nicht offensichtlich eindeutig und ein einzelnes Wort ist: **erst auflisten, auf Auswahl warten, dann YAML generieren** — niemals direkt YAML ausgeben!
+
+
+only german for sentences
+also french for just the single word translation
+
+du sollst mir für chinesische wörter direkt die YAML geben!!!
+
+Bitte aufpassen, dass es richtiges YAML ist. Keine falschen Doppelpunkte und Anführungszeichen (vlt alles immer Escapen?)
+Haufuige Fehler
+  (hier:

--- a/ai.py
+++ b/ai.py
@@ -374,7 +374,7 @@ Return ONLY valid JSON, no explanation, no markdown:
 # ---------------------------------------------------------------------------
 
 def _fill_translations(sentences: list[dict], progress_key: str | None = None) -> None:
-    """Translate sentence_zh → sentence_en in-place using Google Translate."""
+    """Translate sentence_zh → sentence_de and sentence_fr in-place using Google Translate."""
     try:
         import translator as _t
         texts = [s.get("sentence_zh", "") for s in sentences]
@@ -383,14 +383,18 @@ def _fill_translations(sentences: list[dict], progress_key: str | None = None) -
         if progress_key and total > 0:
             _set_progress(progress_key, phase="translating",
                           msg=f"Translating… 0/{total}", percent=88)
-            results = _t.translate_batch(texts)
+            de_results = _t.translate_batch(texts, target="de")
+            fr_results = _t.translate_batch(texts, target="fr")
             _set_progress(progress_key, phase="translating",
                           msg=f"Translating… {total}/{total}", percent=92)
         else:
-            results = _t.translate_batch(texts)
+            de_results = _t.translate_batch(texts, target="de")
+            fr_results = _t.translate_batch(texts, target="fr")
 
-        for s, en in zip(sentences, results):
-            s["sentence_en"] = en
+        for s, de, fr in zip(sentences, de_results, fr_results):
+            s["sentence_de"] = de
+            s["sentence_fr"] = fr
+            s.setdefault("sentence_en", "")
     except Exception as e:
         err = str(e)
         vpn_hint = " (VPN issue?)" if any(k in err.lower() for k in ("eof", "connect", "timeout", "proxy", "ssl")) else ""
@@ -399,6 +403,8 @@ def _fill_translations(sentences: list[dict], progress_key: str | None = None) -
             _story_progress[progress_key]["translate_warn"] = f"⚠ Translation failed{vpn_hint}"
         for s in sentences:
             s.setdefault("sentence_en", "")
+            s.setdefault("sentence_de", "")
+            s.setdefault("sentence_fr", "")
 
 
 def _fallback_sentences(cards: list[dict]) -> list[dict]:
@@ -408,6 +414,8 @@ def _fallback_sentences(cards: list[dict]) -> list[dict]:
             "word_id": c["word_id"],
             "sentence_zh": f"我学了{c['word_zh']}这个词。",
             "sentence_en": "",
+            "sentence_de": "",
+            "sentence_fr": "",
         }
         for c in cards
     ]

--- a/database/cards.py
+++ b/database/cards.py
@@ -467,7 +467,7 @@ def count_due(deck_id: int, category: str) -> dict:
 
 
 def update_word(word_id: int, fields: dict) -> None:
-    allowed = {"word_zh", "pinyin", "definition", "pos", "traditional", "definition_zh", "notes", "hsk_level", "definition_de"}
+    allowed = {"word_zh", "pinyin", "definition", "pos", "traditional", "definition_zh", "notes", "hsk_level", "definition_de", "definition_fr"}
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:
         return

--- a/database/core.py
+++ b/database/core.py
@@ -115,6 +115,8 @@ def init_db() -> None:
         conn.execute("ALTER TABLE entries ADD COLUMN date_yaml TEXT")
     if "definition_de" not in cols:
         conn.execute("ALTER TABLE entries ADD COLUMN definition_de TEXT")
+    if "definition_fr" not in cols:
+        conn.execute("ALTER TABLE entries ADD COLUMN definition_fr TEXT")
     if "source_sentence" not in cols:
         conn.execute("ALTER TABLE entries ADD COLUMN source_sentence TEXT")
     if "grammar_notes" not in cols:
@@ -166,6 +168,11 @@ def init_db() -> None:
     if "topic" not in story_cols:
         conn.execute("ALTER TABLE stories ADD COLUMN topic TEXT")
     _migrate_stories_category(conn)
+    ss_cols = {r["name"] for r in conn.execute("PRAGMA table_info(story_sentences)").fetchall()}
+    if "sentence_de" not in ss_cols:
+        conn.execute("ALTER TABLE story_sentences ADD COLUMN sentence_de TEXT")
+    if "sentence_fr" not in ss_cols:
+        conn.execute("ALTER TABLE story_sentences ADD COLUMN sentence_fr TEXT")
 
     deck_cols = {r["name"] for r in conn.execute("PRAGMA table_info(decks)").fetchall()}
     if "deleted_at" not in deck_cols:

--- a/database/entries.py
+++ b/database/entries.py
@@ -14,10 +14,10 @@ def insert_word(word: dict) -> int:
         """INSERT OR IGNORE INTO entries
            (word_zh, pinyin, definition, pos, hsk_level,
             traditional, definition_zh, source, note_type,
-            notes, date_yaml, source_sentence, grammar_notes, register, definition_de)
+            notes, date_yaml, source_sentence, grammar_notes, register, definition_de, definition_fr)
            VALUES (:word_zh, :pinyin, :definition, :pos, :hsk_level,
                    :traditional, :definition_zh, :source, :note_type,
-                   :notes, :date_yaml, :source_sentence, :grammar_notes, :register, :definition_de)""",
+                   :notes, :date_yaml, :source_sentence, :grammar_notes, :register, :definition_de, :definition_fr)""",
         {
             **word,
             "note_type":       word.get("note_type", "vocabulary"),
@@ -27,6 +27,7 @@ def insert_word(word: dict) -> int:
             "grammar_notes":   word.get("grammar_notes"),
             "register":        word.get("register"),
             "definition_de":   word.get("definition_de"),
+            "definition_fr":   word.get("definition_fr"),
         },
     )
     # Backfill notes / date_yaml for entries that existed before these fields were added

--- a/database/stories.py
+++ b/database/stories.py
@@ -54,9 +54,10 @@ def create_story(date_str: str, category: str, deck_id: int,
     story_id = cur.lastrowid
     for s in sentences:
         conn.execute(
-            """INSERT INTO story_sentences (story_id, word_id, position, sentence_zh, sentence_en)
-               VALUES (?, ?, ?, ?, ?)""",
-            (story_id, s["word_id"], s["position"], s["sentence_zh"], s["sentence_en"]),
+            """INSERT INTO story_sentences (story_id, word_id, position, sentence_zh, sentence_en, sentence_de, sentence_fr)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (story_id, s["word_id"], s["position"], s["sentence_zh"],
+             s.get("sentence_en", ""), s.get("sentence_de"), s.get("sentence_fr")),
         )
     conn.commit()
     conn.close()

--- a/importer.py
+++ b/importer.py
@@ -305,6 +305,7 @@ def _build_word_dict(entry: dict, source: str, note_type: str = "vocabulary") ->
         "pinyin":          entry.get("pinyin"),
         "definition":      entry.get("english"),
         "definition_de":   entry.get("german"),
+        "definition_fr":   entry.get("french"),
         "pos":             entry.get("pos"),
         "hsk_level":       _hsk_to_int(str(entry.get("hsk", ""))),
         "traditional":     entry.get("traditional"),

--- a/schema.sql
+++ b/schema.sql
@@ -129,6 +129,7 @@ CREATE TABLE IF NOT EXISTS entries (
     source_sentence TEXT,           -- original source-language sentence (e.g. German) for sentence notes
     grammar_notes   TEXT,           -- grammar explanation (e.g. grammar_de from YAML)
     definition_de   TEXT,           -- German translation / definition
+    definition_fr   TEXT,           -- French translation / definition
     note_type       TEXT NOT NULL DEFAULT 'vocabulary',
                         -- vocabulary | sentence | chengyu | expression | grammar
     register        TEXT CHECK(register IN ('spoken', 'written', 'both', 'spoken_colloquial', 'spoken_neutral', 'neutral', 'formal_written', 'literary'))
@@ -298,7 +299,9 @@ CREATE TABLE IF NOT EXISTS story_sentences (
     word_id     INTEGER NOT NULL REFERENCES entries(id) ON DELETE CASCADE,
     position    INTEGER NOT NULL,
     sentence_zh TEXT NOT NULL,
-    sentence_en TEXT NOT NULL,
+    sentence_en TEXT NOT NULL DEFAULT '',
+    sentence_de TEXT,
+    sentence_fr TEXT,
     UNIQUE(story_id, word_id),
     UNIQUE(story_id, position)
 );

--- a/static/app.js
+++ b/static/app.js
@@ -2692,18 +2692,18 @@ function revealAnswer() {
   }
 
   // Sentence notes have no story — hide story button; show German/French translation
-  const _sentDeEl = document.getElementById('sentence-de');
   const _sentFrEl = document.getElementById('sentence-fr');
+  const _sentDeEl = document.getElementById('sentence-de');
   if (isSentenceNote) {
-    _sentDeEl.textContent = card.definition || '';
-    _sentDeEl.style.display = card.definition ? '' : 'none';
     _sentFrEl.textContent = '';
     _sentFrEl.style.display = 'none';
+    _sentDeEl.textContent = card.definition || '';
+    _sentDeEl.style.display = card.definition ? '' : 'none';
   } else {
-    _sentDeEl.textContent = sentence?.sentence_de || '';
-    _sentDeEl.style.display = sentence?.sentence_de ? '' : 'none';
     _sentFrEl.textContent = sentence?.sentence_fr || '';
     _sentFrEl.style.display = sentence?.sentence_fr ? '' : 'none';
+    _sentDeEl.textContent = sentence?.sentence_de || '';
+    _sentDeEl.style.display = sentence?.sentence_de ? '' : 'none';
   }
   const noteType = wordDetails?.note_type || card.note_type;
   const wordZhEl = document.getElementById('word-zh');
@@ -3479,8 +3479,8 @@ function openStoryModal() {
       <span class="story-num">${s.position + 1}</span>
       <div class="story-content">
         <div class="story-zh">${highlighted}</div>
-        ${s.sentence_de ? `<div class="story-de">🇩🇪 ${s.sentence_de}</div>` : ''}
         ${s.sentence_fr ? `<div class="story-fr">🇫🇷 ${s.sentence_fr}</div>` : ''}
+        ${s.sentence_de ? `<div class="story-de">🇩🇪 ${s.sentence_de}</div>` : ''}
       </div>
       <button class="story-play-btn" onclick="storyJumpTo(${s.position})" title="Play">▶</button>
     </div>`;

--- a/static/app.js
+++ b/static/app.js
@@ -1358,6 +1358,9 @@ function renderWordDetail(word) {
   const defDeEl = document.getElementById('wd-def-de');
   defDeEl.textContent = word.definition_de ? `🇩🇪 ${word.definition_de}` : '';
   defDeEl.style.display = word.definition_de ? 'block' : 'none';
+  const defFrEl = document.getElementById('wd-def-fr');
+  defFrEl.textContent = word.definition_fr ? `🇫🇷 ${word.definition_fr}` : '';
+  defFrEl.style.display = word.definition_fr ? 'block' : 'none';
 
   // Synonyms / antonyms section — collapsible, clickable
   const relEl = document.getElementById('wd-relations-section');
@@ -2407,14 +2410,14 @@ function loadCard(c, counts) {
               // Word bank: sentence just loaded — update hint and rebuild token bank
               const enFront = document.getElementById('sentence-en-front');
               enFront.style.display = 'flex';
-              enFront.textContent = sentence.sentence_en || '';
+              enFront.textContent = sentence.sentence_de || sentence.sentence_fr || '';
               if (document.getElementById('word-bank-wrap').style.display !== 'none') {
                 renderWordBankUI();
               }
             } else if (isCreating && isSentenceNt) {
               // Sentence notes: update English prompt
               const inp = document.getElementById('sentence-en-front');
-              if (inp.style.display !== 'none') inp.textContent = sentence.sentence_en || '';
+              if (inp.style.display !== 'none') inp.textContent = sentence.sentence_de || sentence.sentence_fr || '';
             }
           }
         }
@@ -2547,8 +2550,8 @@ function showFront() {
       userInput = '';
       setTimeout(() => inp.focus(), 80);
     } else {
-      // Word bank mode: English translation as hint; word bank renders below
-      document.getElementById('sentence-en-front').textContent = sentence?.sentence_en || '';
+      // Word bank mode: German/French translation as hint; word bank renders below
+      document.getElementById('sentence-en-front').textContent = sentence?.sentence_de || sentence?.sentence_fr || '';
       userInput = '';
       renderWordBankUI();
     }
@@ -2688,10 +2691,20 @@ function revealAnswer() {
     document.getElementById('sentence-back').innerHTML = renderSentence();
   }
 
-  // Sentence notes have no story — hide story button and English sentence from story
-  document.getElementById('sentence-en').textContent = isSentenceNote
-    ? (card.definition || '')
-    : (sentence?.sentence_en || '');
+  // Sentence notes have no story — hide story button; show German/French translation
+  const _sentDeEl = document.getElementById('sentence-de');
+  const _sentFrEl = document.getElementById('sentence-fr');
+  if (isSentenceNote) {
+    _sentDeEl.textContent = card.definition || '';
+    _sentDeEl.style.display = card.definition ? '' : 'none';
+    _sentFrEl.textContent = '';
+    _sentFrEl.style.display = 'none';
+  } else {
+    _sentDeEl.textContent = sentence?.sentence_de || '';
+    _sentDeEl.style.display = sentence?.sentence_de ? '' : 'none';
+    _sentFrEl.textContent = sentence?.sentence_fr || '';
+    _sentFrEl.style.display = sentence?.sentence_fr ? '' : 'none';
+  }
   const noteType = wordDetails?.note_type || card.note_type;
   const wordZhEl = document.getElementById('word-zh');
   const isMultiWord = noteType === 'sentence' || noteType === 'chengyu' || noteType === 'expression';
@@ -2705,8 +2718,11 @@ function revealAnswer() {
   wordPinEl.style.display = isSentenceNote ? 'none' : '';
   document.getElementById('word-def').textContent = card.definition || '';
   const wordDefDeEl = document.getElementById('word-def-de');
-  wordDefDeEl.textContent = card.definition_de || '';
+  wordDefDeEl.textContent = card.definition_de ? `🇩🇪 ${card.definition_de}` : '';
   wordDefDeEl.style.display = card.definition_de ? 'block' : 'none';
+  const wordDefFrEl = document.getElementById('word-def-fr');
+  wordDefFrEl.textContent = card.definition_fr ? `🇫🇷 ${card.definition_fr}` : '';
+  wordDefFrEl.style.display = card.definition_fr ? 'block' : 'none';
 
   const posEl = document.getElementById('word-pos');
   posEl.textContent   = card.pos || '';
@@ -3463,7 +3479,8 @@ function openStoryModal() {
       <span class="story-num">${s.position + 1}</span>
       <div class="story-content">
         <div class="story-zh">${highlighted}</div>
-        <div class="story-en">${s.sentence_en}</div>
+        ${s.sentence_de ? `<div class="story-de">🇩🇪 ${s.sentence_de}</div>` : ''}
+        ${s.sentence_fr ? `<div class="story-fr">🇫🇷 ${s.sentence_fr}</div>` : ''}
       </div>
       <button class="story-play-btn" onclick="storyJumpTo(${s.position})" title="Play">▶</button>
     </div>`;
@@ -3597,6 +3614,7 @@ function _openEditModal(wordObj) {
   document.getElementById('edit-traditional').value   = wordObj.traditional   || '';
   document.getElementById('edit-definition-zh').value = wordObj.definition_zh || '';
   document.getElementById('edit-definition-de').value = wordObj.definition_de || '';
+  document.getElementById('edit-definition-fr').value = wordObj.definition_fr || '';
   document.getElementById('edit-notes').value         = wordObj.notes         || '';
   // Show card action menu only when opened during active review
   const menuWrap = document.getElementById('edit-card-menu-wrap');
@@ -3718,6 +3736,7 @@ async function saveEditCard() {
     traditional:   document.getElementById('edit-traditional').value.trim(),
     definition_zh: document.getElementById('edit-definition-zh').value.trim(),
     definition_de: document.getElementById('edit-definition-de').value.trim(),
+    definition_fr: document.getElementById('edit-definition-fr').value.trim(),
     notes:         document.getElementById('edit-notes').value.trim(),
   };
   try {
@@ -3732,14 +3751,18 @@ async function saveEditCard() {
         definition: updated.definition, pos: updated.pos,
         traditional: updated.traditional, definition_zh: updated.definition_zh,
         definition_de: updated.definition_de,
+        definition_fr: updated.definition_fr,
         notes: updated.notes,
       });
       document.getElementById('word-zh').textContent  = updated.word_zh || '';
       document.getElementById('word-pin').textContent = updated.pinyin  || '';
       document.getElementById('word-def').textContent = updated.definition || '';
       const wordDefDeEl2 = document.getElementById('word-def-de');
-      wordDefDeEl2.textContent = updated.definition_de || '';
+      wordDefDeEl2.textContent = updated.definition_de ? `🇩🇪 ${updated.definition_de}` : '';
       wordDefDeEl2.style.display = updated.definition_de ? 'block' : 'none';
+      const wordDefFrEl2 = document.getElementById('word-def-fr');
+      wordDefFrEl2.textContent = updated.definition_fr ? `🇫🇷 ${updated.definition_fr}` : '';
+      wordDefFrEl2.style.display = updated.definition_fr ? 'block' : 'none';
       const posEl = document.getElementById('word-pos');
       posEl.textContent   = updated.pos || '';
       posEl.style.display = updated.pos ? 'inline-block' : 'none';

--- a/static/index.html
+++ b/static/index.html
@@ -155,8 +155,9 @@
 
         <!-- 2. Pinyin row (blurred by default, p to reveal) -->
         <div class="pinyin-row" id="pinyin-row"></div>
-        <!-- English translation of the sentence -->
-        <div class="sentence-en" id="sentence-en"></div>
+        <!-- German and French translation of the sentence -->
+        <div class="sentence-de" id="sentence-de"></div>
+        <div class="sentence-fr" id="sentence-fr"></div>
 
         <!-- 3. Rating buttons (immediately visible after flip) -->
         <div class="rating-row" id="rating-row">
@@ -173,6 +174,7 @@
           <div class="word-pos-row"><span class="word-pos" id="word-pos"></span><span class="word-register" id="word-register" style="display:none"></span></div>
           <div class="word-def" id="word-def"></div>
           <div class="word-def-de" id="word-def-de" style="display:none"></div>
+          <div class="word-def-fr" id="word-def-fr" style="display:none"></div>
           <!-- Notes — populated by JS, hidden when empty -->
           <div id="notes-section"></div>
           <!-- Example sentences — populated by JS -->
@@ -267,6 +269,7 @@
       </div>
       <div class="wd-def-zh" id="wd-def-zh" style="display:none"></div>
       <div class="wd-def-de" id="wd-def-de" style="display:none"></div>
+      <div class="wd-def-fr" id="wd-def-fr" style="display:none"></div>
       <button class="wd-edit-btn" id="wd-edit-btn">Edit</button>
       <button class="wd-back-review-btn" id="wd-back-review-btn" style="display:none" onclick="goBack()">← Review</button>
     </div>
@@ -487,6 +490,7 @@
     <label class="edit-label">Traditional<input class="edit-input" id="edit-traditional" type="text" lang="zh"></label>
     <label class="edit-label">Chinese definition<input class="edit-input" id="edit-definition-zh" type="text" lang="zh"></label>
     <label class="edit-label">German definition<input class="edit-input" id="edit-definition-de" type="text"></label>
+    <label class="edit-label">French definition<input class="edit-input" id="edit-definition-fr" type="text"></label>
     <label class="edit-label">Notes<textarea class="edit-input edit-notes" id="edit-notes" rows="3"></textarea></label>
   </div>
   <div class="edit-card-actions">

--- a/static/index.html
+++ b/static/index.html
@@ -155,9 +155,9 @@
 
         <!-- 2. Pinyin row (blurred by default, p to reveal) -->
         <div class="pinyin-row" id="pinyin-row"></div>
-        <!-- German and French translation of the sentence -->
-        <div class="sentence-de" id="sentence-de"></div>
+        <!-- French and German translation of the sentence -->
         <div class="sentence-fr" id="sentence-fr"></div>
+        <div class="sentence-de" id="sentence-de"></div>
 
         <!-- 3. Rating buttons (immediately visible after flip) -->
         <div class="rating-row" id="rating-row">
@@ -173,8 +173,8 @@
           <div class="word-pin" id="word-pin"></div>
           <div class="word-pos-row"><span class="word-pos" id="word-pos"></span><span class="word-register" id="word-register" style="display:none"></span></div>
           <div class="word-def" id="word-def"></div>
-          <div class="word-def-de" id="word-def-de" style="display:none"></div>
           <div class="word-def-fr" id="word-def-fr" style="display:none"></div>
+          <div class="word-def-de" id="word-def-de" style="display:none"></div>
           <!-- Notes — populated by JS, hidden when empty -->
           <div id="notes-section"></div>
           <!-- Example sentences — populated by JS -->
@@ -268,8 +268,8 @@
         <span class="wd-def" id="wd-def"></span>
       </div>
       <div class="wd-def-zh" id="wd-def-zh" style="display:none"></div>
-      <div class="wd-def-de" id="wd-def-de" style="display:none"></div>
       <div class="wd-def-fr" id="wd-def-fr" style="display:none"></div>
+      <div class="wd-def-de" id="wd-def-de" style="display:none"></div>
       <button class="wd-edit-btn" id="wd-edit-btn">Edit</button>
       <button class="wd-back-review-btn" id="wd-back-review-btn" style="display:none" onclick="goBack()">← Review</button>
     </div>

--- a/static/style.css
+++ b/static/style.css
@@ -586,6 +586,7 @@ main.browse-open {
 .word-pos-row { text-align: center; margin: 2px 0; }
 .word-def  { font-size: 16px; color: var(--text); text-align: center; margin-bottom: 4px; }
 .word-def-de { font-size: 14px; color: var(--muted); text-align: center; margin-bottom: 4px; }
+.word-def-fr { font-size: 14px; color: var(--muted); text-align: center; margin-bottom: 4px; }
 
 /* ── Edit card ───────────────────────────────────────── */
 .edit-card-btn {
@@ -867,7 +868,8 @@ main.browse-open {
 .story-sentence-current .story-num { color: var(--primary); }
 .story-content { flex: 1; }
 .story-zh  { font-size: 18px; line-height: 1.5; }
-.story-en  { font-size: 13px; color: var(--muted); margin-top: 3px; }
+.story-de  { font-size: 13px; color: var(--muted); margin-top: 3px; }
+.story-fr  { font-size: 13px; color: var(--muted); margin-top: 2px; }
 .story-target { color: var(--primary); font-weight: 700; }
 .story-controls {
   display: flex;
@@ -957,7 +959,8 @@ main.browse-open {
 .py-zh  { font-size: 18px; }
 .py-target .py-syl { color: var(--primary); font-weight: 700; }
 .py-target .py-zh  { color: var(--primary); font-weight: 700; }
-.sentence-en {
+.sentence-de,
+.sentence-fr {
   flex: 1;
   text-align: center;
   font-size: 14px;
@@ -1989,6 +1992,7 @@ main.browse-open {
 .wd-def    { font-size: 16px; color: var(--text); }
 .wd-def-zh { font-size: 14px; color: var(--muted); margin-top: 4px; }
 .wd-def-de { font-size: 14px; color: var(--muted); margin-top: 2px; }
+.wd-def-fr { font-size: 14px; color: var(--muted); margin-top: 2px; }
 .word-register {
   display: inline-block;
   font-size: 11px;

--- a/translator.py
+++ b/translator.py
@@ -1,5 +1,5 @@
 """
-Chinese → English translation using Google Translate (via deep_translator).
+Chinese → target language translation using Google Translate (via deep_translator).
 
 Requires internet access (VPN recommended in China).
 Install: pip install deep-translator
@@ -8,54 +8,58 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-_translator = None
+_translators: dict[str, object] = {}
 
 
-def _load() -> None:
-    global _translator
-    if _translator is not None:
-        return
+def _load(target: str) -> object | None:
+    if target in _translators:
+        return _translators[target]
     try:
         from deep_translator import GoogleTranslator
-        _translator = GoogleTranslator(source="zh-CN", target="en")
-        logger.info("translator: GoogleTranslator loaded")
+        t = GoogleTranslator(source="zh-CN", target=target)
+        _translators[target] = t
+        logger.info("translator: GoogleTranslator loaded (target=%s)", target)
+        return t
     except Exception as e:
-        logger.error("translator: failed to load — %s", e)
-        _translator = None
+        logger.error("translator: failed to load (target=%s) — %s", target, e)
+        _translators[target] = None
+        return None
 
 
-def translate_zh_en(text: str) -> str:
-    """Translate a Chinese string to English. Returns original text on failure."""
-    _load()
-    if _translator is None or not text.strip():
+def translate_zh(text: str, target: str = "en") -> str:
+    """Translate a Chinese string to the target language. Returns original on failure."""
+    t = _load(target)
+    if t is None or not text.strip():
         return text
     try:
-        return _translator.translate(text) or text
+        return t.translate(text) or text
     except Exception as e:
-        logger.warning("translator: error — %s", e)
+        logger.warning("translator: error (target=%s) — %s", target, e)
         return text
 
 
-def translate_batch(texts: list[str]) -> list[str]:
-    """Translate a list of Chinese strings to English in a single HTTP request."""
-    _load()
-    if _translator is None:
+def translate_batch(texts: list[str], target: str = "en") -> list[str]:
+    """Translate a list of Chinese strings in a single HTTP request."""
+    t = _load(target)
+    if t is None:
         return texts
     if not texts:
         return texts
 
-    # Join with newline — Google Translate preserves \n, so one request suffices.
     sep = "\n"
-    combined = sep.join(t.strip() or " " for t in texts)
+    combined = sep.join(text.strip() or " " for text in texts)
     try:
-        translated = _translator.translate(combined) or combined
+        translated = t.translate(combined) or combined
         parts = translated.split(sep)
-        # If split count matches, return aligned results; otherwise fall back.
         if len(parts) == len(texts):
-            return [p.strip() or t for p, t in zip(parts, texts)]
+            return [p.strip() or orig for p, orig in zip(parts, texts)]
         logger.warning("translator: split count mismatch (%d vs %d), falling back", len(parts), len(texts))
     except Exception as e:
-        logger.warning("translator: batch error — %s", e)
+        logger.warning("translator: batch error (target=%s) — %s", target, e)
 
-    # Fallback: translate one by one
-    return [translate_zh_en(t) for t in texts]
+    return [translate_zh(text, target) for text in texts]
+
+
+# Legacy aliases kept for any callers that used the old API
+def translate_zh_en(text: str) -> str:
+    return translate_zh(text, target="en")


### PR DESCRIPTION
## 变更内容

### 数据库
- `entries` 加 `definition_fr`（法语定义）字段
- `story_sentences` 加 `sentence_de` 和 `sentence_fr` 字段

### 后端
- `importer.py`：从 YAML `french` 字段读取 `definition_fr`
- `translator.py`：重构为支持多目标语言（de/fr/en），兼容旧 API
- `ai.py`：故事句子翻译改为生成德语+法语（原为英语）
- `database/entries.py`、`database/cards.py`：包含 `definition_fr`
- `database/stories.py`：存储/读取 `sentence_de`/`sentence_fr`

### 前端
- 复习卡片背面：显示 🇩🇪 德语 + 🇫🇷 法语句子翻译
- Creating 模式提示：改用德语翻译
- 词汇详情面板：显示 `definition_fr`
- 故事弹窗：每句显示德/法翻译
- 编辑表单：加法语定义输入框

## 测试方法
- 重新生成一个故事，查看故事弹窗中是否有 🇩🇪/🇫🇷 翻译
- 翻转复习卡片，确认显示德语和法语翻译（无英语）
- 在 YAML 文件中添加 `french: ...` 字段并导入，检查词汇详情是否显示 🇫🇷
- 打开编辑表单，确认有法语定义输入框

Closes #238