### PR TITLE
feat: 添加内容模式选择器——故事/问答/说明文

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -86,16 +86,18 @@ def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2
                    model: str = DEFAULT_MODEL,
                    progress_key: str | None = None,
                    grammar_focus: str | None = None,
-                   grammar_pct: int = 75) -> tuple[list[dict], str]:
+                   grammar_pct: int = 75,
+                   mode: str = "story") -> tuple[list[dict], str]:
     """
-    Generate a short Mandarin story, one sentence per card.
+    Generate Mandarin content, one sentence per card.
 
     cards:         list of dicts with keys word_id, word_zh, pinyin, definition, pos
-    topic:         optional theme/setting to guide the story
+    topic:         optional theme/question/topic to guide the content
     max_hsk:       maximum HSK level for non-target background vocabulary (1-6)
     model:         model ID to use for generation
     grammar_focus: optional grammar pattern to encourage (e.g. "把字句")
     grammar_pct:   approximate percentage of sentences that should use the grammar (0-100)
+    mode:          "story" | "qa" | "expository"
     Returns: (sentences, prompt_text)
       sentences: list of {word_id, sentence_zh, sentence_en} — same length as cards.
       prompt_text: the full prompt string sent to the AI.
@@ -129,7 +131,6 @@ def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2
             )
     word_list = "\n".join(word_list_lines)
 
-    topic_line = f"- The story should be set around this topic or theme: {topic}\n" if topic else ""
     if grammar_focus:
         n_sentences = max(1, round(len(cards) * grammar_pct / 100))
         grammar_line = (
@@ -144,7 +145,18 @@ def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2
 
     grammar_first = f"GRAMMAR FOCUS (plan each sentence before writing it):\n{grammar_line}\n" if grammar_focus else ""
 
-    prompt = f"""Write a short Mandarin Chinese story to help an HSK 4-5 learner review vocabulary.
+    if mode == "qa":
+        task_line = f"Answer the following question in Mandarin Chinese, one sentence at a time, to help an HSK 4-5 learner review vocabulary.\nQuestion: {topic or 'Describe something interesting.'}"
+        style_rule = f"- The sentences together should form a coherent, informative answer to the question above\n- Do NOT use fictional characters or narrative story structure"
+    elif mode == "expository":
+        task_line = f"Write a short informative text in Mandarin Chinese about the following topic, to help an HSK 4-5 learner review vocabulary.\nTopic: {topic or 'an interesting subject'}"
+        style_rule = f"- The sentences together should form a coherent, factual explanation of the topic above\n- Do NOT use fictional characters or narrative story structure"
+    else:
+        task_line = "Write a short Mandarin Chinese story to help an HSK 4-5 learner review vocabulary."
+        topic_clause = f"- The story should be set around this topic or theme: {topic}\n" if topic else ""
+        style_rule = f"{topic_clause}- The sentences must form a coherent narrative with the same recurring characters"
+
+    prompt = f"""{task_line}
 
 {grammar_first}Target words — write exactly one sentence per word, in this order:
 {word_list}
@@ -156,7 +168,7 @@ Rules:
 - Use proper Chinese punctuation — include commas（，）where natural pauses occur
 - Use only HSK 1-{max_hsk} vocabulary for non-target words
 - Please keep each sentence as short and simple as possible — shorter is better, as long as all other rules are still met
-{topic_line}- The sentences must form a coherent narrative with the same recurring characters
+{style_rule}
 - NEVER use ASCII double-quote characters (") inside Chinese sentences — use 「」or （）instead if quoting is needed
 - Return ONLY valid JSON, no explanation, no markdown:
 [
@@ -164,7 +176,7 @@ Rules:
   ...
 ]"""
 
-    logger.info("[%s] generate_story: %d 张卡片", model, len(cards))
+    logger.info("[%s] generate_story: %d 张卡片 mode=%s", model, len(cards), mode)
     logger.debug("Prompt:\n%s", prompt)
 
     # 150 tokens per sentence is generous; add 200 for overhead/fences.

--- a/routes/story.py
+++ b/routes/story.py
@@ -85,7 +85,8 @@ def _validated_model(model: str | None) -> str:
 def get_story(deck_id: int, category: str,
               topic: str | None = None, max_hsk: int = 3,
               model: str | None = None,
-              grammar_focus: str | None = None, grammar_pct: int = 75):
+              grammar_focus: str | None = None, grammar_pct: int = 75,
+              mode: str = "story"):
     if database.is_sentences_deck(deck_id):
         return None
 
