### PR TITLE
feat: 德语翻译默认模糊，按 S 或点击显示

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -191,7 +191,9 @@ Rules:
 ]
 - "tokens": segment sentence_zh into natural words (NOT individual characters). Each token is [text, word_id_or_null].
   Assign a target word's word_id to the token whose text matches it exactly; use null for all other tokens.
-  Joining all token texts must exactly reproduce sentence_zh."""
+  Joining all token texts must exactly reproduce sentence_zh.
+  CRITICAL: If a target word appears inside a larger compound word, you MUST split that compound so the target word is its own separate token.
+  Example: target="款", sentence has "新款" → tokens must be ["新", null], ["款", word_id] — NEVER ["新款", null]."""
 
     logger.info("[%s] generate_story: %d 张卡片 mode=%s", model, len(cards), mode)
     logger.debug("Prompt:\n%s", prompt)

--- a/static/app.js
+++ b/static/app.js
@@ -3383,11 +3383,19 @@ async function _buildWordBank() {
   // Build ordered sequence from tokens [[text, word_id_or_null], ...]
   let order;
   if (sentence.tokens && sentence.tokens.length) {
-    order = sentence.tokens.map(([text, wid]) =>
-      text === target
-        ? { type: 'target', word: target }
-        : { type: 'char', char: text }
-    );
+    order = sentence.tokens.flatMap(([text, wid]) => {
+      if (text === target) return [{ type: 'target', word: target }];
+      if (target.length > 0 && text.includes(target)) {
+        // Target is embedded in a larger token — split it out
+        const idx = text.indexOf(target);
+        const parts = [];
+        if (idx > 0) parts.push({ type: 'char', char: text.slice(0, idx) });
+        parts.push({ type: 'target', word: target });
+        if (idx + target.length < text.length) parts.push({ type: 'char', char: text.slice(idx + target.length) });
+        return parts;
+      }
+      return [{ type: 'char', char: text }];
+    });
   } else {
     // Fallback: split by target word boundary, then individual chars
     const rawTokens = [];

--- a/static/app.js
+++ b/static/app.js
@@ -2714,12 +2714,23 @@ function showFront() {
   document.getElementById('creating-input-wrap').style.display = (isCreating && !isCloze) ? 'flex' : 'none';
   document.getElementById('word-bank-wrap').style.display      = isCloze ? 'flex' : 'none';
 
-  // Creating: target word translation hint (FR > DE > EN)
+  // Creating: target word translation hint — FR visible, DE blurred (press S to reveal); fallback EN
   const wordDefHint = document.getElementById('creating-word-def');
   if (isCreating) {
-    const defText = card.definition_fr || card.definition_de || card.definition || '';
-    wordDefHint.textContent = defText;
-    wordDefHint.style.display = defText ? 'block' : 'none';
+    const hasFr = !!card.definition_fr;
+    const hasDe = !!card.definition_de;
+    if (hasFr || hasDe) {
+      let html = '';
+      if (hasFr) html += `<span class="cwd-fr">🇫🇷 ${card.definition_fr}</span>`;
+      if (hasDe) html += `<span class="cwd-de blurred" onclick="this.classList.remove('blurred')" title="Press S to reveal">🇩🇪 ${card.definition_de}</span>`;
+      wordDefHint.innerHTML = html;
+      wordDefHint.style.display = 'block';
+    } else if (card.definition) {
+      wordDefHint.textContent = card.definition;
+      wordDefHint.style.display = 'block';
+    } else {
+      wordDefHint.style.display = 'none';
+    }
   } else {
     wordDefHint.style.display = 'none';
   }
@@ -5669,7 +5680,12 @@ document.addEventListener('keydown', async e => {
       e.preventDefault(); togglePinyin();
     } else if (e.key === 's') {
       e.preventDefault();
-      document.getElementById('sentence-front')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      const deSpan = document.querySelector('#creating-word-def .cwd-de');
+      if (!backVisible && deSpan) {
+        deSpan.classList.toggle('blurred');
+      } else {
+        document.getElementById('sentence-front')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
     } else if (e.key === ' ') {
       e.preventDefault(); if (!backVisible) revealAnswer();
     } else if (['1','2','3','4'].includes(e.key) && backVisible) {

--- a/static/app.js
+++ b/static/app.js
@@ -2714,7 +2714,7 @@ function showFront() {
   document.getElementById('creating-input-wrap').style.display = (isCreating && !isCloze) ? 'flex' : 'none';
   document.getElementById('word-bank-wrap').style.display      = isCloze ? 'flex' : 'none';
 
-  // Creating: target word translation hint — FR visible, DE blurred (press S to reveal); fallback EN
+  // Creating: FR always visible; DE hidden until S is pressed; fallback EN
   const wordDefHint = document.getElementById('creating-word-def');
   if (isCreating) {
     const hasFr = !!card.definition_fr;
@@ -2722,7 +2722,7 @@ function showFront() {
     if (hasFr || hasDe) {
       let html = '';
       if (hasFr) html += `<span class="cwd-fr">🇫🇷 ${card.definition_fr}</span>`;
-      if (hasDe) html += `<span class="cwd-de blurred" onclick="this.classList.remove('blurred')" title="Press S to reveal">🇩🇪 ${card.definition_de}</span>`;
+      if (hasDe) html += `${hasFr ? '<br>' : ''}<span class="cwd-de" style="display:none">🇩🇪 ${card.definition_de}</span>`;
       wordDefHint.innerHTML = html;
       wordDefHint.style.display = 'block';
     } else if (card.definition) {
@@ -5682,7 +5682,7 @@ document.addEventListener('keydown', async e => {
       e.preventDefault();
       const deSpan = document.querySelector('#creating-word-def .cwd-de');
       if (!backVisible && deSpan) {
-        deSpan.classList.toggle('blurred');
+        deSpan.style.display = deSpan.style.display === 'none' ? 'inline' : 'none';
       } else {
         document.getElementById('sentence-front')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
       }

--- a/static/app.js
+++ b/static/app.js
@@ -2714,23 +2714,15 @@ function showFront() {
   document.getElementById('creating-input-wrap').style.display = (isCreating && !isCloze) ? 'flex' : 'none';
   document.getElementById('word-bank-wrap').style.display      = isCloze ? 'flex' : 'none';
 
-  // Creating: FR always visible; DE hidden until S is pressed; fallback EN
+  // Creating: show FR and DE (both always visible); fallback EN if neither exists
   const wordDefHint = document.getElementById('creating-word-def');
   if (isCreating) {
-    const hasFr = !!card.definition_fr;
-    const hasDe = !!card.definition_de;
-    if (hasFr || hasDe) {
-      let html = '';
-      if (hasFr) html += `<span class="cwd-fr">🇫🇷 ${card.definition_fr}</span>`;
-      if (hasDe) html += `${hasFr ? '<br>' : ''}<span class="cwd-de" style="display:none">🇩🇪 ${card.definition_de}</span>`;
-      wordDefHint.innerHTML = html;
-      wordDefHint.style.display = 'block';
-    } else if (card.definition) {
-      wordDefHint.textContent = card.definition;
-      wordDefHint.style.display = 'block';
-    } else {
-      wordDefHint.style.display = 'none';
-    }
+    const parts = [];
+    if (card.definition_fr) parts.push(`🇫🇷 ${card.definition_fr}`);
+    if (card.definition_de) parts.push(`🇩🇪 ${card.definition_de}`);
+    const defText = parts.length ? parts.join('<br>') : (card.definition || '');
+    wordDefHint.innerHTML = defText;
+    wordDefHint.style.display = defText ? 'block' : 'none';
   } else {
     wordDefHint.style.display = 'none';
   }
@@ -5680,12 +5672,7 @@ document.addEventListener('keydown', async e => {
       e.preventDefault(); togglePinyin();
     } else if (e.key === 's') {
       e.preventDefault();
-      const deSpan = document.querySelector('#creating-word-def .cwd-de');
-      if (!backVisible && deSpan) {
-        deSpan.style.display = deSpan.style.display === 'none' ? 'inline' : 'none';
-      } else {
-        document.getElementById('sentence-front')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      }
+      document.getElementById('sentence-front')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     } else if (e.key === ' ') {
       e.preventDefault(); if (!backVisible) revealAnswer();
     } else if (['1','2','3','4'].includes(e.key) && backVisible) {

--- a/static/app.js
+++ b/static/app.js
@@ -3286,19 +3286,26 @@ function _initListenHint() {
 }
 
 function _renderListenHint(threshold) {
-  const zh = sentence?.sentence_zh;
+  // Sentence notes are excluded from stories; fall back to card.word_zh (the sentence itself).
+  const isSentenceNote = card?.note_type === 'sentence';
+  const zh = sentence?.sentence_zh || (isSentenceNote ? card?.word_zh : null);
   const el = document.getElementById('listen-hint-sentence');
   if (!zh) { el.textContent = ''; return; }
 
   const isCjk = ch => ch >= '一' && ch <= '鿿';
-  const targetPositions = _getTargetPositions(zh);
+  // Sentence notes have no single "target word" to blank — reveal based on HSK only.
+  const targetPositions = isSentenceNote && !sentence ? new Set() : _getTargetPositions(zh);
 
   // Reveal tokens harder than the threshold (level > threshold, or unknown to HSK).
   // threshold=0 means "All": level > 0 is true for every known word, null words also qualify.
   const revealPositions = new Set();
-  if (_hskLevels && sentence?.tokens?.length) {
+  if (_hskLevels) {
+    // Use story tokens when available; fall back to char-by-char for sentence notes.
+    const tokens = sentence?.tokens?.length
+      ? sentence.tokens
+      : [...zh].map(ch => [ch, null]);
     let pos = 0;
-    for (const [tok] of sentence.tokens) {
+    for (const [tok] of tokens) {
       const tokStart = zh.indexOf(tok, pos);
       if (tokStart === -1) { pos += tok.length; continue; }
       const tokEnd = tokStart + tok.length;

--- a/static/style.css
+++ b/static/style.css
@@ -1259,20 +1259,6 @@ main.browse-open {
   text-align: center;
   font-style: italic;
   margin-top: -8px;
-  display: flex;
-  gap: 12px;
-  justify-content: center;
-  flex-wrap: wrap;
-}
-.cwd-de.blurred {
-  filter: blur(4px);
-  opacity: 0.35;
-  transition: filter 0.2s ease, opacity 0.2s ease;
-  user-select: none;
-  cursor: pointer;
-}
-.cwd-de {
-  transition: filter 0.2s ease, opacity 0.2s ease;
 }
 .creating-input-wrap {
   display: flex;

--- a/static/style.css
+++ b/static/style.css
@@ -1259,6 +1259,20 @@ main.browse-open {
   text-align: center;
   font-style: italic;
   margin-top: -8px;
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.cwd-de.blurred {
+  filter: blur(4px);
+  opacity: 0.35;
+  transition: filter 0.2s ease, opacity 0.2s ease;
+  user-select: none;
+  cursor: pointer;
+}
+.cwd-de {
+  transition: filter 0.2s ease, opacity 0.2s ease;
 }
 .creating-input-wrap {
   display: flex;


### PR DESCRIPTION
## 变更内容

在创建（Creating）模式卡片正面：
- 🇫🇷 法语翻译：直接显示
- 🇩🇪 德语翻译：默认模糊，按 **S** 键或**点击**揭开
- 两者都没有：显示英语翻译

模糊效果与拼音提示（`filter: blur + opacity`）风格一致。

## 修改文件

- `static/app.js`：渲染 FR/DE 为独立 span，S 键逻辑改为切换 DE 模糊状态
- `static/style.css`：新增 `.cwd-de.blurred` 模糊样式

## 测试方法

1. 进入创建模式，确认法语直接显示、德语模糊
2. 按 S 键或点击德语文字，确认模糊消失
3. 再按 S 键，确认重新模糊

Closes #255