### PR TITLE
fix: 学习中卡片优先级 — 队列构建时纳入当日未来到期卡片

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -164,7 +164,7 @@ Rules:
 - Write the sentences in the same order as the target word list above
 - For items marked [SENTENCE]: use that exact text as the sentence, unchanged
 - Use proper Chinese punctuation — include commas（，）where natural pauses occur
-- Use only HSK 1-{max_hsk} vocabulary for non-target words
+- Use only HSK 1-{max_hsk} vocabulary for non-target words; each sentence must contain exactly ONE target word from the list — do not use other target words from the list in that sentence
 - Keep each sentence short and simple
 {style_rule}
 - NEVER use ASCII double-quote characters (") inside Chinese sentences — use 「」or （）instead

--- a/database/cards.py
+++ b/database/cards.py
@@ -274,6 +274,7 @@ def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = Fa
     from itertools import groupby
 
     today = anki_today().isoformat()
+    tomorrow = (date.fromisoformat(today) + timedelta(days=1)).isoformat()
     now = datetime.now().isoformat(timespec="seconds")
     conn = get_db()
 
@@ -294,11 +295,11 @@ def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = Fa
              AND c.deleted_at IS NULL
              AND (c.buried_until IS NULL OR c.buried_until < ?)
              AND (
-               (c.state IN ('learning', 'relearn') AND c.due <= ?)
+               (c.state IN ('learning', 'relearn') AND c.due < ?)
                OR (c.state = 'review' AND c.due <= ?)
                OR (c.state = 'new' AND c.due <= ?)
              )""",
-        (deck_id, category, today, now, today, today),
+        (deck_id, category, today, tomorrow, today, today),
     ).fetchall()
 
     all_cards = [dict(r) for r in rows]


### PR DESCRIPTION
## 问题

在复习会话中，即使界面显示有若干张"学习中"卡片，系统仍然提供了复习卡片。

**根本原因：** `get_due_cards` 的 SQL 只拉取 `due <= now` 的学习中卡片。队列（SessionQueue）在首次访问时一次性构建，之后不再重建。如果学习中卡片的到期时间（例如1分钟或10分钟步骤）在队列构建之后才到来，这些卡片完全不在队列里——既不在 `intraday`，也不在 `main`——但 `count_due`（每次 API 请求都实时查数据库）仍然把它们计入学习中数量，造成界面显示与实际队列不一致。

## 修复

将 `learning/relearn` 状态卡片的查询上界从 `now` 改为 `tomorrow`（下一个 Anki 日），把当日全部学习中卡片——包括尚未到期的——都纳入构建结果。

- 这些卡片通过 `_is_intraday`（检查 due 中是否含 `T`）进入 `intraday` 队列
- `get_next` 里的 `e["due"] <= now` 检查保证它们只在真正到期后才被提供
- 未到期时，系统继续按正常顺序提供复习/新建卡片

## 影响范围

- 仅修改 `database/cards.py` 的 `get_due_cards`
- `get_due_cards_multi` 和 `get_due_cards_any_cat` 都通过调用 `get_due_cards` 获益，无需单独修改

## 测试方法

1. 复习一张学习中卡片，评为"Again"（1分钟步骤）
2. 继续复习，确认下一张卡片仍为学习中卡片（若有），而非直接跳到复习卡片
3. 等约1分钟后，确认刚才那张卡片再次出现，且优先于复习卡片

Closes #（待建 Issue）