@@ -106,8 +107,8 @@ def get_story(deck_id: int, category: str,
     chosen_model = _validated_model(model)
     story = None
     cards = _get_cards_for_story(deck_id, category)
-    logger.info("story  GENERATE deck=%d cat=%s due_cards=%d topic=%r max_hsk=%d model=%s",
-                deck_id, category, len(cards), topic, max_hsk, chosen_model)
+    logger.info("story  GENERATE deck=%d cat=%s due_cards=%d topic=%r max_hsk=%d model=%s mode=%s",
+                deck_id, category, len(cards), topic, max_hsk, chosen_model, mode)
     if cards:
         progress_key = f"{deck_id}/{category}"
         ai._story_progress[progress_key] = {"phase": "starting", "msg": "Starting…", "percent": 5}
@@ -117,7 +118,8 @@ def get_story(deck_id: int, category: str,
                                                        model=chosen_model,
                                                        progress_key=progress_key,
                                                        grammar_focus=grammar_focus,
-                                                       grammar_pct=grammar_pct)
+                                                       grammar_pct=grammar_pct,
+                                                       mode=mode)
             for i, s in enumerate(sentences):
                 s["position"] = i
             database.create_story(today, category, deck_id, sentences, prompt_text, topic)
@@ -147,7 +149,8 @@ def get_story(deck_id: int, category: str,
 def regenerate_story(deck_id: int, category: str,
                      topic: str | None = None, max_hsk: int = 3,
                      model: str | None = None,
-                     grammar_focus: str | None = None, grammar_pct: int = 75):
+                     grammar_focus: str | None = None, grammar_pct: int = 75,
+                     mode: str = "story"):
     if database.is_sentences_deck(deck_id):
         return None
     if DISABLE_AI:
@@ -155,8 +158,8 @@ def regenerate_story(deck_id: int, category: str,
     chosen_model = _validated_model(model)
     today = database.anki_today().isoformat()
     cards = _get_cards_for_story(deck_id, category)
-    logger.info("regen  deck=%d cat=%s due_cards=%d topic=%r max_hsk=%d model=%s",
-                deck_id, category, len(cards), topic, max_hsk, chosen_model)
+    logger.info("regen  deck=%d cat=%s due_cards=%d topic=%r max_hsk=%d model=%s mode=%s",
+                deck_id, category, len(cards), topic, max_hsk, chosen_model, mode)
     if not cards:
         return None
     progress_key = f"{deck_id}/{category}"
@@ -167,7 +170,8 @@ def regenerate_story(deck_id: int, category: str,
                                                    model=chosen_model,
                                                    progress_key=progress_key,
                                                    grammar_focus=grammar_focus,
-                                                   grammar_pct=grammar_pct)
+                                                   grammar_pct=grammar_pct,
+                                                   mode=mode)
         for i, s in enumerate(sentences):
             s["position"] = i
         database.create_story(today, category, deck_id, sentences, prompt_text, topic)

--- a/static/app.js
+++ b/static/app.js
@@ -2122,7 +2122,7 @@ async function startReview(id, cat, name, noStory = false) {
   }
 }
 
