### PR TITLE
feat: 多词汇单句——AI 可将多个目标词放入同一句，批量评分

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -97,7 +97,7 @@ def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2
                    grammar_pct: int = 75,
                    mode: str = "story") -> tuple[list[dict], str]:
     """
-    Generate Mandarin content, one sentence per card.
+    Generate Mandarin sentences covering all target vocab words.
 
     cards:         list of dicts with keys word_id, word_zh, pinyin, definition, pos
     topic:         optional theme/question/topic to guide the content
@@ -107,20 +107,20 @@ def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2
     grammar_pct:   approximate percentage of sentences that should use the grammar (0-100)
     mode:          "story" | "qa" | "expository"
     Returns: (sentences, prompt_text)
-      sentences: list of {word_id, sentence_zh, sentence_en} — same length as cards.
+      sentences: list of {word_ids: [int, ...], sentence_zh, sentence_en, sentence_de, sentence_fr}.
+                 Multiple cards may share one sentence. Each card's word_id appears in exactly one sentence.
       prompt_text: the full prompt string sent to the AI.
     Returns ([], "") immediately if cards is empty (no API call made).
     """
     if not cards:
         return [], ""
 
+    word_id_set = {c["word_id"] for c in cards}
+
     def _is_sentence(word_zh: str) -> bool:
         return word_zh.endswith(('。', '！', '？', '!', '?'))
 
     def _word_in_sentence(word_zh: str, sentence_zh: str) -> bool:
-        """For pattern words containing '...' or '…', check that every non-dot hanzi
-        character appears in the sentence (the AI fills the gap with real words).
-        For normal words, fall back to a simple substring check."""
         if '...' in word_zh or '…' in word_zh:
             chars = [c for c in word_zh if c not in '.…']
             return all(c in sentence_zh for c in chars)
