### PR TITLE
fix: Sentences 牌组导致阅读暂停徽章不更新

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -322,8 +322,12 @@ Rules:
                           msg=f"✓ {len(parsed)} sentences (patched)", percent=93)
             return parsed, prompt
 
-    logger.warning("generate_story: falling back to placeholder sentences")
-    return _fallback_sentences(cards), prompt
+    missing_count = len(last_partial[1]) if last_partial else len(cards)
+    raise RuntimeError(
+        f"Story generation failed after 3 attempts "
+        f"({missing_count} word(s) still missing from the story). "
+        "Please try again or switch to a different model."
+    )
 
 
 def _patch_missing(sentences: list[dict], missing_word_ids: list[int],

--- a/database/cards.py
+++ b/database/cards.py
@@ -1018,7 +1018,8 @@ def get_category_all_suspended(deck_id: int, category: str) -> bool:
     conn.close()
     total = row["total"] or 0
     suspended = row["suspended_count"] or 0
-    return total > 0 and total == suspended
+    # total==0 means no suspendable cards (e.g. Sentences deck) → treat as suspended
+    return total == suspended
 
 
 def toggle_category_suspension(deck_id: int, category: str) -> dict:

--- a/main.py
+++ b/main.py
@@ -200,7 +200,11 @@ try:
 
     @app.get("/")
     def root():
-        return FileResponse("static/index.html")
+        return FileResponse("static/index.html", headers={
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            "Pragma": "no-cache",
+            "Expires": "0",
+        })
 
     app.include_router(decks.router)
     app.include_router(review.router)

--- a/routes/story.py
+++ b/routes/story.py
@@ -69,7 +69,7 @@ def _get_cards_for_story(deck_id: int, category: str) -> list:
     return cards
 
 
-CHUNK_SIZE = 60
+CHUNK_SIZE = 100
 
 
 def _generate_story_sentences(cards: list, *, topic, max_hsk, model, progress_key,

--- a/routes/story.py
+++ b/routes/story.py
@@ -69,6 +69,36 @@ def _get_cards_for_story(deck_id: int, category: str) -> list:
     return cards
 
 
+CHUNK_SIZE = 60
+
+
+def _generate_story_sentences(cards: list, *, topic, max_hsk, model, progress_key,
+                               grammar_focus, grammar_pct, mode) -> tuple[list, str]:
+    """Generate story sentences, splitting into chunks of CHUNK_SIZE when cards > CHUNK_SIZE."""
+    if len(cards) <= CHUNK_SIZE:
+        return ai.generate_story(cards, topic=topic, max_hsk=max_hsk, model=model,
+                                 progress_key=progress_key, grammar_focus=grammar_focus,
+                                 grammar_pct=grammar_pct, mode=mode)
+
+    chunks = [cards[i:i + CHUNK_SIZE] for i in range(0, len(cards), CHUNK_SIZE)]
+    logger.info("story  CHUNKED %d cards → %d chunks of ≤%d", len(cards), len(chunks), CHUNK_SIZE)
+    all_sentences: list[dict] = []
+    combined_prompt = ""
+    for idx, chunk in enumerate(chunks):
+        ai._set_progress(progress_key, phase="generating",
+                         msg=f"Generating chunk {idx + 1}/{len(chunks)}…",
+                         percent=5 + int(85 * idx / len(chunks)))
+        chunk_sentences, chunk_prompt = ai.generate_story(
+            chunk, topic=topic, max_hsk=max_hsk, model=model,
+            progress_key=None,  # suppress per-chunk progress spam
+            grammar_focus=grammar_focus, grammar_pct=grammar_pct, mode=mode,
+        )
+        all_sentences.extend(chunk_sentences)
+        if idx == 0:
+            combined_prompt = chunk_prompt
+    return all_sentences, combined_prompt
+
+
 ALLOWED_MODELS = {
     "glm-4-flash",
     "glm-4-air",
@@ -120,12 +150,10 @@ def get_story(deck_id: int, category: str,
         ai._story_progress[progress_key] = {"phase": "starting", "msg": "Starting…", "percent": 5}
         last_error = None
         try:
-            sentences, prompt_text = ai.generate_story(cards, topic=topic, max_hsk=max_hsk,
-                                                       model=chosen_model,
-                                                       progress_key=progress_key,
-                                                       grammar_focus=grammar_focus,
-                                                       grammar_pct=grammar_pct,
-                                                       mode=mode)
+            sentences, prompt_text = _generate_story_sentences(
+                cards, topic=topic, max_hsk=max_hsk, model=chosen_model,
+                progress_key=progress_key, grammar_focus=grammar_focus,
+                grammar_pct=grammar_pct, mode=mode)
             for i, s in enumerate(sentences):
                 s["position"] = i
             database.create_story(today, category, deck_id, sentences, prompt_text, topic)
@@ -172,12 +200,10 @@ def regenerate_story(deck_id: int, category: str,
     ai._story_progress[progress_key] = {"phase": "starting", "msg": "Starting…", "percent": 5}
     last_error = None
     try:
-        sentences, prompt_text = ai.generate_story(cards, topic=topic, max_hsk=max_hsk,
-                                                   model=chosen_model,
-                                                   progress_key=progress_key,
-                                                   grammar_focus=grammar_focus,
-                                                   grammar_pct=grammar_pct,
-                                                   mode=mode)
+        sentences, prompt_text = _generate_story_sentences(
+            cards, topic=topic, max_hsk=max_hsk, model=chosen_model,
+            progress_key=progress_key, grammar_focus=grammar_focus,
+            grammar_pct=grammar_pct, mode=mode)
         for i, s in enumerate(sentences):
             s["position"] = i
         database.create_story(today, category, deck_id, sentences, prompt_text, topic)

--- a/static/app.js
+++ b/static/app.js
@@ -5569,25 +5569,6 @@ async function importYamlEntry() {
   }
 }
 
-// ── Server restart ───────────────────────────────────────────────────────────
-async function restartServer() {
-  const btn = document.getElementById('restart-btn');
-  btn.classList.add('spinning');
-  btn.disabled = true;
-  try {
-    await fetch('/api/restart', { method: 'POST' });
-  } catch (_) { /* server going down — expected */ }
-
-  // Poll until the server is back up, then reload
-  const poll = async () => {
-    try {
-      const r = await fetch('/api/decks');
-      if (r.ok) { location.reload(); return; }
-    } catch (_) {}
-    setTimeout(poll, 400);
-  };
-  setTimeout(poll, 600);
-}
 
 function _isVisible(id) {
   const el = document.getElementById(id);
@@ -5663,11 +5644,6 @@ document.addEventListener('keydown', async e => {
       saveEditCard();
       return;
     }
-  }
-
-  if (e.key === 'R' && e.shiftKey && !e.ctrlKey && !e.metaKey) {
-    if (!inInput) { e.preventDefault(); restartServer(); }
-    return;
   }
 
   // Enter in word-detail → back to review (if opened from review)

--- a/static/app.js
+++ b/static/app.js
@@ -2857,6 +2857,7 @@ function revealAnswer() {
         const color = pct >= 100 ? 'var(--good)' : pct >= 60 ? 'var(--hard)' : 'var(--again)';
         matchBar.innerHTML = `<span class="match-bar" style="color:${color}">${bar} ${pct}%</span>`;
         matchBar.style.display = 'block';
+        if (pct >= 100) triggerApplause();
       } else {
         matchBar.style.display = 'none';
       }
@@ -2870,6 +2871,7 @@ function revealAnswer() {
         const color = pct >= 80 ? 'var(--good)' : pct >= 50 ? 'var(--hard)' : 'var(--again)';
         matchBar.innerHTML = `<span class="match-bar" style="color:${color}">${bar} ${pct}%</span>`;
         matchBar.style.display = 'block';
+        if (pct >= 100) triggerApplause();
       } else {
         matchBar.style.display = 'none';
       }
@@ -3431,6 +3433,23 @@ async function _buildWordBank() {
         : { type: 'char', char: tok }
     );
   }
+  // Handle case where NLP tokenizer splits the target across consecutive tokens
+  // e.g., "怎么可能" tokenized as ["怎么", "可能"] — merge them into one target token
+  if (!targetParts) {
+    for (let i = 0; i < order.length; i++) {
+      if (order[i].type !== 'char') continue;
+      let acc = '';
+      let j = i;
+      while (j < order.length && order[j].type === 'char') {
+        acc += order[j].char;
+        if (acc === target) { order.splice(i, j - i + 1, { type: 'target', word: target }); break; }
+        if (!target.startsWith(acc)) break;
+        j++;
+      }
+      if (order[i]?.type === 'target') break;
+    }
+  }
+
   // For separable words, count how many parts were found; for normal words, check if any target found
   const targetCount = order.filter(it => it.type === 'target').length;
   const expectedCount = targetParts ? targetParts.length : 1;
@@ -6159,6 +6178,23 @@ document.addEventListener('click', function(e) {
     body: JSON.stringify({ action }),
   }).catch(() => {});
 }, true);
+
+// ── Confetti (100% score) ─────────────────────────────────────────────────────
+function triggerApplause() {
+  const colors = ['#16a34a', '#2563eb', '#d97706', '#dc2626', '#0891b2', '#9333ea'];
+  const count = 48;
+  for (let i = 0; i < count; i++) {
+    const el = document.createElement('div');
+    el.className = 'confetti-piece';
+    el.style.left = Math.random() * 100 + 'vw';
+    el.style.backgroundColor = colors[Math.floor(Math.random() * colors.length)];
+    el.style.animationDuration = (1.0 + Math.random() * 1.2) + 's';
+    el.style.animationDelay = (Math.random() * 0.4) + 's';
+    el.style.borderRadius = Math.random() > 0.5 ? '50%' : '2px';
+    document.body.appendChild(el);
+    el.addEventListener('animationend', () => el.remove());
+  }
+}
 
 // ── Boot ─────────────────────────────────────────────────────────────────────
 loadDecks();

--- a/static/app.js
+++ b/static/app.js
@@ -182,10 +182,13 @@ function _renderCal() {
 
   timelineEl.innerHTML = html;
 
-  // Scroll the tile to show the current month
+  // Scroll the calendar tile so the current month is at the top
   if (todayMonthId) {
-    const el = document.getElementById(todayMonthId);
-    if (el) requestAnimationFrame(() => el.scrollIntoView({ block: 'start', behavior: 'instant' }));
+    requestAnimationFrame(() => {
+      const panel = document.getElementById('review-cal-panel');
+      const el    = document.getElementById(todayMonthId);
+      if (panel && el) panel.scrollTop = el.offsetTop;
+    });
   }
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -102,70 +102,91 @@ function _buildCalDayMap() {
 }
 
 function _renderCal() {
-  const labelEl = document.getElementById('cal-month-label');
-  const gridEl  = document.getElementById('cal-grid');
-  if (!labelEl || !gridEl) return;
+  const timelineEl = document.getElementById('cal-timeline');
+  if (!timelineEl) return;
 
   const today = new Date();
   const todayStr = today.toISOString().slice(0, 10);
-
   const monthNames = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-  labelEl.textContent = `${monthNames[_calMonth]} ${_calYear}`;
-
   const dayMap = _buildCalDayMap();
 
-  const firstDay = new Date(_calYear, _calMonth, 1);
-  let startOffset = firstDay.getDay() - 1;
-  if (startOffset < 0) startOffset = 6;
-
-  const daysInMonth = new Date(_calYear, _calMonth + 1, 0).getDate();
+  // Range: first history date → today + 3 months
+  const allDates = [
+    ...(_calData?.history || []).map(h => h.date),
+    ...(_calData?.future  || []).map(f => f.due),
+  ];
+  let startDate = today;
+  if (allDates.length) {
+    const minStr = allDates.reduce((a, b) => a < b ? a : b);
+    const parsed = new Date(minStr);
+    if (!isNaN(parsed)) startDate = parsed;
+  }
+  const endDate = new Date(today.getFullYear(), today.getMonth() + 4, 0); // last day of today+3 months
 
   let html = '';
-  for (let i = 0; i < startOffset; i++) html += '<div class="cal-cell cal-empty"></div>';
+  let yr = startDate.getFullYear(), mo = startDate.getMonth();
+  const endYr = endDate.getFullYear(), endMo = endDate.getMonth();
+  let todayMonthId = null;
 
-  for (let d = 1; d <= daysInMonth; d++) {
-    const mm = String(_calMonth + 1).padStart(2, '0');
-    const dd = String(d).padStart(2, '0');
-    const dateStr = `${_calYear}-${mm}-${dd}`;
-    const isToday = dateStr === todayStr;
-    const info = dayMap[dateStr];
+  while (yr < endYr || (yr === endYr && mo <= endMo)) {
+    const monthId = `cal-month-${yr}-${mo}`;
+    if (yr === today.getFullYear() && mo === today.getMonth()) todayMonthId = monthId;
 
-    html += `<div class="cal-cell${isToday ? ' cal-today' : ''}">`;
-    if (info) {
-      html += '<div class="cal-chips">';
-      for (const r of info.ratings) {
-        const rCls = _RATING_CLASS[r.rating] || 'good';
-        const letter = _CAT_LETTER[r.category] || '?';
-        html += `<span class="cal-chip cal-chip-${rCls}" title="${r.category}: ${rCls}">${letter}</span>`;
-      }
-      for (const f of info.dues) {
-        const cCls = _CAT_CLASS[f.category] || '';
-        const letter = _CAT_LETTER[f.category] || '?';
-        html += `<span class="cal-chip cal-chip-due-${cCls}" title="${f.category} due">${letter}</span>`;
+    html += `<div class="cal-month-block" id="${monthId}">`;
+    html += `<div class="cal-month-heading">${monthNames[mo]} ${yr}</div>`;
+    html += `<div class="cal-weekdays"><span>Mo</span><span>Tu</span><span>We</span><span>Th</span><span>Fr</span><span>Sa</span><span>Su</span></div>`;
+    html += `<div class="cal-grid">`;
+
+    const firstDay = new Date(yr, mo, 1);
+    let startOffset = firstDay.getDay() - 1;
+    if (startOffset < 0) startOffset = 6;
+    for (let i = 0; i < startOffset; i++) html += '<div class="cal-cell cal-empty"></div>';
+
+    const daysInMonth = new Date(yr, mo + 1, 0).getDate();
+    for (let d = 1; d <= daysInMonth; d++) {
+      const mm = String(mo + 1).padStart(2, '0');
+      const dd = String(d).padStart(2, '0');
+      const dateStr = `${yr}-${mm}-${dd}`;
+      const isToday = dateStr === todayStr;
+      const info = dayMap[dateStr];
+
+      html += `<div class="cal-cell${isToday ? ' cal-today' : ''}">`;
+      if (info) {
+        html += '<div class="cal-chips">';
+        for (const r of info.ratings) {
+          const rCls = _RATING_CLASS[r.rating] || 'good';
+          const letter = _CAT_LETTER[r.category] || '?';
+          html += `<span class="cal-chip cal-chip-${rCls}" title="${r.category}: ${rCls}">${letter}</span>`;
+        }
+        for (const f of info.dues) {
+          const cCls = _CAT_CLASS[f.category] || '';
+          const letter = _CAT_LETTER[f.category] || '?';
+          html += `<span class="cal-chip cal-chip-due-${cCls}" title="${f.category} due">${letter}</span>`;
+        }
+        html += '</div>';
+      } else if (isToday && _calCategory) {
+        const letter = _CAT_LETTER[_calCategory] || '?';
+        const cCls   = _CAT_CLASS[_calCategory]  || '';
+        html += `<div class="cal-chips"><span class="cal-chip cal-chip-due-${cCls}" title="${_calCategory} today">${letter}</span></div>`;
+      } else {
+        html += `<span class="cal-day-num${isToday ? ' cal-day-num-today' : ''}">${d}</span>`;
       }
       html += '</div>';
-    } else if (isToday && _calCategory) {
-      const letter = _CAT_LETTER[_calCategory] || '?';
-      const cCls   = _CAT_CLASS[_calCategory]  || '';
-      html += `<div class="cal-chips"><span class="cal-chip cal-chip-due-${cCls}" title="${_calCategory} today">${letter}</span></div>`;
-    } else {
-      html += `<span class="cal-day-num${isToday ? ' cal-day-num-today' : ''}">${d}</span>`;
     }
-    html += '</div>';
+
+    html += '</div></div>'; // close cal-grid + cal-month-block
+
+    mo++;
+    if (mo > 11) { mo = 0; yr++; }
   }
 
-  gridEl.innerHTML = html;
-}
+  timelineEl.innerHTML = html;
 
-function calPrevMonth() {
-  _calMonth--;
-  if (_calMonth < 0) { _calMonth = 11; _calYear--; }
-  _renderCal();
-}
-function calNextMonth() {
-  _calMonth++;
-  if (_calMonth > 11) { _calMonth = 0; _calYear++; }
-  _renderCal();
+  // Scroll the tile to show the current month
+  if (todayMonthId) {
+    const el = document.getElementById(todayMonthId);
+    if (el) requestAnimationFrame(() => el.scrollIntoView({ block: 'start', behavior: 'instant' }));
+  }
 }
 
 async function _loadCardCalendar(cardId, category) {
@@ -317,6 +338,8 @@ function showView(name) {
     name === 'browse' ? 'flex' : 'block';
   document.querySelector('main').classList.toggle('browse-open', name === 'browse');
   document.querySelector('main').classList.toggle('review-open', name === 'review');
+  const countsRow = document.getElementById('counts-row');
+  if (countsRow) countsRow.style.display = name === 'review' ? 'flex' : 'none';
   document.getElementById('back-btn').style.display = name === 'decks' ? 'none' : 'block';
   document.getElementById('header-title').textContent =
     name === 'review'       ? deckName :

--- a/static/app.js
+++ b/static/app.js
@@ -2632,7 +2632,7 @@ function loadCard(c, counts) {
   // Deck path bar
   const deckPath = document.getElementById('card-deck-path');
   if (card.deck_path) {
-    deckPath.textContent = card.deck_path;
+    deckPath.textContent = card.deck_path.replace(/_/g, ' ');
     deckPath.style.display = 'block';
   } else {
     deckPath.style.display = 'none';
@@ -2710,6 +2710,8 @@ function showFront() {
   document.getElementById('side-back').style.display = 'none';
   const _vp = document.getElementById('review-vocab-panel');
   if (_vp) _vp.style.display = 'none';
+  const _mascot = document.getElementById('cal-front-mascot');
+  if (_mascot) _mascot.style.display = 'flex';
 
   // Listening elements
   document.getElementById('front-listen-icon').style.display = isListening ? 'flex' : 'none';
@@ -2830,6 +2832,8 @@ function revealAnswer() {
   document.getElementById('side-back').style.gap = '16px';
   const _vpBack = document.getElementById('review-vocab-panel');
   if (_vpBack) _vpBack.style.display = '';
+  const _mascotBack = document.getElementById('cal-front-mascot');
+  if (_mascotBack) _mascotBack.style.display = 'none';
   document.getElementById('back-meta-play-btn').style.display = isCreating ? 'none' : 'flex';
   _updateListenCounters();
 

--- a/static/app.js
+++ b/static/app.js
@@ -169,11 +169,10 @@ function calNextMonth() {
 }
 
 async function _loadCardCalendar(cardId, category) {
-  const el = document.getElementById('card-calendar');
-  if (!el) return;
+  const panel = document.getElementById('review-cal-panel');
   _calData     = null;
   _calCategory = category || null;
-  el.style.display = 'none';
+  if (panel) panel.style.display = 'none';
   try {
     const data = await api('GET', `/api/cards/${cardId}/calendar`);
     if (!data) return;
@@ -182,7 +181,7 @@ async function _loadCardCalendar(cardId, category) {
     _calYear  = today.getFullYear();
     _calMonth = today.getMonth();
     _renderCal();
-    el.style.display = 'block';
+    if (panel) panel.style.display = '';
   } catch (e) { /* silently skip if unavailable */ }
 }
 
@@ -317,6 +316,7 @@ function showView(name) {
   document.getElementById(`view-${name}`).style.display =
     name === 'browse' ? 'flex' : 'block';
   document.querySelector('main').classList.toggle('browse-open', name === 'browse');
+  document.querySelector('main').classList.toggle('review-open', name === 'review');
   document.getElementById('back-btn').style.display = name === 'decks' ? 'none' : 'block';
   document.getElementById('header-title').textContent =
     name === 'review'       ? deckName :
@@ -2685,6 +2685,8 @@ function showFront() {
   document.getElementById('side-front').style.flexDirection = 'column';
   document.getElementById('side-front').style.gap = '16px';
   document.getElementById('side-back').style.display = 'none';
+  const _vp = document.getElementById('review-vocab-panel');
+  if (_vp) _vp.style.display = 'none';
 
   // Listening elements
   document.getElementById('front-listen-icon').style.display = isListening ? 'flex' : 'none';
@@ -2803,6 +2805,8 @@ function revealAnswer() {
   document.getElementById('side-back').style.display  = 'flex';
   document.getElementById('side-back').style.flexDirection = 'column';
   document.getElementById('side-back').style.gap = '16px';
+  const _vpBack = document.getElementById('review-vocab-panel');
+  if (_vpBack) _vpBack.style.display = '';
   document.getElementById('back-meta-play-btn').style.display = isCreating ? 'none' : 'flex';
   _updateListenCounters();
 

--- a/static/app.js
+++ b/static/app.js
@@ -198,7 +198,11 @@ function _renderCal() {
     requestAnimationFrame(() => {
       const panel = document.getElementById('review-cal-panel');
       const el    = document.getElementById(scrollTargetId);
-      if (panel && el) panel.scrollTop = el.offsetTop;
+      if (panel && el) {
+        const panelRect = panel.getBoundingClientRect();
+        const elRect    = el.getBoundingClientRect();
+        panel.scrollTop += elRect.top - panelRect.top;
+      }
     });
   }
 }

--- a/static/app.js
+++ b/static/app.js
@@ -2708,10 +2708,10 @@ function showFront() {
   document.getElementById('side-front').style.flexDirection = 'column';
   document.getElementById('side-front').style.gap = '16px';
   document.getElementById('side-back').style.display = 'none';
-  const _vp = document.getElementById('review-vocab-panel');
-  if (_vp) _vp.style.display = 'none';
-  const _mascot = document.getElementById('cal-front-mascot');
+  const _mascot = document.getElementById('front-mascot');
   if (_mascot) _mascot.style.display = 'flex';
+  const _vc = document.getElementById('vocab-content');
+  if (_vc) _vc.style.display = 'none';
 
   // Listening elements
   document.getElementById('front-listen-icon').style.display = isListening ? 'flex' : 'none';
@@ -2830,10 +2830,10 @@ function revealAnswer() {
   document.getElementById('side-back').style.display  = 'flex';
   document.getElementById('side-back').style.flexDirection = 'column';
   document.getElementById('side-back').style.gap = '16px';
-  const _vpBack = document.getElementById('review-vocab-panel');
-  if (_vpBack) _vpBack.style.display = '';
-  const _mascotBack = document.getElementById('cal-front-mascot');
+  const _mascotBack = document.getElementById('front-mascot');
   if (_mascotBack) _mascotBack.style.display = 'none';
+  const _vcBack = document.getElementById('vocab-content');
+  if (_vcBack) _vcBack.style.display = 'block';
   document.getElementById('back-meta-play-btn').style.display = isCreating ? 'none' : 'flex';
   _updateListenCounters();
 
@@ -5650,6 +5650,11 @@ document.addEventListener('keydown', async e => {
     }
   }
 
+  if (e.key === 'R' && e.shiftKey && !e.ctrlKey && !e.metaKey) {
+    if (!inInput) { e.preventDefault(); _restartServer(); }
+    return;
+  }
+
   // Enter in word-detail → back to review (if opened from review)
   if (e.key === 'Enter' && !e.metaKey && !e.ctrlKey && !e.altKey && !inInput && !_hasOpenModal()) {
     if (document.getElementById('view-word-detail')?.style.display !== 'none' && _prevView === 'review') {
@@ -6201,6 +6206,16 @@ function triggerApplause() {
     document.body.appendChild(el);
     el.addEventListener('animationend', () => el.remove());
   }
+}
+
+// ── Server restart (Shift+R, no button) ──────────────────────────────────────
+async function _restartServer() {
+  try { await fetch('/api/restart', { method: 'POST' }); } catch (_) {}
+  const poll = async () => {
+    try { const r = await fetch('/api/decks'); if (r.ok) { location.reload(); return; } } catch (_) {}
+    setTimeout(poll, 400);
+  };
+  setTimeout(poll, 600);
 }
 
 // ── Boot ─────────────────────────────────────────────────────────────────────

--- a/static/app.js
+++ b/static/app.js
@@ -123,6 +123,16 @@ function _renderCal() {
   }
   const endDate = new Date(today.getFullYear(), today.getMonth() + 4, 0); // last day of today+3 months
 
+  // Find first review date to scroll to on open
+  const histDates = (_calData?.history || []).map(h => h.date).filter(Boolean).sort();
+  let firstMonthId = null;
+  if (histDates.length) {
+    const firstParsed = new Date(histDates[0]);
+    if (!isNaN(firstParsed)) {
+      firstMonthId = `cal-month-${firstParsed.getFullYear()}-${firstParsed.getMonth()}`;
+    }
+  }
+
   let html = '';
   let yr = startDate.getFullYear(), mo = startDate.getMonth();
   const endYr = endDate.getFullYear(), endMo = endDate.getMonth();
@@ -182,11 +192,12 @@ function _renderCal() {
 
   timelineEl.innerHTML = html;
 
-  // Scroll the calendar tile so the current month is at the top
-  if (todayMonthId) {
+  // Scroll to first reviewed month (or today if no history)
+  const scrollTargetId = firstMonthId || todayMonthId;
+  if (scrollTargetId) {
     requestAnimationFrame(() => {
       const panel = document.getElementById('review-cal-panel');
-      const el    = document.getElementById(todayMonthId);
+      const el    = document.getElementById(scrollTargetId);
       if (panel && el) panel.scrollTop = el.offsetTop;
     });
   }

--- a/static/index.html
+++ b/static/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AnkiAdvanced</title>
-  <link rel="stylesheet" href="/static/style.css?v=2">
+  <link rel="stylesheet" href="/static/style.css?v=3">
 </head>
 <body>
 
@@ -524,7 +524,7 @@
 </div>
 
 <div id="word-tip" style="display:none"></div>
-<script src="/static/app.js"></script>
+<script src="/static/app.js?v=3"></script>
 
 <!-- Edit card modal -->
 <div id="edit-modal-overlay" onclick="closeEditCard()" style="display:none"></div>

--- a/static/index.html
+++ b/static/index.html
@@ -212,16 +212,9 @@
       </div><!-- /review-center-tile -->
 
       <!-- RIGHT: Notes / Examples / Word Analysis tile (hidden until card flip) -->
-      <div class="review-side-tile" id="review-vocab-panel" style="display:none">
-        <div id="notes-section"></div>
-        <div id="examples-section"></div>
-        <div id="word-analysis-section"></div>
-        <button class="edit-card-btn" id="edit-card-btn" onclick="openEditCard()">Edit card</button>
-      </div>
-
-      <!-- LEFT: Calendar tile (hidden until data loads; shown on desktop to the left via order) -->
-      <div class="review-side-tile review-cal-tile" id="review-cal-panel" style="display:none">
-        <div id="cal-front-mascot" class="cal-front-mascot" style="display:none">
+      <!-- RIGHT: Mascot (front) + Notes/Examples/Word Analysis (back) -->
+      <div class="review-side-tile" id="review-vocab-panel">
+        <div id="front-mascot" class="front-mascot">
 <pre class="mascot-art">
   /\___/\
  (= ^.^ =)
@@ -231,6 +224,16 @@
 </pre>
           <div class="mascot-caption">Focus — show answer when ready!</div>
         </div>
+        <div id="vocab-content" style="display:none">
+          <div id="notes-section"></div>
+          <div id="examples-section"></div>
+          <div id="word-analysis-section"></div>
+          <button class="edit-card-btn" id="edit-card-btn" onclick="openEditCard()">Edit card</button>
+        </div>
+      </div>
+
+      <!-- LEFT: Calendar tile (hidden until data loads; shown on desktop to the left via order) -->
+      <div class="review-side-tile review-cal-tile" id="review-cal-panel" style="display:none">
         <div id="card-calendar" class="card-calendar">
           <div id="cal-timeline"></div>
           <div class="cal-legend">

--- a/static/index.html
+++ b/static/index.html
@@ -11,6 +11,41 @@
 <header>
   <button id="back-btn" onclick="goBack()">←</button>
   <h1 id="header-title">AnkiAdvanced</h1>
+  <!-- Review counts — shown only during review, hidden otherwise -->
+  <div class="counts-row" id="counts-row" style="display:none">
+    <div class="cnt-item" id="cnt-item-new">
+      <b id="cnt-new" class="n-new">0</b>
+      <span class="cnt-label">new</span>
+    </div>
+    <div class="cnt-item" id="cnt-item-lrn">
+      <b id="cnt-lrn" class="n-lrn">0</b>
+      <span class="cnt-label">learning</span>
+    </div>
+    <div class="cnt-item" id="cnt-item-rev">
+      <b id="cnt-rev" class="n-rev">0</b>
+      <span class="cnt-label">review</span>
+    </div>
+    <div id="cnt-by-cat" style="display:none">
+      <div class="cnt-cat-item" id="cnt-cat-reading">
+        <span class="cnt-cat-zh">读</span>
+        <span class="cnt-cat-nums"><b id="cnt-r-new" class="n-new">0</b>·<b id="cnt-r-lrn" class="n-lrn">0</b>·<b id="cnt-r-rev" class="n-rev">0</b></span>
+        <span id="cnt-r-rr" class="cnt-cat-rr"></span>
+      </div>
+      <div class="cnt-cat-item" id="cnt-cat-listening">
+        <span class="cnt-cat-zh">听</span>
+        <span class="cnt-cat-nums"><b id="cnt-l-new" class="n-new">0</b>·<b id="cnt-l-lrn" class="n-lrn">0</b>·<b id="cnt-l-rev" class="n-rev">0</b></span>
+        <span id="cnt-l-rr" class="cnt-cat-rr"></span>
+      </div>
+      <div class="cnt-cat-item" id="cnt-cat-creating">
+        <span class="cnt-cat-zh">创</span>
+        <span class="cnt-cat-nums"><b id="cnt-c-new" class="n-new">0</b>·<b id="cnt-c-lrn" class="n-lrn">0</b>·<b id="cnt-c-rev" class="n-rev">0</b></span>
+        <span id="cnt-c-rr" class="cnt-cat-rr"></span>
+      </div>
+    </div>
+    <span id="review-rr-badge" class="review-rr-badge" style="display:none" title="Daily retention rate"></span>
+    <span id="avg-time-badge" class="review-rr-badge" style="display:none" title="Average time per card this session"></span>
+    <button class="undo-btn" id="undo-btn" onclick="undoReview()" title="Undo last rating [Z]" disabled>↩ Undo</button>
+  </div>
   <button id="header-regen-btn" onclick="regenerateStory()" title="Regenerate story" style="display:none">↺</button>
   <button id="restart-btn" onclick="restartServer()" title="Restart server (Shift+R)">↺</button>
 </header>
@@ -33,41 +68,6 @@
 
   <!-- Review -->
   <div id="view-review">
-    <div class="counts-row">
-      <div class="cnt-item" id="cnt-item-new">
-        <b id="cnt-new" class="n-new">0</b>
-        <span class="cnt-label">new</span>
-      </div>
-      <div class="cnt-item" id="cnt-item-lrn">
-        <b id="cnt-lrn" class="n-lrn">0</b>
-        <span class="cnt-label">learning</span>
-      </div>
-      <div class="cnt-item" id="cnt-item-rev">
-        <b id="cnt-rev" class="n-rev">0</b>
-        <span class="cnt-label">review</span>
-      </div>
-      <div id="cnt-by-cat" style="display:none">
-        <div class="cnt-cat-item" id="cnt-cat-reading">
-          <span class="cnt-cat-zh">读</span>
-          <span class="cnt-cat-nums"><b id="cnt-r-new" class="n-new">0</b>·<b id="cnt-r-lrn" class="n-lrn">0</b>·<b id="cnt-r-rev" class="n-rev">0</b></span>
-          <span id="cnt-r-rr" class="cnt-cat-rr"></span>
-        </div>
-        <div class="cnt-cat-item" id="cnt-cat-listening">
-          <span class="cnt-cat-zh">听</span>
-          <span class="cnt-cat-nums"><b id="cnt-l-new" class="n-new">0</b>·<b id="cnt-l-lrn" class="n-lrn">0</b>·<b id="cnt-l-rev" class="n-rev">0</b></span>
-          <span id="cnt-l-rr" class="cnt-cat-rr"></span>
-        </div>
-        <div class="cnt-cat-item" id="cnt-cat-creating">
-          <span class="cnt-cat-zh">创</span>
-          <span class="cnt-cat-nums"><b id="cnt-c-new" class="n-new">0</b>·<b id="cnt-c-lrn" class="n-lrn">0</b>·<b id="cnt-c-rev" class="n-rev">0</b></span>
-          <span id="cnt-c-rr" class="cnt-cat-rr"></span>
-        </div>
-      </div>
-      <div style="display:flex;gap:6px;margin-left:auto;align-items:center">
-        <span id="review-rr-badge" class="review-rr-badge" style="display:none" title="Daily retention rate"></span>
-        <button class="undo-btn" id="undo-btn" onclick="undoReview()" title="Undo last rating [Z]" disabled>↩ Undo</button>
-      </div>
-    </div>
 
     <!-- Three-panel layout: [calendar] [card] [vocab detail] -->
     <div class="review-layout">
@@ -91,7 +91,6 @@
                 <button id="back-meta-play-btn" class="play-icon-btn play-icon-sm" onclick="playSentence()" style="display:none" title="Play audio">🔊</button>
                 <span class="listen-counter listen-counter-back" id="listen-counter-back" style="display:none"></span>
               </div>
-              <span id="avg-time-badge" class="review-rr-badge" style="display:none" title="Average time per card this session"></span>
               <div id="card-timer" style="display:none"></div>
               <div id="card-type-badge"></div>
               <div class="wd-card-menu-wrap" id="review-card-menu-wrap">
@@ -220,15 +219,7 @@
       <!-- LEFT: Calendar tile (hidden until data loads; shown on desktop to the left via order) -->
       <div class="review-side-tile review-cal-tile" id="review-cal-panel" style="display:none">
         <div id="card-calendar" class="card-calendar">
-          <div class="cal-header">
-            <button class="cal-nav-btn" onclick="calPrevMonth()">‹</button>
-            <span id="cal-month-label" class="cal-month-label"></span>
-            <button class="cal-nav-btn" onclick="calNextMonth()">›</button>
-          </div>
-          <div class="cal-weekdays">
-            <span>Mo</span><span>Tu</span><span>We</span><span>Th</span><span>Fr</span><span>Sa</span><span>Su</span>
-          </div>
-          <div class="cal-grid" id="cal-grid"></div>
+          <div id="cal-timeline"></div>
           <div class="cal-legend">
             <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-again"></span>Again</span>
             <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-hard"></span>Hard</span>

--- a/static/index.html
+++ b/static/index.html
@@ -222,7 +222,7 @@
  (       )
   \_____/
 </pre>
-          <div class="mascot-caption">Focus — show answer when ready!</div>
+          <div class="mascot-caption">专注 — 准备好了就翻牌</div>
         </div>
         <div id="vocab-content" style="display:none">
           <div id="notes-section"></div>

--- a/static/index.html
+++ b/static/index.html
@@ -9,8 +9,10 @@
 <body>
 
 <header>
-  <button id="back-btn" onclick="goBack()">←</button>
-  <h1 id="header-title">AnkiAdvanced</h1>
+  <div class="header-left">
+    <button id="back-btn" onclick="goBack()">←</button>
+    <h1 id="header-title">AnkiAdvanced</h1>
+  </div>
   <!-- Review counts — shown only during review, hidden otherwise -->
   <div class="counts-row" id="counts-row" style="display:none">
     <div class="cnt-item" id="cnt-item-new">
@@ -46,8 +48,10 @@
     <span id="avg-time-badge" class="review-rr-badge" style="display:none" title="Average time per card this session"></span>
     <button class="undo-btn" id="undo-btn" onclick="undoReview()" title="Undo last rating [Z]" disabled>↩ Undo</button>
   </div>
-  <button id="header-regen-btn" onclick="regenerateStory()" title="Regenerate story" style="display:none">↺</button>
-  <button id="restart-btn" onclick="restartServer()" title="Restart server (Shift+R)">↺</button>
+  <div class="header-right">
+    <button id="header-regen-btn" onclick="regenerateStory()" title="Regenerate story" style="display:none">↺</button>
+    <button id="restart-btn" onclick="restartServer()" title="Restart server (Shift+R)">↻</button>
+  </div>
 </header>
 
 <main>

--- a/static/index.html
+++ b/static/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AnkiAdvanced</title>
-  <link rel="stylesheet" href="/static/style.css?v=3">
+  <link rel="stylesheet" href="/static/style.css?v=4">
 </head>
 <body>
 
@@ -527,7 +527,7 @@
 </div>
 
 <div id="word-tip" style="display:none"></div>
-<script src="/static/app.js?v=3"></script>
+<script src="/static/app.js?v=4"></script>
 
 <!-- Edit card modal -->
 <div id="edit-modal-overlay" onclick="closeEditCard()" style="display:none"></div>

--- a/static/index.html
+++ b/static/index.html
@@ -69,169 +69,180 @@
       </div>
     </div>
 
-    <div class="review-card" id="review-card">
+    <!-- Three-panel layout: [calendar] [card] [vocab detail] -->
+    <div class="review-layout">
 
-      <!-- Deck path bar: full-width breadcrumb above meta row -->
-      <div id="card-deck-path" class="card-deck-path" style="display:none"></div>
+      <!-- CENTER: Main review card — DOM first so mobile shows it first -->
+      <div class="review-center-tile">
+        <div class="review-card" id="review-card">
 
-      <!-- Story info row: sentence count + topic (clickable → full story) -->
-      <div id="story-info-row" style="display:none" onclick="openStoryModal()" title="View full story"></div>
+          <!-- Deck path bar: full-width breadcrumb above meta row -->
+          <div id="card-deck-path" class="card-deck-path" style="display:none"></div>
 
-      <!-- Card meta row: category circles (centre) + right group -->
-      <div class="card-meta-row">
-        <div id="review-cat-row" style="flex:1"></div>
-        <div class="card-meta-right">
-          <button id="card-hsk-badge" class="card-hsk-badge" onclick="enrichCard()" title="Ask AI to fill HSK level &amp; character data" style="display:none"></button>
-          <div class="back-play-group">
-            <button id="back-meta-play-btn" class="play-icon-btn play-icon-sm" onclick="playSentence()" style="display:none" title="Play audio">🔊</button>
-            <span class="listen-counter listen-counter-back" id="listen-counter-back" style="display:none"></span>
-          </div>
-          <span id="avg-time-badge" class="review-rr-badge" style="display:none" title="Average time per card this session"></span>
-          <div id="card-timer" style="display:none"></div>
-          <div id="card-type-badge"></div>
-          <div class="wd-card-menu-wrap" id="review-card-menu-wrap">
-            <button class="wd-menu-btn" onclick="toggleReviewCardMenu(event)">⋯</button>
-            <div class="wd-card-menu" id="review-card-menu" style="display:none">
-              <button class="wd-menu-item" onclick="reviewCardAction('bury')">Bury until tomorrow</button>
-              <button class="wd-menu-item" id="review-suspend-btn" onclick="reviewCardAction('suspend')">Suspend</button>
-              <button class="wd-menu-item wd-menu-item-danger" onclick="reviewCardAction('delete')">Delete card</button>
+          <!-- Story info row: sentence count + topic (clickable → full story) -->
+          <div id="story-info-row" style="display:none" onclick="openStoryModal()" title="View full story"></div>
+
+          <!-- Card meta row: category circles (centre) + right group -->
+          <div class="card-meta-row">
+            <div id="review-cat-row" style="flex:1"></div>
+            <div class="card-meta-right">
+              <button id="card-hsk-badge" class="card-hsk-badge" onclick="enrichCard()" title="Ask AI to fill HSK level &amp; character data" style="display:none"></button>
+              <div class="back-play-group">
+                <button id="back-meta-play-btn" class="play-icon-btn play-icon-sm" onclick="playSentence()" style="display:none" title="Play audio">🔊</button>
+                <span class="listen-counter listen-counter-back" id="listen-counter-back" style="display:none"></span>
+              </div>
+              <span id="avg-time-badge" class="review-rr-badge" style="display:none" title="Average time per card this session"></span>
+              <div id="card-timer" style="display:none"></div>
+              <div id="card-type-badge"></div>
+              <div class="wd-card-menu-wrap" id="review-card-menu-wrap">
+                <button class="wd-menu-btn" onclick="toggleReviewCardMenu(event)">⋯</button>
+                <div class="wd-card-menu" id="review-card-menu" style="display:none">
+                  <button class="wd-menu-item" onclick="reviewCardAction('bury')">Bury until tomorrow</button>
+                  <button class="wd-menu-item" id="review-suspend-btn" onclick="reviewCardAction('suspend')">Suspend</button>
+                  <button class="wd-menu-item wd-menu-item-danger" onclick="reviewCardAction('delete')">Delete card</button>
+                </div>
+              </div>
             </div>
           </div>
-        </div>
-      </div>
 
-      <!-- Front side (content varies by category) -->
-      <div id="side-front">
-        <!-- Listening: speaker icon (clickable) + repeat counter -->
-        <div class="listen-icon-wrap" id="front-listen-icon" style="display:none">
-          <button class="listen-icon" onclick="playSentence()">🔊</button>
-          <span class="listen-counter" id="listen-counter" style="display:none"></span>
-        </div>
-        <!-- Listening: hint sentence with slider (shows % of non-target chars) -->
-        <div id="listen-hint-wrap" style="display:none">
-          <div class="listen-hint-sentence" id="listen-hint-sentence"></div>
-          <div class="listen-hint-slider-row">
-            <span class="listen-hint-label">Hint</span>
-            <input type="range" id="listen-hint-slider" min="0" max="6" value="5"
-                   oninput="onListenHintSlider(this.value)">
-            <span class="listen-hint-pct" id="listen-hint-pct">HSK 5+</span>
-          </div>
-        </div>
-        <!-- Creating: English/German context sentence (shown above Chinese for cloze) -->
-        <div class="sentence-en-front" id="sentence-en-front"></div>
-        <!-- Creating: target word translation hint (FR > DE > EN) -->
-        <div class="creating-word-def" id="creating-word-def" style="display:none"></div>
-        <!-- Reading / Cloze: Chinese sentence on front (reading shows full, cloze shows blanked) -->
-        <div class="sentence" id="sentence-front"></div>
-        <div class="creating-input-wrap" id="creating-input-wrap">
-          <div class="input-label" id="creating-input-label">Fill in the blank</div>
-          <input type="text" id="creating-input" placeholder="Type the missing word…"
-                 autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
-                 onkeydown="if(event.key==='Enter')revealAnswer()">
-        </div>
-        <!-- Word bank (creating mode, non-sentence notes) -->
-        <div id="word-bank-wrap" style="display:none">
-          <div class="input-label">Reconstruct the sentence</div>
-          <div class="word-bank-skeleton" id="word-bank-skeleton"></div>
-          <div class="word-bank-tokens" id="word-bank-tokens"></div>
-          <input type="text" id="word-bank-input"
-                 autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
-                 placeholder="Fill blanks left to right: tile numbers + target word (e.g. 3 1 努力 2 5 4)"
-                 oninput="updateWordBankPreview(this.value)"
-                 onkeydown="if(event.key==='Enter')revealAnswer()">
-        </div>
-        <button class="reveal-btn" id="reveal-btn" onclick="revealAnswer()">Show Answer</button>
-      </div>
-
-      <!-- Back: sentence → ratings → full vocab detail -->
-      <div id="side-back" style="display:none">
-
-        <!-- Creating only: answer comparison -->
-        <div class="answer-compare" id="creating-answer-section" style="display:none">
-          <div class="answer-block">
-            <div class="answer-block-label">Your answer</div>
-            <div class="answer-block-text answer-user" id="user-answer-text"></div>
-            <div id="answer-match-bar" style="display:none"></div>
-          </div>
-          <div class="answer-block">
-            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:4px">
-              <div class="answer-block-label" style="margin-bottom:0">Correct</div>
-              <button class="play-icon-btn" onclick="playSentence()" title="Play audio">▶</button>
+          <!-- Front side (content varies by category) -->
+          <div id="side-front">
+            <!-- Listening: speaker icon (clickable) + repeat counter -->
+            <div class="listen-icon-wrap" id="front-listen-icon" style="display:none">
+              <button class="listen-icon" onclick="playSentence()">🔊</button>
+              <span class="listen-counter" id="listen-counter" style="display:none"></span>
             </div>
-            <div class="answer-block-text answer-correct" id="correct-answer-text"></div>
+            <!-- Listening: hint sentence with slider (shows % of non-target chars) -->
+            <div id="listen-hint-wrap" style="display:none">
+              <div class="listen-hint-sentence" id="listen-hint-sentence"></div>
+              <div class="listen-hint-slider-row">
+                <span class="listen-hint-label">Hint</span>
+                <input type="range" id="listen-hint-slider" min="0" max="6" value="5"
+                       oninput="onListenHintSlider(this.value)">
+                <span class="listen-hint-pct" id="listen-hint-pct">HSK 5+</span>
+              </div>
+            </div>
+            <!-- Creating: English/German context sentence (shown above Chinese for cloze) -->
+            <div class="sentence-en-front" id="sentence-en-front"></div>
+            <!-- Creating: target word translation hint (FR > DE > EN) -->
+            <div class="creating-word-def" id="creating-word-def" style="display:none"></div>
+            <!-- Reading / Cloze: Chinese sentence on front (reading shows full, cloze shows blanked) -->
+            <div class="sentence" id="sentence-front"></div>
+            <div class="creating-input-wrap" id="creating-input-wrap">
+              <div class="input-label" id="creating-input-label">Fill in the blank</div>
+              <input type="text" id="creating-input" placeholder="Type the missing word…"
+                     autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
+                     onkeydown="if(event.key==='Enter')revealAnswer()">
+            </div>
+            <!-- Word bank (creating mode, non-sentence notes) -->
+            <div id="word-bank-wrap" style="display:none">
+              <div class="input-label">Reconstruct the sentence</div>
+              <div class="word-bank-skeleton" id="word-bank-skeleton"></div>
+              <div class="word-bank-tokens" id="word-bank-tokens"></div>
+              <input type="text" id="word-bank-input"
+                     autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
+                     placeholder="Fill blanks left to right: tile numbers + target word (e.g. 3 1 努力 2 5 4)"
+                     oninput="updateWordBankPreview(this.value)"
+                     onkeydown="if(event.key==='Enter')revealAnswer()">
+            </div>
+            <button class="reveal-btn" id="reveal-btn" onclick="revealAnswer()">Show Answer</button>
           </div>
-        </div>
 
-        <!-- 1. Sentence (listening/reading back; hidden for creating) -->
-        <div class="sentence-row" id="sentence-row-back">
-          <div class="sentence" id="sentence-back"></div>
-        </div>
+          <!-- Back: sentence → ratings → word summary (no collapsible sections) -->
+          <div id="side-back" style="display:none">
 
-        <!-- 2. Pinyin row (blurred by default, p to reveal) -->
-        <div class="pinyin-row" id="pinyin-row"></div>
-        <!-- French and German translation of the sentence -->
-        <div class="sentence-fr" id="sentence-fr"></div>
-        <div class="sentence-de" id="sentence-de"></div>
+            <!-- Creating only: answer comparison -->
+            <div class="answer-compare" id="creating-answer-section" style="display:none">
+              <div class="answer-block">
+                <div class="answer-block-label">Your answer</div>
+                <div class="answer-block-text answer-user" id="user-answer-text"></div>
+                <div id="answer-match-bar" style="display:none"></div>
+              </div>
+              <div class="answer-block">
+                <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:4px">
+                  <div class="answer-block-label" style="margin-bottom:0">Correct</div>
+                  <button class="play-icon-btn" onclick="playSentence()" title="Play audio">▶</button>
+                </div>
+                <div class="answer-block-text answer-correct" id="correct-answer-text"></div>
+              </div>
+            </div>
 
-        <!-- 3. Rating buttons (immediately visible after flip) -->
-        <!-- Single-word mode: standard 4-button row -->
-        <div class="rating-row" id="rating-row">
-          <button class="r-btn r-again" onclick="rate(1)">Again<small id="int-1"></small></button>
-          <button class="r-btn r-hard"  onclick="rate(2)">Hard<small id="int-2"></small></button>
-          <button class="r-btn r-good"  onclick="rate(3)">Good<small id="int-3"></small></button>
-          <button class="r-btn r-easy"  onclick="rate(4)">Easy<small id="int-4"></small></button>
-        </div>
-        <!-- Multi-word mode: one rating row per vocab word, then a submit button -->
-        <div class="multi-rating" id="multi-rating" style="display:none">
-          <div class="multi-rating-rows" id="multi-rating-rows"></div>
-          <div class="multi-rating-submit-row">
-            <button class="multi-rating-submit r-btn r-good" id="multi-rating-submit"
-                    onclick="submitMultiRating()" disabled>Submit all ratings</button>
+            <!-- 1. Sentence (listening/reading back; hidden for creating) -->
+            <div class="sentence-row" id="sentence-row-back">
+              <div class="sentence" id="sentence-back"></div>
+            </div>
+
+            <!-- 2. Pinyin row (blurred by default, p to reveal) -->
+            <div class="pinyin-row" id="pinyin-row"></div>
+            <!-- French and German translation of the sentence -->
+            <div class="sentence-fr" id="sentence-fr"></div>
+            <div class="sentence-de" id="sentence-de"></div>
+
+            <!-- 3. Rating buttons (immediately visible after flip) -->
+            <div class="rating-row" id="rating-row">
+              <button class="r-btn r-again" onclick="rate(1)">Again<small id="int-1"></small></button>
+              <button class="r-btn r-hard"  onclick="rate(2)">Hard<small id="int-2"></small></button>
+              <button class="r-btn r-good"  onclick="rate(3)">Good<small id="int-3"></small></button>
+              <button class="r-btn r-easy"  onclick="rate(4)">Easy<small id="int-4"></small></button>
+            </div>
+            <!-- Multi-word mode: one rating row per vocab word, then a submit button -->
+            <div class="multi-rating" id="multi-rating" style="display:none">
+              <div class="multi-rating-rows" id="multi-rating-rows"></div>
+              <div class="multi-rating-submit-row">
+                <button class="multi-rating-submit r-btn r-good" id="multi-rating-submit"
+                        onclick="submitMultiRating()" disabled>Submit all ratings</button>
+              </div>
+            </div>
+
+            <!-- Word summary: character, pinyin, pos, definition -->
+            <div class="vocab-detail">
+              <div class="word-big" id="word-zh"></div>
+              <div class="word-pin" id="word-pin"></div>
+              <div class="word-pos-row"><span class="word-pos" id="word-pos"></span><span class="word-register" id="word-register" style="display:none"></span></div>
+              <div class="word-def" id="word-def"></div>
+              <div class="word-def-fr" id="word-def-fr" style="display:none"></div>
+              <div class="word-def-de" id="word-def-de" style="display:none"></div>
+            </div>
+
           </div>
-        </div>
 
-        <!-- 3. Full vocabulary info (below the fold) -->
-        <div class="vocab-detail">
-          <div class="word-big" id="word-zh"></div>
-          <div class="word-pin" id="word-pin"></div>
-          <div class="word-pos-row"><span class="word-pos" id="word-pos"></span><span class="word-register" id="word-register" style="display:none"></span></div>
-          <div class="word-def" id="word-def"></div>
-          <div class="word-def-fr" id="word-def-fr" style="display:none"></div>
-          <div class="word-def-de" id="word-def-de" style="display:none"></div>
-          <!-- Notes — populated by JS, hidden when empty -->
-          <div id="notes-section"></div>
-          <!-- Example sentences — populated by JS -->
-          <div id="examples-section"></div>
-          <!-- Word Analysis — populated by JS, open by default -->
-          <div id="word-analysis-section"></div>
-          <button class="edit-card-btn" id="edit-card-btn" onclick="openEditCard()">Edit card</button>
         </div>
+      </div><!-- /review-center-tile -->
 
+      <!-- RIGHT: Notes / Examples / Word Analysis tile (hidden until card flip) -->
+      <div class="review-side-tile" id="review-vocab-panel" style="display:none">
+        <div id="notes-section"></div>
+        <div id="examples-section"></div>
+        <div id="word-analysis-section"></div>
+        <button class="edit-card-btn" id="edit-card-btn" onclick="openEditCard()">Edit card</button>
       </div>
 
-      <!-- Card schedule calendar -->
-      <div id="card-calendar" class="card-calendar" style="display:none">
-        <div class="cal-header">
-          <button class="cal-nav-btn" onclick="calPrevMonth()">‹</button>
-          <span id="cal-month-label" class="cal-month-label"></span>
-          <button class="cal-nav-btn" onclick="calNextMonth()">›</button>
+      <!-- LEFT: Calendar tile (hidden until data loads; shown on desktop to the left via order) -->
+      <div class="review-side-tile review-cal-tile" id="review-cal-panel" style="display:none">
+        <div id="card-calendar" class="card-calendar">
+          <div class="cal-header">
+            <button class="cal-nav-btn" onclick="calPrevMonth()">‹</button>
+            <span id="cal-month-label" class="cal-month-label"></span>
+            <button class="cal-nav-btn" onclick="calNextMonth()">›</button>
+          </div>
+          <div class="cal-weekdays">
+            <span>Mo</span><span>Tu</span><span>We</span><span>Th</span><span>Fr</span><span>Sa</span><span>Su</span>
+          </div>
+          <div class="cal-grid" id="cal-grid"></div>
+          <div class="cal-legend">
+            <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-again"></span>Again</span>
+            <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-hard"></span>Hard</span>
+            <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-good"></span>Good</span>
+            <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-easy"></span>Easy</span>
+            <span class="cal-legend-sep"></span>
+            <span class="cal-legend-item cal-legend-cat">听 Listening</span>
+            <span class="cal-legend-item cal-legend-cat">读 Reading</span>
+            <span class="cal-legend-item cal-legend-cat">创 Creating</span>
+          </div>
         </div>
-        <div class="cal-weekdays">
-          <span>Mo</span><span>Tu</span><span>We</span><span>Th</span><span>Fr</span><span>Sa</span><span>Su</span>
-        </div>
-        <div class="cal-grid" id="cal-grid"></div>
-        <div class="cal-legend">
-          <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-again"></span>Again</span>
-          <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-hard"></span>Hard</span>
-          <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-good"></span>Good</span>
-          <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-easy"></span>Easy</span>
-          <span class="cal-legend-sep"></span>
-          <span class="cal-legend-item cal-legend-cat">听 Listening</span>
-          <span class="cal-legend-item cal-legend-cat">读 Reading</span>
-          <span class="cal-legend-item cal-legend-cat">创 Creating</span>
-        </div>
-      </div>
-    </div>
+      </div><!-- /review-cal-panel -->
+
+    </div><!-- /review-layout -->
   </div>
 
   <!-- Done -->

--- a/static/index.html
+++ b/static/index.html
@@ -221,6 +221,16 @@
 
       <!-- LEFT: Calendar tile (hidden until data loads; shown on desktop to the left via order) -->
       <div class="review-side-tile review-cal-tile" id="review-cal-panel" style="display:none">
+        <div id="cal-front-mascot" class="cal-front-mascot" style="display:none">
+<pre class="mascot-art">
+  /\___/\
+ (= ^.^ =)
+  )     (
+ (       )
+  \_____/
+</pre>
+          <div class="mascot-caption">Focus — show answer when ready!</div>
+        </div>
         <div id="card-calendar" class="card-calendar">
           <div id="cal-timeline"></div>
           <div class="cal-legend">

--- a/static/index.html
+++ b/static/index.html
@@ -50,7 +50,6 @@
   </div>
   <div class="header-right">
     <button id="header-regen-btn" onclick="regenerateStory()" title="Regenerate story" style="display:none">↺</button>
-    <button id="restart-btn" onclick="restartServer()" title="Restart server (Shift+R)">↻</button>
   </div>
 </header>
 

--- a/static/style.css
+++ b/static/style.css
@@ -3348,9 +3348,10 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   .review-layout {
     display: grid;
     grid-template-columns: 300px 500px 300px;
-    grid-template-rows: calc(100vh - 90px);
+    grid-template-rows: calc(100vh - 106px);
     gap: 16px;
     justify-content: center;
+    padding-top: 16px;
   }
   .review-center-tile {
     grid-column: 2;

--- a/static/style.css
+++ b/static/style.css
@@ -3192,9 +3192,7 @@ details[open] .cat-override-summary::before { content: '▼ '; }
 
 /* ── Card schedule calendar ──────────────────────────────────────────────── */
 .card-calendar {
-  margin: 12px 0 4px;
-  border-top: 1px solid var(--border);
-  padding-top: 10px;
+  margin: 0;
 }
 .cal-header {
   display: flex;
@@ -3311,6 +3309,47 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   gap: 3px;
   font-size: 0.62rem;
   color: var(--text-muted);
+}
+
+/* ── Three-panel review layout ────────────────────────────── */
+.review-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* Side tiles: card-like styling on both mobile and desktop */
+.review-side-tile {
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 20px 16px 16px;
+}
+
+
+/* Desktop: three columns side by side */
+@media (min-width: 1100px) {
+  main.review-open {
+    max-width: 1200px;
+  }
+  .review-layout {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 16px;
+  }
+  .review-center-tile {
+    flex: 0 0 500px;
+    order: 2;
+  }
+  #review-vocab-panel {
+    flex: 0 0 240px;
+    order: 3;
+  }
+  #review-cal-panel {
+    flex: 0 0 240px;
+    order: 1;
+  }
 }
 
 /* ── Confetti (100% score celebration) ──────────────────── */

--- a/static/style.css
+++ b/static/style.css
@@ -76,19 +76,6 @@ header h1 { font-size: 18px; font-weight: 700; }
   margin-left: 4px;
 }
 #header-regen-btn:hover { background: var(--border); color: #6366f1; }
-#restart-btn {
-  background: none;
-  border: none;
-  font-size: 18px;
-  cursor: pointer;
-  color: var(--muted);
-  padding: 2px 6px;
-  border-radius: 6px;
-  line-height: 1;
-  margin-left: auto;
-}
-#restart-btn:hover { background: var(--border); }
-#restart-btn.spinning { animation: spin 0.8s linear infinite; }
 
 /* ── Layout ──────────────────────────────────────────── */
 main {
@@ -3356,6 +3343,7 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   main.review-open {
     max-width: 1200px;
     padding: 0;
+    overflow: hidden;
   }
   .review-layout {
     display: grid;

--- a/static/style.css
+++ b/static/style.css
@@ -197,7 +197,8 @@ main.browse-open {
   display: flex;
   gap: 16px;
   align-items: center;
-  margin-bottom: 18px;
+  flex: 1;
+  min-width: 0;
 }
 .cnt-item {
   display: flex;
@@ -3318,7 +3319,7 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   gap: 12px;
 }
 
-/* Side tiles: card-like styling on both mobile and desktop */
+/* Side tiles: card-like styling */
 .review-side-tile {
   background: var(--card);
   border-radius: var(--radius);
@@ -3326,28 +3327,57 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   padding: 20px 16px 16px;
 }
 
+/* Calendar month sections in timeline */
+.cal-month-block {
+  margin-bottom: 20px;
+}
+.cal-month-heading {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
 
-/* Desktop: three columns side by side */
+/* Desktop: three columns side by side, each independently scrollable */
 @media (min-width: 1100px) {
   main.review-open {
-    max-width: 1200px;
+    max-width: 1260px;
+    overflow: hidden;
+    padding-bottom: 0;
   }
   .review-layout {
     flex-direction: row;
-    align-items: flex-start;
+    align-items: stretch;
     justify-content: center;
     gap: 16px;
+    height: calc(100vh - 90px);
+  }
+  .review-center-tile,
+  .review-side-tile {
+    overflow-y: auto;
+    height: 100%;
   }
   .review-center-tile {
     flex: 0 0 500px;
     order: 2;
+    /* center tile is not a card itself, just a container */
+    background: none;
+    box-shadow: none;
+    padding: 0;
+    border-radius: 0;
+  }
+  .review-center-tile .review-card {
+    height: 100%;
+    overflow-y: auto;
   }
   #review-vocab-panel {
-    flex: 0 0 240px;
+    flex: 0 0 300px;
     order: 3;
   }
   #review-cal-panel {
-    flex: 0 0 240px;
+    flex: 0 0 300px;
     order: 1;
   }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -3310,8 +3310,8 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   color: var(--text-muted);
 }
 
-/* ── Front-side mascot in calendar tile ─────────────────── */
-.cal-front-mascot {
+/* ── Front-side mascot in vocab tile ───────────────────── */
+.front-mascot {
   flex-direction: column;
   align-items: center;
   justify-content: center;

--- a/static/style.css
+++ b/static/style.css
@@ -31,13 +31,25 @@ body {
 header {
   background: var(--card);
   border-bottom: 1px solid var(--border);
-  padding: 14px 20px;
-  display: flex;
+  padding: 10px 20px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   position: sticky;
   top: 0;
   z-index: 10;
+}
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.header-right {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
 }
 #back-btn {
   background: none;
@@ -197,8 +209,7 @@ main.browse-open {
   display: flex;
   gap: 16px;
   align-items: center;
-  flex: 1;
-  min-width: 0;
+  justify-content: center;
 }
 .cnt-item {
   display: flex;
@@ -3340,45 +3351,39 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   margin-bottom: 4px;
 }
 
-/* Desktop: three columns side by side, each independently scrollable */
+/* Desktop: fixed three-column grid so center tile is ALWAYS centered */
 @media (min-width: 1100px) {
   main.review-open {
-    max-width: 1260px;
+    max-width: 1160px;
     overflow: hidden;
     padding-bottom: 0;
   }
   .review-layout {
-    flex-direction: row;
-    align-items: stretch;
-    justify-content: center;
+    display: grid;
+    grid-template-columns: 300px 500px 300px;
+    grid-template-rows: calc(100vh - 90px);
     gap: 16px;
-    height: calc(100vh - 90px);
-  }
-  .review-center-tile,
-  .review-side-tile {
-    overflow-y: auto;
-    height: 100%;
+    justify-content: center;
   }
   .review-center-tile {
-    flex: 0 0 500px;
-    order: 2;
-    /* center tile is not a card itself, just a container */
+    grid-column: 2;
     background: none;
     box-shadow: none;
     padding: 0;
     border-radius: 0;
+    overflow-y: auto;
   }
   .review-center-tile .review-card {
     height: 100%;
     overflow-y: auto;
   }
-  #review-vocab-panel {
-    flex: 0 0 300px;
-    order: 3;
-  }
   #review-cal-panel {
-    flex: 0 0 300px;
-    order: 1;
+    grid-column: 1;
+    overflow-y: auto;
+  }
+  #review-vocab-panel {
+    grid-column: 3;
+    overflow-y: auto;
   }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -3312,3 +3312,20 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   font-size: 0.62rem;
   color: var(--text-muted);
 }
+
+/* ── Confetti (100% score celebration) ──────────────────── */
+@keyframes confetti-fall {
+  0%   { transform: translateY(-20px) rotate(0deg); opacity: 1; }
+  80%  { opacity: 1; }
+  100% { transform: translateY(100vh) rotate(720deg); opacity: 0; }
+}
+.confetti-piece {
+  position: fixed;
+  top: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  pointer-events: none;
+  z-index: 9999;
+  animation: confetti-fall linear forwards;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -3315,10 +3315,8 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 24px 12px 16px;
-  gap: 8px;
-  border-bottom: 1px solid var(--border);
-  margin-bottom: 16px;
+  flex: 1;
+  gap: 12px;
 }
 .mascot-art {
   font-family: monospace;
@@ -3349,6 +3347,8 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   border-radius: var(--radius);
   box-shadow: var(--shadow);
   padding: 20px 16px 16px;
+  display: flex;
+  flex-direction: column;
 }
 
 /* Calendar month sections in timeline */

--- a/static/style.css
+++ b/static/style.css
@@ -3366,6 +3366,7 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   }
   .review-center-tile {
     grid-column: 2;
+    grid-row: 1;
     background: none;
     box-shadow: none;
     padding: 0;
@@ -3378,10 +3379,12 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   }
   #review-cal-panel {
     grid-column: 1;
+    grid-row: 1;
     overflow-y: auto;
   }
   #review-vocab-panel {
     grid-column: 3;
+    grid-row: 1;
     overflow-y: auto;
   }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -3241,7 +3241,7 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   gap: 2px;
 }
 .cal-cell.cal-today { outline: 2px solid var(--primary, #6366f1); outline-offset: -2px; border-radius: 4px; }
-.cal-cell.cal-empty { pointer-events: none; }
+.cal-cell.cal-empty { pointer-events: none; border-color: transparent; background: none; }
 .cal-day-num {
   font-size: 0.65rem;
   color: var(--text-muted);
@@ -3308,6 +3308,32 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   gap: 3px;
   font-size: 0.62rem;
   color: var(--text-muted);
+}
+
+/* ── Front-side mascot in calendar tile ─────────────────── */
+.cal-front-mascot {
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 12px 16px;
+  gap: 8px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 16px;
+}
+.mascot-art {
+  font-family: monospace;
+  font-size: 0.82rem;
+  line-height: 1.4;
+  color: var(--text-muted);
+  margin: 0;
+  text-align: center;
+  letter-spacing: 0.05em;
+}
+.mascot-caption {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  text-align: center;
+  font-style: italic;
 }
 
 /* ── Three-panel review layout ────────────────────────────── */

--- a/static/style.css
+++ b/static/style.css
@@ -3354,9 +3354,8 @@ details[open] .cat-override-summary::before { content: '▼ '; }
 /* Desktop: fixed three-column grid so center tile is ALWAYS centered */
 @media (min-width: 1100px) {
   main.review-open {
-    max-width: 1160px;
-    overflow: hidden;
-    padding-bottom: 0;
+    max-width: 1200px;
+    padding: 0;
   }
   .review-layout {
     display: grid;


### PR DESCRIPTION
## 问题原因

`Sentences · Reading` 叶节点只含 `note_type = sentence` 的卡片。

`get_category_all_suspended` 会排除句子类型，查询结果 `total = 0`，
原来的逻辑 `return total > 0 and total == suspended` 返回 `False`。

父级聚合用 `leaves.every(l => !!l.all_suspended)` 检查，
只要有一个叶节点是 `False`，整个 Reading 的 ⏸ 就不会变成 ▶。

## 修复

`total == suspended`（即 `0 == 0`）视为"没有可暂停卡片 = 已暂停"。

## 测试方法

1. 在 All 牌组点击 R（Reading）的 ⏸ 按钮
2. 徽章应变为 ▶
3. 再点击恢复，变回 ⏸

Closes #(无对应 Issue，小修复)