-async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct) {
+async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story') {
   setLoading('Generating story…', true);
   setLoadingStep(10, null, 'Sending request to AI…');
   _startFakeProgress(10, 55, 45000);
@@ -2130,7 +2130,7 @@ async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct) {
     const storyDeckId = rootDeckId || deckId;
     const storyCategory = rootDeckId ? 'unified' : category;
     _startStoryProgressPoll(storyDeckId, storyCategory);
-    const storyUrl = `/api/story/${storyDeckId}/${storyCategory}` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct);
+    const storyUrl = `/api/story/${storyDeckId}/${storyCategory}` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode);
     let todayData, storyData;
     try {
       [todayData, storyData] = await Promise.all([
@@ -2148,7 +2148,7 @@ async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct) {
 
     _stopFakeProgress(); _stopStoryProgressPoll();
     setLoadingStep(65, null, 'Story received, processing…');
-    story = await _resolveStory(storyData, storyDeckId, storyCategory, topic, maxHsk, grammarFocus, grammarPct);
+    story = await _resolveStory(storyData, storyDeckId, storyCategory, topic, maxHsk, grammarFocus, grammarPct, mode);
 
     if (!todayData.card) {
       showView('done');
@@ -2176,13 +2176,14 @@ async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct) {
   }
 }
 
-function _storyParams(topic, maxHsk, model, grammarFocus, grammarPct) {
+function _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode) {
   const p = new URLSearchParams();
   if (topic)                              p.set('topic', topic);
   if (maxHsk !== 3)                       p.set('max_hsk', maxHsk);
   if (model && model !== 'deepseek-chat') p.set('model', model);
   if (grammarFocus)                       p.set('grammar_focus', grammarFocus);
   if (grammarFocus && grammarPct !== 75)  p.set('grammar_pct', grammarPct);
+  if (mode && mode !== 'story')           p.set('mode', mode);
   const s = p.toString();
   return s ? '?' + s : '';
 }
@@ -2203,7 +2204,7 @@ async function startReviewMixed(id, name, noStory = false) {
       return;
     }
     if (noStory) {
-      await _doStartReviewMixed(null, 2, null, null, 50, true);
+      await _doStartReviewMixed(null, 2, null, null, 50, 'story', true);
       return;
     }
     const c = todayData.counts;
@@ -2212,7 +2213,7 @@ async function startReviewMixed(id, name, noStory = false) {
     const firstCat = todayData.card.category;
     const { has_story, estimated_tokens } = await api('GET', `/api/story/${id}/unified/count`);
     if (has_story) {
-      await _doStartReviewMixed(null, 2, null, null, 50);
+      await _doStartReviewMixed(null, 2, null, null, 50, 'story');
     } else {
       openStorySetup(total, { isMixed: true, learningCount: learning, estimatedTokens: estimated_tokens });
     }
@@ -2223,7 +2224,7 @@ async function startReviewMixed(id, name, noStory = false) {
   }
 }
 
-async function _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPct, noStory = false) {
+async function _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', noStory = false) {
   setLoading(noStory ? 'Loading…' : 'Generating stories…', !noStory);
   if (!noStory) {
     setLoadingStep(10, null, 'Sending request to AI…');
@@ -2243,7 +2244,7 @@ async function _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPc
     if (!noStory) {
       // Load a single unified story covering all categories (1 AI call instead of 3)
       try {
-        story = await api('GET', `/api/story/${rootDeckId}/unified` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct));
+        story = await api('GET', `/api/story/${rootDeckId}/unified` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode));
       } catch (e) {
         _stopFakeProgress(); _stopStoryProgressPoll();
         _showLoadingError('AI request failed', e.message);
@@ -2302,7 +2303,7 @@ async function startReviewUnfinished() {
   }
 }
 
-async function _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, grammarPct) {
+async function _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story') {
   unfinishedMode = true;
   setLoading('Loading cards…');
   try {
@@ -2319,7 +2320,7 @@ async function _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, gram
     const firstDeckId = todayData.card.deck_id;
     // Load a single unified story for the first card's deck
     try {
-      story = await api('GET', `/api/story/${firstDeckId}/unified` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct));
+      story = await api('GET', `/api/story/${firstDeckId}/unified` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode));
     } catch (_) {}
     fetch(`/api/preload-session/${firstDeckId}/unified`, { method: 'POST' }).catch(() => {});
     showView('review');
@@ -3356,7 +3357,7 @@ function storyErrorUseHistory() {
   if (_storyErrorResolve) { _storyErrorResolve({ action: 'history' }); _storyErrorResolve = null; }
 }
 
-async function _resolveStory(storyData, resolvedeckId, resolveCat, topic, maxHsk, grammarFocus, grammarPct) {
+async function _resolveStory(storyData, resolvedeckId, resolveCat, topic, maxHsk, grammarFocus, grammarPct, mode = 'story') {
   if (!storyData?.error) return storyData;
   const choice = await _openStoryErrorModal(storyData);
   if (choice.action === 'skip') return null;
@@ -3371,12 +3372,12 @@ async function _resolveStory(storyData, resolvedeckId, resolveCat, topic, maxHsk
   _startStoryProgressPoll(resolvedeckId, resolveCat);
   let newData;
   try {
-    newData = await api('GET', `/api/story/${resolvedeckId}/${resolveCat}` + _storyParams(topic, maxHsk, choice.model, grammarFocus, grammarPct));
+    newData = await api('GET', `/api/story/${resolvedeckId}/${resolveCat}` + _storyParams(topic, maxHsk, choice.model, grammarFocus, grammarPct, mode));
   } catch (e) {
     newData = { error: true, reason: e.message, model: choice.model, has_history: storyData.has_history };
   }
   _stopFakeProgress(); _stopStoryProgressPoll();
-  return _resolveStory(newData, resolvedeckId, resolveCat, topic, maxHsk, grammarFocus, grammarPct);
+  return _resolveStory(newData, resolvedeckId, resolveCat, topic, maxHsk, grammarFocus, grammarPct, mode);
 }
 
 // ── Story setup modal ────────────────────────────────────────────────────────
@@ -3414,7 +3415,9 @@ function openStorySetup(sentenceCount, { isMixed = false, isUnfinished = false, 
   document.getElementById('setup-grammar').value = '';
   document.getElementById('setup-grammar-pct').value = 50;
   document.getElementById('setup-hsk-slider').value = 2;
+  document.getElementById('setup-mode').value = 'story';
   updateHskLabel();
+  updateSetupMode();
   document.getElementById('setup-modal-overlay').style.display = 'block';
   document.getElementById('setup-modal').style.display        = 'flex';
   document.getElementById('setup-topic').focus();
@@ -3433,23 +3436,44 @@ function updateHskLabel() {
   document.getElementById('setup-hsk-badge').textContent = `HSK ${v}`;
 }
 
+function updateSetupMode() {
+  const mode = document.getElementById('setup-mode').value;
+  const topicLabel = document.getElementById('setup-topic-label');
+  const topicInput = document.getElementById('setup-topic');
+  const btn = document.getElementById('setup-generate-btn');
+  if (mode === 'qa') {
+    topicLabel.childNodes[0].textContent = 'Question ';
+    topicInput.placeholder = 'e.g. How was life in ancient China?';
+    btn.textContent = 'Generate answer';
+  } else if (mode === 'expository') {
+    topicLabel.childNodes[0].textContent = 'Topic ';
+    topicInput.placeholder = 'e.g. The Second World War';
+    btn.textContent = 'Generate text';
+  } else {
+    topicLabel.childNodes[0].textContent = 'Topic ';
+    topicInput.placeholder = 'e.g. a day at a coffee shop';
+    btn.textContent = 'Generate story';
+  }
+}
+
 function confirmStorySetup() {
   const topic       = document.getElementById('setup-topic').value.trim() || null;
   const maxHsk      = parseInt(document.getElementById('setup-hsk-slider').value, 10);
   const model       = document.getElementById('setup-model').value;
   const grammarFocus = document.getElementById('setup-grammar').value.trim() || null;
   const grammarPct  = parseInt(document.getElementById('setup-grammar-pct').value, 10) || 75;
+  const mode        = document.getElementById('setup-mode').value;
   _closeSetupModal();
   if (_setupIsDeckListRegen) {
-    _doRegenStoryForDeckList(_deckListRegenId, topic, maxHsk, model, grammarFocus, grammarPct);
+    _doRegenStoryForDeckList(_deckListRegenId, topic, maxHsk, model, grammarFocus, grammarPct, mode);
   } else if (_setupIsRegen) {
-    _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct);
+    _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct, mode);
   } else if (_setupIsUnfinished) {
-    _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, grammarPct);
+    _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, grammarPct, mode);
   } else if (_setupIsMixed) {
-    _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPct);
+    _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPct, mode);
   } else {
-    _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct);
+    _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mode);
   }
 }
 
