### PR TITLE
feat: 导入移动时自动取消暂停，显示当前牌组

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -83,7 +83,9 @@ def move_cards_to_deck(word_id: int, target_deck_ids: dict,
         if deck_id is None:
             continue
         cur = conn.execute(
-            """UPDATE cards SET deck_id=?
+            """UPDATE cards SET deck_id=?,
+               state=CASE WHEN state='suspended' THEN COALESCE(pre_suspend_state,'new') ELSE state END,
+               pre_suspend_state=CASE WHEN state='suspended' THEN NULL ELSE pre_suspend_state END
                WHERE word_id=? AND category=? AND deleted_at IS NULL""",
             (deck_id, word_id, cat),
         )

--- a/database/decks.py
+++ b/database/decks.py
@@ -261,3 +261,16 @@ def get_or_create_deck_path(path: str) -> int:
     for segment in segments:
         parent_id = get_or_create_deck(segment, parent_id=parent_id)
     return parent_id
+
+
+def get_word_deck_names(word_id: int) -> list[str]:
+    """Return the unique deck names (leaf only) where cards for this word live."""
+    conn = get_db()
+    rows = conn.execute(
+        """SELECT DISTINCT d.name FROM cards c
+           JOIN decks d ON d.id = c.deck_id
+           WHERE c.word_id = ? AND c.deleted_at IS NULL AND d.deleted_at IS NULL""",
+        (word_id,),
+    ).fetchall()
+    conn.close()
+    return [r["name"] for r in rows]

--- a/importer.py
+++ b/importer.py
@@ -232,11 +232,13 @@ def preview_yaml_content(content: str) -> dict:
         existing = database.get_word_by_zh(word_zh)
         if existing and database.word_has_cards(existing["id"]):
             summary["duplicate"] += 1
+            deck_names = database.get_word_deck_names(existing["id"])
             result_entries.append({
                 "simplified": word_zh, "note_type": note_type,
                 "english": english, "hsk": hsk,
                 "status": "duplicate", "reason": None,
                 "raw_yaml": raw,
+                "current_decks": deck_names,
             })
         else:
             summary["ok"] += 1

--- a/static/app.js
+++ b/static/app.js
@@ -4989,8 +4989,12 @@ function _importRenderTable() {
         dupAction === 'move_import' ? `
         <span style="margin-left:4px;font-size:11px;color:var(--clr-muted,#888)">→ import deck</span>
         ${catCheckboxes}` : '';
+      const currentDecksHtml = (e.current_decks && e.current_decks.length)
+        ? `<span style="font-size:10px;color:var(--clr-muted,#888);margin-right:4px" title="Currently in: ${_ea(e.current_decks.join(', '))}">📂 ${_ea(e.current_decks.join(', '))}</span>`
+        : '';
       midCols = `<td colspan="4" style="padding:2px 6px">
         <div style="display:flex;align-items:center;flex-wrap:wrap;gap:2px">
+          ${currentDecksHtml}
           <select style="font-size:11px" onchange="importSetDupAction(${_ea(JSON.stringify(e.simplified))}, this.value)">
             <option value="skip"${dupAction==='skip'?' selected':''}>Skip</option>
             <option value="reset"${dupAction==='reset'?' selected':''}>Reset progress</option>


### PR DESCRIPTION
## 变更内容

- **自动取消暂停**：选择"Move to import deck"或"Move to deck…"时，如果卡片处于 suspended 状态，会自动恢复为之前的状态（`pre_suspend_state`，默认 `new`）
- **显示当前牌组**：导入预览表格中，重复词条的操作栏现在显示该词目前所在的牌组名（📂 标签）

## 测试方法

1. 有一个已 suspended 的词，导入同一个词选择 Move，确认移动后卡片变为 active
2. 导入包含重复词的 YAML，确认表格中 ⚠ 行显示"📂 牌组名"
3. 没有卡片的新词：不显示 📂 标签（正常）