### PR TITLE
fix: 修复推理模型故事生成失败并改进日志 (#266)

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -55,13 +55,14 @@ def _openai_client(model: str) -> openai.OpenAI:
     raise ValueError(f"Unknown provider for model: {model}")
 
 
-def _is_reasoning_model(model: str) -> bool:
-    """Return True if the model uses an internal reasoning/thinking phase before output."""
-    return any(s in model.lower() for s in ("r1", "reasoner", "v4-flash", "thinking", "v3-flash"))
+def _call_api(model: str, messages: list, max_tokens: int, purpose: str,
+              thinking: bool = False) -> str:
+    """Call the appropriate provider, log usage, and return the raw text response.
 
-
-def _call_api(model: str, messages: list, max_tokens: int, purpose: str) -> str:
-    """Call the appropriate provider, log usage, and return the raw text response."""
+    thinking: enable DeepSeek thinking/reasoning mode (default False — disabled).
+              deepseek-v4-flash defaults to thinking=on server-side, so we must
+              explicitly disable it for tasks that don't need chain-of-thought.
+    """
     t0 = time.time()
     if model.startswith("claude-"):
         client = anthropic.Anthropic()
@@ -78,7 +79,13 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str) -> str:
         return msg.content[0].text.strip()
     else:
         client = _openai_client(model)
-        resp = client.chat.completions.create(model=model, max_tokens=max_tokens, messages=messages)
+        extra: dict = {}
+        if model.startswith("deepseek-"):
+            extra["extra_body"] = {"thinking": {"type": "enabled" if thinking else "disabled"}}
+            logger.debug("[%s] thinking=%s", model, thinking)
+        resp = client.chat.completions.create(
+            model=model, max_tokens=max_tokens, messages=messages, **extra
+        )
         elapsed = time.time() - t0
         choice = resp.choices[0]
         content = choice.message.content
@@ -99,12 +106,10 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str) -> str:
         if choice.finish_reason == "length":
             if reasoning_chars > 0 and not content:
                 logger.warning(
-                    "[%s] Reasoning model exhausted max_tokens=%d on thinking "
-                    "(%d reasoning chars) — no content produced. "
-                    "Increase max_tokens for this model.",
+                    "[%s] thinking mode exhausted max_tokens=%d (%d reasoning chars) "
+                    "— no content produced. Pass thinking=False or increase max_tokens.",
                     model, max_tokens, reasoning_chars,
                 )
-                logger.debug("[%s] reasoning snippet: %.500s…", model, reasoning)
             else:
                 logger.warning("[%s] response truncated (finish_reason=length, max_tokens=%d, "
                                "content_chars=%d)", model, max_tokens, len(content or ""))
@@ -203,12 +208,9 @@ Return ONLY a numbered list of Chinese sentences, no explanation:
 1. ...
 2. ..."""
 
-    # Reasoning models (e.g. deepseek-v4-flash) spend tokens on internal thinking
-    # before writing output — they need a much larger budget to avoid content=None.
-    max_tokens = 32768 if _is_reasoning_model(model) else 8192
+    max_tokens = 8192
 
-    logger.info("[%s] generate_story: %d 张卡片 mode=%s max_tokens=%d reasoning_model=%s",
-                model, len(cards), mode, max_tokens, _is_reasoning_model(model))
+    logger.info("[%s] generate_story: %d 张卡片 mode=%s", model, len(cards), mode)
     logger.debug("Prompt:\n%s", prompt)
 
     card_by_id = {c["word_id"]: c for c in cards}

--- a/ai.py
+++ b/ai.py
@@ -55,6 +55,11 @@ def _openai_client(model: str) -> openai.OpenAI:
     raise ValueError(f"Unknown provider for model: {model}")
 
 
+def _is_reasoning_model(model: str) -> bool:
+    """Return True if the model uses an internal reasoning/thinking phase before output."""
+    return any(s in model.lower() for s in ("r1", "reasoner", "v4-flash", "thinking", "v3-flash"))
+
+
 def _call_api(model: str, messages: list, max_tokens: int, purpose: str) -> str:
     """Call the appropriate provider, log usage, and return the raw text response."""
     t0 = time.time()
@@ -75,22 +80,39 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str) -> str:
         client = _openai_client(model)
         resp = client.chat.completions.create(model=model, max_tokens=max_tokens, messages=messages)
         elapsed = time.time() - t0
-        logger.info("[%s] API call done in %.1fs — in=%d out=%d purpose=%s",
-                    model, elapsed, resp.usage.prompt_tokens, resp.usage.completion_tokens, purpose)
+        choice = resp.choices[0]
+        content = choice.message.content
+        reasoning = getattr(choice.message, "reasoning_content", None)
+        reasoning_chars = len(reasoning) if reasoning else 0
+
+        logger.info("[%s] API call done in %.1fs — in=%d out=%d reasoning_chars=%d purpose=%s",
+                    model, elapsed,
+                    resp.usage.prompt_tokens, resp.usage.completion_tokens,
+                    reasoning_chars, purpose)
         database.log_api_call(
             model=resp.model,
             input_tokens=resp.usage.prompt_tokens,
             output_tokens=resp.usage.completion_tokens,
             purpose=purpose,
         )
-        choice = resp.choices[0]
+
         if choice.finish_reason == "length":
-            logger.warning("[%s] response truncated (finish_reason=length, max_tokens=%d)", model, max_tokens)
-        content = choice.message.content
-        if not content:
-            reasoning = getattr(choice.message, "reasoning_content", None)
-            logger.warning("[%s] content=None (reasoning_tokens=%d)", model,
-                           len(reasoning) if reasoning else 0)
+            if reasoning_chars > 0 and not content:
+                logger.warning(
+                    "[%s] Reasoning model exhausted max_tokens=%d on thinking "
+                    "(%d reasoning chars) — no content produced. "
+                    "Increase max_tokens for this model.",
+                    model, max_tokens, reasoning_chars,
+                )
+                logger.debug("[%s] reasoning snippet: %.500s…", model, reasoning)
+            else:
+                logger.warning("[%s] response truncated (finish_reason=length, max_tokens=%d, "
+                               "content_chars=%d)", model, max_tokens, len(content or ""))
+
+        if not content and not reasoning:
+            logger.warning("[%s] empty response — no content and no reasoning (purpose=%s)",
+                           model, purpose)
+
         return (content or "").strip()
 
 
@@ -181,10 +203,13 @@ Return ONLY a numbered list of Chinese sentences, no explanation:
 1. ...
 2. ..."""
 
