### PR TITLE
feat: AI 字段重新生成（Notes / Examples / Word Analysis）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -463,13 +463,18 @@ def regenerate_entry_fields(
     logger.info("[%s] regenerate_entry_fields: %s fields=%s", model, word_zh, fields)
     raw = _call_api(model, [{"role": "user", "content": prompt}], max_tokens=1800,
                     purpose=f"regen:{word_zh}")
+    logger.info("regenerate_entry_fields raw response for %s: %s", word_zh, raw[:500])
 
     json_match = re.search(r'\{.*\}', raw, re.DOTALL)
     if json_match:
         raw = json_match.group(0)
 
     try:
-        return json.loads(raw)
+        parsed = json.loads(raw)
+        logger.info("regenerate_entry_fields parsed keys=%s chars=%s",
+                    list(parsed.keys()),
+                    [c.get("char") for c in parsed.get("characters", [])])
+        return parsed
     except (json.JSONDecodeError, TypeError) as e:
         logger.error("regenerate_entry_fields: JSON parse error for %s: %s", word_zh, e)
         return {}

--- a/ai.py
+++ b/ai.py
@@ -21,7 +21,7 @@ import database
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_MODEL = "deepseek-chat"
+DEFAULT_MODEL = "deepseek-v4-flash"
 
 # Per-session story generation progress: key → {phase, msg, percent, translate_warn?}
 _story_progress: dict[str, dict] = {}
@@ -530,7 +530,7 @@ Return ONLY valid JSON, no explanation, no markdown:
         return {"etymology": "", "translation": ""}
 
 
-_ENRICH_MODEL = "deepseek-chat"
+_ENRICH_MODEL = "deepseek-v4-flash"
 
 
 def enrich_word(word: dict, characters: list[dict], model: str = DEFAULT_MODEL) -> dict:

--- a/ai.py
+++ b/ai.py
@@ -460,21 +460,17 @@ def regenerate_entry_fields(
         + f"\n\nReturn ONLY valid JSON with exactly these top-level keys:\n{json_template}"
     )
 
-    print(f"[REGEN] calling AI: word={word_zh!r} fields={fields}", flush=True)
+    logger.info("[%s] regenerate_entry_fields: %s fields=%s", model, word_zh, fields)
     raw = _call_api(model, [{"role": "user", "content": prompt}], max_tokens=1800,
                     purpose=f"regen:{word_zh}")
-    print(f"[REGEN] raw AI response for {word_zh!r}:\n{raw}\n", flush=True)
 
     json_match = re.search(r'\{.*\}', raw, re.DOTALL)
     if json_match:
         raw = json_match.group(0)
 
     try:
-        parsed = json.loads(raw)
-        print(f"[REGEN] parsed keys={list(parsed.keys())} chars={[c.get('char') for c in parsed.get('characters', [])]}", flush=True)
-        return parsed
+        return json.loads(raw)
     except (json.JSONDecodeError, TypeError) as e:
-        print(f"[REGEN] JSON parse error for {word_zh!r}: {e}", flush=True)
         logger.error("regenerate_entry_fields: JSON parse error for %s: %s", word_zh, e)
         return {}
 

--- a/ai.py
+++ b/ai.py
@@ -342,6 +342,139 @@ def _patch_missing(sentences: list[dict], missing_word_ids: list[int],
                           "sentence_en": "", "sentence_de": "", "sentence_fr": ""})
 
 
+def regenerate_entry_fields(
+    word: dict,
+    characters: list[dict],
+    fields: list[str],
+    model: str = DEFAULT_MODEL,
+) -> dict:
+    """
+    Regenerate specified fields for a vocabulary entry using SKILL.md format.
+
+    fields: subset of ["notes", "examples", "etymology", "compounds"]
+    Returns a dict with a subset of:
+      notes:      str  (German prose)
+      examples:   list[{zh, pinyin, english, de}]
+      characters: list[{char, etymology?, compounds?}]
+    """
+    if not fields:
+        return {}
+
+    note_type = word.get("note_type", "vocabulary")
+    word_zh   = word.get("word_zh", "")
+    trad      = word.get("traditional", "")
+    pinyin_   = word.get("pinyin", "")
+    eng       = word.get("definition", "")
+    de        = word.get("definition_de", "")
+    hsk       = word.get("hsk_level", "")
+    register  = word.get("register", "")
+
+    want_notes    = "notes" in fields
+    want_examples = "examples" in fields
+    want_etym     = "etymology" in fields
+    want_comp     = "compounds" in fields
+    want_chars    = want_etym or want_comp
+
+    # --- Entry header ---
+    trad_line = f" / traditional: {trad}" if trad and trad != word_zh else ""
+    entry_block = (
+        f"type: {note_type}\n"
+        f"simplified: {word_zh}{trad_line}\n"
+        f"pinyin: {pinyin_}\n"
+        f"english: {eng}\n"
+        f"german: {de}\n"
+        f"hsk: {hsk}\n"
+        f"register: {register}"
+    )
+
+    # --- Character list (only when needed) ---
+    char_block = ""
+    if want_chars and characters:
+        lines = [
+            f"  - {c['char']} (pinyin: {c.get('pinyin', '')}, HSK {c.get('hsk_level', '?')})"
+            for c in characters
+        ]
+        char_block = "\nCharacters:\n" + "\n".join(lines)
+
+    # --- Per-field instructions ---
+    sections: list[str] = []
+
+    if want_notes:
+        if note_type == "sentence":
+            sections.append(
+                "NOTES: Write a German explanation for this sentence (2-3 paragraphs).\n"
+                "Include: breakdown of key vocabulary + grammar; list key components as "
+                "「- 词语 (pinyin) — meaning」; explain grammar structures used."
+            )
+        else:
+            sections.append(
+                "NOTES: Write German usage notes (2-4 paragraphs). Include:\n"
+                "- Opening sentence on what the word means and how it's used\n"
+                "- **Häufige Ausdrücke:** with 3-5 collocations (「- 词语 (pinyin) — German meaning」)\n"
+                "- **Wichtiger Unterschied:** comparing with a similar word (if applicable)\n"
+                "- **Kulturelle Anmerkung:** (if relevant)"
+            )
+
+    if want_examples:
+        sections.append(
+            "EXAMPLES: Generate 3-4 example sentences. Each must use the target word verbatim.\n"
+            "Each example: {\"zh\": \"<sentence>\", \"pinyin\": \"<full pinyin>\", "
+            "\"english\": \"<translation>\", \"de\": \"<German translation>\"}"
+        )
+
+    if want_chars:
+        char_field_lines = []
+        if want_etym:
+            char_field_lines.append(
+                "  - etymology: 2-4 sentences German PROSE (NO bullet points) on components, "
+                "historical origin, meaning evolution"
+            )
+        if want_comp:
+            char_field_lines.append(
+                "  - compounds: 3-5 common compound words using this character. "
+                "Each: {\"simplified\": \"词\", \"pinyin\": \"...\", \"meaning\": \"German (NO colons)\"}"
+            )
+        sections.append("CHARACTER DATA: For each character above:\n" + "\n".join(char_field_lines))
+
+    # --- JSON template ---
+    json_keys = []
+    if want_notes:
+        json_keys.append('  "notes": "<German prose>"')
+    if want_examples:
+        json_keys.append('  "examples": [{"zh": "...", "pinyin": "...", "english": "...", "de": "..."}]')
+    if want_chars:
+        char_obj_keys = '"char": "X"'
+        if want_etym:
+            char_obj_keys += ', "etymology": "..."'
+        if want_comp:
+            char_obj_keys += ', "compounds": [{"simplified": "...", "pinyin": "...", "meaning": "..."}]'
+        json_keys.append(f'  "characters": [{{{char_obj_keys}}}]')
+
+    json_template = "{\n" + ",\n".join(json_keys) + "\n}"
+
+    prompt = (
+        f"You are a Chinese dictionary expert generating SRS flashcard content.\n\n"
+        f"Entry:\n{entry_block}{char_block}\n\n"
+        f"Generate ONLY the fields listed. All German text must be in German.\n\n"
+        + "\n\n".join(sections)
+        + f"\n\nReturn ONLY valid JSON with exactly these top-level keys:\n{json_template}"
+    )
+
+    logger.info("[%s] regenerate_entry_fields: %s fields=%s", model, word_zh, fields)
+    raw = _call_api(model, [{"role": "user", "content": prompt}], max_tokens=1800,
+                    purpose=f"regen:{word_zh}")
+
+    json_match = re.search(r'\{.*\}', raw, re.DOTALL)
+    if json_match:
+        raw = json_match.group(0)
+
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as e:
+        logger.error("regenerate_entry_fields: JSON parse error for %s: %s", word_zh, e)
+        return {}
+
+
 def generate_character_info(char: str, pinyin: str, model: str = DEFAULT_MODEL) -> dict:
     """
     Generate etymology and translation for a single Chinese character.

--- a/ai.py
+++ b/ai.py
@@ -374,6 +374,7 @@ def regenerate_entry_fields(
     want_etym     = "etymology" in fields
     want_comp     = "compounds" in fields
     want_chars    = want_etym or want_comp
+    want_def      = any(f in fields for f in ("definition", "definition_zh", "definition_de", "definition_fr", "pos"))
 
     # --- Entry header ---
     trad_line = f" / traditional: {trad}" if trad and trad != word_zh else ""
@@ -398,6 +399,20 @@ def regenerate_entry_fields(
 
     # --- Per-field instructions ---
     sections: list[str] = []
+
+    if want_def:
+        def_lines = ["Generate concise one-line definitions. Keep each under 10 words."]
+        if "pos" in fields:
+            def_lines.append('- pos: part of speech abbreviation (e.g. "v.", "n.", "adj.", "adv.", "expr.", "pron.", "conj.")')
+        if "definition" in fields:
+            def_lines.append('- definition: English definition (e.g. "to study; to learn")')
+        if "definition_zh" in fields:
+            def_lines.append('- definition_zh: Chinese definition (e.g. "学习；研究")')
+        if "definition_de" in fields:
+            def_lines.append('- definition_de: German definition (e.g. "studieren; lernen")')
+        if "definition_fr" in fields:
+            def_lines.append('- definition_fr: French definition (e.g. "étudier; apprendre")')
+        sections.append("DEFINITION FIELDS:\n" + "\n".join(def_lines))
 
     if want_notes:
         if note_type == "sentence":
@@ -438,6 +453,16 @@ def regenerate_entry_fields(
 
     # --- JSON template ---
     json_keys = []
+    if "pos" in fields:
+        json_keys.append('  "pos": "v."')
+    if "definition" in fields:
+        json_keys.append('  "definition": "<English>"')
+    if "definition_zh" in fields:
+        json_keys.append('  "definition_zh": "<中文>"')
+    if "definition_de" in fields:
+        json_keys.append('  "definition_de": "<Deutsch>"')
+    if "definition_fr" in fields:
+        json_keys.append('  "definition_fr": "<français>"')
     if want_notes:
         json_keys.append('  "notes": "<German prose>"')
     if want_examples:

--- a/ai.py
+++ b/ai.py
@@ -460,10 +460,10 @@ def regenerate_entry_fields(
         + f"\n\nReturn ONLY valid JSON with exactly these top-level keys:\n{json_template}"
     )
 
-    logger.info("[%s] regenerate_entry_fields: %s fields=%s", model, word_zh, fields)
+    print(f"[REGEN] calling AI: word={word_zh!r} fields={fields}", flush=True)
     raw = _call_api(model, [{"role": "user", "content": prompt}], max_tokens=1800,
                     purpose=f"regen:{word_zh}")
-    logger.info("regenerate_entry_fields raw response for %s: %s", word_zh, raw[:500])
+    print(f"[REGEN] raw AI response for {word_zh!r}:\n{raw}\n", flush=True)
 
     json_match = re.search(r'\{.*\}', raw, re.DOTALL)
     if json_match:
@@ -471,11 +471,10 @@ def regenerate_entry_fields(
 
     try:
         parsed = json.loads(raw)
-        logger.info("regenerate_entry_fields parsed keys=%s chars=%s",
-                    list(parsed.keys()),
-                    [c.get("char") for c in parsed.get("characters", [])])
+        print(f"[REGEN] parsed keys={list(parsed.keys())} chars={[c.get('char') for c in parsed.get('characters', [])]}", flush=True)
         return parsed
     except (json.JSONDecodeError, TypeError) as e:
+        print(f"[REGEN] JSON parse error for {word_zh!r}: {e}", flush=True)
         logger.error("regenerate_entry_fields: JSON parse error for %s: %s", word_zh, e)
         return {}
 

--- a/database/entries.py
+++ b/database/entries.py
@@ -193,6 +193,13 @@ def insert_word_relation(word_id: int, related_zh: str,
     conn.close()
 
 
+def delete_word_examples(word_id: int) -> None:
+    conn = get_db()
+    conn.execute("DELETE FROM entry_examples WHERE word_id = ?", (word_id,))
+    conn.commit()
+    conn.close()
+
+
 def get_word_examples(word_id: int) -> list[dict]:
     conn = get_db()
     rows = conn.execute(

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -50,6 +50,78 @@ def _apply_enrich_result(word: dict, characters: list, result: dict) -> None:
             database.update_character(existing["char_id"], updates)
 
 
+@router.post("/api/word/{word_id}/regenerate-fields")
+def regenerate_word_fields(word_id: int, body: dict):
+    """Regenerate one or more fields for a vocabulary entry using AI.
+
+    body: {"fields": ["notes", "examples", "etymology", "compounds"]}
+    Supports both simple words and multi-component entries (chengyu/expression/sentence).
+    """
+    fields = body.get("fields", [])
+    valid = {"notes", "examples", "etymology", "compounds"}
+    fields = [f for f in fields if f in valid]
+    if not fields:
+        raise HTTPException(status_code=400, detail=f"fields must be a non-empty subset of {sorted(valid)}")
+
+    word = database.get_word(word_id)
+    if not word:
+        raise HTTPException(status_code=404, detail="Word not found")
+
+    want_char_data = "etymology" in fields or "compounds" in fields
+
+    components = database.get_note_components(word_id)
+    if components:
+        # Multi-component entry: regenerate notes on the top-level entry,
+        # but character fields are regenerated on each component separately.
+        if "notes" in fields or "examples" in fields:
+            chars = database.get_word_characters(word_id)
+            result = ai.regenerate_entry_fields(word, chars, [f for f in fields if f in ("notes", "examples")])
+            _apply_regen_result(word_id, result, fields=fields, characters=chars)
+
+        if want_char_data:
+            for comp in components:
+                comp_chars = database.get_word_characters(comp["id"])
+                comp_fields = [f for f in fields if f in ("etymology", "compounds")]
+                result = ai.regenerate_entry_fields(comp, comp_chars, comp_fields)
+                _apply_regen_result(comp["id"], result, fields=comp_fields, characters=comp_chars)
+    else:
+        characters = database.get_word_characters(word_id)
+        result = ai.regenerate_entry_fields(word, characters, fields)
+        _apply_regen_result(word_id, result, fields=fields, characters=characters)
+
+    return database.get_word_full(word_id)
+
+
+def _apply_regen_result(word_id: int, result: dict, fields: list, characters: list) -> None:
+    if "notes" in fields and result.get("notes"):
+        database.update_word(word_id, {"notes": result["notes"]})
+
+    if "examples" in fields and result.get("examples"):
+        database.delete_word_examples(word_id)
+        for i, ex in enumerate(result["examples"]):
+            if ex.get("zh"):
+                database.insert_word_example(
+                    word_id,
+                    ex["zh"],
+                    ex.get("pinyin"),
+                    ex.get("english"),
+                    ex.get("de"),
+                    position=i,
+                )
+
+    char_map = {c["char"]: c for c in characters}
+    for char_data in result.get("characters", []):
+        ch = char_data.get("char")
+        if not ch or ch not in char_map:
+            continue
+        existing = char_map[ch]
+        char_id = existing["char_id"]
+        if "etymology" in fields and char_data.get("etymology"):
+            database.update_character(char_id, {"etymology": char_data["etymology"]})
+        if "compounds" in fields and char_data.get("compounds"):
+            database.upsert_character_compounds(char_id, char_data["compounds"])
+
+
 @router.post("/api/word/{word_id}/ai-enrich")
 def ai_enrich_word(word_id: int):
     word = database.get_word(word_id)

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -50,55 +50,55 @@ def _apply_enrich_result(word: dict, characters: list, result: dict) -> None:
             database.update_character(existing["char_id"], updates)
 
 
-@router.post("/api/word/{word_id}/regenerate-fields")
-def regenerate_word_fields(word_id: int, body: dict):
-    """Regenerate one or more fields for a vocabulary entry using AI.
+def _enrich_chars_with_id(char_results: list, db_chars: list, output: list) -> None:
+    """Match AI char results to DB chars by character string, attach char_id, append to output."""
+    char_map = {c["char"]: c for c in db_chars}
+    for char_data in char_results:
+        ch = char_data.get("char")
+        if ch and ch in char_map:
+            char_data["char_id"] = char_map[ch]["char_id"]
+            output.append(char_data)
 
