### PR TITLE
fix: 将创建模式词块数量从5个减少到4个

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3393,7 +3393,7 @@ async function _buildWordBank() {
   // If target wasn't found in tokens, append it
   if (!order.some(it => it.type === 'target')) order.push({ type: 'target', word: target });
 
-  const MAX_TILES = 5;
+  const MAX_TILES = 4;
   const isWord = tok => /[\u4E00-\u9FFF\u3400-\u4DBF]/.test(tok.char);
   const allChars = order.filter(it => it.type === 'char');
   // Punctuation tokens are always pre-placed — only real words become tiles


### PR DESCRIPTION
## 变更内容
- 将"创建"模式中的最大词块数量（MAX_TILES）从 5 改为 4
- 现在词块区显示4个真实词块 + 1个假词块（干扰词）

## 测试方法
- 进入"创建"模式复习，确认词块区显示4个真实词块+1个假词块