-    logger.info("[%s] generate_story: %d 张卡片 mode=%s", model, len(cards), mode)
-    logger.debug("Prompt:\n%s", prompt)
+    # Reasoning models (e.g. deepseek-v4-flash) spend tokens on internal thinking
+    # before writing output — they need a much larger budget to avoid content=None.
+    max_tokens = 32768 if _is_reasoning_model(model) else 8192
 
-    max_tokens = 8192
+    logger.info("[%s] generate_story: %d 张卡片 mode=%s max_tokens=%d reasoning_model=%s",
+                model, len(cards), mode, max_tokens, _is_reasoning_model(model))
+    logger.debug("Prompt:\n%s", prompt)
 
     card_by_id = {c["word_id"]: c for c in cards}
     t_start = time.time()
@@ -207,7 +232,15 @@ Return ONLY a numbered list of Chinese sentences, no explanation:
                 sentences_zh.append(m.group(1).strip())
 
         if not sentences_zh:
-            logger.error("generate_story: no numbered sentences found in response")
+            if not raw:
+                logger.error("generate_story: attempt %d — empty response from API "
+                             "(model=%s, max_tokens=%d). "
+                             "If this is a reasoning model, it may have exhausted its token budget on thinking.",
+                             attempt + 1, model, max_tokens)
+            else:
+                logger.error("generate_story: attempt %d — no numbered sentences found "
+                             "(response was %d chars):\n%.500s…",
+                             attempt + 1, len(raw), raw)
             continue
 
         # Match target words to sentences by string search

--- a/main.py
+++ b/main.py
@@ -92,6 +92,7 @@ logging.root.setLevel(os.environ.get("LOG_LEVEL", "INFO").upper())
 logging.root.addHandler(_handler)
 logger = logging.getLogger("main")
 logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 
 # ---------------------------------------------------------------------------

--- a/static/app.js
+++ b/static/app.js
@@ -4853,7 +4853,7 @@ function _importRenderTable() {
     const isDuplicate = e.status === 'duplicate';
     let midCols;
     if (isDuplicate) {
-      const dupAction = cfg.duplicate_action || 'skip';
+      const dupAction = cfg.duplicate_action || 'move_import';
       const moveTarget = cfg.move_target || '';
       const moveCats = cfg.move_categories || null; // null = all
       const catChecked = (cat) => (!moveCats || moveCats.includes(cat)) ? 'checked' : '';


### PR DESCRIPTION
## 变更内容

### 主要修复（`ai.py`）
- 新增 `_is_reasoning_model()` 函数，通过模型名称关键词（r1、v4-flash、thinking、reasoner）识别推理模型
- 故事生成时对推理模型自动将 `max_tokens` 从 8192 提升至 32768，避免 token 耗尽导致 `content=None`
- `_call_api` INFO 日志新增 `reasoning_chars` 字段，一眼看出推理模型是否正常输出
- 推理模型 token 耗尽时，WARNING 日志明确说明原因（而不是只显示 `content=None`）
- `generate_story` 空响应时区分"推理模型耗尽 token"与"找不到编号句子"，分别输出不同 ERROR 日志

### 小修复
- `main.py`：抑制 urllib3 DEBUG 日志（减少无关噪音）
- `static/app.js`：导入页面重复条目的默认操作改为 `move_import`

## 测试方法
- 启动服务，触发故事生成
- 观察日志中出现 `max_tokens=32768 reasoning_model=True` 字样
- 不应再出现 `content=None` + `no numbered sentences found` 连续失败

Closes #266