-    body: {"fields": ["notes", "examples", "etymology", "compounds"]}
-    Supports both simple words and multi-component entries (chengyu/expression/sentence).
+
+def _run_regen_ai(word_id: int, word: dict, fields: list) -> tuple[dict, list]:
+    """Run AI field regeneration and return (top_result, all_characters_enriched).
+
+    top_result  — notes/examples for the top-level entry.
+    all_characters — list of {char, char_id, etymology?, compounds?} across all components.
     """
-    fields = body.get("fields", [])
-    valid = {"notes", "examples", "etymology", "compounds"}
-    fields = [f for f in fields if f in valid]
-    if not fields:
-        raise HTTPException(status_code=400, detail=f"fields must be a non-empty subset of {sorted(valid)}")
-
-    word = database.get_word(word_id)
-    if not word:
-        raise HTTPException(status_code=404, detail="Word not found")
-
     want_char_data = "etymology" in fields or "compounds" in fields
-
     components = database.get_note_components(word_id)
+    top_result: dict = {}
+    all_characters: list = []
+
     if components:
-        # Multi-component entry: regenerate notes on the top-level entry,
-        # but character fields are regenerated on each component separately.
         if "notes" in fields or "examples" in fields:
             chars = database.get_word_characters(word_id)
-            result = ai.regenerate_entry_fields(word, chars, [f for f in fields if f in ("notes", "examples")])
-            _apply_regen_result(word_id, result, fields=fields, characters=chars)
+            top_fields = [f for f in fields if f in ("notes", "examples")]
+            top_result = ai.regenerate_entry_fields(word, chars, top_fields)
 
         if want_char_data:
+            comp_fields = [f for f in fields if f in ("etymology", "compounds")]
             for comp in components:
                 comp_chars = database.get_word_characters(comp["id"])
-                comp_fields = [f for f in fields if f in ("etymology", "compounds")]
                 result = ai.regenerate_entry_fields(comp, comp_chars, comp_fields)
-                _apply_regen_result(comp["id"], result, fields=comp_fields, characters=comp_chars)
+                _enrich_chars_with_id(result.get("characters", []), comp_chars, all_characters)
     else:
         characters = database.get_word_characters(word_id)
-        result = ai.regenerate_entry_fields(word, characters, fields)
-        _apply_regen_result(word_id, result, fields=fields, characters=characters)
+        top_result = ai.regenerate_entry_fields(word, characters, fields)
+        _enrich_chars_with_id(top_result.get("characters", []), characters, all_characters)
 
-    return database.get_word_full(word_id)
+    return top_result, all_characters
 
 
-def _apply_regen_result(word_id: int, result: dict, fields: list, characters: list) -> None:
-    if "notes" in fields and result.get("notes"):
-        database.update_word(word_id, {"notes": result["notes"]})
+def _save_regen_result(word_id: int, fields: list, top_result: dict, all_characters: list) -> None:
+    """Persist regen result to the database."""
+    if "notes" in fields and top_result.get("notes"):
+        database.update_word(word_id, {"notes": top_result["notes"]})
 
-    if "examples" in fields and result.get("examples"):
+    if "examples" in fields and top_result.get("examples"):
         database.delete_word_examples(word_id)
