### PR TITLE
fix: 修复无 entry_characters 词条的 AI 字段重新生成

### DIFF
--- a/routes/browse.py
+++ b/routes/browse.py
@@ -105,6 +105,21 @@ def _run_regen_ai(word_id: int, word: dict, fields: list) -> tuple[dict, list]:
                 _enrich_chars_with_id(result.get("characters", []), comp_chars, all_characters)
     else:
         characters = database.get_word_characters(word_id)
+        if want_char_data and not characters:
+            # No entry_characters linked — derive from word_zh so the AI knows which chars to analyze
+            for ch in word.get("word_zh", ""):
+                basic = database.get_character(ch)
+                if basic:
+                    full = database.get_character_by_id(basic["id"])
+                    if full:
+                        characters.append({
+                            "char_id": full["id"],
+                            "char": ch,
+                            "pinyin": full.get("pinyin", ""),
+                            "hsk_level": full.get("hsk_level", ""),
+                            "etymology": full.get("etymology", ""),
+                            "compounds": full.get("compounds", []),
+                        })
         top_result = ai.regenerate_entry_fields(word, characters, fields)
         _enrich_chars_with_id(top_result.get("characters", []), characters, all_characters)
 
@@ -135,10 +150,13 @@ def _save_regen_result(word_id: int, fields: list, top_result: dict, all_charact
                     position=i,
                 )
 
-    for char_data in all_characters:
+    existing_chars = {c["char_id"] for c in database.get_word_characters(word_id)}
+    for i, char_data in enumerate(all_characters):
         char_id = char_data.get("char_id")
         if not char_id:
             continue
+        if char_id not in existing_chars:
+            database.insert_word_character(word_id, char_id, i, None)
         if "etymology" in fields and char_data.get("etymology"):
             database.update_character(char_id, {"etymology": char_data["etymology"]})
         if "compounds" in fields and char_data.get("compounds"):


### PR DESCRIPTION
## 变更内容

- `_run_regen_ai`：若词条没有 entry_characters 但请求 etymology/compounds，自动从 word_zh 逐字提取汉字并查表，保证 AI 收到正确的汉字列表
- `_save_regen_result`：Apply 时若 entry_characters 尚未存在，自动创建，使 Word Analysis 面板之后能正常显示

## 测试方法

1. 找到"三教九流"（或任何没有 Word Analysis 的词条）
2. 点击 Word Analysis 旁边的 ↺ 重新生成
3. AI Preview 应该显示 三/教/九/流 的汉字数据，而不是随机错误字
4. 点击 Apply → Word Analysis 面板应立即出现正确内容

Closes #262