@@ -143,7 +143,7 @@ def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2
         n_sentences = max(1, round(len(cards) * grammar_pct / 100))
         grammar_line = (
             f"- Grammar focus: use the pattern 「{grammar_focus}」 in roughly "
-            f"{n_sentences} of the {len(cards)} sentences (about {grammar_pct}%).\n"
+            f"{n_sentences} of the sentences (about {grammar_pct}%).\n"
             f"  For each sentence, decide BEFORE writing: what specific grammar fragment will you use "
             f"(e.g. 「三年以内」「十八岁以上」)? Write that fragment in the \"grammar_fragment\" field. "
             f"If you are not using the pattern for a sentence, set \"grammar_fragment\" to \"\".\n"
@@ -155,145 +155,150 @@ def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2
 
     if mode == "qa":
         task_line = f"Answer the following question in Mandarin Chinese, one sentence at a time, to help an HSK 4-5 learner review vocabulary.\nQuestion: {topic or 'Describe something interesting.'}"
-        style_rule = f"- The sentences together should form a coherent, informative answer to the question above\n- Do NOT use fictional characters or narrative story structure"
+        style_rule = "- The sentences together should form a coherent, informative answer to the question above\n- Do NOT use fictional characters or narrative story structure"
     elif mode == "expository":
         task_line = f"Write a short informative text in Mandarin Chinese about the following topic, to help an HSK 4-5 learner review vocabulary.\nTopic: {topic or 'an interesting subject'}"
-        style_rule = f"- The sentences together should form a coherent, factual explanation of the topic above\n- Do NOT use fictional characters or narrative story structure"
+        style_rule = "- The sentences together should form a coherent, factual explanation of the topic above\n- Do NOT use fictional characters or narrative story structure"
     else:
         task_line = "Write a short Mandarin Chinese story to help an HSK 4-5 learner review vocabulary."
         topic_clause = f"- The story should be set around this topic or theme: {topic}\n" if topic else ""
         style_rule = f"{topic_clause}- The sentences must form a coherent narrative with the same recurring characters"
 
+    grammar_frag_field = ', "grammar_fragment": "<fragment or empty string>"' if grammar_focus else ""
+
     prompt = f"""{task_line}
 
-{grammar_first}Target words — write exactly one sentence per word, in this order:
+{grammar_first}Target words (each must appear in at least one sentence):
 {word_list}
 
 Rules:
-- Exactly {len(cards)} sentences total
-- For items marked [USE AS-IS]: use that text verbatim as sentence_zh
-- For all other items: write a sentence that naturally contains the target word
+- Each target word MUST appear verbatim in exactly one sentence
+- You may combine multiple target words into a single sentence when they fit naturally — this is encouraged
+- For items marked [USE AS-IS]: use that text verbatim as sentence_zh; include its word_id in word_ids
 - Use proper Chinese punctuation — include commas（，）where natural pauses occur
 - Use only HSK 1-{max_hsk} vocabulary for non-target words
-- Please keep each sentence as short and simple as possible — shorter is better, as long as all other rules are still met
+- Keep each sentence as short and simple as possible
 {style_rule}
 - NEVER use ASCII double-quote characters (") inside Chinese sentences — use 「」or （）instead if quoting is needed
-- Return ONLY valid JSON, no explanation, no markdown:
+- Return ONLY valid JSON array of sentence objects, no explanation, no markdown:
 [
-  {{"word_id": <integer>{', "grammar_fragment": "<fragment or empty string>"' if grammar_focus else ''}, "sentence_zh": "<Chinese sentence>"}},
+  {{"word_ids": [<integer>, ...]{grammar_frag_field}, "sentence_zh": "<Chinese sentence>"}},
   ...
 ]"""
 
     logger.info("[%s] generate_story: %d 张卡片 mode=%s", model, len(cards), mode)
     logger.debug("Prompt:\n%s", prompt)
 
-    # 150 tokens per sentence is generous; add 200 for overhead/fences.
-    # DeepSeek and other OpenAI-compatible providers cap at 8192.
     max_tokens = len(cards) * 150 + 200
     if not model.startswith("claude-"):
         max_tokens = min(max_tokens, 8192)
 
+    card_by_id = {c["word_id"]: c for c in cards}
     t_start = time.time()
     missing_hint = ""
-    last_partial: tuple | None = None  # (result, missing_pairs) from best attempt
+    last_partial: tuple | None = None  # (sentences, missing_word_ids)
     for attempt in range(3):
         retry_label = f" (retry {attempt}/{2})" if attempt > 0 else ""
         _set_progress(progress_key, phase="request", attempt=attempt + 1,
                       msg=f"Sending request to AI…{retry_label}", percent=max(5, 10 - attempt * 4))
-        full_prompt = prompt + missing_hint
-        raw = _call_api(model, [{"role": "user", "content": full_prompt}], max_tokens,
+        raw = _call_api(model, [{"role": "user", "content": prompt + missing_hint}], max_tokens,
                         purpose="story")
 
         logger.debug("Raw response attempt=%d (%d chars):\n%s", attempt + 1, len(raw), raw)
 
-        # Try to extract a JSON array from the response (handles markdown fences,
-        # leading/trailing text, or extra commentary the model sometimes adds)
         json_match = re.search(r'\[\s*\{.*?\}\s*\]', raw, re.DOTALL)
         if json_match:
             raw = json_match.group(0)
 
         try:
-            result = json.loads(raw)
-            if isinstance(result, list) and len(result) >= 1:
-                result = result[:len(cards)]
-                for item, card in zip(result, cards):
-                    item["word_id"] = card["word_id"]
-                if len(result) == len(cards):
-                    missing_pairs = [
-                        (item, card)
-                        for item, card in zip(result, cards)
-                        if not _is_sentence(card["word_zh"])
-                        and not _word_in_sentence(card["word_zh"], item.get("sentence_zh", ""))
-                    ]
-                    if missing_pairs:
-                        last_partial = (result, missing_pairs)
-                        missing_words = [card["word_zh"] for _, card in missing_pairs]
-                        logger.warning(
-                            "generate_story: attempt %d — words missing from sentences: %s",
-                            attempt + 1, missing_words,
-                        )
-                        _set_progress(progress_key, phase="warning", attempt=attempt + 1,
-                                      msg=f"⚠ Attempt {attempt + 1}: missing {missing_words} — retrying",
-                                      percent=0)
-                        missing_ratio = len(missing_pairs) / len(cards)
-                        if attempt >= 1 and missing_ratio < 0.03:
-                            logger.info(
-                                "generate_story: accepting partial result after attempt %d "
-                                "(%.1f%% missing) — patching %d word(s) with source sentence: %s",
-                                attempt + 1, missing_ratio * 100, len(missing_pairs), missing_words,
-                            )
-                            for item, card in missing_pairs:
-                                item["sentence_zh"] = card.get("source_sentence") or f"我学了{card['word_zh']}这个词。"
-                            _set_progress(progress_key, phase="translating",
-                                          msg="Translating sentences…", percent=88)
-                            _fill_translations(result, progress_key=progress_key)
-                            _set_progress(progress_key, phase="ai_done",
-                                          msg=f"✓ {len(result)} sentences (attempt {attempt + 1})", percent=93)
-                            return result, prompt
-                        missing_hint = (
-                            f"\n\nIMPORTANT: Your previous attempt was missing these words "
-                            f"— each MUST appear verbatim in its sentence: {', '.join(missing_words)}"
-                        )
-                        continue
-                    logger.info("generate_story: success — %d sentences (attempt %d) in %.1fs total",
-                                len(result), attempt + 1, time.time() - t_start)
+            parsed = json.loads(raw)
+            if not (isinstance(parsed, list) and len(parsed) >= 1):
+                continue
+
+            # Collect all word_ids mentioned across sentences
+            seen_ids: dict[int, int] = {}  # word_id → sentence index (first occurrence)
+            for si, item in enumerate(parsed):
+                for wid in item.get("word_ids", []):
+                    if wid not in seen_ids:
+                        seen_ids[wid] = si
+
+            # Find which target words are missing or covered multiple times
+            missing_ids = [wid for wid in word_id_set if wid not in seen_ids]
+            # Ignore extra word_ids the AI invented (not in our target set)
+            for item in parsed:
+                item["word_ids"] = [wid for wid in item.get("word_ids", []) if wid in word_id_set]
+
+            # Check that every word actually appears in its sentence
+            bad_pairs: list[tuple[int, str, str]] = []  # (word_id, word_zh, sentence_zh)
+            for item in parsed:
+                for wid in item.get("word_ids", []):
+                    card = card_by_id.get(wid)
+                    if card and not _is_sentence(card["word_zh"]) and \
+                            not _word_in_sentence(card["word_zh"], item.get("sentence_zh", "")):
+                        bad_pairs.append((wid, card["word_zh"], item.get("sentence_zh", "")))
+
+            all_missing = missing_ids + [wid for wid, _, _ in bad_pairs]
+            if all_missing:
+                missing_words = [card_by_id[wid]["word_zh"] for wid in all_missing if wid in card_by_id]
+                logger.warning("generate_story: attempt %d — words missing/not found: %s",
+                               attempt + 1, missing_words)
+                _set_progress(progress_key, phase="warning", attempt=attempt + 1,
+                              msg=f"⚠ Attempt {attempt + 1}: missing {missing_words} — retrying",
+                              percent=0)
+                missing_ratio = len(all_missing) / len(cards)
+                last_partial = (parsed, all_missing)
+                if attempt >= 1 and missing_ratio < 0.03:
+                    _patch_missing(parsed, all_missing, card_by_id)
                     _set_progress(progress_key, phase="translating",
                                   msg="Translating sentences…", percent=88)
-                    # Translate sentences locally (no extra AI call needed)
-                    _fill_translations(result, progress_key=progress_key)
-                    total_elapsed = time.time() - t_start
-                    logger.info("generate_story: DONE — %.1fs total (AI + translation)", total_elapsed)
+                    _fill_translations(parsed, progress_key=progress_key)
                     _set_progress(progress_key, phase="ai_done",
-                                  msg=f"✓ {len(result)} sentences (attempt {attempt + 1})", percent=93)
-                    return result, prompt
-                else:
-                    logger.warning("generate_story: count mismatch — got %d, need %d",
-                                   len(result), len(cards))
+                                  msg=f"✓ {len(parsed)} sentences (attempt {attempt + 1})", percent=93)
+                    return parsed, prompt
+                missing_hint = (
+                    f"\n\nIMPORTANT: Your previous attempt was missing these words "
+                    f"— each MUST appear verbatim in its sentence: {', '.join(missing_words)}"
+                )
+                continue
+
+            logger.info("generate_story: success — %d sentences covering %d words (attempt %d) in %.1fs",
+                        len(parsed), len(cards), attempt + 1, time.time() - t_start)
+            _set_progress(progress_key, phase="translating",
+                          msg="Translating sentences…", percent=88)
+            _fill_translations(parsed, progress_key=progress_key)
+            logger.info("generate_story: DONE — %.1fs total", time.time() - t_start)
+            _set_progress(progress_key, phase="ai_done",
+                          msg=f"✓ {len(parsed)} sentences (attempt {attempt + 1})", percent=93)
+            return parsed, prompt
+
         except (json.JSONDecodeError, TypeError, KeyError) as e:
             logger.error("generate_story: JSON parse error: %s", e)
 
-    # If the best attempt had < 3% missing words, accept it and patch with source sentences
     if last_partial is not None:
-        result, missing_pairs = last_partial
-        missing_ratio = len(missing_pairs) / len(cards)
-        if missing_ratio < 0.03:
-            missing_words = [card["word_zh"] for _, card in missing_pairs]
-            logger.info(
-                "generate_story: accepting partial result (%.1f%% missing) — "
-                "patching %d word(s) with source sentence: %s",
-                missing_ratio * 100, len(missing_pairs), missing_words,
-            )
-            for item, card in missing_pairs:
-                item["sentence_zh"] = card.get("source_sentence") or f"我学了{card['word_zh']}这个词。"
+        parsed, missing_ids = last_partial
+        if len(missing_ids) / len(cards) < 0.03:
+            _patch_missing(parsed, missing_ids, card_by_id)
             _set_progress(progress_key, phase="translating",
                           msg="Translating sentences…", percent=88)
-            _fill_translations(result, progress_key=progress_key)
+            _fill_translations(parsed, progress_key=progress_key)
             _set_progress(progress_key, phase="ai_done",
-                          msg=f"✓ {len(result)} sentences (patched)", percent=93)
-            return result, prompt
+                          msg=f"✓ {len(parsed)} sentences (patched)", percent=93)
+            return parsed, prompt
 
     logger.warning("generate_story: falling back to placeholder sentences")
     return _fallback_sentences(cards), prompt