-        for i, ex in enumerate(result["examples"]):
+        for i, ex in enumerate(top_result["examples"]):
             if ex.get("zh"):
                 database.insert_word_example(
                     word_id,
@@ -109,17 +109,66 @@ def _apply_regen_result(word_id: int, result: dict, fields: list, characters: li
                     position=i,
                 )
 
-    char_map = {c["char"]: c for c in characters}
-    for char_data in result.get("characters", []):
-        ch = char_data.get("char")
-        if not ch or ch not in char_map:
+    for char_data in all_characters:
+        char_id = char_data.get("char_id")
+        if not char_id:
             continue
-        existing = char_map[ch]
-        char_id = existing["char_id"]
         if "etymology" in fields and char_data.get("etymology"):
             database.update_character(char_id, {"etymology": char_data["etymology"]})
         if "compounds" in fields and char_data.get("compounds"):
             database.upsert_character_compounds(char_id, char_data["compounds"])
+
+
+@router.post("/api/word/{word_id}/regenerate-fields")
+def regenerate_word_fields(word_id: int, body: dict):
+    """Regenerate one or more fields for a vocabulary entry using AI.
+
+    body: {"fields": [...], "preview": false}
+    When preview=true, returns raw AI result without saving (for the frontend preview modal).
+    fields: subset of ["notes", "examples", "etymology", "compounds"]
+    """
+    fields = body.get("fields", [])
+    preview = body.get("preview", False)
+    valid = {"notes", "examples", "etymology", "compounds"}
+    fields = [f for f in fields if f in valid]
+    if not fields:
+        raise HTTPException(status_code=400, detail=f"fields must be a non-empty subset of {sorted(valid)}")
+
+    word = database.get_word(word_id)
+    if not word:
+        raise HTTPException(status_code=404, detail="Word not found")
+
+    top_result, all_characters = _run_regen_ai(word_id, word, fields)
+
+    if preview:
+        aggregated: dict = {}
+        if top_result.get("notes"):    aggregated["notes"] = top_result["notes"]
+        if top_result.get("examples"): aggregated["examples"] = top_result["examples"]
+        if all_characters:             aggregated["characters"] = all_characters
+        return {"fields": fields, "result": aggregated}
+
+    _save_regen_result(word_id, fields, top_result, all_characters)
+    return database.get_word_full(word_id)
+
+
+@router.post("/api/word/{word_id}/apply-regen-result")
+def apply_regen_result(word_id: int, body: dict):
+    """Apply a (possibly user-edited) AI regen result returned by preview mode."""
+    fields = body.get("fields", [])
+    result = body.get("result", {})
+    valid = {"notes", "examples", "etymology", "compounds"}
+    fields = [f for f in fields if f in valid]
+    if not fields:
+        raise HTTPException(status_code=400, detail="fields required")
+
+    word = database.get_word(word_id)
+    if not word:
+        raise HTTPException(status_code=404, detail="Word not found")
+
+    top_result = {k: result[k] for k in ("notes", "examples") if k in result}
+    all_characters = result.get("characters", [])
+    _save_regen_result(word_id, fields, top_result, all_characters)
+    return database.get_word_full(word_id)
 
 
 @router.post("/api/word/{word_id}/ai-enrich")

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -1,4 +1,5 @@
 import json as _json
+import logging
 
 import ai
 import database
@@ -6,6 +7,8 @@ import importer
 from fastapi import APIRouter, HTTPException
 from pypinyin import pinyin as _pinyin, Style
 from .utils import queue_mgr as _queue_mgr
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -71,23 +74,31 @@ def _run_regen_ai(word_id: int, word: dict, fields: list) -> tuple[dict, list]:
     top_result: dict = {}
     all_characters: list = []
 
+    logger.info("regen word_id=%s fields=%s components=%s", word_id, fields, [c.get("word_zh") for c in components])
+
     if components:
         if "notes" in fields or "examples" in fields:
             chars = database.get_word_characters(word_id)
             top_fields = [f for f in fields if f in ("notes", "examples")]
             top_result = ai.regenerate_entry_fields(word, chars, top_fields)
+            logger.info("regen top_result keys=%s", list(top_result.keys()))
 
         if want_char_data:
             comp_fields = [f for f in fields if f in ("etymology", "compounds")]
             for comp in components:
                 comp_chars = database.get_word_characters(comp["id"])
+                logger.info("regen comp=%s comp_chars=%s", comp.get("word_zh"), [c.get("char") for c in comp_chars])
                 result = ai.regenerate_entry_fields(comp, comp_chars, comp_fields)
+                logger.info("regen comp result keys=%s chars_returned=%s", list(result.keys()), [c.get("char") for c in result.get("characters", [])])
                 _enrich_chars_with_id(result.get("characters", []), comp_chars, all_characters)
     else:
         characters = database.get_word_characters(word_id)
+        logger.info("regen chars=%s", [c.get("char") for c in characters])
         top_result = ai.regenerate_entry_fields(word, characters, fields)
+        logger.info("regen top_result keys=%s chars_returned=%s", list(top_result.keys()), [c.get("char") for c in top_result.get("characters", [])])
         _enrich_chars_with_id(top_result.get("characters", []), characters, all_characters)
 
+    logger.info("regen all_characters count=%s chars=%s", len(all_characters), [c.get("char") for c in all_characters])
     return top_result, all_characters
 
 
@@ -145,6 +156,7 @@ def regenerate_word_fields(word_id: int, body: dict):
         if top_result.get("notes"):    aggregated["notes"] = top_result["notes"]
         if top_result.get("examples"): aggregated["examples"] = top_result["examples"]
         if all_characters:             aggregated["characters"] = all_characters
+        logger.info("regen preview response: fields=%s result_keys=%s", fields, list(aggregated.keys()))
         return {"fields": fields, "result": aggregated}
 
     _save_regen_result(word_id, fields, top_result, all_characters)

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -54,13 +54,26 @@ def _apply_enrich_result(word: dict, characters: list, result: dict) -> None:
 
 
 def _enrich_chars_with_id(char_results: list, db_chars: list, output: list) -> None:
-    """Match AI char results to DB chars by character string, attach char_id, append to output."""
+    """Match AI char results to DB chars by character string, attach char_id, append to output.
+
+    If a character isn't in entry_characters for this word, fall back to looking it up
+    directly in the characters table (handles expressions with no entry_characters rows).
+    """
     char_map = {c["char"]: c for c in db_chars}
     for char_data in char_results:
         ch = char_data.get("char")
-        if ch and ch in char_map:
+        if not ch:
+            continue
+        if ch in char_map:
             char_data["char_id"] = char_map[ch]["char_id"]
-            output.append(char_data)
+        else:
+            # Fallback: look up by character string in the characters table
+            rec = database.get_character(ch)
+            if rec:
+                char_data["char_id"] = rec["id"]
+            else:
+                char_data["char_id"] = None  # preview-only, won't be saved
+        output.append(char_data)
 
 
 def _run_regen_ai(word_id: int, word: dict, fields: list) -> tuple[dict, list]:
@@ -74,8 +87,6 @@ def _run_regen_ai(word_id: int, word: dict, fields: list) -> tuple[dict, list]:
     top_result: dict = {}
     all_characters: list = []
 
-    logger.info("regen word_id=%s fields=%s components=%s", word_id, fields, [c.get("word_zh") for c in components])
-
     if components:
         if "notes" in fields or "examples" in fields:
             chars = database.get_word_characters(word_id)
@@ -86,15 +97,11 @@ def _run_regen_ai(word_id: int, word: dict, fields: list) -> tuple[dict, list]:
             comp_fields = [f for f in fields if f in ("etymology", "compounds")]
             for comp in components:
                 comp_chars = database.get_word_characters(comp["id"])
-                print(f"[REGEN] comp={comp.get('word_zh')!r} comp_chars={[c.get('char') for c in comp_chars]}", flush=True)
                 result = ai.regenerate_entry_fields(comp, comp_chars, comp_fields)
-                print(f"[REGEN] comp result keys={list(result.keys())} chars_returned={[c.get('char') for c in result.get('characters', [])]}", flush=True)
                 _enrich_chars_with_id(result.get("characters", []), comp_chars, all_characters)
     else:
         characters = database.get_word_characters(word_id)
-        print(f"[REGEN] no components, chars={[c.get('char') for c in characters]}", flush=True)
         top_result = ai.regenerate_entry_fields(word, characters, fields)
-        print(f"[REGEN] top_result keys={list(top_result.keys())} chars_returned={[c.get('char') for c in top_result.get('characters', [])]}", flush=True)
         _enrich_chars_with_id(top_result.get("characters", []), characters, all_characters)
 
     print(f"[REGEN] FINAL all_characters count={len(all_characters)} chars={[c.get('char') for c in all_characters]}", flush=True)
@@ -155,7 +162,6 @@ def regenerate_word_fields(word_id: int, body: dict):
         if top_result.get("notes"):    aggregated["notes"] = top_result["notes"]
         if top_result.get("examples"): aggregated["examples"] = top_result["examples"]
         if all_characters:             aggregated["characters"] = all_characters
-        logger.info("regen preview response: fields=%s result_keys=%s", fields, list(aggregated.keys()))
         return {"fields": fields, "result": aggregated}
 
     _save_regen_result(word_id, fields, top_result, all_characters)

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -81,24 +81,23 @@ def _run_regen_ai(word_id: int, word: dict, fields: list) -> tuple[dict, list]:
             chars = database.get_word_characters(word_id)
             top_fields = [f for f in fields if f in ("notes", "examples")]
             top_result = ai.regenerate_entry_fields(word, chars, top_fields)
-            logger.info("regen top_result keys=%s", list(top_result.keys()))
 
         if want_char_data:
             comp_fields = [f for f in fields if f in ("etymology", "compounds")]
             for comp in components:
                 comp_chars = database.get_word_characters(comp["id"])
-                logger.info("regen comp=%s comp_chars=%s", comp.get("word_zh"), [c.get("char") for c in comp_chars])
+                print(f"[REGEN] comp={comp.get('word_zh')!r} comp_chars={[c.get('char') for c in comp_chars]}", flush=True)
                 result = ai.regenerate_entry_fields(comp, comp_chars, comp_fields)
-                logger.info("regen comp result keys=%s chars_returned=%s", list(result.keys()), [c.get("char") for c in result.get("characters", [])])
+                print(f"[REGEN] comp result keys={list(result.keys())} chars_returned={[c.get('char') for c in result.get('characters', [])]}", flush=True)
                 _enrich_chars_with_id(result.get("characters", []), comp_chars, all_characters)
     else:
         characters = database.get_word_characters(word_id)
-        logger.info("regen chars=%s", [c.get("char") for c in characters])
+        print(f"[REGEN] no components, chars={[c.get('char') for c in characters]}", flush=True)
         top_result = ai.regenerate_entry_fields(word, characters, fields)
-        logger.info("regen top_result keys=%s chars_returned=%s", list(top_result.keys()), [c.get("char") for c in top_result.get("characters", [])])
+        print(f"[REGEN] top_result keys={list(top_result.keys())} chars_returned={[c.get('char') for c in top_result.get('characters', [])]}", flush=True)
         _enrich_chars_with_id(top_result.get("characters", []), characters, all_characters)
 
-    logger.info("regen all_characters count=%s chars=%s", len(all_characters), [c.get("char") for c in all_characters])
+    print(f"[REGEN] FINAL all_characters count={len(all_characters)} chars={[c.get('char') for c in all_characters]}", flush=True)
     return top_result, all_characters
 
 

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -76,10 +76,14 @@ def _enrich_chars_with_id(char_results: list, db_chars: list, output: list) -> N
         output.append(char_data)
 
 
+_TOP_FIELDS = {"notes", "examples", "definition", "definition_zh", "definition_de", "definition_fr", "pos"}
+_CHAR_FIELDS = {"etymology", "compounds"}
+
+
 def _run_regen_ai(word_id: int, word: dict, fields: list) -> tuple[dict, list]:
     """Run AI field regeneration and return (top_result, all_characters_enriched).
 
-    top_result  — notes/examples for the top-level entry.
+    top_result  — notes/examples/definition/pos for the top-level entry.
     all_characters — list of {char, char_id, etymology?, compounds?} across all components.
     """
     want_char_data = "etymology" in fields or "compounds" in fields
@@ -88,9 +92,9 @@ def _run_regen_ai(word_id: int, word: dict, fields: list) -> tuple[dict, list]:
     all_characters: list = []
 
     if components:
-        if "notes" in fields or "examples" in fields:
+        top_fields = [f for f in fields if f in _TOP_FIELDS]
+        if top_fields:
             chars = database.get_word_characters(word_id)
-            top_fields = [f for f in fields if f in ("notes", "examples")]
             top_result = ai.regenerate_entry_fields(word, chars, top_fields)
 
         if want_char_data:
@@ -110,6 +114,11 @@ def _run_regen_ai(word_id: int, word: dict, fields: list) -> tuple[dict, list]:
 
 def _save_regen_result(word_id: int, fields: list, top_result: dict, all_characters: list) -> None:
     """Persist regen result to the database."""
+    def_updates = {f: top_result[f] for f in ("definition", "definition_zh", "definition_de", "definition_fr", "pos")
+                   if f in fields and top_result.get(f)}
+    if def_updates:
+        database.update_word(word_id, def_updates)
+
     if "notes" in fields and top_result.get("notes"):
         database.update_word(word_id, {"notes": top_result["notes"]})
 
@@ -146,7 +155,7 @@ def regenerate_word_fields(word_id: int, body: dict):
     """
     fields = body.get("fields", [])
     preview = body.get("preview", False)
-    valid = {"notes", "examples", "etymology", "compounds"}
+    valid = _TOP_FIELDS | _CHAR_FIELDS
     fields = [f for f in fields if f in valid]
     if not fields:
         raise HTTPException(status_code=400, detail=f"fields must be a non-empty subset of {sorted(valid)}")
@@ -159,9 +168,11 @@ def regenerate_word_fields(word_id: int, body: dict):
 
     if preview:
         aggregated: dict = {}
-        if top_result.get("notes"):    aggregated["notes"] = top_result["notes"]
-        if top_result.get("examples"): aggregated["examples"] = top_result["examples"]
-        if all_characters:             aggregated["characters"] = all_characters
+        for f in ("pos", "definition", "definition_zh", "definition_de", "definition_fr", "notes", "examples"):
+            if top_result.get(f):
+                aggregated[f] = top_result[f]
+        if all_characters:
+            aggregated["characters"] = all_characters
         return {"fields": fields, "result": aggregated}
 
     _save_regen_result(word_id, fields, top_result, all_characters)
@@ -173,7 +184,7 @@ def apply_regen_result(word_id: int, body: dict):
     """Apply a (possibly user-edited) AI regen result returned by preview mode."""
     fields = body.get("fields", [])
     result = body.get("result", {})
-    valid = {"notes", "examples", "etymology", "compounds"}
+    valid = _TOP_FIELDS | _CHAR_FIELDS
     fields = [f for f in fields if f in valid]
     if not fields:
         raise HTTPException(status_code=400, detail="fields required")
@@ -182,7 +193,8 @@ def apply_regen_result(word_id: int, body: dict):
     if not word:
         raise HTTPException(status_code=404, detail="Word not found")
 
-    top_result = {k: result[k] for k in ("notes", "examples") if k in result}
+    top_keys = ("pos", "definition", "definition_zh", "definition_de", "definition_fr", "notes", "examples")
+    top_result = {k: result[k] for k in top_keys if k in result}
     all_characters = result.get("characters", [])
     _save_regen_result(word_id, fields, top_result, all_characters)
     return database.get_word_full(word_id)

--- a/routes/story.py
+++ b/routes/story.py
@@ -102,7 +102,8 @@ def _generate_story_sentences(cards: list, *, topic, max_hsk, model, progress_ke
 ALLOWED_MODELS = {
     "glm-4-flash",
     "glm-4-air",
-    "deepseek-chat",
+    "deepseek-v4-flash",
+    "deepseek-v4-pro",
     "qwen-turbo",
     "claude-haiku-4-5-20251001",
     "claude-sonnet-4-6",

--- a/static/app.js
+++ b/static/app.js
@@ -3356,23 +3356,21 @@ function renderVocabDetail(container, examples, wordId) {
   const items = examples ?? wordDetails?.examples ?? [];
   const wid = wordId ?? _getActiveWordId();
   const bodyId = el.id + '-body';
-  if (items.length > 0) {
-    const html = items.map(ex => {
-      let h = `<div class="example-item">`;
-      h += `<div class="example-zh">${ex.example_zh || ''}</div>`;
-      if (ex.example_pinyin) h += `<div class="example-pin">${ex.example_pinyin}</div>`;
-      if (ex.example_de)     h += `<div class="example-de">${ex.example_de}</div>`;
-      h += `</div>`;
-      return h;
-    }).join('');
-    const regenBtn = wid ? `<button class="field-regen-btn" onclick="event.stopPropagation();regenFields(${wid},['examples'],'${el.id}')" title="Regenerate examples">↺</button>` : '';
-    el.innerHTML =
-      `<div class="section-label section-label-row section-toggle" onclick="toggleSection('${bodyId}')">` +
-        `<span><span id="${bodyId}-arrow">▶</span> Examples</span>${regenBtn}</div>` +
-      `<div id="${bodyId}" style="display:none">${html}</div>`;
-  } else {
-    el.innerHTML = '';
-  }
+  const regenBtn = wid ? `<button class="field-regen-btn" onclick="event.stopPropagation();regenFields(${wid},['examples'],'${el.id}')" title="Regenerate examples">↺</button>` : '';
+  const html = items.length > 0
+    ? items.map(ex => {
+        let h = `<div class="example-item">`;
+        h += `<div class="example-zh">${ex.example_zh || ''}</div>`;
+        if (ex.example_pinyin) h += `<div class="example-pin">${ex.example_pinyin}</div>`;
+        if (ex.example_de)     h += `<div class="example-de">${ex.example_de}</div>`;
+        h += `</div>`;
+        return h;
+      }).join('')
+    : `<div class="section-empty">—</div>`;
+  el.innerHTML =
+    `<div class="section-label section-label-row section-toggle" onclick="toggleSection('${bodyId}')">` +
+      `<span><span id="${bodyId}-arrow">▶</span> Examples</span>${regenBtn}</div>` +
+    `<div id="${bodyId}" style="display:none">${html}</div>`;
 }
 
 function renderNotesSection(container, notes, wordId) {
@@ -3380,17 +3378,15 @@ function renderNotesSection(container, notes, wordId) {
   const text = notes ?? card?.notes;
   const wid = wordId ?? _getActiveWordId();
   const bodyId = el.id + '-body';
-  if (text) {
-    const regenBtn = wid ? `<button class="field-regen-btn" onclick="event.stopPropagation();regenFields(${wid},['notes'],'${el.id}')" title="Regenerate notes">↺</button>` : '';
-    el.innerHTML =
-      `<div class="section-label section-label-row section-toggle" onclick="toggleSection('${bodyId}')">` +
-        `<span><span id="${bodyId}-arrow">▶</span> Notes</span>${regenBtn}</div>` +
-      `<div id="${bodyId}" class="notes-body" style="display:none">${renderMarkdown(text)}</div>`;
-    el.style.display = '';
-  } else {
-    el.innerHTML = '';
-    el.style.display = 'none';
-  }
+  const regenBtn = wid ? `<button class="field-regen-btn" onclick="event.stopPropagation();regenFields(${wid},['notes'],'${el.id}')" title="Regenerate notes">↺</button>` : '';
+  const bodyContent = text
+    ? `<div class="notes-body">${renderMarkdown(text)}</div>`
+    : `<div class="section-empty">—</div>`;
+  el.innerHTML =
+    `<div class="section-label section-label-row section-toggle" onclick="toggleSection('${bodyId}')">` +
+      `<span><span id="${bodyId}-arrow">▶</span> Notes</span>${regenBtn}</div>` +
+    `<div id="${bodyId}" style="display:none">${bodyContent}</div>`;
+  el.style.display = '';
 }
 
 function renderWordAnalysis(container, wordData, wordId) {
@@ -3421,8 +3417,14 @@ function renderWordAnalysis(container, wordData, wordId) {
     }];
   }
 
+  const wid = wordId ?? _getActiveWordId();
+  const regenBtnWA = wid ? `<button class="field-regen-btn" onclick="event.stopPropagation();regenFields(${wid},['etymology','compounds'],'${el.id}')" title="Regenerate etymology &amp; compounds">↺</button>` : '';
+
   if (wordGroups.length === 0) {
-    el.innerHTML = '';
+    el.innerHTML =
+      `<div class="section-label section-label-row section-toggle" onclick="toggleSection('${bodyId}')">` +
+        `<span><span id="${bodyId}-arrow">▶</span> Word Analysis</span>${regenBtnWA}</div>` +
+      `<div id="${bodyId}" class="wa-list" style="display:none"><div class="section-empty">—</div></div>`;
     return;
   }
 
@@ -3497,11 +3499,9 @@ function renderWordAnalysis(container, wordData, wordId) {
       `</div>`;
   }).join('');
 
-  const wid = wordId ?? _getActiveWordId();
-  const regenBtn = wid ? `<button class="field-regen-btn" onclick="event.stopPropagation();regenFields(${wid},['etymology','compounds'],'${el.id}')" title="Regenerate etymology &amp; compounds">↺</button>` : '';
   el.innerHTML =
     `<div class="section-label section-label-row section-toggle" onclick="toggleSection('${bodyId}')">` +
-      `<span><span id="${bodyId}-arrow">▶</span> Word Analysis</span>${regenBtn}</div>` +
+      `<span><span id="${bodyId}-arrow">▶</span> Word Analysis</span>${regenBtnWA}</div>` +
     `<div id="${bodyId}" class="wa-list" style="display:none">${wordCards}</div>`;
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -1530,8 +1530,8 @@ function renderWordDetail(word) {
   document.getElementById('wd-pinyin').textContent = word.pinyin || '';
   document.getElementById('wd-def').textContent = word.definition || '';
   const posEl = document.getElementById('wd-pos');
-  posEl.textContent = word.pos || '';
-  posEl.style.display = word.pos ? 'inline-block' : 'none';
+  posEl.textContent = word.pos || '—';
+  posEl.style.display = 'inline-block';
   const regEl = document.getElementById('wd-register');
   const regLabels = {
     spoken: '口语', written: '书面语', both: '通用',

--- a/static/app.js
+++ b/static/app.js
@@ -3132,13 +3132,185 @@ function _getActiveWordId() {
   return _currentWordId ?? wordDetails?.id ?? card?.word_id ?? null;
 }
 
+// ── Regen preview modal ──────────────────────────────────────────────────────
+let _regenState = null; // { wordId, fields, containerId }
+
 async function regenFields(wordId, fields, containerId) {
   const el = document.getElementById(containerId);
   const btn = el?.querySelector('.field-regen-btn');
   if (btn) { btn.disabled = true; btn.textContent = '…'; }
   try {
-    await api('POST', `/api/word/${wordId}/regenerate-fields`, { fields });
-    const updated = await api('GET', `/api/word/${wordId}`);
+    const preview = await api('POST', `/api/word/${wordId}/regenerate-fields`, { fields, preview: true });
+    _regenState = { wordId, fields, containerId };
+    _showRegenPreviewModal(preview);
+  } catch (e) {
+    showError('Regeneration failed: ' + e.message);
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = '↺'; }
+  }
+}
+
+function _showRegenPreviewModal(previewData) {
+  _closeRegenPreviewModal();
+  const { fields, result } = previewData;
+  const overlay = document.createElement('div');
+  overlay.id = 'regen-preview-overlay';
+  overlay.className = 'regen-preview-overlay';
+  overlay.onclick = (e) => { if (e.target === overlay) _closeRegenPreviewModal(); };
+
+  const wantEtym = fields.includes('etymology');
+  const wantComp = fields.includes('compounds');
+
+  let bodyHtml = '';
+
+  if (fields.includes('notes')) {
+    const text = (result.notes || '').replace(/"/g, '&quot;');
+    bodyHtml += `<div>
+      <div class="regen-section-label">Notes</div>
+      <textarea id="regen-notes-text" class="regen-notes-textarea">${result.notes || ''}</textarea>
+    </div>`;
+  }
+
+  if (fields.includes('examples')) {
+    const exRows = (result.examples || []).map((ex, i) => _regenExampleRowHtml(ex, i)).join('');
+    bodyHtml += `<div>
+      <div class="regen-section-label">Examples</div>
+      <div class="regen-example-labels">
+        <span>ZH</span><span>Pinyin</span><span>English</span><span>DE</span><span></span>
+      </div>
+      <div id="regen-examples-list">${exRows}</div>
+      <button class="regen-add-btn" onclick="_addRegenExample()">+ Add example</button>
+    </div>`;
+  }
+
+  if (wantEtym || wantComp) {
+    const chars = result.characters || [];
+    const charSections = chars.map(c => {
+      const charEsc = (c.char || '').replace(/'/g, "\\'");
+      let inner = `<div class="regen-char-header">${c.char || ''}</div>`;
+      if (wantEtym) {
+        inner += `<textarea class="regen-etym-textarea" data-field="etymology" placeholder="Etymology…">${c.etymology || ''}</textarea>`;
+      }
+      if (wantComp) {
+        const cpRows = (c.compounds || []).map(cp => _regenCompoundRowHtml(cp)).join('');
+        inner += `<div class="regen-compound-labels">
+          <span>Simplified</span><span>Pinyin</span><span>Meaning</span><span></span>
+        </div>
+        <div class="regen-compounds-list">${cpRows}</div>
+        <button class="regen-add-btn" onclick="_addRegenCompound(this)">+ Add compound</button>`;
+      }
+      return `<div class="regen-char-group" data-char-id="${c.char_id || ''}" data-char="${charEsc}">${inner}</div>`;
+    }).join('');
+    bodyHtml += `<div>
+      <div class="regen-section-label">Characters</div>
+      <div id="regen-chars-list">${charSections}</div>
+    </div>`;
+  }
+
+  overlay.innerHTML = `<div class="regen-preview-modal" onclick="event.stopPropagation()">
+    <div class="regen-preview-header">
+      <span>AI Preview</span>
+      <button onclick="_closeRegenPreviewModal()">×</button>
+    </div>
+    <div class="regen-preview-body">${bodyHtml}</div>
+    <div class="regen-preview-footer">
+      <button class="regen-btn regen-btn-regenerate" id="regen-btn-regen" onclick="_rerunRegen()">↺ Regenerate</button>
+      <button class="regen-btn regen-btn-reject" onclick="_closeRegenPreviewModal()">✗ Reject</button>
+      <button class="regen-btn regen-btn-apply" id="regen-btn-apply" onclick="_applyRegenResult()">✓ Apply</button>
+    </div>
+  </div>`;
+  document.body.appendChild(overlay);
+}
+
+function _regenExampleRowHtml(ex, idx) {
+  const esc = s => (s || '').replace(/"/g, '&quot;');
+  return `<div class="regen-example-row">
+    <input type="text" data-field="zh" value="${esc(ex.zh)}" placeholder="中文">
+    <input type="text" data-field="pinyin" value="${esc(ex.pinyin)}" placeholder="pīnyīn">
+    <input type="text" data-field="english" value="${esc(ex.english)}" placeholder="English">
+    <input type="text" data-field="de" value="${esc(ex.de)}" placeholder="Deutsch">
+    <button class="regen-row-del" onclick="this.closest('.regen-example-row').remove()">−</button>
+  </div>`;
+}
+
+function _regenCompoundRowHtml(cp) {
+  const esc = s => (s || '').replace(/"/g, '&quot;');
+  return `<div class="regen-compound-row">
+    <input type="text" data-field="simplified" value="${esc(cp.simplified || cp.compound_zh)}" placeholder="词">
+    <input type="text" data-field="pinyin" value="${esc(cp.pinyin)}" placeholder="pīnyīn">
+    <input type="text" data-field="meaning" value="${esc(cp.meaning)}" placeholder="Bedeutung">
+    <button class="regen-row-del" onclick="this.closest('.regen-compound-row').remove()">−</button>
+  </div>`;
+}
+
+function _addRegenExample() {
+  const list = document.getElementById('regen-examples-list');
+  if (list) list.insertAdjacentHTML('beforeend', _regenExampleRowHtml({}, list.children.length));
+}
+
+function _addRegenCompound(btn) {
+  const list = btn.previousElementSibling;
+  if (list) list.insertAdjacentHTML('beforeend', _regenCompoundRowHtml({}));
+}
+
+function _closeRegenPreviewModal() {
+  document.getElementById('regen-preview-overlay')?.remove();
+}
+
+function _getRegenResultFromModal() {
+  const result = {};
+  const fields = _regenState?.fields || [];
+
+  if (fields.includes('notes')) {
+    result.notes = document.getElementById('regen-notes-text')?.value?.trim() || '';
+  }
+
+  if (fields.includes('examples')) {
+    const rows = document.querySelectorAll('#regen-examples-list .regen-example-row');
+    result.examples = Array.from(rows).map(row => ({
+      zh:      row.querySelector('[data-field="zh"]')?.value?.trim() || '',
+      pinyin:  row.querySelector('[data-field="pinyin"]')?.value?.trim() || '',
+      english: row.querySelector('[data-field="english"]')?.value?.trim() || '',
+      de:      row.querySelector('[data-field="de"]')?.value?.trim() || '',
+    })).filter(ex => ex.zh);
+  }
+
+  if (fields.includes('etymology') || fields.includes('compounds')) {
+    const charGroups = document.querySelectorAll('#regen-chars-list .regen-char-group');
+    result.characters = Array.from(charGroups).map(group => {
+      const charResult = {
+        char:    group.dataset.char,
+        char_id: parseInt(group.dataset.charId) || undefined,
+      };
+      if (fields.includes('etymology')) {
+        charResult.etymology = group.querySelector('[data-field="etymology"]')?.value?.trim() || '';
+      }
+      if (fields.includes('compounds')) {
+        const cpRows = group.querySelectorAll('.regen-compound-row');
+        charResult.compounds = Array.from(cpRows).map(row => ({
+          simplified: row.querySelector('[data-field="simplified"]')?.value?.trim() || '',
+          pinyin:     row.querySelector('[data-field="pinyin"]')?.value?.trim() || '',
+          meaning:    row.querySelector('[data-field="meaning"]')?.value?.trim() || '',
+        })).filter(c => c.simplified);
+      }
+      return charResult;
+    });
+  }
+
+  return result;
+}
+
+async function _applyRegenResult() {
+  const { wordId, fields, containerId } = _regenState || {};
+  if (!wordId) return;
+  const applyBtn = document.getElementById('regen-btn-apply');
+  const regenBtn = document.getElementById('regen-btn-regen');
+  if (applyBtn) applyBtn.disabled = true;
+  if (regenBtn) regenBtn.disabled = true;
+  try {
+    const result = _getRegenResultFromModal();
+    const updated = await api('POST', `/api/word/${wordId}/apply-regen-result`, { fields, result });
+    _closeRegenPreviewModal();
     if (_currentWordId === wordId) {
       updated.cards = wordDetails?.cards || [];
       renderWordDetail(updated);
@@ -3146,17 +3318,36 @@ async function regenFields(wordId, fields, containerId) {
       if (wordDetails?.id === wordId) wordDetails = updated;
       const target = document.getElementById(containerId);
       if (!target) return;
-      if (fields.includes('notes'))    renderNotesSection(target, updated.notes, wordId);
+      if (fields.includes('notes'))         renderNotesSection(target, updated.notes, wordId);
       else if (fields.includes('examples')) renderVocabDetail(target, updated.examples, wordId);
-      else renderWordAnalysis(target, updated, wordId);
-      const body = document.getElementById(containerId + '-body');
+      else                                  renderWordAnalysis(target, updated, wordId);
+      const body  = document.getElementById(containerId + '-body');
       const arrow = document.getElementById(containerId + '-body-arrow');
       if (body)  body.style.display = 'block';
       if (arrow) arrow.textContent = '▼';
     }
   } catch (e) {
+    showError('Apply failed: ' + e.message);
+    if (applyBtn) applyBtn.disabled = false;
+    if (regenBtn) regenBtn.disabled = false;
+  }
+}
+
+async function _rerunRegen() {
+  const { wordId, fields, containerId } = _regenState || {};
+  if (!wordId) return;
+  const regenBtn = document.getElementById('regen-btn-regen');
+  const applyBtn = document.getElementById('regen-btn-apply');
+  if (regenBtn) { regenBtn.disabled = true; regenBtn.textContent = '…'; }
+  if (applyBtn) applyBtn.disabled = true;
+  try {
+    const preview = await api('POST', `/api/word/${wordId}/regenerate-fields`, { fields, preview: true });
+    _regenState = { wordId, fields, containerId };
+    _showRegenPreviewModal(preview);
+  } catch (e) {
     showError('Regeneration failed: ' + e.message);
-    if (btn) { btn.disabled = false; btn.textContent = '↺'; }
+    if (regenBtn) { regenBtn.disabled = false; regenBtn.textContent = '↺ Regenerate'; }
+    if (applyBtn) applyBtn.disabled = false;
   }
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -1967,6 +1967,8 @@ function renderCostModal(data) {
       const model = c.model
         .replace('claude-', '')
         .replace('-20251001', '')
+        .replace('deepseek-v4-flash', 'DeepSeek V4 Flash')
+        .replace('deepseek-v4-pro', 'DeepSeek V4 Pro')
         .replace('deepseek-chat', 'DeepSeek V3')
         .replace('deepseek-reasoner', 'DeepSeek R1')
         .replace('glm-4-flash', 'GLM-4-Flash')
@@ -2382,7 +2384,7 @@ function _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode) {
   const p = new URLSearchParams();
   if (topic)                              p.set('topic', topic);
   if (maxHsk !== 3)                       p.set('max_hsk', maxHsk);
-  if (model && model !== 'deepseek-chat') p.set('model', model);
+  if (model && model !== 'deepseek-v4-flash') p.set('model', model);
   if (grammarFocus)                       p.set('grammar_focus', grammarFocus);
   if (grammarFocus && grammarPct !== 75)  p.set('grammar_pct', grammarPct);
   if (mode && mode !== 'story')           p.set('mode', mode);
@@ -3347,6 +3349,7 @@ async function _applyRegenResult() {
     if (wordDetails?.id === wordId) wordDetails = updated;
     const DEF_FIELDS = ['definition', 'definition_zh', 'definition_de', 'definition_fr', 'pos'];
     const isDefRegen = fields.some(f => DEF_FIELDS.includes(f));
+    console.log('[apply] wordId=', wordId, '_currentWordId=', _currentWordId, 'fields=', fields, 'containerId=', containerId, 'isDefRegen=', isDefRegen);
     if (isDefRegen && _currentWordId === wordId) {
       // Definition/POS regen: full re-render is safe (header is always visible)
       updated.cards = wordDetails?.cards || [];
@@ -3354,6 +3357,7 @@ async function _applyRegenResult() {
     } else {
       // Section regen (notes/examples/etymology/compounds): targeted re-render to keep section open
       const target = document.getElementById(containerId);
+      console.log('[apply] target=', target, 'containerId=', containerId);
       if (target) {
         if (isDefRegen) {
           const posEl = document.getElementById('wd-pos');
@@ -3371,6 +3375,7 @@ async function _applyRegenResult() {
         else                                    renderWordAnalysis(target, updated, wordId);
         const body  = document.getElementById(containerId + '-body');
         const arrow = document.getElementById(containerId + '-body-arrow');
+        console.log('[apply] body=', body, 'arrow=', arrow);
         if (body)  body.style.display = 'block';
         if (arrow) arrow.textContent = '▼';
       }

--- a/static/app.js
+++ b/static/app.js
@@ -1584,9 +1584,9 @@ function renderWordDetail(word) {
   }
 
   // Shared sections (notes, examples, word analysis)
-  renderNotesSection(document.getElementById('wd-notes-section'), word.notes);
-  renderVocabDetail(document.getElementById('wd-examples-section'), word.examples);
-  renderWordAnalysis(document.getElementById('wd-word-analysis-section'), word);
+  renderNotesSection(document.getElementById('wd-notes-section'), word.notes, word.id);
+  renderVocabDetail(document.getElementById('wd-examples-section'), word.examples, word.id);
+  renderWordAnalysis(document.getElementById('wd-word-analysis-section'), word, word.id);
 
   // Cards section
   renderWordDetailCards(word.cards || [], word.id);
@@ -3128,9 +3128,42 @@ async function toggleReviewCat(cardId) {
   }
 }
 
-function renderVocabDetail(container, examples) {
+function _getActiveWordId() {
+  return _currentWordId ?? wordDetails?.id ?? card?.word_id ?? null;
+}
+
+async function regenFields(wordId, fields, containerId) {
+  const el = document.getElementById(containerId);
+  const btn = el?.querySelector('.field-regen-btn');
+  if (btn) { btn.disabled = true; btn.textContent = '…'; }
+  try {
+    await api('POST', `/api/word/${wordId}/regenerate-fields`, { fields });
+    const updated = await api('GET', `/api/word/${wordId}`);
+    if (_currentWordId === wordId) {
+      updated.cards = wordDetails?.cards || [];
+      renderWordDetail(updated);
+    } else {
+      if (wordDetails?.id === wordId) wordDetails = updated;
+      const target = document.getElementById(containerId);
+      if (!target) return;
+      if (fields.includes('notes'))    renderNotesSection(target, updated.notes, wordId);
+      else if (fields.includes('examples')) renderVocabDetail(target, updated.examples, wordId);
+      else renderWordAnalysis(target, updated, wordId);
+      const body = document.getElementById(containerId + '-body');
+      const arrow = document.getElementById(containerId + '-body-arrow');
+      if (body)  body.style.display = 'block';
+      if (arrow) arrow.textContent = '▼';
+    }
+  } catch (e) {
+    showError('Regeneration failed: ' + e.message);
+    if (btn) { btn.disabled = false; btn.textContent = '↺'; }
+  }
+}
+
+function renderVocabDetail(container, examples, wordId) {
   const el = container ?? document.getElementById('examples-section');
   const items = examples ?? wordDetails?.examples ?? [];
+  const wid = wordId ?? _getActiveWordId();
   const bodyId = el.id + '-body';
   if (items.length > 0) {
     const html = items.map(ex => {
@@ -3141,23 +3174,26 @@ function renderVocabDetail(container, examples) {
       h += `</div>`;
       return h;
     }).join('');
+    const regenBtn = wid ? `<button class="field-regen-btn" onclick="event.stopPropagation();regenFields(${wid},['examples'],'${el.id}')" title="Regenerate examples">↺</button>` : '';
     el.innerHTML =
-      `<div class="section-label section-toggle" onclick="toggleSection('${bodyId}')">` +
-        `<span id="${bodyId}-arrow">▶</span> Examples</div>` +
+      `<div class="section-label section-label-row section-toggle" onclick="toggleSection('${bodyId}')">` +
+        `<span><span id="${bodyId}-arrow">▶</span> Examples</span>${regenBtn}</div>` +
       `<div id="${bodyId}" style="display:none">${html}</div>`;
   } else {
     el.innerHTML = '';
   }
 }
 
-function renderNotesSection(container, notes) {
+function renderNotesSection(container, notes, wordId) {
   const el = container ?? document.getElementById('notes-section');
   const text = notes ?? card?.notes;
+  const wid = wordId ?? _getActiveWordId();
   const bodyId = el.id + '-body';
   if (text) {
+    const regenBtn = wid ? `<button class="field-regen-btn" onclick="event.stopPropagation();regenFields(${wid},['notes'],'${el.id}')" title="Regenerate notes">↺</button>` : '';
     el.innerHTML =
-      `<div class="section-label section-toggle" onclick="toggleSection('${bodyId}')">` +
-        `<span id="${bodyId}-arrow">▶</span> Notes</div>` +
+      `<div class="section-label section-label-row section-toggle" onclick="toggleSection('${bodyId}')">` +
+        `<span><span id="${bodyId}-arrow">▶</span> Notes</span>${regenBtn}</div>` +
       `<div id="${bodyId}" class="notes-body" style="display:none">${renderMarkdown(text)}</div>`;
     el.style.display = '';
   } else {
@@ -3166,7 +3202,7 @@ function renderNotesSection(container, notes) {
   }
 }
 
-function renderWordAnalysis(container, wordData) {
+function renderWordAnalysis(container, wordData, wordId) {
   const el = container ?? document.getElementById('word-analysis-section');
   const wd = wordData ?? wordDetails;
   const nt = wd?.note_type ?? card?.note_type;
@@ -3270,9 +3306,11 @@ function renderWordAnalysis(container, wordData) {
       `</div>`;
   }).join('');
 
+  const wid = wordId ?? _getActiveWordId();
+  const regenBtn = wid ? `<button class="field-regen-btn" onclick="event.stopPropagation();regenFields(${wid},['etymology','compounds'],'${el.id}')" title="Regenerate etymology &amp; compounds">↺</button>` : '';
   el.innerHTML =
-    `<div class="section-label section-toggle" onclick="toggleSection('${bodyId}')">` +
-      `<span id="${bodyId}-arrow">▶</span> Word Analysis</div>` +
+    `<div class="section-label section-label-row section-toggle" onclick="toggleSection('${bodyId}')">` +
+      `<span><span id="${bodyId}-arrow">▶</span> Word Analysis</span>${regenBtn}</div>` +
     `<div id="${bodyId}" class="wa-list" style="display:none">${wordCards}</div>`;
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -1554,6 +1554,13 @@ function renderWordDetail(word) {
   defFrEl.textContent = word.definition_fr ? `🇫🇷 ${word.definition_fr}` : '';
   defFrEl.style.display = word.definition_fr ? 'block' : 'none';
 
+  const defRegenEl = document.getElementById('wd-def-regen');
+  if (defRegenEl) {
+    defRegenEl.innerHTML = word.id
+      ? `<button class="field-regen-btn" onclick="event.stopPropagation();regenFields(${word.id},['definition','definition_zh','definition_de','definition_fr','pos'],'wd-def-block')" title="Regenerate definitions & part of speech">↺</button>`
+      : '';
+  }
+
   // Synonyms / antonyms section — collapsible, clickable
   const relEl = document.getElementById('wd-relations-section');
   const synonyms = (word.relations || []).filter(r => r.relation_type === 'synonym');
@@ -3163,6 +3170,23 @@ function _showRegenPreviewModal(previewData) {
 
   let bodyHtml = '';
 
+  const DEF_FIELDS = ['definition', 'definition_zh', 'definition_de', 'definition_fr', 'pos'];
+  if (fields.some(f => DEF_FIELDS.includes(f))) {
+    const esc = s => (s || '').replace(/"/g, '&quot;');
+    let defHtml = '';
+    if (fields.includes('pos'))
+      defHtml += `<div class="regen-def-row"><label>POS</label><input type="text" id="regen-pos" value="${esc(result.pos)}" placeholder="n. / v. / adj."></div>`;
+    if (fields.includes('definition'))
+      defHtml += `<div class="regen-def-row"><label>EN</label><input type="text" id="regen-def" value="${esc(result.definition)}" placeholder="English definition"></div>`;
+    if (fields.includes('definition_zh'))
+      defHtml += `<div class="regen-def-row"><label>ZH</label><input type="text" id="regen-def-zh" value="${esc(result.definition_zh)}" placeholder="中文释义"></div>`;
+    if (fields.includes('definition_de'))
+      defHtml += `<div class="regen-def-row"><label>DE</label><input type="text" id="regen-def-de" value="${esc(result.definition_de)}" placeholder="Deutsche Definition"></div>`;
+    if (fields.includes('definition_fr'))
+      defHtml += `<div class="regen-def-row"><label>FR</label><input type="text" id="regen-def-fr" value="${esc(result.definition_fr)}" placeholder="Définition française"></div>`;
+    bodyHtml += `<div><div class="regen-section-label">Definitions &amp; Part of Speech</div><div class="regen-def-group">${defHtml}</div></div>`;
+  }
+
   if (fields.includes('notes')) {
     const text = (result.notes || '').replace(/"/g, '&quot;');
     bodyHtml += `<div>
@@ -3261,6 +3285,15 @@ function _getRegenResultFromModal() {
   const result = {};
   const fields = _regenState?.fields || [];
 
+  const DEF_FIELDS = ['definition', 'definition_zh', 'definition_de', 'definition_fr', 'pos'];
+  if (fields.some(f => DEF_FIELDS.includes(f))) {
+    if (fields.includes('pos'))           result.pos           = document.getElementById('regen-pos')?.value?.trim()    || '';
+    if (fields.includes('definition'))    result.definition    = document.getElementById('regen-def')?.value?.trim()    || '';
+    if (fields.includes('definition_zh')) result.definition_zh = document.getElementById('regen-def-zh')?.value?.trim() || '';
+    if (fields.includes('definition_de')) result.definition_de = document.getElementById('regen-def-de')?.value?.trim() || '';
+    if (fields.includes('definition_fr')) result.definition_fr = document.getElementById('regen-def-fr')?.value?.trim() || '';
+  }
+
   if (fields.includes('notes')) {
     result.notes = document.getElementById('regen-notes-text')?.value?.trim() || '';
   }
@@ -3318,7 +3351,19 @@ async function _applyRegenResult() {
       if (wordDetails?.id === wordId) wordDetails = updated;
       const target = document.getElementById(containerId);
       if (!target) return;
-      if (fields.includes('notes'))         renderNotesSection(target, updated.notes, wordId);
+      const DEF_FIELDS = ['definition', 'definition_zh', 'definition_de', 'definition_fr', 'pos'];
+      if (fields.some(f => DEF_FIELDS.includes(f))) {
+        const posEl = document.getElementById('wd-pos');
+        if (posEl) { posEl.textContent = updated.pos || ''; posEl.style.display = updated.pos ? 'inline-block' : 'none'; }
+        const defEl = document.getElementById('wd-def');
+        if (defEl) defEl.textContent = updated.definition || '';
+        const defZhEl = document.getElementById('wd-def-zh');
+        if (defZhEl) { defZhEl.textContent = updated.definition_zh || ''; defZhEl.style.display = updated.definition_zh ? 'block' : 'none'; }
+        const defDeEl = document.getElementById('wd-def-de');
+        if (defDeEl) { defDeEl.textContent = updated.definition_de ? `🇩🇪 ${updated.definition_de}` : ''; defDeEl.style.display = updated.definition_de ? 'block' : 'none'; }
+        const defFrEl = document.getElementById('wd-def-fr');
+        if (defFrEl) { defFrEl.textContent = updated.definition_fr ? `🇫🇷 ${updated.definition_fr}` : ''; defFrEl.style.display = updated.definition_fr ? 'block' : 'none'; }
+      } else if (fields.includes('notes'))         renderNotesSection(target, updated.notes, wordId);
       else if (fields.includes('examples')) renderVocabDetail(target, updated.examples, wordId);
       else                                  renderWordAnalysis(target, updated, wordId);
       const body  = document.getElementById(containerId + '-body');

--- a/static/app.js
+++ b/static/app.js
@@ -3344,32 +3344,36 @@ async function _applyRegenResult() {
     const result = _getRegenResultFromModal();
     const updated = await api('POST', `/api/word/${wordId}/apply-regen-result`, { fields, result });
     _closeRegenPreviewModal();
-    if (_currentWordId === wordId) {
+    if (wordDetails?.id === wordId) wordDetails = updated;
+    const DEF_FIELDS = ['definition', 'definition_zh', 'definition_de', 'definition_fr', 'pos'];
+    const isDefRegen = fields.some(f => DEF_FIELDS.includes(f));
+    if (isDefRegen && _currentWordId === wordId) {
+      // Definition/POS regen: full re-render is safe (header is always visible)
       updated.cards = wordDetails?.cards || [];
       renderWordDetail(updated);
     } else {
-      if (wordDetails?.id === wordId) wordDetails = updated;
+      // Section regen (notes/examples/etymology/compounds): targeted re-render to keep section open
       const target = document.getElementById(containerId);
-      if (!target) return;
-      const DEF_FIELDS = ['definition', 'definition_zh', 'definition_de', 'definition_fr', 'pos'];
-      if (fields.some(f => DEF_FIELDS.includes(f))) {
-        const posEl = document.getElementById('wd-pos');
-        if (posEl) { posEl.textContent = updated.pos || ''; posEl.style.display = updated.pos ? 'inline-block' : 'none'; }
-        const defEl = document.getElementById('wd-def');
-        if (defEl) defEl.textContent = updated.definition || '';
-        const defZhEl = document.getElementById('wd-def-zh');
-        if (defZhEl) { defZhEl.textContent = updated.definition_zh || ''; defZhEl.style.display = updated.definition_zh ? 'block' : 'none'; }
-        const defDeEl = document.getElementById('wd-def-de');
-        if (defDeEl) { defDeEl.textContent = updated.definition_de ? `🇩🇪 ${updated.definition_de}` : ''; defDeEl.style.display = updated.definition_de ? 'block' : 'none'; }
-        const defFrEl = document.getElementById('wd-def-fr');
-        if (defFrEl) { defFrEl.textContent = updated.definition_fr ? `🇫🇷 ${updated.definition_fr}` : ''; defFrEl.style.display = updated.definition_fr ? 'block' : 'none'; }
-      } else if (fields.includes('notes'))         renderNotesSection(target, updated.notes, wordId);
-      else if (fields.includes('examples')) renderVocabDetail(target, updated.examples, wordId);
-      else                                  renderWordAnalysis(target, updated, wordId);
-      const body  = document.getElementById(containerId + '-body');
-      const arrow = document.getElementById(containerId + '-body-arrow');
-      if (body)  body.style.display = 'block';
-      if (arrow) arrow.textContent = '▼';
+      if (target) {
+        if (isDefRegen) {
+          const posEl = document.getElementById('wd-pos');
+          if (posEl) { posEl.textContent = updated.pos || '—'; posEl.style.display = 'inline-block'; }
+          const defEl = document.getElementById('wd-def');
+          if (defEl) defEl.textContent = updated.definition || '';
+          const defZhEl = document.getElementById('wd-def-zh');
+          if (defZhEl) { defZhEl.textContent = updated.definition_zh || ''; defZhEl.style.display = updated.definition_zh ? 'block' : 'none'; }
+          const defDeEl = document.getElementById('wd-def-de');
+          if (defDeEl) { defDeEl.textContent = updated.definition_de ? `🇩🇪 ${updated.definition_de}` : ''; defDeEl.style.display = updated.definition_de ? 'block' : 'none'; }
+          const defFrEl = document.getElementById('wd-def-fr');
+          if (defFrEl) { defFrEl.textContent = updated.definition_fr ? `🇫🇷 ${updated.definition_fr}` : ''; defFrEl.style.display = updated.definition_fr ? 'block' : 'none'; }
+        } else if (fields.includes('notes'))    renderNotesSection(target, updated.notes, wordId);
+        else if (fields.includes('examples'))   renderVocabDetail(target, updated.examples, wordId);
+        else                                    renderWordAnalysis(target, updated, wordId);
+        const body  = document.getElementById(containerId + '-body');
+        const arrow = document.getElementById(containerId + '-body-arrow');
+        if (body)  body.style.display = 'block';
+        if (arrow) arrow.textContent = '▼';
+      }
     }
   } catch (e) {
     showError('Apply failed: ' + e.message);

--- a/static/index.html
+++ b/static/index.html
@@ -616,7 +616,8 @@
       <select class="edit-input" id="setup-model">
         <option value="glm-4-flash">GLM-4-Flash — free, great Chinese</option>
         <option value="glm-4-air">GLM-4-Air — paid, higher quality</option>
-        <option value="deepseek-chat" selected>DeepSeek V3 — cheap, reliable</option>
+        <option value="deepseek-v4-flash" selected>DeepSeek V4 Flash — cheap, reliable</option>
+        <option value="deepseek-v4-pro">DeepSeek V4 Pro — higher quality</option>
         <option value="qwen-turbo">Qwen Turbo — Alibaba, cheap</option>
         <option value="claude-haiku-4-5-20251001">Haiku — Anthropic fast</option>
         <option value="claude-sonnet-4-6">Sonnet — Anthropic balanced</option>
@@ -869,7 +870,8 @@
       <select class="edit-input" id="story-error-model">
         <option value="glm-4-flash">GLM-4-Flash — free, great Chinese</option>
         <option value="glm-4-air">GLM-4-Air — paid, higher quality</option>
-        <option value="deepseek-chat">DeepSeek V3 — cheap, reliable</option>
+        <option value="deepseek-v4-flash">DeepSeek V4 Flash — cheap, reliable</option>
+        <option value="deepseek-v4-pro">DeepSeek V4 Pro — higher quality</option>
         <option value="qwen-turbo">Qwen Turbo — Alibaba, cheap</option>
         <option value="claude-haiku-4-5-20251001">Haiku — Anthropic fast</option>
         <option value="claude-sonnet-4-6">Sonnet — Anthropic balanced</option>

--- a/static/index.html
+++ b/static/index.html
@@ -326,14 +326,17 @@
     <div class="wd-header">
       <div class="wd-hanzi" id="wd-hanzi"></div>
       <div class="wd-pinyin" id="wd-pinyin"></div>
-      <div class="wd-pos-def-row">
-        <span class="word-pos" id="wd-pos" style="display:none"></span>
-        <span class="word-register" id="wd-register" style="display:none"></span>
-        <span class="wd-def" id="wd-def"></span>
+      <div id="wd-def-block">
+        <div class="wd-pos-def-row">
+          <span class="word-pos" id="wd-pos" style="display:none"></span>
+          <span class="word-register" id="wd-register" style="display:none"></span>
+          <span class="wd-def" id="wd-def"></span>
+          <span id="wd-def-regen"></span>
+        </div>
+        <div class="wd-def-zh" id="wd-def-zh" style="display:none"></div>
+        <div class="wd-def-fr" id="wd-def-fr" style="display:none"></div>
+        <div class="wd-def-de" id="wd-def-de" style="display:none"></div>
       </div>
-      <div class="wd-def-zh" id="wd-def-zh" style="display:none"></div>
-      <div class="wd-def-fr" id="wd-def-fr" style="display:none"></div>
-      <div class="wd-def-de" id="wd-def-de" style="display:none"></div>
       <button class="wd-edit-btn" id="wd-edit-btn">Edit</button>
       <button class="wd-back-review-btn" id="wd-back-review-btn" style="display:none" onclick="goBack()">← Review</button>
     </div>

--- a/static/style.css
+++ b/static/style.css
@@ -881,6 +881,27 @@ main.browse-open {
 }
 .section-toggle:hover { color: var(--primary); }
 
+.section-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.field-regen-btn {
+  background: none;
+  border: none;
+  font-size: 14px;
+  cursor: pointer;
+  color: var(--muted);
+  padding: 0 4px;
+  line-height: 1;
+  opacity: 0;
+  transition: opacity 0.15s;
+  flex-shrink: 0;
+}
+.section-label-row:hover .field-regen-btn { opacity: 0.7; }
+.field-regen-btn:hover { opacity: 1 !important; color: var(--primary); }
+.field-regen-btn:disabled { cursor: wait; opacity: 0.4 !important; }
+
 /* Character rows */
 .char-row {
   display: flex;

--- a/static/style.css
+++ b/static/style.css
@@ -899,7 +899,6 @@ main.browse-open {
   flex-shrink: 0;
 }
 .section-label-row:hover .field-regen-btn { opacity: 0.7; }
-#wd-def-block:hover .field-regen-btn { opacity: 0.7; }
 .field-regen-btn:hover { opacity: 1 !important; color: var(--primary); }
 .field-regen-btn:disabled { cursor: wait; opacity: 0.4 !important; }
 .section-empty { color: var(--muted); font-size: 12px; padding: 6px 0; }
@@ -2233,7 +2232,19 @@ main.browse-open {
   padding: 20px 18px 16px;
   text-align: center;
   margin-bottom: 12px;
+  position: relative;
 }
+#wd-def-regen {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+}
+#wd-def-regen .field-regen-btn {
+  opacity: 0.45;
+  font-size: 16px;
+  padding: 2px 6px;
+}
+#wd-def-regen .field-regen-btn:hover { opacity: 1 !important; color: var(--primary); }
 .wd-edit-btn {
   margin-top: 12px;
   padding: 5px 18px;

--- a/static/style.css
+++ b/static/style.css
@@ -902,6 +902,109 @@ main.browse-open {
 .field-regen-btn:hover { opacity: 1 !important; color: var(--primary); }
 .field-regen-btn:disabled { cursor: wait; opacity: 0.4 !important; }
 
+/* Regen preview modal */
+.regen-preview-overlay {
+  position: fixed; inset: 0; background: rgba(0,0,0,0.55);
+  z-index: 1100; display: flex; align-items: center; justify-content: center;
+}
+.regen-preview-modal {
+  background: var(--card-bg); border-radius: 10px; width: 640px; max-width: 96vw;
+  max-height: 88vh; display: flex; flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.35); overflow: hidden;
+}
+.regen-preview-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 18px 12px; border-bottom: 1px solid var(--border);
+  font-size: 15px; font-weight: 600; color: var(--text);
+}
+.regen-preview-header button {
+  background: none; border: none; font-size: 20px; line-height: 1;
+  cursor: pointer; color: var(--muted); padding: 0 2px;
+}
+.regen-preview-header button:hover { color: var(--text); }
+.regen-preview-body {
+  overflow-y: auto; padding: 16px 18px; flex: 1; display: flex; flex-direction: column; gap: 16px;
+}
+.regen-section-label {
+  font-size: 11px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.06em; color: var(--muted); margin-bottom: 6px;
+}
+.regen-notes-textarea {
+  width: 100%; box-sizing: border-box; min-height: 140px; resize: vertical;
+  background: var(--bg); border: 1px solid var(--border); border-radius: 6px;
+  color: var(--text); padding: 10px 12px; font-family: inherit; font-size: 13px;
+  line-height: 1.55;
+}
+.regen-notes-textarea:focus { outline: none; border-color: var(--primary); }
+.regen-example-row {
+  display: grid; grid-template-columns: 1fr 1fr 1fr 1fr auto;
+  gap: 6px; align-items: center; margin-bottom: 6px;
+}
+.regen-example-row input {
+  background: var(--bg); border: 1px solid var(--border); border-radius: 5px;
+  color: var(--text); padding: 5px 8px; font-family: inherit; font-size: 12px;
+  width: 100%; box-sizing: border-box;
+}
+.regen-example-row input:focus { outline: none; border-color: var(--primary); }
+.regen-example-labels {
+  display: grid; grid-template-columns: 1fr 1fr 1fr 1fr auto;
+  gap: 6px; margin-bottom: 2px;
+}
+.regen-example-labels span {
+  font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em;
+}
+.regen-row-del {
+  background: none; border: none; cursor: pointer; color: var(--muted);
+  font-size: 16px; line-height: 1; padding: 0 2px;
+}
+.regen-row-del:hover { color: #e53e3e; }
+.regen-add-btn {
+  background: none; border: 1px dashed var(--border); border-radius: 5px;
+  color: var(--muted); font-size: 12px; cursor: pointer; padding: 4px 10px;
+  margin-top: 2px; width: 100%;
+}
+.regen-add-btn:hover { color: var(--primary); border-color: var(--primary); }
+.regen-char-group { margin-bottom: 12px; }
+.regen-char-header {
+  font-size: 14px; font-weight: 600; color: var(--text); margin-bottom: 6px;
+}
+.regen-etym-textarea {
+  width: 100%; box-sizing: border-box; min-height: 72px; resize: vertical;
+  background: var(--bg); border: 1px solid var(--border); border-radius: 6px;
+  color: var(--text); padding: 8px 10px; font-family: inherit; font-size: 12px;
+  line-height: 1.5; margin-bottom: 8px;
+}
+.regen-etym-textarea:focus { outline: none; border-color: var(--primary); }
+.regen-compound-row {
+  display: grid; grid-template-columns: 100px 120px 1fr auto;
+  gap: 5px; align-items: center; margin-bottom: 4px;
+}
+.regen-compound-row input {
+  background: var(--bg); border: 1px solid var(--border); border-radius: 5px;
+  color: var(--text); padding: 4px 7px; font-family: inherit; font-size: 12px;
+  width: 100%; box-sizing: border-box;
+}
+.regen-compound-row input:focus { outline: none; border-color: var(--primary); }
+.regen-compound-labels {
+  display: grid; grid-template-columns: 100px 120px 1fr auto;
+  gap: 5px; margin-bottom: 2px;
+}
+.regen-compound-labels span {
+  font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em;
+}
+.regen-preview-footer {
+  display: flex; gap: 8px; justify-content: flex-end;
+  padding: 12px 18px; border-top: 1px solid var(--border);
+}
+.regen-btn { border-radius: 6px; padding: 7px 16px; font-size: 13px; cursor: pointer; border: 1px solid; }
+.regen-btn-regenerate { background: none; border-color: var(--border); color: var(--muted); }
+.regen-btn-regenerate:hover { color: var(--text); border-color: var(--text); }
+.regen-btn-reject { background: none; border-color: var(--border); color: var(--muted); }
+.regen-btn-reject:hover { color: #e53e3e; border-color: #e53e3e; }
+.regen-btn-apply { background: var(--primary); border-color: var(--primary); color: #fff; font-weight: 600; }
+.regen-btn-apply:hover { opacity: 0.88; }
+.regen-btn:disabled { opacity: 0.45; cursor: wait; }
+
 /* Character rows */
 .char-row {
   display: flex;

--- a/static/style.css
+++ b/static/style.css
@@ -899,6 +899,7 @@ main.browse-open {
   flex-shrink: 0;
 }
 .section-label-row:hover .field-regen-btn { opacity: 0.7; }
+#wd-def-block:hover .field-regen-btn { opacity: 0.7; }
 .field-regen-btn:hover { opacity: 1 !important; color: var(--primary); }
 .field-regen-btn:disabled { cursor: wait; opacity: 0.4 !important; }
 .section-empty { color: var(--muted); font-size: 12px; padding: 6px 0; }
@@ -993,6 +994,10 @@ main.browse-open {
 .regen-compound-labels span {
   font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em;
 }
+.regen-def-group { display: flex; flex-direction: column; gap: 8px; }
+.regen-def-row { display: flex; align-items: center; gap: 10px; }
+.regen-def-row label { min-width: 36px; font-size: 11px; color: var(--muted); font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+.regen-def-row input { flex: 1; padding: 6px 8px; background: var(--bg); border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-size: 13px; }
 .regen-preview-footer {
   display: flex; gap: 8px; justify-content: flex-end;
   padding: 12px 18px; border-top: 1px solid var(--border);
@@ -1288,7 +1293,7 @@ main.browse-open {
 }
 .wa-char-row:last-child { border-bottom: none; }
 .wa-char-zh-col { display: inline-flex; flex-direction: column; align-items: center; flex-shrink: 0; }
-.wa-char-zh  { font-size: 22px; }
+.wa-char-zh  { font-size: 22px; font-weight: 700; }
 .wa-char-trad { font-size: 22px; font-weight: 700; color: var(--muted); line-height: 1.2; }
 .wa-char-right {
   display: flex;

--- a/static/style.css
+++ b/static/style.css
@@ -909,7 +909,7 @@ main.browse-open {
   z-index: 1100; display: flex; align-items: center; justify-content: center;
 }
 .regen-preview-modal {
-  background: var(--card-bg); border-radius: 10px; width: 640px; max-width: 96vw;
+  background: var(--card); border-radius: 10px; width: 640px; max-width: 96vw;
   max-height: 88vh; display: flex; flex-direction: column;
   box-shadow: 0 8px 32px rgba(0,0,0,0.35); overflow: hidden;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -1369,7 +1369,7 @@ main.browse-open {
 }
 .wa-compound-pin { font-size: 11px; color: var(--muted); }
 .wa-compound-meaning { font-size: 11px; color: var(--muted); font-style: italic; }
-.wa-compound-hl { text-decoration: underline; }
+.wa-compound-hl { font-weight: 700; }
 
 /* ── Creating: front input ───────────────────────────── */
 .sentence-en-front {

--- a/static/style.css
+++ b/static/style.css
@@ -901,6 +901,7 @@ main.browse-open {
 .section-label-row:hover .field-regen-btn { opacity: 0.7; }
 .field-regen-btn:hover { opacity: 1 !important; color: var(--primary); }
 .field-regen-btn:disabled { cursor: wait; opacity: 0.4 !important; }
+.section-empty { color: var(--muted); font-size: 12px; padding: 6px 0; }
 
 /* Regen preview modal */
 .regen-preview-overlay {

--- a/static/style.css
+++ b/static/style.css
@@ -923,7 +923,7 @@ main.browse-open {
 }
 .regen-preview-header button:hover { color: var(--text); }
 .regen-preview-body {
-  overflow-y: auto; padding: 16px 18px; flex: 1; display: flex; flex-direction: column; gap: 16px;
+  overflow-y: auto; padding: 16px 18px; flex: 1; min-height: 0; display: flex; flex-direction: column; gap: 16px;
 }
 .regen-section-label {
   font-size: 11px; font-weight: 700; text-transform: uppercase;


### PR DESCRIPTION
## 变更内容

- 新增 `POST /api/word/{id}/regenerate-fields` 接口，支持按需重新生成以下字段：
  - `notes` — 德语用法说明（遵循 SKILL.md note 格式）
  - `examples` — 2–4 个例句（zh/pinyin/english/de）
  - `etymology` — 各汉字的德语词源（散文体）
  - `compounds` — 各汉字的复合词列表
- AI 提示词基于 SKILL.md 格式动态构建，只请求指定字段
- 正确处理多组件词条（成语/习语/句子），etymology/compounds 在各子词上分别生成
- 前端：在 Notes、Examples、Word Analysis 三个折叠区标题旁添加悬停显示的 ↺ 按钮
- 按钮调用 regenFields(wordId, fields, containerId)，完成后自动刷新对应区域

## 测试方法

1. 打开任意单词详情页（Browse 或 Review 界面）
2. 鼠标悬停在 NOTES / EXAMPLES / WORD ANALYSIS 标题上，可见右侧 ↺ 按钮
3. 点击按钮，等待 AI 生成（确保 DEEPSEEK_API_KEY 已设置）
4. 内容自动刷新