### PR TITLE
feat: 创建卡片正面显示目标生词翻译（法语 > 德语 > 英语）

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -107,7 +107,7 @@ def get_card(card_id: int) -> dict | None:
            )
            SELECT c.*,
                   w.word_zh, w.pinyin, w.definition, w.pos, w.hsk_level,
-                  w.traditional, w.definition_zh, w.note_type, w.notes, w.definition_de, w.register,
+                  w.traditional, w.definition_zh, w.note_type, w.notes, w.definition_de, w.definition_fr, w.register,
                   d.name AS deck_name,
                   CASE WHEN d.category IS NOT NULL THEN
                     (SELECT group_concat(name, ' › ')
@@ -283,7 +283,7 @@ def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = Fa
     rows = conn.execute(
         """SELECT c.*, w.word_zh, w.pinyin, w.definition, w.pos,
                   w.hsk_level, w.traditional, w.definition_zh,
-                  w.note_type, w.source_sentence, w.notes, w.definition_de, w.register
+                  w.note_type, w.source_sentence, w.notes, w.definition_de, w.definition_fr, w.register
            FROM cards c
            JOIN entries w ON w.id = c.word_id
            WHERE c.deck_id = ?

--- a/static/app.js
+++ b/static/app.js
@@ -2714,6 +2714,16 @@ function showFront() {
   document.getElementById('creating-input-wrap').style.display = (isCreating && !isCloze) ? 'flex' : 'none';
   document.getElementById('word-bank-wrap').style.display      = isCloze ? 'flex' : 'none';
 
+  // Creating: target word translation hint (FR > DE > EN)
+  const wordDefHint = document.getElementById('creating-word-def');
+  if (isCreating) {
+    const defText = card.definition_fr || card.definition_de || card.definition || '';
+    wordDefHint.textContent = defText;
+    wordDefHint.style.display = defText ? 'block' : 'none';
+  } else {
+    wordDefHint.style.display = 'none';
+  }
+
   if (isCreating) {
     if (isSentence) {
       // Sentence notes: show the German/English source as prompt

--- a/static/index.html
+++ b/static/index.html
@@ -119,6 +119,8 @@
         </div>
         <!-- Creating: English/German context sentence (shown above Chinese for cloze) -->
         <div class="sentence-en-front" id="sentence-en-front"></div>
+        <!-- Creating: target word translation hint (FR > DE > EN) -->
+        <div class="creating-word-def" id="creating-word-def" style="display:none"></div>
         <!-- Reading / Cloze: Chinese sentence on front (reading shows full, cloze shows blanked) -->
         <div class="sentence" id="sentence-front"></div>
         <div class="creating-input-wrap" id="creating-input-wrap">

--- a/static/style.css
+++ b/static/style.css
@@ -1253,6 +1253,13 @@ main.browse-open {
   align-items: center;
   justify-content: center;
 }
+.creating-word-def {
+  font-size: 15px;
+  color: var(--text-muted);
+  text-align: center;
+  font-style: italic;
+  margin-top: -8px;
+}
 .creating-input-wrap {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 变更内容

- 创建模式卡片正面，在句子提示词下方新增目标生词的翻译提示
- 优先级：法语 > 德语 > 英语（回退顺序）
- 三者都没有则不显示
- 样式：灰色斜体小字，居中

## 修改文件

- `database/cards.py`：两个卡片查询均加入 `definition_fr` 字段
- `static/index.html`：新增 `#creating-word-def` 元素
- `static/app.js`：加载创建卡片时填充并控制显示/隐藏
- `static/style.css`：新增 `.creating-word-def` 样式

## 测试方法

1. 启动服务器，进入任意牌组的创建（Creating）模式
2. 确认句子下方有生词翻译提示（灰色斜体）
3. 检查有法语翻译的词显示法语，只有德语的显示德语，都没有显示英语