### PR TITLE
feat: 将保留率徽章改为显示每日保留率

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -105,7 +105,17 @@
       "Bash(python3 -c \"import json,sys; d=json.load\\(sys.stdin\\); [print\\(p\\) for p in d if ''''serena'''' in str\\(p\\).lower\\(\\)]\")",
       "Bash(rm -rf /Users/daniel/.claude/plugins/cache/claude-plugins-official/serena)",
       "Bash(rm -rf /Users/daniel/Documents/AnkiAdvanced/.serena)",
-      "Skill(commit-commands:commit)"
+      "Skill(commit-commands:commit)",
+      "Bash(bash /Users/daniel/Documents/AnkiAdvanced/backup.sh)",
+      "Bash(crontab -l)",
+      "Read(//Users/daniel/Library/LaunchAgents/**)",
+      "Bash(launchctl load *)",
+      "Bash(launchctl list *)",
+      "Bash(plutil *)",
+      "Bash(launchctl unload *)",
+      "Bash(launchctl start *)",
+      "Bash(cat /Users/daniel/Documents/AnkiAdvanced/ldn174.md)",
+      "Read(//tmp/**)"
     ]
   },
   "hooks": {
@@ -141,4 +151,3 @@
     ]
   }
 }
-

--- a/database/cards.py
+++ b/database/cards.py
@@ -1162,12 +1162,11 @@ def get_card_calendar_data(card_id: int) -> dict:
     ).fetchall()
 
     future = conn.execute(
-        """SELECT c.due, c.category, c.state
+        """SELECT MAX(DATE(c.due), DATE('now')) AS due, c.category, c.state
            FROM cards c
            WHERE c.word_id = ?
              AND c.state NOT IN ('suspended')
-             AND c.deleted_at IS NULL
-             AND DATE(c.due) >= DATE('now')""",
+             AND c.deleted_at IS NULL""",
         (word_id,),
     ).fetchall()
 

--- a/database/cards.py
+++ b/database/cards.py
@@ -1140,3 +1140,38 @@ def toggle_deck_all_suspension(deck_id: int) -> dict:
     conn.commit()
     conn.close()
     return {"all_suspended": not has_active}
+
+
+def get_card_calendar_data(card_id: int) -> dict:
+    """Return past review history and future due dates for all category cards of the same word."""
+    conn = get_db()
+
+    word_row = conn.execute("SELECT word_id FROM cards WHERE id = ?", (card_id,)).fetchone()
+    if not word_row:
+        conn.close()
+        return {"history": [], "future": []}
+    word_id = word_row["word_id"]
+
+    history = conn.execute(
+        """SELECT DATE(rl.reviewed_at) AS date, rl.rating, c.category
+           FROM review_log rl
+           JOIN cards c ON c.id = rl.card_id
+           WHERE c.word_id = ?
+           ORDER BY rl.reviewed_at""",
+        (word_id,),
+    ).fetchall()
+
+    future = conn.execute(
+        """SELECT c.due, c.category, c.state
+           FROM cards c
+           WHERE c.word_id = ?
+             AND c.state NOT IN ('suspended')
+             AND c.deleted_at IS NULL""",
+        (word_id,),
+    ).fetchall()
+
+    conn.close()
+    return {
+        "history": [{"date": r["date"], "rating": r["rating"], "category": r["category"]} for r in history],
+        "future":  [{"due": r["due"][:10], "category": r["category"], "state": r["state"]} for r in future],
+    }

--- a/database/cards.py
+++ b/database/cards.py
@@ -1166,7 +1166,8 @@ def get_card_calendar_data(card_id: int) -> dict:
            FROM cards c
            WHERE c.word_id = ?
              AND c.state NOT IN ('suspended')
-             AND c.deleted_at IS NULL""",
+             AND c.deleted_at IS NULL
+             AND DATE(c.due) >= DATE('now')""",
         (word_id,),
     ).fetchall()
 

--- a/database/entries.py
+++ b/database/entries.py
@@ -479,3 +479,17 @@ def get_word_characters(word_id: int) -> list[dict]:
         result.append(d)
     conn.close()
     return result
+
+
+def get_random_word(exclude_word: str = "") -> str | None:
+    conn = get_db()
+    row = conn.execute(
+        """SELECT word_zh FROM entries
+           WHERE note_type = 'vocabulary'
+             AND word_zh != ?
+             AND length(word_zh) BETWEEN 1 AND 3
+           ORDER BY RANDOM() LIMIT 1""",
+        (exclude_word,),
+    ).fetchone()
+    conn.close()
+    return row["word_zh"] if row else None

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -77,6 +77,12 @@ def browse_words():
     return database.get_words_for_browse()
 
 
+@router.get("/api/words/random")
+def random_word(exclude: str = ""):
+    word = database.get_random_word(exclude)
+    return {"word": word}
+
+
 @router.get("/api/hanzi")
 def get_all_hanzi():
     return database.get_all_characters()

--- a/routes/review.py
+++ b/routes/review.py
@@ -307,3 +307,8 @@ def bury_card(card_id: int):
 def unbury_card(card_id: int):
     database.unbury_card(card_id)
     return {"ok": True}
+
+
+@router.get("/api/cards/{card_id}/calendar")
+def get_card_calendar(card_id: int):
+    return database.get_card_calendar_data(card_id)

--- a/static/app.js
+++ b/static/app.js
@@ -3296,7 +3296,10 @@ function _parseWordBankInput(text) {
       }
       raw.push(chars[i++]);
     } else {
-      i++; // skip spaces / punctuation typed by mistake
+      // Include punctuation that matches a tile char (e.g. ，。、)
+      const ch = chars[i];
+      if (wordBankTokens.some(t => t.char === ch)) raw.push(ch);
+      i++;
     }
   }
   // Walk wordBankOrder: pre-placed tokens auto-fill; tiles and target come from user input in order
@@ -3339,6 +3342,9 @@ function updateWordBankPreview(text) {
     } else { i++; }
   }
   wordBankTokens.forEach(t => { if (cjkText.includes(t.char)) usedNums.add(t.num); });