+
+
+def _patch_missing(sentences: list[dict], missing_word_ids: list[int],
+                   card_by_id: dict[int, dict]) -> None:
+    """Append fallback sentences for words the AI failed to include."""
+    for wid in missing_word_ids:
+        card = card_by_id.get(wid)
+        if not card:
+            continue
+        fallback_zh = card.get("source_sentence") or f"我学了{card['word_zh']}这个词。"
+        sentences.append({"word_ids": [wid], "sentence_zh": fallback_zh,
+                          "sentence_en": "", "sentence_de": "", "sentence_fr": ""})
 
 
 def generate_character_info(char: str, pinyin: str, model: str = DEFAULT_MODEL) -> dict:
@@ -439,7 +444,7 @@ def _fallback_sentences(cards: list[dict]) -> list[dict]:
     """Minimal sentences used when the AI response cannot be parsed."""
     result = [
         {
-            "word_id": c["word_id"],
+            "word_ids": [c["word_id"]],
             "sentence_zh": f"我学了{c['word_zh']}这个词。",
             "sentence_en": "",
             "sentence_de": "",

--- a/database/cards.py
+++ b/database/cards.py
@@ -1175,3 +1175,21 @@ def get_card_calendar_data(card_id: int) -> dict:
         "history": [{"date": r["date"], "rating": r["rating"], "category": r["category"]} for r in history],
         "future":  [{"due": r["due"][:10], "category": r["category"], "state": r["state"]} for r in future],
     }
+
+
+def get_cards_by_word_ids(word_ids: list[int], category: str) -> list[dict]:
+    """Return [{word_id, card_id}] for each word_id that has a non-deleted card in category."""
+    if not word_ids:
+        return []
+    conn = get_db()
+    placeholders = ",".join("?" * len(word_ids))
+    rows = conn.execute(
+        f"""SELECT word_id, id AS card_id FROM cards
+            WHERE word_id IN ({placeholders})
+              AND category = ?
+              AND deleted_at IS NULL
+            ORDER BY word_id""",
+        (*word_ids, category),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]

--- a/database/core.py
+++ b/database/core.py
@@ -173,6 +173,19 @@ def init_db() -> None:
         conn.execute("ALTER TABLE story_sentences ADD COLUMN sentence_de TEXT")
     if "sentence_fr" not in ss_cols:
         conn.execute("ALTER TABLE story_sentences ADD COLUMN sentence_fr TEXT")
+    if "word_id" in ss_cols:
+        _migrate_story_sentences_multi_word(conn)
+    existing_tables = {r["name"] for r in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    ).fetchall()}
+    if "story_sentence_words" not in existing_tables:
+        conn.execute("""CREATE TABLE story_sentence_words (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            sentence_id INTEGER NOT NULL REFERENCES story_sentences(id) ON DELETE CASCADE,
+            word_id     INTEGER NOT NULL REFERENCES entries(id) ON DELETE CASCADE,
+            UNIQUE(sentence_id, word_id)
+        )""")
+        conn.commit()
 
     deck_cols = {r["name"] for r in conn.execute("PRAGMA table_info(decks)").fetchall()}
     if "deleted_at" not in deck_cols:
@@ -297,6 +310,44 @@ def init_db() -> None:
     _migrate_sentences_deck(conn, all_id, preset_id)
     conn.commit()
     conn.close()
+
+
+def _migrate_story_sentences_multi_word(conn: sqlite3.Connection) -> None:
+    """Rebuild story_sentences to remove word_id column, create story_sentence_words."""
+    conn.executescript("""
+        PRAGMA foreign_keys=OFF;
+
+        CREATE TABLE story_sentences_new (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            story_id    INTEGER NOT NULL REFERENCES stories(id) ON DELETE CASCADE,
+            position    INTEGER NOT NULL,
+            sentence_zh TEXT NOT NULL,
+            sentence_en TEXT NOT NULL DEFAULT '',
+            sentence_de TEXT,
+            sentence_fr TEXT,
+            UNIQUE(story_id, position)
+        );
+
+        INSERT INTO story_sentences_new (id, story_id, position, sentence_zh, sentence_en, sentence_de, sentence_fr)
+        SELECT id, story_id, position, sentence_zh, sentence_en, sentence_de, sentence_fr
+        FROM story_sentences;
+
+        CREATE TABLE IF NOT EXISTS story_sentence_words (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            sentence_id INTEGER NOT NULL REFERENCES story_sentences(id) ON DELETE CASCADE,
+            word_id     INTEGER NOT NULL REFERENCES entries(id) ON DELETE CASCADE,
+            UNIQUE(sentence_id, word_id)
+        );
+
+        INSERT INTO story_sentence_words (sentence_id, word_id)
+        SELECT id, word_id FROM story_sentences;
+
+        DROP TABLE story_sentences;
+        ALTER TABLE story_sentences_new RENAME TO story_sentences;
+
+        PRAGMA foreign_keys=ON;
+    """)
+    conn.commit()
 
 
 def _migrate_stories_category(conn: sqlite3.Connection) -> None:

--- a/database/stories.py
+++ b/database/stories.py
@@ -45,7 +45,11 @@ def get_latest_story(deck_id: int, category: str) -> dict | None:
 def create_story(date_str: str, category: str, deck_id: int,
                  sentences: list[dict], prompt_text: str | None = None,
                  topic: str | None = None) -> int:
-    """Always inserts a new story row. Returns story_id."""
+    """Always inserts a new story row. Returns story_id.
+
+    Each sentence dict must have: position, sentence_zh, word_ids (list of entry IDs).
+    Optional: sentence_en, sentence_de, sentence_fr.
+    """
     conn = get_db()
     cur = conn.execute(
         "INSERT INTO stories (date, category, deck_id, prompt_text, topic) VALUES (?, ?, ?, ?, ?)",
@@ -53,21 +57,31 @@ def create_story(date_str: str, category: str, deck_id: int,
     )
     story_id = cur.lastrowid
     for s in sentences:
-        conn.execute(
-            """INSERT INTO story_sentences (story_id, word_id, position, sentence_zh, sentence_en, sentence_de, sentence_fr)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
-            (story_id, s["word_id"], s["position"], s["sentence_zh"],
+        sent_cur = conn.execute(
+            """INSERT INTO story_sentences (story_id, position, sentence_zh, sentence_en, sentence_de, sentence_fr)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (story_id, s["position"], s["sentence_zh"],
              s.get("sentence_en", ""), s.get("sentence_de"), s.get("sentence_fr")),
         )
+        sentence_id = sent_cur.lastrowid
+        for word_id in s.get("word_ids", []):
+            conn.execute(
+                "INSERT INTO story_sentence_words (sentence_id, word_id) VALUES (?, ?)",
+                (sentence_id, word_id),
+            )
     conn.commit()
     conn.close()
     return story_id
 
 
 def get_sentence_for_word(story_id: int, word_id: int) -> dict | None:
+    """Return the first sentence (lowest position) in this story that contains word_id."""
     conn = get_db()
     row = conn.execute(
-        "SELECT * FROM story_sentences WHERE story_id = ? AND word_id = ?",
+        """SELECT s.* FROM story_sentences s
+           JOIN story_sentence_words sw ON sw.sentence_id = s.id
+           WHERE s.story_id = ? AND sw.word_id = ?
+           ORDER BY s.position ASC LIMIT 1""",
         (story_id, word_id),
     ).fetchone()
     conn.close()
@@ -75,15 +89,44 @@ def get_sentence_for_word(story_id: int, word_id: int) -> dict | None:
 
 
 def get_story_sentences(story_id: int) -> list[dict]:
+    """Return all sentences for a story, each with word_ids and words list."""
     conn = get_db()
-    rows = conn.execute(
-        """SELECT s.*, w.word_zh, w.definition
-           FROM story_sentences s JOIN entries w ON w.id = s.word_id
-           WHERE s.story_id = ? ORDER BY s.position""",
+    sent_rows = conn.execute(
+        "SELECT * FROM story_sentences WHERE story_id = ? ORDER BY position",
+        (story_id,),
+    ).fetchall()
+
+    word_rows = conn.execute(
+        """SELECT sw.sentence_id, e.id AS word_id, e.word_zh, e.definition
+           FROM story_sentence_words sw
+           JOIN story_sentences ss ON ss.id = sw.sentence_id
+           JOIN entries e ON e.id = sw.word_id
+           WHERE ss.story_id = ?
+           ORDER BY sw.sentence_id, sw.id""",
         (story_id,),
     ).fetchall()
     conn.close()
-    return [dict(r) for r in rows]
+
+    words_by_sentence: dict[int, list] = {}
+    for w in word_rows:
+        words_by_sentence.setdefault(w["sentence_id"], []).append({
+            "word_id": w["word_id"],
+            "word_zh": w["word_zh"],
+            "definition": w["definition"],
+        })
+
+    result = []
+    for s in sent_rows:
+        d = dict(s)
+        wlist = words_by_sentence.get(s["id"], [])
+        d["word_ids"] = [w["word_id"] for w in wlist]
+        d["words"] = wlist
+        # Legacy compat: expose word_zh / definition of first word for callers that still use them
+        if wlist:
+            d["word_zh"] = wlist[0]["word_zh"]
+            d["definition"] = wlist[0]["definition"]
+        result.append(d)
+    return result
 
 
 def get_due_cards_unified(deck_id: int) -> list[dict]:

--- a/routes/review.py
+++ b/routes/review.py
@@ -244,13 +244,155 @@ def submit_review(card_id: int, rating: int, user_response: str | None = None,
     return {"next_card": next_card, "counts": counts}
 
 
+@router.post("/api/review/batch")
+def submit_review_batch(
+    body: list[dict],
+    root_deck_id: int | None = None,
+    unfinished_mode: bool = False,
+    parent_deck_id: int | None = None,
+):
+    """Rate multiple cards at once (multi-word sentence). body: [{card_id, rating}, ...]."""
+    if not body:
+        raise HTTPException(status_code=400, detail="Empty batch")
+
+    batch_entries = []
+    all_newly_buried: list[int] = []
+    last_updated = None
+    last_deck_id = None
+    last_cat = None
+    queue_key = None
+    build_fn = None
+
+    for item in body:
+        card_id = item["card_id"]
+        rating  = item["rating"]
+        card_before = database.get_card(card_id)
+        updated, log_id = srs.apply_review(card_id, rating)
+        deck_id = updated["deck_id"]
+        cat     = updated["category"]
+        last_updated = updated
+        last_deck_id = deck_id
+        last_cat     = cat
+
+        preset = database.get_preset_for_deck(deck_id)
+        sibling_sep    = preset.get("sibling_separation", 3)
+        sibling_factor = preset.get("sibling_factor", 0.2)
+        database.apply_sibling_repulsion(card_id, updated.get("interval", 0), sibling_sep, sibling_factor)
+
+        siblings_before = database.get_sibling_cards(card_id)
+        siblings_snapshot = [{"id": s["id"], "buried_until": s["buried_until"]} for s in siblings_before]
+
+        bury_new, bury_review, bury_learning = database.resolve_bury_flags(preset)
+        database.bury_siblings(updated["word_id"], cat,
+                               bury_new=bury_new, bury_review=bury_review, bury_learning=bury_learning)
+
+        today_str = database.anki_today().isoformat()
+        was_buried = {s["id"] for s in siblings_before
+                      if s.get("buried_until") is not None and s.get("buried_until") >= today_str}
+        siblings_after = database.get_sibling_cards(card_id)
+        newly_buried = [s["id"] for s in siblings_after
+                        if s.get("buried_until") == today_str and s["id"] not in was_buried]
+        all_newly_buried.extend(newly_buried)
+
+        batch_entries.append({
+            "card_before":       card_before,
+            "log_id":            log_id,
+            "siblings_snapshot": siblings_snapshot,
+        })
+
+        if queue_key is None:
+            if root_deck_id:
+                queue_key, build_fn = _key_and_build(root_deck_id=root_deck_id)
+            elif parent_deck_id:
+                ids = leaf_ids(parent_deck_id, cat)
+                queue_key, build_fn = _key_and_build(ids=ids, category=cat)
+            else:
+                queue_key, build_fn = _key_and_build(deck_id=deck_id, category=cat)
+
+    _undo_stack.append({
+        "batch":           True,
+        "batch_entries":   batch_entries,
+        "queue_key":       queue_key,
+        "root_deck_id":    root_deck_id,
+        "parent_deck_id":  parent_deck_id,
+        "unfinished_mode": unfinished_mode,
+        "deck_id":         last_deck_id,
+        "category":        last_cat,
+    })
+
+    first_card_id = body[0]["card_id"]
+    rated_card_ids = {item["card_id"] for item in body}
+
+    if unfinished_mode:
+        next_card = database.get_next_unfinished_card()
+        if next_card:
+            next_card["intervals"] = srs.preview_intervals(next_card)
+        counts = database.count_unfinished()
+    elif root_deck_id:
+        for item in body:
+            updated_card = database.get_card(item["card_id"])
+            if updated_card:
+                _queue_mgr.after_review(queue_key, item["card_id"], updated_card, [])
+        _queue_mgr.after_review(queue_key, first_card_id, database.get_card(first_card_id) or {},
+                                list(rated_card_ids - {first_card_id}) + all_newly_buried)
+        next_card = _next_card_from_queue(queue_key, build_fn)
+        counts = database.count_due_any_cat(root_deck_id)
+        counts["by_cat"] = database.count_due_by_category(root_deck_id)
+    elif parent_deck_id:
+        ids = leaf_ids(parent_deck_id, last_cat)
+        _queue_mgr.after_review(queue_key, first_card_id,
+                                database.get_card(first_card_id) or {},
+                                list(rated_card_ids - {first_card_id}) + all_newly_buried)
+        next_card = _next_card_from_queue(queue_key, build_fn)
+        counts = database.count_due_multi(ids, last_cat)
+        counts["by_cat"] = database.count_due_by_category(parent_deck_id)
+    else:
+        _queue_mgr.after_review(queue_key, first_card_id,
+                                database.get_card(first_card_id) or {},
+                                list(rated_card_ids - {first_card_id}) + all_newly_buried)
+        next_card = _next_card_from_queue(queue_key, build_fn)
+        counts = database.count_due(last_deck_id, last_cat)
+        parent_id = database.get_parent_deck_id(last_deck_id)
+        counts["by_cat"] = database.count_due_by_category(parent_id or last_deck_id)
+
+    return {"next_card": next_card, "counts": counts}
+
+
 @router.post("/api/review/undo")
 def undo_review():
     if not _undo_stack:
         raise HTTPException(status_code=404, detail="Nothing to undo")
 
     entry = _undo_stack.pop()
-    cb    = entry["card_before"]
+
+    if entry.get("batch"):
+        for be in reversed(entry["batch_entries"]):
+            cb = be["card_before"]
+            database.update_card(cb["id"], state=cb["state"], due=cb["due"],
+                                 step_index=cb["step_index"], interval=cb["interval"],
+                                 ease=cb["ease"], repetitions=cb["repetitions"], lapses=cb["lapses"])
+            database.delete_review_log(be["log_id"])
+            for sib in be.get("siblings_snapshot", []):
+                database.set_card_buried_until(sib["id"], sib["buried_until"])
+        _queue_mgr.invalidate(entry.get("queue_key"))
+        # Return the first card of the batch as the restored card
+        cb = entry["batch_entries"][0]["card_before"]
+        restored = database.get_card(cb["id"])
+        restored["intervals"] = srs.preview_intervals(restored)
+        deck_id = entry["deck_id"]
+        cat     = entry["category"]
+        if entry["root_deck_id"]:
+            counts = database.count_due_any_cat(entry["root_deck_id"])
+        elif entry["parent_deck_id"]:
+            ids    = leaf_ids(entry["parent_deck_id"], cat)
+            counts = database.count_due_multi(ids, cat)
+        else:
+            counts = database.count_due(deck_id, cat)
+        logger.info("undo batch review (%d cards), restored first=%s (stack=%d)",
+                    len(entry["batch_entries"]), restored["word_zh"], len(_undo_stack))
+        return {"card": restored, "counts": counts, "stack_size": len(_undo_stack)}
+
+    cb = entry["card_before"]
 
     # Restore the card to its pre-review state
     database.update_card(

--- a/routes/review.py
+++ b/routes/review.py
@@ -439,6 +439,16 @@ def undo_review():
     return {"card": restored, "counts": counts, "stack_size": len(_undo_stack)}
 
 
+@router.get("/api/cards/by-word")
+def get_cards_by_word(word_ids: str, category: str):
+    """Return [{word_id, card_id}] for the given comma-separated word_ids and category."""
+    try:
+        ids = [int(x) for x in word_ids.split(",") if x.strip()]
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid word_ids")
+    return database.get_cards_by_word_ids(ids, category)
+
+
 @router.post("/api/cards/{card_id}/bury")
 def bury_card(card_id: int):
     database.bury_card(card_id)

--- a/schema.sql
+++ b/schema.sql
@@ -296,14 +296,22 @@ CREATE TABLE IF NOT EXISTS stories (
 CREATE TABLE IF NOT EXISTS story_sentences (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     story_id    INTEGER NOT NULL REFERENCES stories(id) ON DELETE CASCADE,
-    word_id     INTEGER NOT NULL REFERENCES entries(id) ON DELETE CASCADE,
     position    INTEGER NOT NULL,
     sentence_zh TEXT NOT NULL,
     sentence_en TEXT NOT NULL DEFAULT '',
     sentence_de TEXT,
     sentence_fr TEXT,
-    UNIQUE(story_id, word_id),
     UNIQUE(story_id, position)
+);
+
+-- ---------------------------------------------------------------------------
+-- story_sentence_words  (many-to-many: sentences ↔ vocab entries)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS story_sentence_words (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    sentence_id INTEGER NOT NULL REFERENCES story_sentences(id) ON DELETE CASCADE,
+    word_id     INTEGER NOT NULL REFERENCES entries(id) ON DELETE CASCADE,
+    UNIQUE(sentence_id, word_id)
 );
 
 -- ---------------------------------------------------------------------------

--- a/static/app.js
+++ b/static/app.js
@@ -3469,6 +3469,28 @@ function diffClozeAnswer(userInput, targetWord) {
 
 // State: {word_id → rating} for the current multi-word sentence
 const _multiRatings = {};
+let _multiRatingFocused = null;   // word_id currently in "rating mode", or null
+
+function _setMultiFocusedWord(wordId) {
+  _multiRatingFocused = wordId;
+  document.querySelectorAll('#multi-rating-rows .multi-rating-row').forEach(row => {
+    row.classList.toggle('row-focused', Number(row.dataset.wordId) === wordId);
+  });
+}
+
+function _clearMultiFocus() {
+  _multiRatingFocused = null;
+  document.querySelectorAll('#multi-rating-rows .multi-rating-row').forEach(row => {
+    row.classList.remove('row-focused');
+  });
+}
+
+function _autoAdvanceMultiFocus() {
+  const rows = [...document.querySelectorAll('#multi-rating-rows .multi-rating-row')];
+  const next = rows.find(r => _multiRatings[Number(r.dataset.wordId)] === undefined);
+  if (next) _setMultiFocusedWord(Number(next.dataset.wordId));
+  else _clearMultiFocus();
+}
 
 function _renderMultiRatingIfNeeded() {
   const ratingRow  = document.getElementById('rating-row');
@@ -3486,8 +3508,9 @@ function _renderMultiRatingIfNeeded() {
   ratingRow.style.display  = 'none';
   multiBlock.style.display = '';
 
-  // Clear previous selections
+  // Clear previous selections and focus state
   Object.keys(_multiRatings).forEach(k => delete _multiRatings[k]);
+  _multiRatingFocused = null;
   document.getElementById('multi-rating-submit').disabled = true;
 
   const allWords = [{ word_id: card.word_id, word_zh: card.word_zh }, ...coWords];
@@ -3517,6 +3540,7 @@ function _pickMultiRating(wordId, rating, btn) {
   const row = btn.closest('.multi-rating-row');
   row.querySelectorAll('.multi-r-btn').forEach(b => b.classList.remove('selected'));
   btn.classList.add('selected');
+  row.classList.add('rated');
   _multiRatings[wordId] = rating;
 
   // Enable submit when all words have a rating
@@ -5381,6 +5405,12 @@ document.addEventListener('keydown', async e => {
   const inInput = _isEditableFocusTarget(document.activeElement);
 
   if (e.key === 'Escape') {
+    // Exit multi-word rating focus mode
+    if (_multiRatingFocused !== null) {
+      e.preventDefault();
+      _clearMultiFocus();
+      return;
+    }
     const storyOverlay = document.getElementById('story-modal-overlay');
     if (storyOverlay && storyOverlay.style.display !== 'none') {
       e.preventDefault();
@@ -5504,8 +5534,26 @@ document.addEventListener('keydown', async e => {
       e.preventDefault(); if (!backVisible) revealAnswer();
     } else if (['1','2','3','4'].includes(e.key) && backVisible) {
       e.preventDefault();
-      const btns = document.querySelectorAll('.r-btn');
-      if (btns.length && !btns[0].disabled) rate(Number(e.key));
+      const multiVisible = document.getElementById('multi-rating')?.style.display !== 'none';
+      if (multiVisible) {
+        const wordRows = [...document.querySelectorAll('#multi-rating-rows .multi-rating-row')];
+        if (_multiRatingFocused !== null) {
+          // In rating mode: 1-4 pick the rating for the focused word
+          const btn = document.querySelector(
+            `#multi-rating-rows .multi-rating-row[data-word-id="${_multiRatingFocused}"] .multi-r-btn[data-r="${e.key}"]`
+          );
+          if (btn) { _pickMultiRating(_multiRatingFocused, Number(e.key), btn); _autoAdvanceMultiFocus(); }
+        } else {
+          // Not in rating mode: 1-N select which word to focus
+          const idx = Number(e.key) - 1;
+          if (idx >= 0 && idx < wordRows.length) {
+            _setMultiFocusedWord(Number(wordRows[idx].dataset.wordId));
+          }
+        }
+      } else {
+        const btns = document.querySelectorAll('.r-btn');
+        if (btns.length && !btns[0].disabled) rate(Number(e.key));
+      }
     } else if (e.key === 'z') {
       const undoBtn = document.getElementById('undo-btn');
       if (undoBtn && !undoBtn.disabled) { e.preventDefault(); undoReview(); }

--- a/static/app.js
+++ b/static/app.js
@@ -2542,7 +2542,7 @@ function loadCard(c, counts) {
 
   // Find sentence for this card's word in the story.
   // If no match, leave sentence null — renderSentence() will show just the word.
-  sentence = story?.sentences?.find(s => s.word_id === card.word_id) || null;
+  sentence = story?.sentences?.find(s => s.word_ids?.includes(card.word_id)) || null;
 
   // In unfinished mode or mixed mode: story may be from a different deck/category.
   // Async-load the correct story and update the display when it arrives.
@@ -2556,7 +2556,7 @@ function loadCard(c, counts) {
         fetch(`/api/preload-session/${storyDeckId}/unified`, { method: 'POST' }).catch(() => {});
         if (s?.sentences) {
           story    = s;
-          sentence = story.sentences.find(s => s.word_id === card.word_id) || null;
+          sentence = story.sentences.find(s => s.word_ids?.includes(card.word_id)) || null;
           if (sentence) {
             _updateStoryInfoRow();
             const isListening  = category === 'listening';
@@ -2908,6 +2908,9 @@ function revealAnswer() {
   // Re-enable rating buttons
   document.querySelectorAll('.r-btn').forEach(b => b.disabled = false);
 
+  // Show multi-word rating UI when the sentence contains multiple vocab words
+  _renderMultiRatingIfNeeded();
+
   // Populate character breakdown, examples, notes, grammar, and word analysis
   renderVocabDetail();
   renderNotesSection();
@@ -3203,15 +3206,16 @@ function _callRenderWordAnalysis() {
 // ── Render sentence (with target word highlighted) ──────────────────────────
 function renderSentence() {
   if (!sentence) {
-    // No story sentence — just show the word itself
     return `<span class="hl">${card.word_zh}</span>`;
   }
-  const zh   = sentence.sentence_zh;
-  const word = card.word_zh;
-  // Wrap in <span> so the flex container has a single child — avoids flex
-  // treating the text node and the highlight span as separate block items
-  const inner = zh.replace(word, `<span class="hl">${word}</span>`);
-  return `<span>${inner}</span>`;
+  let zh = sentence.sentence_zh;
+  // Highlight co-occurring vocab words (secondary), then the current card's word (primary)
+  const coWords = (sentence.words || []).filter(w => w.word_id !== card.word_id);
+  for (const w of coWords) {
+    zh = zh.replace(w.word_zh, `<span class="hl-secondary">${w.word_zh}</span>`);
+  }
+  zh = zh.replace(card.word_zh, `<span class="hl">${card.word_zh}</span>`);
+  return `<span>${zh}</span>`;
 }
 
 // ── Pick a random 2-char CJK word that doesn't overlap with excludeWord ─────
@@ -3459,6 +3463,123 @@ function diffClozeAnswer(userInput, targetWord) {
   const matched = userChars.filter((ch, i) => ch === targetChars[i]).length;
   const pct = targetChars.length > 0 ? Math.round((matched / targetChars.length) * 100) : 0;
   return { html, pct };
+}
+
+// ── Multi-word sentence rating UI ────────────────────────────────────────────
+
+// State: {word_id → rating} for the current multi-word sentence
+const _multiRatings = {};
+
+function _renderMultiRatingIfNeeded() {
+  const ratingRow  = document.getElementById('rating-row');
+  const multiBlock = document.getElementById('multi-rating');
+  const coWords = (sentence?.words || []).filter(w => w.word_id !== card?.word_id);
+
+  if (!sentence || coWords.length === 0) {
+    // Single-word (or no sentence): use normal rating row
+    ratingRow.style.display  = '';
+    multiBlock.style.display = 'none';
+    return;
+  }
+
+  // Multi-word sentence: hide normal buttons, show multi-rating block
+  ratingRow.style.display  = 'none';
+  multiBlock.style.display = '';
+
+  // Clear previous selections
+  Object.keys(_multiRatings).forEach(k => delete _multiRatings[k]);
+  document.getElementById('multi-rating-submit').disabled = true;
+
+  const allWords = [{ word_id: card.word_id, word_zh: card.word_zh }, ...coWords];
+  const iv = card.intervals || {};
+  const container = document.getElementById('multi-rating-rows');
+  container.innerHTML = allWords.map(w => {
+    const isMain = w.word_id === card.word_id;
+    const label = isMain ? `${w.word_zh} ★` : w.word_zh;
+    return `<div class="multi-rating-row" data-word-id="${w.word_id}">
+      <span class="multi-word-label${isMain ? ' multi-word-main' : ''}">${label}</span>
+      <div class="multi-btn-group">
+        ${[1,2,3,4].map(r => {
+          const names = ['Again','Hard','Good','Easy'];
+          const ivLabel = (isMain && iv[r]) ? `<small>${iv[r]}</small>` : '';
+          return `<button class="r-btn r-${names[r-1].toLowerCase()} multi-r-btn"
+                    data-word="${w.word_id}" data-r="${r}"
+                    onclick="_pickMultiRating(${w.word_id},${r},this)">
+                    ${names[r-1]}${ivLabel}</button>`;
+        }).join('')}
+      </div>
+    </div>`;
+  }).join('');
+}
+
+function _pickMultiRating(wordId, rating, btn) {
+  // Deselect other buttons in this row, select this one
+  const row = btn.closest('.multi-rating-row');
+  row.querySelectorAll('.multi-r-btn').forEach(b => b.classList.remove('selected'));
+  btn.classList.add('selected');
+  _multiRatings[wordId] = rating;
+
+  // Enable submit when all words have a rating
+  const allWords = document.querySelectorAll('#multi-rating-rows .multi-rating-row');
+  const allRated = [...allWords].every(r => _multiRatings[Number(r.dataset.wordId)] !== undefined);
+  document.getElementById('multi-rating-submit').disabled = !allRated;
+}
+
+async function submitMultiRating() {
+  document.querySelectorAll('.r-btn').forEach(b => b.disabled = true);
+  if (_timerStart) {
+    _sessionTotalMs += Date.now() - _timerStart;
+    _sessionRatedCount++;
+    _updateAvgTimeBadge();
+  }
+
+  // Build batch payload: current card first, then co-words
+  // We need the actual card IDs for all words — look them up from the queue/story
+  const allWordIds = Object.keys(_multiRatings).map(Number);
+  // card.id corresponds to card.word_id; for co-occurring words we need their card IDs.
+  // We'll use a helper endpoint to get card IDs by word_id + category.
+  let batchItems;
+  try {
+    const coWordIds = allWordIds.filter(wid => wid !== card.word_id);
+    let cardIdMap = { [card.word_id]: card.id };
+    if (coWordIds.length > 0) {
+      // Fetch card IDs for co-words in the same category
+      const idsRes = await api('GET',
+        `/api/cards/by-word?word_ids=${coWordIds.join(',')}&category=${encodeURIComponent(category)}`);
+      for (const entry of (idsRes || [])) cardIdMap[entry.word_id] = entry.card_id;
+    }
+    batchItems = allWordIds
+      .filter(wid => cardIdMap[wid] != null)
+      .map(wid => ({ card_id: cardIdMap[wid], rating: _multiRatings[wid] }));
+  } catch (e) {
+    showError('Failed to look up card IDs: ' + e.message);
+    document.querySelectorAll('.r-btn').forEach(b => b.disabled = false);
+    return;
+  }
+
+  try {
+    let url = `/api/review/batch`;
+    const params = [];
+    if (unfinishedMode) params.push('unfinished_mode=true');
+    else if (rootDeckId) params.push(`root_deck_id=${rootDeckId}`);
+    else if (deckId) params.push(`parent_deck_id=${deckId}`);
+    if (params.length) url += '?' + params.join('&');
+
+    const result = await api('POST', url, batchItems);
+    _sessionReviewedCount++;
+    if (!result.next_card) {
+      rootDeckId = null;
+      unfinishedMode = false;
+      showView('done');
+      return;
+    }
+    if (unfinishedMode || rootDeckId) category = result.next_card.category;
+    loadCard(result.next_card, result.counts);
+    document.getElementById('undo-btn').disabled = false;
+  } catch (e) {
+    showError('Submit failed: ' + e.message);
+    document.querySelectorAll('.r-btn').forEach(b => b.disabled = false);
+  }
 }
 
 // ── Submit rating ───────────────────────────────────────────────────────────
@@ -4121,7 +4242,7 @@ async function _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct
     _stopFakeProgress(); _stopStoryProgressPoll();
     setLoadingStep(65, null, 'Story received, processing…');
     story = await _resolveStory(storyData, storyDeckId, storyCategory, topic, maxHsk, grammarFocus, grammarPct, mode);
-    sentence = story?.sentences?.find(s => s.word_id === card.word_id) || null;
+    sentence = story?.sentences?.find(s => s.word_ids?.includes(card.word_id)) || null;
     _updateStoryInfoRow();
 
     const sentenceCount = story?.sentences?.length ?? 0;

--- a/static/index.html
+++ b/static/index.html
@@ -64,7 +64,6 @@
         </div>
       </div>
       <div style="display:flex;gap:6px;margin-left:auto;align-items:center">
-        <span id="avg-time-badge" class="review-rr-badge" style="display:none" title="Average time per card this session"></span>
         <span id="review-rr-badge" class="review-rr-badge" style="display:none" title="Daily retention rate"></span>
         <button class="undo-btn" id="undo-btn" onclick="undoReview()" title="Undo last rating [Z]" disabled>↩ Undo</button>
       </div>
@@ -87,6 +86,7 @@
             <button id="back-meta-play-btn" class="play-icon-btn play-icon-sm" onclick="playSentence()" style="display:none" title="Play audio">🔊</button>
             <span class="listen-counter listen-counter-back" id="listen-counter-back" style="display:none"></span>
           </div>
+          <span id="avg-time-badge" class="review-rr-badge" style="display:none" title="Average time per card this session"></span>
           <div id="card-timer" style="display:none"></div>
           <div id="card-type-badge"></div>
           <div class="wd-card-menu-wrap" id="review-card-menu-wrap">
@@ -162,11 +162,20 @@
         <div class="sentence-de" id="sentence-de"></div>
 
         <!-- 3. Rating buttons (immediately visible after flip) -->
+        <!-- Single-word mode: standard 4-button row -->
         <div class="rating-row" id="rating-row">
           <button class="r-btn r-again" onclick="rate(1)">Again<small id="int-1"></small></button>
           <button class="r-btn r-hard"  onclick="rate(2)">Hard<small id="int-2"></small></button>
           <button class="r-btn r-good"  onclick="rate(3)">Good<small id="int-3"></small></button>
           <button class="r-btn r-easy"  onclick="rate(4)">Easy<small id="int-4"></small></button>
+        </div>
+        <!-- Multi-word mode: one rating row per vocab word, then a submit button -->
+        <div class="multi-rating" id="multi-rating" style="display:none">
+          <div class="multi-rating-rows" id="multi-rating-rows"></div>
+          <div class="multi-rating-submit-row">
+            <button class="multi-rating-submit r-btn r-good" id="multi-rating-submit"
+                    onclick="submitMultiRating()" disabled>Submit all ratings</button>
+          </div>
         </div>
 
         <!-- 3. Full vocabulary info (below the fold) -->

--- a/static/style.css
+++ b/static/style.css
@@ -604,6 +604,17 @@ main.browse-open {
   opacity: 0.4;
   cursor: not-allowed;
 }
+/* Keyboard focus mode: highlight the active row */
+.multi-rating-row.row-focused {
+  background: var(--surface2, rgba(255,255,255,0.06));
+  border-radius: 8px;
+  outline: 2px solid var(--accent, #6366f1);
+  outline-offset: -2px;
+}
+/* Already-rated rows: grey out non-selected buttons */
+.multi-rating-row.rated .multi-r-btn:not(.selected) {
+  opacity: 0.3;
+}
 .r-btn {
   padding: 11px 4px 9px;
   border: none;

--- a/static/style.css
+++ b/static/style.css
@@ -383,6 +383,7 @@ main.browse-open {
   min-height: 90px;
 }
 .sentence .hl { color: var(--primary); font-weight: 700; }
+.sentence .hl-secondary { color: var(--hard, #f59e0b); font-weight: 600; }
 .answer-user .hl { color: var(--primary); font-weight: 700; }
 
 /* Small inline play icon next to sentence on back */
@@ -544,6 +545,64 @@ main.browse-open {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 8px;
+}
+
+/* Multi-word sentence rating UI */
+.multi-rating {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.multi-rating-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.multi-rating-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.multi-word-label {
+  min-width: 60px;
+  font-size: 14px;
+  color: var(--text-muted, #888);
+  flex-shrink: 0;
+}
+.multi-word-label.multi-word-main {
+  color: var(--primary);
+  font-weight: 700;
+}
+.multi-btn-group {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 4px;
+  flex: 1;
+}
+.multi-r-btn {
+  padding: 7px 4px 6px;
+  font-size: 12px;
+  opacity: 0.75;
+}
+.multi-r-btn.selected {
+  opacity: 1;
+  outline: 2px solid #fff;
+  outline-offset: -2px;
+}
+.multi-rating-submit-row {
+  display: flex;
+  justify-content: center;
+  margin-top: 2px;
+}
+.multi-rating-submit {
+  min-width: 180px;
+  padding: 10px 20px;
+  font-size: 13px;
+  background: var(--good, #22c55e);
+}
+.multi-rating-submit:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 .r-btn {
   padding: 11px 4px 9px;


### PR DESCRIPTION
## 变更内容

### 数据库层
- `schema.sql`：`story_sentences` 移除 `word_id` 列和 `UNIQUE(story_id, word_id)` 约束，新增 `story_sentence_words` 多对多关联表
- `database/core.py`：`init_db()` 自动检测旧库并执行迁移（重建表 + 迁移数据）
- `database/stories.py`：`create_story()` 支持 `word_ids` 列表；`get_story_sentences()` 返回每句的 `word_ids` 和 `words` 数组；`get_sentence_for_word()` 改为取位置最小的句子（首次出现规则）
- `database/cards.py`：新增 `get_cards_by_word_ids()` 批量查卡片

### AI 层
- `ai.py`：提示词允许多词合句（鼓励自然组合），AI 返回格式改为 `[{"word_ids": [...], "sentence_zh": "..."}]`，验证逻辑改为每个目标词恰好出现一次

### 后端路由
- `routes/review.py`：
  - 新增 `POST /api/review/batch` 批量评分接口（支持原子 undo）
  - 新增 `GET /api/cards/by-word?word_ids=&category=` 查询接口
  - 路由顺序调整：`/api/cards/by-word` 置于 `/{card_id}` 路由之前避免 FastAPI 路径冲突

### 前端
- `static/app.js`：句子查找改为 `word_ids.includes()`，`renderSentence()` 用 `.hl-secondary` 高亮共现词，新增多词评分 UI（全部选分后激活提交按钮，调用 batch 接口）
- `static/index.html`：新增 `#multi-rating` 区块
- `static/style.css`：新增 `.hl-secondary` 和多词评分 UI 样式

## 测试方法
1. `bash run.dev.sh` 启动开发服务器
2. 生成新故事，确认 `story_sentence_words` 表有记录
3. 启用真实 AI（`DISABLE_AI=0`），生成含多词合句的故事
4. 复习时触发多词句子，确认出现多行评分 UI
5. 提交评分后，确认所有共现词从队列消失
6. 测试 undo 功能（批量回滚）

Closes #245