@@ -3842,7 +3866,7 @@ async function regenerateStory() {
   }
 }
 
-async function _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct) {
+async function _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story') {
   setLoading('Regenerating story…', true);
   setLoadingStep(10, null, 'Sending request to AI…');
   _startFakeProgress(10, 55, 45000);
@@ -3852,7 +3876,7 @@ async function _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct
     _startStoryProgressPoll(storyDeckId, storyCategory);
     let storyData;
     try {
-      storyData = await api('POST', `/api/story/${storyDeckId}/${storyCategory}/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct));
+      storyData = await api('POST', `/api/story/${storyDeckId}/${storyCategory}/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode));
     } catch (e) {
       _stopFakeProgress(); _stopStoryProgressPoll();
       _showLoadingError('AI request failed', e.message);
@@ -3863,7 +3887,7 @@ async function _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct
     }
     _stopFakeProgress(); _stopStoryProgressPoll();
     setLoadingStep(65, null, 'Story received, processing…');
-    story = await _resolveStory(storyData, storyDeckId, storyCategory, topic, maxHsk, grammarFocus, grammarPct);
+    story = await _resolveStory(storyData, storyDeckId, storyCategory, topic, maxHsk, grammarFocus, grammarPct, mode);
     sentence = story?.sentences?.find(s => s.word_id === card.word_id) || null;
     _updateStoryInfoRow();
 
