### PR TITLE
fix: 创建模式词块数从五个改为四个

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3393,7 +3393,7 @@ async function _buildWordBank() {
   // If target wasn't found in tokens, append it
   if (!order.some(it => it.type === 'target')) order.push({ type: 'target', word: target });
 
-  const MAX_TILES = 5;
+  const MAX_TILES = 4;
   const isWord = tok => /[\u4E00-\u9FFF\u3400-\u4DBF]/.test(tok.char);
   const allChars = order.filter(it => it.type === 'char');
   // Punctuation tokens are always pre-placed — only real words become tiles


### PR DESCRIPTION
## 变更内容

- 将 `static/app.js` 中的 `MAX_TILES` 从 `5` 改为 `4`
- 创建模式词块排列：现在显示 **4个目标词 + 1个随机干扰词**

## 背景

这个改动原本在 PR #251 的分支上完成，但因为是在合并前才提交且未推送到远程，squash merge 后丢失了，需要单独补上。

## 测试方法

进入任意牌组的"创建"类别复习，确认词块区域显示 4 个词块（加 1 个随机词）而不是 5 个。