+  // Also mark punctuation tiles as used when their char appears in raw input
+  const rawText = text.replace(/\s+/g, '');
+  wordBankTokens.forEach(t => { if (!isCjk(t.char[0]) && rawText.includes(t.char)) usedNums.add(t.num); });
   document.querySelectorAll('.wb-token-btn').forEach(btn => {
     const num = parseInt(btn.querySelector('.wb-num').textContent, 10);
     btn.classList.toggle('wb-used', usedNums.has(num));

--- a/static/app.js
+++ b/static/app.js
@@ -3259,8 +3259,16 @@ function _buildWordBank() {
   // If target wasn't found in tokens, append it
   if (!order.some(it => it.type === 'target')) order.push({ type: 'target', word: target });
 
-  const chars    = order.filter(it => it.type === 'char');
-  const shuffled = [...chars].sort(() => Math.random() - 0.5);
+  const MAX_TILES = 5;
+  const allChars = order.filter(it => it.type === 'char');
+  if (allChars.length > MAX_TILES) {
+    // Pick MAX_TILES random positions to be tiles; the rest become pre-placed
+    const tileIdxSet = new Set();
+    while (tileIdxSet.size < MAX_TILES) tileIdxSet.add(Math.floor(Math.random() * allChars.length));
+    allChars.forEach((c, i) => { if (!tileIdxSet.has(i)) c.type = 'pre'; });
+  }
+  const tileChars = order.filter(it => it.type === 'char');
+  const shuffled  = [...tileChars].sort(() => Math.random() - 0.5);
   shuffled.forEach((item, n) => { item.num = n + 1; });
 
   wordBankOrder  = order;
@@ -3291,13 +3299,22 @@ function _parseWordBankInput(text) {
       i++; // skip spaces / punctuation typed by mistake
     }
   }
-  return raw.map(part => {
-    if (/^\d+$/.test(part)) {
-      const tok = wordBankTokens.find(t => t.num === parseInt(part, 10));
-      return tok ? tok.char : '?';
+  // Walk wordBankOrder: pre-placed tokens auto-fill; tiles and target come from user input in order
+  let rawIdx = 0;
+  const result = [];
+  for (const tok of wordBankOrder) {
+    if (tok.type === 'pre') { result.push(tok.char); continue; }
+    if (rawIdx >= raw.length) break; // user hasn't typed this far yet
+    const part = raw[rawIdx++];
+    if (tok.type === 'char') {
+      const n = parseInt(part, 10);
+      const tile = isNaN(n) ? null : wordBankTokens.find(t => t.num === n);
+      result.push(tile ? tile.char : part);
+    } else {
+      result.push(part); // target: pass CJK through
     }
-    return part;
-  });
+  }
+  return result;
 }
 
 function updateWordBankPreview(text) {
@@ -3342,9 +3359,19 @@ function renderWordBankUI() {
 
   document.getElementById('word-bank-preview').textContent = '…';
 
+  // Sentence skeleton: pre-placed tokens shown, numbered blanks for tiles, [?] for target
+  const skelEl = document.getElementById('word-bank-skeleton');
+  if (skelEl) {
+    skelEl.innerHTML = wordBankOrder.map(tok => {
+      if (tok.type === 'pre')    return `<span class="wb-skel-pre">${tok.char}</span>`;
+      if (tok.type === 'char')   return `<span class="wb-skel-blank">[${tok.num}]</span>`;
+      return `<span class="wb-skel-target">[?]</span>`;
+    }).join('');
+  }
+
   const tokensEl = document.getElementById('word-bank-tokens');
   tokensEl.innerHTML = wordBankTokens.map(tok =>
-    `<button class="wb-token-btn" onclick="wordBankAddToken(${tok.num})">`
+    `<button class="wb-token-btn" onmousedown="event.preventDefault()" onclick="wordBankAddToken(${tok.num})">`
     + `<span class="wb-num">${tok.num}</span>`
     + `<span class="wb-char">${tok.char}</span>`
     + `</button>`

--- a/static/app.js
+++ b/static/app.js
@@ -64,6 +64,111 @@ let _timerInterval = null;
 let _timerStart = null;
 let _sessionTotalMs = 0;
 let _sessionRatedCount = 0;
+
+// ── Card schedule calendar ───────────────────────────────────────────────────
+let _calData     = null;   // {history, future} from API
+let _calYear     = null;
+let _calMonth    = null;   // 0-based
+
+const _RATING_CLASS = { 1: 'again', 2: 'hard', 3: 'good', 4: 'easy' };
+const _CAT_ABBR     = { listening: 'L', reading: 'R', creating: 'C' };
+
+function _calKey(dateStr) { return dateStr; }  // "YYYY-MM-DD"
+
+function _buildCalDayMap() {
+  // Returns map: "YYYY-MM-DD" → { ratings: [{rating,category}], dues: [{category,state}] }
+  const map = {};
+  for (const h of (_calData?.history || [])) {
+    const k = h.date;
+    if (!map[k]) map[k] = { ratings: [], dues: [] };
+    map[k].ratings.push({ rating: h.rating, category: h.category });
+  }
+  for (const f of (_calData?.future || [])) {
+    const k = f.due;
+    if (!map[k]) map[k] = { ratings: [], dues: [] };
+    map[k].dues.push({ category: f.category, state: f.state });
+  }
+  return map;
+}
+
+function _renderCal() {
+  const labelEl = document.getElementById('cal-month-label');
+  const gridEl  = document.getElementById('cal-grid');
+  if (!labelEl || !gridEl) return;
+
+  const today = new Date();
+  const todayStr = today.toISOString().slice(0, 10);
+
+  const monthNames = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  labelEl.textContent = `${monthNames[_calMonth]} ${_calYear}`;
+
+  const dayMap = _buildCalDayMap();
+
+  // First day of month (Mon=0 offset)
+  const firstDay = new Date(_calYear, _calMonth, 1);
+  let startOffset = firstDay.getDay() - 1;  // Mon=0
+  if (startOffset < 0) startOffset = 6;
+
+  const daysInMonth = new Date(_calYear, _calMonth + 1, 0).getDate();
+
+  let html = '';
+  // Empty cells before first day
+  for (let i = 0; i < startOffset; i++) html += '<div class="cal-cell cal-empty"></div>';
+
+  for (let d = 1; d <= daysInMonth; d++) {
+    const mm = String(_calMonth + 1).padStart(2, '0');
+    const dd = String(d).padStart(2, '0');
+    const dateStr = `${_calYear}-${mm}-${dd}`;
+    const isToday = dateStr === todayStr;
+    const info = dayMap[dateStr];
+
+    html += `<div class="cal-cell${isToday ? ' cal-today' : ''}">`;
+    html += `<span class="cal-day-num">${d}</span>`;
+    if (info) {
+      html += '<div class="cal-dots">';
+      for (const r of info.ratings) {
+        const cls = _RATING_CLASS[r.rating] || 'good';
+        html += `<span class="cal-dot cal-dot-${cls}" title="${r.category}: ${cls}"></span>`;
+      }
+      for (const f of info.dues) {
+        html += `<span class="cal-dot cal-dot-due" title="${f.category} due (${f.state})"></span>`;
+      }
+      html += '</div>';
+    }
+    html += '</div>';
+  }
+
+  gridEl.innerHTML = html;
+}
+
+function calPrevMonth() {
+  _calMonth--;
+  if (_calMonth < 0) { _calMonth = 11; _calYear--; }
+  _renderCal();
+}
+function calNextMonth() {
+  _calMonth++;
+  if (_calMonth > 11) { _calMonth = 0; _calYear++; }
+  _renderCal();
+}
+
+async function _loadCardCalendar(cardId) {
+  const el = document.getElementById('card-calendar');
+  if (!el) return;
+  _calData = null;
+  el.style.display = 'none';
+  try {
+    const data = await api('GET', `/api/cards/${cardId}/calendar`);
+    if (!data) return;
+    _calData = data;
+    const today = new Date();
+    _calYear  = today.getFullYear();
+    _calMonth = today.getMonth();
+    _renderCal();
+    el.style.display = 'block';
+  } catch (e) { /* silently skip if unavailable */ }
+}
+
 // ── Card timer ──────────────────────────────────────────────────────────────
 function _startTimer() {
   _stopTimer();
@@ -2535,6 +2640,7 @@ function loadCard(c, counts) {
 
   showFront();
   _startTimer();
+  _loadCardCalendar(c.id);
 
   // Auto-play audio for the listening category.
   // If sentence is missing and a story fetch is in flight, defer to the fetch callback above.

--- a/static/app.js
+++ b/static/app.js
@@ -71,7 +71,7 @@ let _calYear     = null;
 let _calMonth    = null;   // 0-based
 
 const _RATING_CLASS = { 1: 'again', 2: 'hard', 3: 'good', 4: 'easy' };
-const _CAT_ABBR     = { listening: 'L', reading: 'R', creating: 'C' };
+const _CAT_CLASS    = { listening: 'listening', reading: 'reading', creating: 'creating' };
 
 function _calKey(dateStr) { return dateStr; }  // "YYYY-MM-DD"
 
@@ -127,11 +127,13 @@ function _renderCal() {
     if (info) {
       html += '<div class="cal-dots">';
       for (const r of info.ratings) {
-        const cls = _RATING_CLASS[r.rating] || 'good';
-        html += `<span class="cal-dot cal-dot-${cls}" title="${r.category}: ${cls}"></span>`;
+        const rCls  = _RATING_CLASS[r.rating] || 'good';
+        const cCls  = _CAT_CLASS[r.category]  || '';
+        html += `<span class="cal-dot cal-dot-${rCls} cal-dot-cat-${cCls}" title="${r.category}: ${rCls}"></span>`;
       }
       for (const f of info.dues) {
-        html += `<span class="cal-dot cal-dot-due" title="${f.category} due (${f.state})"></span>`;
+        const cCls = _CAT_CLASS[f.category] || '';
+        html += `<span class="cal-dot cal-dot-due-${cCls}" title="${f.category} due (${f.state})"></span>`;
       }
       html += '</div>';
     }

--- a/static/app.js
+++ b/static/app.js
@@ -472,7 +472,7 @@ async function loadDecks() {
   try {
     const [decks, retention] = await Promise.all([
       api('GET', '/api/decks'),
-      api('GET', '/api/retention?days=1').catch(() => null),
+      api('GET', '/api/retention?days=0').catch(() => null),
     ]);
     _cachedDecks = decks;
     _retentionData = retention;

--- a/static/app.js
+++ b/static/app.js
@@ -69,6 +69,7 @@ let _sessionRatedCount = 0;
 let _calData     = null;   // {history, future} from API
 let _calYear     = null;
 let _calMonth    = null;   // 0-based
+let _calCategory = null;   // current card's category — shown on today even if not in dues
 
 const _RATING_CLASS = { 1: 'again', 2: 'hard', 3: 'good', 4: 'easy' };
 const _CAT_CLASS    = { listening: 'listening', reading: 'reading', creating: 'creating' };
@@ -143,6 +144,10 @@ function _renderCal() {
         html += `<span class="cal-chip cal-chip-due-${cCls}" title="${f.category} due">${letter}</span>`;
       }
       html += '</div>';
+    } else if (isToday && _calCategory) {
+      const letter = _CAT_LETTER[_calCategory] || '?';
+      const cCls   = _CAT_CLASS[_calCategory]  || '';
+      html += `<div class="cal-chips"><span class="cal-chip cal-chip-due-${cCls}" title="${_calCategory} today">${letter}</span></div>`;
     } else {
       html += `<span class="cal-day-num${isToday ? ' cal-day-num-today' : ''}">${d}</span>`;
     }
@@ -163,10 +168,11 @@ function calNextMonth() {
   _renderCal();
 }
 
-async function _loadCardCalendar(cardId) {
+async function _loadCardCalendar(cardId, category) {
   const el = document.getElementById('card-calendar');
   if (!el) return;
-  _calData = null;
+  _calData     = null;
+  _calCategory = category || null;
   el.style.display = 'none';
   try {
     const data = await api('GET', `/api/cards/${cardId}/calendar`);
@@ -2651,7 +2657,7 @@ function loadCard(c, counts) {
 
   showFront();
   _startTimer();
-  _loadCardCalendar(c.id);
+  _loadCardCalendar(c.id, c.category);
 
   // Auto-play audio for the listening category.
   // If sentence is missing and a story fetch is in flight, defer to the fetch callback above.

--- a/static/app.js
+++ b/static/app.js
@@ -3324,30 +3324,50 @@ function _parseWordBankInput(text) {
 }
 
 function updateWordBankPreview(text) {
-  const el = document.getElementById('word-bank-preview');
-  const parts = _parseWordBankInput(text);
-  el.textContent = parts.length ? parts.join('') : '…';
-
-  // Grey out tokens whose number has been typed OR whose char appears in typed CJK text
+  // Compute slot values by walking wordBankOrder with parsed user tokens
   const isCjk = ch => /[\u3000-\u9FFF\uF900-\uFAFF]/.test(ch);
-  const usedNums = new Set();
   const chars = [...text.replace(/\s+/g, '')];
-  const cjkText = chars.filter(isCjk).join('');
+  const raw = [];
   let i = 0;
   while (i < chars.length) {
-    if (/\d/.test(chars[i])) {
+    if (isCjk(chars[i])) {
+      let s = chars[i++];
+      while (i < chars.length && isCjk(chars[i])) s += chars[i++];
+      raw.push(s);
+    } else if (/\d/.test(chars[i])) {
       if (i + 1 < chars.length && /\d/.test(chars[i + 1])) {
         const two = parseInt(chars[i] + chars[i + 1], 10);
-        if (wordBankTokens.some(t => t.num === two)) { usedNums.add(two); i += 2; continue; }
+        if (wordBankTokens.some(t => t.num === two)) { raw.push(String(two)); i += 2; continue; }
       }
-      usedNums.add(parseInt(chars[i], 10));
+      raw.push(chars[i++]);
+    } else {
+      const ch = chars[i];
+      if (wordBankTokens.some(t => t.char === ch)) raw.push(ch);
       i++;
-    } else { i++; }
+    }
   }
-  wordBankTokens.forEach(t => { if (cjkText.includes(t.char)) usedNums.add(t.num); });
-  // Also mark punctuation tiles as used when their char appears in raw input
-  const rawText = text.replace(/\s+/g, '');
-  wordBankTokens.forEach(t => { if (!isCjk(t.char[0]) && rawText.includes(t.char)) usedNums.add(t.num); });
+
+  // Walk wordBankOrder to assign values to numbered slots
+  let rawIdx = 0, slotIdx = 0;
+  const usedNums = new Set();
+  document.querySelectorAll('.wb-skel-blank[data-slot]').forEach(span => span.textContent = '＿');
+
+  for (const tok of wordBankOrder) {
+    if (tok.type === 'pre') continue;
+    const span = document.querySelector(`.wb-skel-blank[data-slot="${slotIdx++}"]`);
+    if (rawIdx >= raw.length) continue;
+    const part = raw[rawIdx++];
+    if (tok.type === 'char') {
+      const n = parseInt(part, 10);
+      const tile = isNaN(n) ? null : wordBankTokens.find(t => t.num === n);
+      if (tile) { usedNums.add(tile.num); if (span) span.textContent = tile.char; }
+      else if (span) span.textContent = part;
+    } else {
+      if (span) span.textContent = part; // target word
+    }
+  }
+
+  // Grey out used tile buttons
   document.querySelectorAll('.wb-token-btn').forEach(btn => {
     const num = parseInt(btn.querySelector('.wb-num').textContent, 10);
     btn.classList.toggle('wb-used', usedNums.has(num));
@@ -3366,15 +3386,13 @@ function renderWordBankUI() {
   _buildWordBank();
   if (!wordBankTokens.length) return; // sentence not loaded yet
 
-  document.getElementById('word-bank-preview').textContent = '…';
-
-  // Sentence skeleton: pre-placed tokens shown as text, blanks for tiles and target
+  // Sentence skeleton: pre-placed tokens shown as text, blanks for tiles/target (data-slot for live update)
   const skelEl = document.getElementById('word-bank-skeleton');
   if (skelEl) {
+    let slotIdx = 0;
     skelEl.innerHTML = wordBankOrder.map(tok => {
-      if (tok.type === 'pre')  return `<span class="wb-skel-pre">${tok.char}</span>`;
-      if (tok.type === 'char') return `<span class="wb-skel-blank">＿</span>`;
-      return `<span class="wb-skel-target">＿</span>`;
+      if (tok.type === 'pre') return `<span class="wb-skel-pre">${tok.char}</span>`;
+      return `<span class="wb-skel-blank" data-slot="${slotIdx++}">＿</span>`;
     }).join('');
   }
 

--- a/static/app.js
+++ b/static/app.js
@@ -3272,6 +3272,24 @@ function _buildWordBank() {
   }
   const tileChars = order.filter(it => it.type === 'char');
   const shuffled  = [...tileChars].sort(() => Math.random() - 0.5);
+
+  // Add a random distractor word (unrelated token to increase difficulty)
+  const DISTRACTOR_WORDS = [
+    '也', '和', '需要', '但是', '因为', '所以', '很', '就', '还', '还是',
+    '只', '都', '一样', '不同', '最', '更', '比', '如果', '虽然', '为了',
+    '不', '没', '要', '能', '会', '可以', '应该', '想', '知道', '看',
+    '说', '听', '写', '读', '学', '教', '来', '去', '给', '对'
+  ];
+  const distractor = {
+    type: 'char',
+    char: DISTRACTOR_WORDS[Math.floor(Math.random() * DISTRACTOR_WORDS.length)],
+    num: -1
+  };
+  // Only add if it's not already in the tokens and different from target word
+  if (!shuffled.some(t => t.char === distractor.char) && distractor.char !== target) {
+    shuffled.push(distractor);
+  }
+
   shuffled.forEach((item, n) => { item.num = n + 1; });
 
   wordBankOrder  = order;

--- a/static/app.js
+++ b/static/app.js
@@ -143,8 +143,8 @@ function _renderCal() {
         html += `<span class="cal-chip cal-chip-due-${cCls}" title="${f.category} due">${letter}</span>`;
       }
       html += '</div>';
-    } else if (isToday) {
-      html += '<div class="cal-today-dot"></div>';
+    } else {
+      html += `<span class="cal-day-num${isToday ? ' cal-day-num-today' : ''}">${d}</span>`;
     }
     html += '</div>';
   }

--- a/static/app.js
+++ b/static/app.js
@@ -327,7 +327,7 @@ async function loadDecks() {
   try {
     const [decks, retention] = await Promise.all([
       api('GET', '/api/decks'),
-      api('GET', '/api/retention').catch(() => null),
+      api('GET', '/api/retention?days=1').catch(() => null),
     ]);
     _cachedDecks = decks;
     _retentionData = retention;
@@ -428,7 +428,7 @@ function _calcDeckRR(deck) {
 
 // Build tooltip text for a deck's RR
 function _rrTooltip(rr) {
-  const lines = [`30d retention: ${_formatRR(rr.overall)} (${rr.total ?? 0} reviews)`];
+  const lines = [`Today's retention: ${_formatRR(rr.overall)} (${rr.total ?? 0} reviews)`];
   const LABELS = { reading: 'R', listening: 'L', creating: 'C' };
   for (const [cat, val] of Object.entries(rr.by_category)) {
     lines.push(`${LABELS[cat] ?? cat}: ${_formatRR(val)}`);
@@ -599,7 +599,7 @@ function renderDecks(decks) {
     const allRRData = _retentionData?.all;
     const allRRVal = allRRData?.total > 0 ? allRRData.correct / allRRData.total : null;
     const allRRBadge = allRRVal !== null
-      ? `<span class="deck-rr-badge" title="30d retention: ${_formatRR(allRRVal)} (${allRRData.total} reviews)">${_formatRR(allRRVal)}</span>`
+      ? `<span class="deck-rr-badge" title="Today's retention: ${_formatRR(allRRVal)} (${allRRData.total} reviews)">${_formatRR(allRRVal)}</span>`
       : '';
     filteredHtml += `
       <div class="tree-row tree-parent">

--- a/static/app.js
+++ b/static/app.js
@@ -3230,7 +3230,7 @@ function pickExtraBlankWord(zh, excludeWord) {
 }
 
 // ── Word bank (creating mode, non-sentence notes) ─────────────────────────
-function _buildWordBank() {
+async function _buildWordBank() {
   const zh = sentence?.sentence_zh;
   if (!zh || !card?.word_zh) return;
   const target = card.word_zh;
@@ -3273,22 +3273,15 @@ function _buildWordBank() {
   const tileChars = order.filter(it => it.type === 'char');
   const shuffled  = [...tileChars].sort(() => Math.random() - 0.5);
 
-  // Add a random distractor word (unrelated token to increase difficulty)
-  const DISTRACTOR_WORDS = [
-    '也', '和', '需要', '但是', '因为', '所以', '很', '就', '还', '还是',
-    '只', '都', '一样', '不同', '最', '更', '比', '如果', '虽然', '为了',
-    '不', '没', '要', '能', '会', '可以', '应该', '想', '知道', '看',
-    '说', '听', '写', '读', '学', '教', '来', '去', '给', '对'
-  ];
-  const distractor = {
-    type: 'char',
-    char: DISTRACTOR_WORDS[Math.floor(Math.random() * DISTRACTOR_WORDS.length)],
-    num: -1
-  };
-  // Only add if it's not already in the tokens and different from target word
-  if (!shuffled.some(t => t.char === distractor.char) && distractor.char !== target) {
-    shuffled.push(distractor);
-  }
+  // Fetch a random distractor word from the database and insert at a random position
+  try {
+    const resp = await fetch(`/api/words/random?exclude=${encodeURIComponent(target)}`);
+    const data = await resp.json();
+    if (data.word && !shuffled.some(t => t.char === data.word)) {
+      const pos = Math.floor(Math.random() * (shuffled.length + 1));
+      shuffled.splice(pos, 0, { type: 'char', char: data.word, num: -1 });
+    }
+  } catch (_) { /* skip distractor if fetch fails */ }
 
   shuffled.forEach((item, n) => { item.num = n + 1; });
 
@@ -3400,8 +3393,8 @@ function wordBankAddToken(num) {
   inp.focus();
 }
 
-function renderWordBankUI() {
-  _buildWordBank();
+async function renderWordBankUI() {
+  await _buildWordBank();
   if (!wordBankTokens.length) return; // sentence not loaded yet
 
   // Sentence skeleton: pre-placed tokens shown as text, blanks for tiles/target (data-slot for live update)

--- a/static/app.js
+++ b/static/app.js
@@ -75,18 +75,27 @@ const _CAT_CLASS    = { listening: 'listening', reading: 'reading', creating: 'c
 
 function _calKey(dateStr) { return dateStr; }  // "YYYY-MM-DD"
 
+const _CAT_LETTER = { listening: 'L', reading: 'R', creating: 'C' };
+
 function _buildCalDayMap() {
-  // Returns map: "YYYY-MM-DD" → { ratings: [{rating,category}], dues: [{category,state}] }
-  const map = {};
+  // Deduplicate: per (date, category) keep only the last review
+  const histByKey = {};
   for (const h of (_calData?.history || [])) {
-    const k = h.date;
-    if (!map[k]) map[k] = { ratings: [], dues: [] };
-    map[k].ratings.push({ rating: h.rating, category: h.category });
+    histByKey[`${h.date}|${h.category}`] = h;
   }
+  const dueByKey = {};
   for (const f of (_calData?.future || [])) {
-    const k = f.due;
-    if (!map[k]) map[k] = { ratings: [], dues: [] };
-    map[k].dues.push({ category: f.category, state: f.state });
+    dueByKey[`${f.due}|${f.category}`] = f;
+  }
+
+  const map = {};
+  for (const h of Object.values(histByKey)) {
+    if (!map[h.date]) map[h.date] = { ratings: [], dues: [] };
+    map[h.date].ratings.push({ rating: h.rating, category: h.category });
+  }
+  for (const f of Object.values(dueByKey)) {
+    if (!map[f.due]) map[f.due] = { ratings: [], dues: [] };
+    map[f.due].dues.push({ category: f.category, state: f.state });
   }
   return map;
 }
@@ -104,15 +113,13 @@ function _renderCal() {
 
   const dayMap = _buildCalDayMap();
 
-  // First day of month (Mon=0 offset)
   const firstDay = new Date(_calYear, _calMonth, 1);
-  let startOffset = firstDay.getDay() - 1;  // Mon=0
+  let startOffset = firstDay.getDay() - 1;
   if (startOffset < 0) startOffset = 6;
 
   const daysInMonth = new Date(_calYear, _calMonth + 1, 0).getDate();
 
   let html = '';
-  // Empty cells before first day
   for (let i = 0; i < startOffset; i++) html += '<div class="cal-cell cal-empty"></div>';
 
   for (let d = 1; d <= daysInMonth; d++) {
@@ -123,19 +130,21 @@ function _renderCal() {
     const info = dayMap[dateStr];
 
     html += `<div class="cal-cell${isToday ? ' cal-today' : ''}">`;
-    html += `<span class="cal-day-num">${d}</span>`;
     if (info) {
-      html += '<div class="cal-dots">';
+      html += '<div class="cal-chips">';
       for (const r of info.ratings) {
-        const rCls  = _RATING_CLASS[r.rating] || 'good';
-        const cCls  = _CAT_CLASS[r.category]  || '';
-        html += `<span class="cal-dot cal-dot-${rCls} cal-dot-cat-${cCls}" title="${r.category}: ${rCls}"></span>`;
+        const rCls = _RATING_CLASS[r.rating] || 'good';
+        const letter = _CAT_LETTER[r.category] || '?';
+        html += `<span class="cal-chip cal-chip-${rCls}" title="${r.category}: ${rCls}">${letter}</span>`;
       }
       for (const f of info.dues) {
         const cCls = _CAT_CLASS[f.category] || '';
-        html += `<span class="cal-dot cal-dot-due-${cCls}" title="${f.category} due (${f.state})"></span>`;
+        const letter = _CAT_LETTER[f.category] || '?';
+        html += `<span class="cal-chip cal-chip-due-${cCls}" title="${f.category} due">${letter}</span>`;
       }
       html += '</div>';
+    } else if (isToday) {
+      html += '<div class="cal-today-dot"></div>';
     }
     html += '</div>';
   }

--- a/static/app.js
+++ b/static/app.js
@@ -60,6 +60,25 @@ let optDeckId    = null; // deck whose options modal is open
 const collapsed  = new Set(JSON.parse(localStorage.getItem('collapsedDecks') || '[]'));  // parent deck IDs that are collapsed
 let _retentionData = null;  // cached result from GET /api/retention
 let _cachedDecks = null;       // last fetched deck tree (for toggle re-renders)
+let _timerInterval = null;
+let _timerStart = null;
+// ── Card timer ──────────────────────────────────────────────────────────────
+function _startTimer() {
+  _stopTimer();
+  _timerStart = Date.now();
+  const el = document.getElementById('card-timer');
+  el.textContent = '0s';
+  el.style.display = 'block';
+  _timerInterval = setInterval(() => {
+    const s = Math.floor((Date.now() - _timerStart) / 1000);
+    el.textContent = s < 60 ? `${s}s` : `${Math.floor(s / 60)}m${s % 60}s`;
+  }, 1000);
+}
+function _stopTimer() {
+  if (_timerInterval) { clearInterval(_timerInterval); _timerInterval = null; }
+  document.getElementById('card-timer').style.display = 'none';
+}
+
 // ── Story info row (Sentence x/y · Topic) ───────────────────────────────────
 function _updateStoryInfoRow() {
   const row = document.getElementById('story-info-row');
@@ -2496,6 +2515,7 @@ function loadCard(c, counts) {
     .catch(() => {});
 
   showFront();
+  _startTimer();
 
   // Auto-play audio for the listening category.
   // If sentence is missing and a story fetch is in flight, defer to the fetch callback above.
@@ -2596,6 +2616,7 @@ function diffAnswer(userInput, correct, wordZh) {
 
 // ── Back of card ────────────────────────────────────────────────────────────
 function revealAnswer() {
+  _stopTimer();
   const isCreating = category === 'creating';
 
   // Capture user input before hiding front

--- a/static/app.js
+++ b/static/app.js
@@ -3260,12 +3260,15 @@ function _buildWordBank() {
   if (!order.some(it => it.type === 'target')) order.push({ type: 'target', word: target });
 
   const MAX_TILES = 5;
+  const isWord = tok => /[\u4E00-\u9FFF\u3400-\u4DBF]/.test(tok.char);
   const allChars = order.filter(it => it.type === 'char');
-  if (allChars.length > MAX_TILES) {
-    // Pick MAX_TILES random positions to be tiles; the rest become pre-placed
+  // Punctuation tokens are always pre-placed — only real words become tiles
+  allChars.forEach(c => { if (!isWord(c)) c.type = 'pre'; });
+  const wordTokens = allChars.filter(c => c.type === 'char');
+  if (wordTokens.length > MAX_TILES) {
     const tileIdxSet = new Set();
-    while (tileIdxSet.size < MAX_TILES) tileIdxSet.add(Math.floor(Math.random() * allChars.length));
-    allChars.forEach((c, i) => { if (!tileIdxSet.has(i)) c.type = 'pre'; });
+    while (tileIdxSet.size < MAX_TILES) tileIdxSet.add(Math.floor(Math.random() * wordTokens.length));
+    wordTokens.forEach((c, i) => { if (!tileIdxSet.has(i)) c.type = 'pre'; });
   }
   const tileChars = order.filter(it => it.type === 'char');
   const shuffled  = [...tileChars].sort(() => Math.random() - 0.5);
@@ -3365,13 +3368,13 @@ function renderWordBankUI() {
 
   document.getElementById('word-bank-preview').textContent = '…';
 
-  // Sentence skeleton: pre-placed tokens shown, numbered blanks for tiles, [?] for target
+  // Sentence skeleton: pre-placed tokens shown as text, blanks for tiles and target
   const skelEl = document.getElementById('word-bank-skeleton');
   if (skelEl) {
     skelEl.innerHTML = wordBankOrder.map(tok => {
-      if (tok.type === 'pre')    return `<span class="wb-skel-pre">${tok.char}</span>`;
-      if (tok.type === 'char')   return `<span class="wb-skel-blank">[${tok.num}]</span>`;
-      return `<span class="wb-skel-target">[?]</span>`;
+      if (tok.type === 'pre')  return `<span class="wb-skel-pre">${tok.char}</span>`;
+      if (tok.type === 'char') return `<span class="wb-skel-blank">＿</span>`;
+      return `<span class="wb-skel-target">＿</span>`;
     }).join('');
   }
 

--- a/static/app.js
+++ b/static/app.js
@@ -75,7 +75,7 @@ const _CAT_CLASS    = { listening: 'listening', reading: 'reading', creating: 'c
 
 function _calKey(dateStr) { return dateStr; }  // "YYYY-MM-DD"
 
-const _CAT_LETTER = { listening: 'L', reading: 'R', creating: 'C' };
+const _CAT_LETTER = { listening: '听', reading: '读', creating: '创' };
 
 function _buildCalDayMap() {
   // Deduplicate: per (date, category) keep only the last review

--- a/static/app.js
+++ b/static/app.js
@@ -62,6 +62,8 @@ let _retentionData = null;  // cached result from GET /api/retention
 let _cachedDecks = null;       // last fetched deck tree (for toggle re-renders)
 let _timerInterval = null;
 let _timerStart = null;
+let _sessionTotalMs = 0;
+let _sessionRatedCount = 0;
 // ── Card timer ──────────────────────────────────────────────────────────────
 function _startTimer() {
   _stopTimer();
@@ -77,6 +79,14 @@ function _startTimer() {
 function _stopTimer() {
   if (_timerInterval) { clearInterval(_timerInterval); _timerInterval = null; }
   document.getElementById('card-timer').style.display = 'none';
+}
+function _updateAvgTimeBadge() {
+  const el = document.getElementById('avg-time-badge');
+  if (_sessionRatedCount === 0) { el.style.display = 'none'; return; }
+  const avgS = Math.round(_sessionTotalMs / _sessionRatedCount / 1000);
+  const label = avgS < 60 ? `${avgS}s` : `${Math.floor(avgS / 60)}m${avgS % 60}s`;
+  el.textContent = `avg ${label}/card`;
+  el.style.display = 'inline';
 }
 
 // ── Story info row (Sentence x/y · Topic) ───────────────────────────────────
@@ -2117,6 +2127,9 @@ async function startReview(id, cat, name, noStory = false) {
   category = cat;
   deckName = name;
   _sessionReviewedCount = 0;
+  _sessionTotalMs = 0;
+  _sessionRatedCount = 0;
+  _updateAvgTimeBadge();
   _updateReviewRRBadge(id);
 
   try {
@@ -2214,6 +2227,9 @@ async function startReviewMixed(id, name, noStory = false) {
   deckName   = name;
   story      = null;
   _sessionReviewedCount = 0;
+  _sessionTotalMs = 0;
+  _sessionRatedCount = 0;
+  _updateAvgTimeBadge();
   _updateReviewRRBadge(id);
   try {
     const todayData = await api('GET', `/api/today-mixed/${id}`);
@@ -2309,6 +2325,9 @@ async function startReviewUnfinished() {
   deckName = 'Unfinished Cards';
   story    = null;
   _sessionReviewedCount = 0;
+  _sessionTotalMs = 0;
+  _sessionRatedCount = 0;
+  _updateAvgTimeBadge();
   try {
     const counts = await api('GET', '/api/today-unfinished');
     if (!counts.card) {
@@ -3257,6 +3276,11 @@ function diffClozeAnswer(userInput, targetWord) {
 // ── Submit rating ───────────────────────────────────────────────────────────
 async function rate(rating) {
   document.querySelectorAll('.r-btn').forEach(b => b.disabled = true);
+  if (_timerStart) {
+    _sessionTotalMs += Date.now() - _timerStart;
+    _sessionRatedCount++;
+    _updateAvgTimeBadge();
+  }
   try {
     let url = `/api/review?card_id=${card.id}&rating=${rating}`;
     if (unfinishedMode) url += `&unfinished_mode=true`;

--- a/static/index.html
+++ b/static/index.html
@@ -64,7 +64,7 @@
         </div>
       </div>
       <div style="display:flex;gap:6px;margin-left:auto;align-items:center">
-        <span id="review-rr-badge" class="review-rr-badge" style="display:none" title="30-day retention rate"></span>
+        <span id="review-rr-badge" class="review-rr-badge" style="display:none" title="Daily retention rate"></span>
         <button class="undo-btn" id="undo-btn" onclick="undoReview()" title="Undo last rating [Z]" disabled>↩ Undo</button>
       </div>
     </div>

--- a/static/index.html
+++ b/static/index.html
@@ -125,7 +125,7 @@
           <div class="word-bank-tokens" id="word-bank-tokens"></div>
           <input type="text" id="word-bank-input"
                  autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
-                 placeholder="Type numbers + target word in order (e.g. 1 2 努力 3)"
+                 placeholder="Fill blanks left to right: tile numbers + target word (e.g. 3 1 努力 2 5 4)"
                  oninput="updateWordBankPreview(this.value)"
                  onkeydown="if(event.key==='Enter')revealAnswer()">
         </div>

--- a/static/index.html
+++ b/static/index.html
@@ -187,6 +187,26 @@
         </div>
 
       </div>
+
+      <!-- Card schedule calendar -->
+      <div id="card-calendar" class="card-calendar" style="display:none">
+        <div class="cal-header">
+          <button class="cal-nav-btn" onclick="calPrevMonth()">‹</button>
+          <span id="cal-month-label" class="cal-month-label"></span>
+          <button class="cal-nav-btn" onclick="calNextMonth()">›</button>
+        </div>
+        <div class="cal-weekdays">
+          <span>Mo</span><span>Tu</span><span>We</span><span>Th</span><span>Fr</span><span>Sa</span><span>Su</span>
+        </div>
+        <div class="cal-grid" id="cal-grid"></div>
+        <div class="cal-legend">
+          <span class="cal-legend-item"><span class="cal-dot cal-dot-again"></span>Again</span>
+          <span class="cal-legend-item"><span class="cal-dot cal-dot-hard"></span>Hard</span>
+          <span class="cal-legend-item"><span class="cal-dot cal-dot-good"></span>Good</span>
+          <span class="cal-legend-item"><span class="cal-dot cal-dot-easy"></span>Easy</span>
+          <span class="cal-legend-item"><span class="cal-dot cal-dot-due"></span>Due</span>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/static/index.html
+++ b/static/index.html
@@ -120,7 +120,6 @@
         <!-- Word bank (creating mode, non-sentence notes) -->
         <div id="word-bank-wrap" style="display:none">
           <div class="input-label">Reconstruct the sentence</div>
-          <div class="word-bank-preview" id="word-bank-preview">…</div>
           <div class="word-bank-skeleton" id="word-bank-skeleton"></div>
           <div class="word-bank-tokens" id="word-bank-tokens"></div>
           <input type="text" id="word-bank-input"

--- a/static/index.html
+++ b/static/index.html
@@ -64,6 +64,7 @@
         </div>
       </div>
       <div style="display:flex;gap:6px;margin-left:auto;align-items:center">
+        <span id="avg-time-badge" class="review-rr-badge" style="display:none" title="Average time per card this session"></span>
         <span id="review-rr-badge" class="review-rr-badge" style="display:none" title="Daily retention rate"></span>
         <button class="undo-btn" id="undo-btn" onclick="undoReview()" title="Undo last rating [Z]" disabled>↩ Undo</button>
       </div>

--- a/static/index.html
+++ b/static/index.html
@@ -200,14 +200,14 @@
         </div>
         <div class="cal-grid" id="cal-grid"></div>
         <div class="cal-legend">
-          <span class="cal-legend-item"><span class="cal-dot cal-dot-again"></span>Again</span>
-          <span class="cal-legend-item"><span class="cal-dot cal-dot-hard"></span>Hard</span>
-          <span class="cal-legend-item"><span class="cal-dot cal-dot-good"></span>Good</span>
-          <span class="cal-legend-item"><span class="cal-dot cal-dot-easy"></span>Easy</span>
+          <span class="cal-legend-item"><span class="cal-chip cal-chip-again">L</span>Again</span>
+          <span class="cal-legend-item"><span class="cal-chip cal-chip-hard">L</span>Hard</span>
+          <span class="cal-legend-item"><span class="cal-chip cal-chip-good">L</span>Good</span>
+          <span class="cal-legend-item"><span class="cal-chip cal-chip-easy">L</span>Easy</span>
           <span class="cal-legend-sep"></span>
-          <span class="cal-legend-item"><span class="cal-dot cal-dot-due-listening"></span>Listening</span>
-          <span class="cal-legend-item"><span class="cal-dot cal-dot-due-reading"></span>Reading</span>
-          <span class="cal-legend-item"><span class="cal-dot cal-dot-due-creating"></span>Creating</span>
+          <span class="cal-legend-item"><span class="cal-chip cal-chip-due-listening">L</span>Listening</span>
+          <span class="cal-legend-item"><span class="cal-chip cal-chip-due-reading">R</span>Reading</span>
+          <span class="cal-legend-item"><span class="cal-chip cal-chip-due-creating">C</span>Creating</span>
         </div>
       </div>
     </div>

--- a/static/index.html
+++ b/static/index.html
@@ -200,10 +200,10 @@
         </div>
         <div class="cal-grid" id="cal-grid"></div>
         <div class="cal-legend">
-          <span class="cal-legend-item"><span class="cal-chip cal-chip-again">L</span>Again</span>
-          <span class="cal-legend-item"><span class="cal-chip cal-chip-hard">L</span>Hard</span>
-          <span class="cal-legend-item"><span class="cal-chip cal-chip-good">L</span>Good</span>
-          <span class="cal-legend-item"><span class="cal-chip cal-chip-easy">L</span>Easy</span>
+          <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-again"></span>Again</span>
+          <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-hard"></span>Hard</span>
+          <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-good"></span>Good</span>
+          <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-easy"></span>Easy</span>
           <span class="cal-legend-sep"></span>
           <span class="cal-legend-item"><span class="cal-chip cal-chip-due-listening">L</span>Listening</span>
           <span class="cal-legend-item"><span class="cal-chip cal-chip-due-reading">R</span>Reading</span>

--- a/static/index.html
+++ b/static/index.html
@@ -205,9 +205,9 @@
           <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-good"></span>Good</span>
           <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-easy"></span>Easy</span>
           <span class="cal-legend-sep"></span>
-          <span class="cal-legend-item"><span class="cal-chip cal-chip-due-listening">L</span>Listening</span>
-          <span class="cal-legend-item"><span class="cal-chip cal-chip-due-reading">R</span>Reading</span>
-          <span class="cal-legend-item"><span class="cal-chip cal-chip-due-creating">C</span>Creating</span>
+          <span class="cal-legend-item cal-legend-cat">听 Listening</span>
+          <span class="cal-legend-item cal-legend-cat">读 Reading</span>
+          <span class="cal-legend-item cal-legend-cat">创 Creating</span>
         </div>
       </div>
     </div>

--- a/static/index.html
+++ b/static/index.html
@@ -121,10 +121,11 @@
         <div id="word-bank-wrap" style="display:none">
           <div class="input-label">Reconstruct the sentence</div>
           <div class="word-bank-preview" id="word-bank-preview">…</div>
+          <div class="word-bank-skeleton" id="word-bank-skeleton"></div>
           <div class="word-bank-tokens" id="word-bank-tokens"></div>
           <input type="text" id="word-bank-input"
                  autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
-                 placeholder="Type numbers + target word (e.g. 3 1 学校 2 4)"
+                 placeholder="Type numbers + target word in order (e.g. 1 2 努力 3)"
                  oninput="updateWordBankPreview(this.value)"
                  onkeydown="if(event.key==='Enter')revealAnswer()">
         </div>

--- a/static/index.html
+++ b/static/index.html
@@ -86,6 +86,7 @@
             <button id="back-meta-play-btn" class="play-icon-btn play-icon-sm" onclick="playSentence()" style="display:none" title="Play audio">🔊</button>
             <span class="listen-counter listen-counter-back" id="listen-counter-back" style="display:none"></span>
           </div>
+          <div id="card-timer" style="display:none"></div>
           <div id="card-type-badge"></div>
           <div class="wd-card-menu-wrap" id="review-card-menu-wrap">
             <button class="wd-menu-btn" onclick="toggleReviewCardMenu(event)">⋯</button>

--- a/static/index.html
+++ b/static/index.html
@@ -204,7 +204,10 @@
           <span class="cal-legend-item"><span class="cal-dot cal-dot-hard"></span>Hard</span>
           <span class="cal-legend-item"><span class="cal-dot cal-dot-good"></span>Good</span>
           <span class="cal-legend-item"><span class="cal-dot cal-dot-easy"></span>Easy</span>
-          <span class="cal-legend-item"><span class="cal-dot cal-dot-due"></span>Due</span>
+          <span class="cal-legend-sep"></span>
+          <span class="cal-legend-item"><span class="cal-dot cal-dot-due-listening"></span>Listening</span>
+          <span class="cal-legend-item"><span class="cal-dot cal-dot-due-reading"></span>Reading</span>
+          <span class="cal-legend-item"><span class="cal-dot cal-dot-due-creating"></span>Creating</span>
         </div>
       </div>
     </div>

--- a/static/style.css
+++ b/static/style.css
@@ -3104,59 +3104,60 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   gap: 2px;
 }
 .cal-cell {
-  min-height: 30px;
+  min-height: 28px;
   border-radius: 4px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: center;
   padding: 2px 1px;
-  position: relative;
+  gap: 2px;
 }
-.cal-cell.cal-today { background: var(--primary-dim, rgba(99,102,241,.12)); }
+.cal-cell.cal-today { outline: 2px solid var(--primary, #6366f1); outline-offset: -2px; border-radius: 4px; }
 .cal-cell.cal-empty { pointer-events: none; }
-.cal-day-num {
-  font-size: 0.65rem;
-  color: var(--text-muted);
-  line-height: 1.2;
+.cal-today-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--primary, #6366f1);
+  opacity: 0.6;
 }
-.cal-today .cal-day-num {
-  color: var(--primary);
-  font-weight: 700;
-}
-.cal-dots {
+.cal-chips {
   display: flex;
   flex-wrap: wrap;
   gap: 2px;
   justify-content: center;
-  margin-top: 1px;
 }
-.cal-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  flex-shrink: 0;
+.cal-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.58rem;
+  font-weight: 800;
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  color: #fff;
+  letter-spacing: 0;
+  line-height: 1;
 }
-.cal-dot-again { background: #ef4444; }
-.cal-dot-hard  { background: #f97316; }
-.cal-dot-good  { background: #22c55e; }
-.cal-dot-easy  { background: #3b82f6; }
-/* Category border on history dots */
-.cal-dot-cat-listening { box-shadow: 0 0 0 2px #818cf8; }
-.cal-dot-cat-reading   { box-shadow: 0 0 0 2px #2dd4bf; }
-.cal-dot-cat-creating  { box-shadow: 0 0 0 2px #fb923c; }
-/* Future due dots — colored by category */
-.cal-dot-due-listening { background: #818cf8; opacity: 0.75; }
-.cal-dot-due-reading   { background: #2dd4bf; opacity: 0.75; }
-.cal-dot-due-creating  { background: #fb923c; opacity: 0.75; }
+/* Past review chips — background = rating */
+.cal-chip-again { background: #ef4444; }
+.cal-chip-hard  { background: #f97316; }
+.cal-chip-good  { background: #22c55e; }
+.cal-chip-easy  { background: #3b82f6; }
+/* Future due chips — background = category */
+.cal-chip-due-listening { background: #818cf8; }
+.cal-chip-due-reading   { background: #2dd4bf; color: #1a5f57; }
+.cal-chip-due-creating  { background: #fb923c; }
 .cal-legend {
   display: flex;
-  gap: 10px;
+  gap: 8px;
   margin-top: 6px;
   flex-wrap: wrap;
   justify-content: center;
 }
-.cal-legend-sep { width: 1px; background: var(--border); margin: 0 2px; }
+.cal-legend-sep { width: 1px; background: var(--border); margin: 0 2px; align-self: stretch; }
 .cal-legend-item {
   display: flex;
   align-items: center;

--- a/static/style.css
+++ b/static/style.css
@@ -1217,19 +1217,8 @@ main.browse-open {
   flex-direction: column;
   gap: 10px;
 }
-.word-bank-preview {
-  min-height: 52px;
-  padding: 10px 14px;
-  border: 2px dashed var(--border);
-  border-radius: 10px;
-  font-size: 24px;
-  color: var(--text);
-  line-height: 1.4;
-  background: var(--bg);
-  letter-spacing: 1px;
-}
 .word-bank-skeleton {
-  font-size: 18px;
+  font-size: 22px;
   line-height: 1.8;
   color: var(--text);
   padding: 6px 0;

--- a/static/style.css
+++ b/static/style.css
@@ -3156,10 +3156,10 @@ details[open] .cat-override-summary::before { content: '▼ '; }
 .cal-chip-hard  { background: #f97316; }
 .cal-chip-good  { background: #22c55e; }
 .cal-chip-easy  { background: #3b82f6; }
-/* Future due chips — hollow outline, no fill (clearly not a rating) */
-.cal-chip-due-listening { background: transparent; border: 1.5px solid #818cf8; color: #818cf8; }
-.cal-chip-due-reading   { background: transparent; border: 1.5px solid #0d9488; color: #0d9488; }
-.cal-chip-due-creating  { background: transparent; border: 1.5px solid #f97316; color: #f97316; }
+/* Future due chips — plain black text, no background, no border */
+.cal-chip-due-listening,
+.cal-chip-due-reading,
+.cal-chip-due-creating  { background: transparent; border: none; color: var(--text, #1f2937); font-weight: 700; }
 .cal-legend {
   display: flex;
   gap: 8px;

--- a/static/style.css
+++ b/static/style.css
@@ -1241,12 +1241,12 @@ main.browse-open {
 .wb-skel-blank {
   color: var(--primary);
   font-weight: 700;
-  padding: 0 2px;
+  letter-spacing: -2px;
 }
 .wb-skel-target {
   color: var(--accent, #e67e22);
   font-weight: 700;
-  padding: 0 2px;
+  letter-spacing: -2px;
 }
 .word-bank-tokens {
   display: flex;

--- a/static/style.css
+++ b/static/style.css
@@ -3060,3 +3060,99 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   60%  { opacity: 1; }
   100% { transform: translateY(var(--rise, -80vh)) scale(1.1) rotate(var(--tilt, 0deg)); opacity: 0; }
 }
+
+/* ── Card schedule calendar ──────────────────────────────────────────────── */
+.card-calendar {
+  margin: 12px 0 4px;
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+.cal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+.cal-nav-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 1.2rem;
+  cursor: pointer;
+  padding: 2px 8px;
+  border-radius: 4px;
+  line-height: 1;
+}
+.cal-nav-btn:hover { background: var(--hover-bg); }
+.cal-month-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+}
+.cal-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  text-align: center;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  margin-bottom: 2px;
+}
+.cal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+.cal-cell {
+  min-height: 30px;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 2px 1px;
+  position: relative;
+}
+.cal-cell.cal-today { background: var(--primary-dim, rgba(99,102,241,.12)); }
+.cal-cell.cal-empty { pointer-events: none; }
+.cal-day-num {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  line-height: 1.2;
+}
+.cal-today .cal-day-num {
+  color: var(--primary);
+  font-weight: 700;
+}
+.cal-dots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  justify-content: center;
+  margin-top: 1px;
+}
+.cal-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.cal-dot-again { background: #ef4444; }
+.cal-dot-hard  { background: #f97316; }
+.cal-dot-good  { background: #22c55e; }
+.cal-dot-easy  { background: #3b82f6; }
+.cal-dot-due   { background: #a855f7; opacity: 0.7; border: 1px solid #a855f7; }
+.cal-legend {
+  display: flex;
+  gap: 10px;
+  margin-top: 6px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.cal-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 0.62rem;
+  color: var(--text-muted);
+}

--- a/static/style.css
+++ b/static/style.css
@@ -3106,6 +3106,7 @@ details[open] .cat-override-summary::before { content: '▼ '; }
 .cal-cell {
   min-height: 28px;
   border-radius: 4px;
+  border: 1px solid var(--border, #e5e7eb);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/static/style.css
+++ b/static/style.css
@@ -1244,7 +1244,7 @@ main.browse-open {
   letter-spacing: -2px;
 }
 .wb-skel-target {
-  color: var(--accent, #e67e22);
+  color: var(--primary);
   font-weight: 700;
   letter-spacing: -2px;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -3116,6 +3116,15 @@ details[open] .cat-override-summary::before { content: '▼ '; }
 }
 .cal-cell.cal-today { outline: 2px solid var(--primary, #6366f1); outline-offset: -2px; border-radius: 4px; }
 .cal-cell.cal-empty { pointer-events: none; }
+.cal-day-num {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  line-height: 1;
+}
+.cal-day-num-today {
+  color: var(--primary, #6366f1);
+  font-weight: 700;
+}
 .cal-today-dot {
   width: 5px;
   height: 5px;

--- a/static/style.css
+++ b/static/style.css
@@ -3156,10 +3156,10 @@ details[open] .cat-override-summary::before { content: '▼ '; }
 .cal-chip-hard  { background: #f97316; }
 .cal-chip-good  { background: #22c55e; }
 .cal-chip-easy  { background: #3b82f6; }
-/* Future due chips — background = category */
-.cal-chip-due-listening { background: #818cf8; }
-.cal-chip-due-reading   { background: #2dd4bf; color: #1a5f57; }
-.cal-chip-due-creating  { background: #fb923c; }
+/* Future due chips — hollow outline, no fill (clearly not a rating) */
+.cal-chip-due-listening { background: transparent; border: 1.5px solid #818cf8; color: #818cf8; }
+.cal-chip-due-reading   { background: transparent; border: 1.5px solid #0d9488; color: #0d9488; }
+.cal-chip-due-creating  { background: transparent; border: 1.5px solid #f97316; color: #f97316; }
 .cal-legend {
   display: flex;
   gap: 8px;

--- a/static/style.css
+++ b/static/style.css
@@ -326,6 +326,15 @@ main.browse-open {
   letter-spacing: 0.5px;
   opacity: 0.7;
 }
+#card-timer {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--muted);
+  letter-spacing: 0.5px;
+  opacity: 0.7;
+  min-width: 24px;
+  text-align: right;
+}
 .card-deck-path {
   width: 100%;
   font-size: 11px;

--- a/static/style.css
+++ b/static/style.css
@@ -3168,6 +3168,13 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   justify-content: center;
 }
 .cal-legend-sep { width: 1px; background: var(--border); margin: 0 2px; align-self: stretch; }
+.cal-legend-swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
 .cal-legend-item {
   display: flex;
   align-items: center;

--- a/static/style.css
+++ b/static/style.css
@@ -3141,7 +3141,14 @@ details[open] .cat-override-summary::before { content: '▼ '; }
 .cal-dot-hard  { background: #f97316; }
 .cal-dot-good  { background: #22c55e; }
 .cal-dot-easy  { background: #3b82f6; }
-.cal-dot-due   { background: #a855f7; opacity: 0.7; border: 1px solid #a855f7; }
+/* Category border on history dots */
+.cal-dot-cat-listening { box-shadow: 0 0 0 2px #818cf8; }
+.cal-dot-cat-reading   { box-shadow: 0 0 0 2px #2dd4bf; }
+.cal-dot-cat-creating  { box-shadow: 0 0 0 2px #fb923c; }
+/* Future due dots — colored by category */
+.cal-dot-due-listening { background: #818cf8; opacity: 0.75; }
+.cal-dot-due-reading   { background: #2dd4bf; opacity: 0.75; }
+.cal-dot-due-creating  { background: #fb923c; opacity: 0.75; }
 .cal-legend {
   display: flex;
   gap: 10px;
@@ -3149,6 +3156,7 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   flex-wrap: wrap;
   justify-content: center;
 }
+.cal-legend-sep { width: 1px; background: var(--border); margin: 0 2px; }
 .cal-legend-item {
   display: flex;
   align-items: center;

--- a/static/style.css
+++ b/static/style.css
@@ -3175,6 +3175,7 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   border-radius: 3px;
   flex-shrink: 0;
 }
+.cal-legend-cat { font-weight: 500; color: var(--text-muted); }
 .cal-legend-item {
   display: flex;
   align-items: center;

--- a/static/style.css
+++ b/static/style.css
@@ -1228,6 +1228,26 @@ main.browse-open {
   background: var(--bg);
   letter-spacing: 1px;
 }
+.word-bank-skeleton {
+  font-size: 18px;
+  line-height: 1.8;
+  color: var(--text);
+  padding: 6px 0;
+  flex-wrap: wrap;
+  display: flex;
+  gap: 2px;
+}
+.wb-skel-pre { color: var(--muted); }
+.wb-skel-blank {
+  color: var(--primary);
+  font-weight: 700;
+  padding: 0 2px;
+}
+.wb-skel-target {
+  color: var(--accent, #e67e22);
+  font-weight: 700;
+  padding: 0 2px;
+}
 .word-bank-tokens {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## 变更内容
- API 调用从 `/api/retention`（30天）改为 `/api/retention?days=1`（仅今日）
- 复习界面和牌组列表的 tooltip 从「30d retention」改为「Today's retention」
- `index.html` 的 badge title 更新为「Daily retention rate」

## 测试方法
- 打开复习界面，确认保留率徽章显示今天的数据
- 悬停徽章，确认 tooltip 显示「Today's retention」