@@ -3914,7 +3938,7 @@ async function regenerateStoryFromList(deckId) {
   document.getElementById('setup-topic').focus();
 }
 
-async function _doRegenStoryForDeckList(deckId, topic, maxHsk, model, grammarFocus, grammarPct) {
+async function _doRegenStoryForDeckList(deckId, topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story') {
   setLoading('Regenerating story…', true);
   setLoadingStep(10, null, 'Sending request to AI…');
   _startFakeProgress(10, 55, 45000);
@@ -3922,7 +3946,7 @@ async function _doRegenStoryForDeckList(deckId, topic, maxHsk, model, grammarFoc
   try {
     let storyData;
     try {
-      storyData = await api('POST', `/api/story/${deckId}/unified/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct));
+      storyData = await api('POST', `/api/story/${deckId}/unified/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode));
     } catch (e) {
       _stopFakeProgress(); _stopStoryProgressPoll();
       _showLoadingError('AI request failed', e.message);

--- a/static/index.html
+++ b/static/index.html
@@ -510,7 +510,14 @@
   <div id="setup-learning-warning" style="display:none;background:var(--again-bg,#fff3cd);color:var(--again-text,#856404);border:1px solid var(--again-border,#ffc107);border-radius:6px;padding:8px 12px;font-size:13px;margin:0 0 8px"></div>
   <div id="setup-token-warning" style="display:none;background:#fff3cd;color:#856404;border:1px solid #ffc107;border-radius:6px;padding:8px 12px;font-size:13px;margin:0 0 8px"></div>
   <div class="edit-card-fields">
-    <label class="edit-label">Topic <span style="font-weight:400;text-transform:none">(optional)</span>
+    <label class="edit-label">Content mode
+      <select class="edit-input" id="setup-mode" onchange="updateSetupMode()">
+        <option value="story">📖 Story — narrative with characters</option>
+        <option value="qa">❓ Q&amp;A — answer a question</option>
+        <option value="expository">📚 Expository — informative text</option>
+      </select>
+    </label>
+    <label class="edit-label" id="setup-topic-label">Topic <span style="font-weight:400;text-transform:none">(optional)</span>
       <input class="edit-input" id="setup-topic" type="text" placeholder="e.g. a day at a coffee shop" onkeydown="if(event.key==='Enter')confirmStorySetup()">
     </label>
     <label class="edit-label">Grammar focus <span style="font-weight:400;text-transform:none">(optional)</span>
@@ -560,7 +567,7 @@
   </div>
   <div class="edit-card-actions">
     <button class="edit-cancel-btn" onclick="cancelStorySetup()">Cancel</button>
-    <button class="edit-save-btn" id="setup-generate-btn" onclick="confirmStorySetup()">Generate story</button>
+    <button class="edit-save-btn" id="setup-generate-btn" onclick="confirmStorySetup()">Generate</button>
   </div>
 </div>
 


### PR DESCRIPTION
## 变更内容

- 设置弹窗新增「Content mode」下拉菜单，支持三种模式：
  - 📖 **Story**（故事）— 现有叙事模式（默认）
  - ❓ **Q&A**（问答）— 直接回答用户问题，生词自然融入每个句子
  - 📚 **Expository**（说明文）— 生成关于某话题的信息性文本
- 选择不同模式时，话题输入框的标签和占位符会动态变化
- 生成按钮文字随模式变化（Generate story / Generate answer / Generate text）
- 后端 `generate_story()` 新增 `mode` 参数，根据模式生成不同风格的提示词
- API `/api/story` 和 `/api/story/.../regenerate` 支持 `mode` 查询参数

## 测试方法

1. 打开设置弹窗，切换模式，检查标签和占位符是否正确变化
2. 选择「Q&A」模式，输入问题（如 "How was life in ancient China?"），生成内容
3. 选择「Story」模式，正常生成故事，确认无回归

Closes #（无对应 Issue）