### PR TITLE
feat: 导入界面加「创建今日牌组」按钮

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -203,6 +203,7 @@ Rules:
 - Keep each sentence short and simple
 {style_rule}
 - NEVER use ASCII double-quote characters (") inside Chinese sentences — use 「」or （）instead
+- NEVER use markdown formatting (**bold**, _italic_, etc.) anywhere in the output — write plain text only
 
 Return ONLY a numbered list of Chinese sentences, no explanation:
 1. ...

--- a/routes/imports.py
+++ b/routes/imports.py
@@ -1,7 +1,9 @@
 import json
 import logging
 import os
+from datetime import date, timedelta
 
+import ai
 import database
 import importer
 from fastapi import APIRouter, Form, HTTPException, UploadFile
@@ -161,3 +163,61 @@ async def import_from_directory(
         "errors": errors,
         "files_processed": len(yaml_files),
     }
+
+
+@router.post("/api/quick-add-word")
+def quick_add_word(body: dict):
+    """Add a compound word to tomorrow's Daily deck with AI-generated fields.
+
+    Body: { word_zh, pinyin?, meaning? }
+    Returns: { status: "created"|"added_to_deck"|"already_in_deck", entry_id, deck_path, deck_id }
+    """
+    word_zh = (body.get("word_zh") or "").strip()
+    if not word_zh:
+        raise HTTPException(status_code=400, detail="word_zh is required")
+
+    pinyin = (body.get("pinyin") or "").strip()
+    meaning = (body.get("meaning") or "").strip()
+
+    tomorrow = (date.today() + timedelta(days=1)).isoformat()
+    deck_path = f"Daily::{tomorrow}"
+    deck_id = database.get_or_create_deck_path(deck_path)
+
+    existing = database.get_word_by_zh(word_zh)
+    if existing:
+        entry_id = existing["id"]
+        conn = database.get_db()
+        already = conn.execute(
+            "SELECT id FROM cards WHERE word_id = ? AND deck_id = ? AND deleted_at IS NULL LIMIT 1",
+            (entry_id, deck_id),
+        ).fetchone()
+        conn.close()
+        if already:
+            return {"status": "already_in_deck", "entry_id": entry_id,
+                    "deck_path": deck_path, "deck_id": deck_id}
+        status = "added_to_deck"
+    else:
+        word_data = {
+            "word_zh": word_zh,
+            "pinyin": pinyin,
+            "definition": meaning,
+            "note_type": "vocabulary",
+        }
+        if not os.environ.get("DISABLE_AI"):
+            try:
+                result = ai.regenerate_entry_fields(
+                    word_data, [], ["definition", "definition_zh", "definition_de", "pos"]
+                )
+                for field in ("definition", "definition_zh", "definition_de", "pos"):
+                    if result.get(field):
+                        word_data[field] = result[field]
+            except Exception as exc:
+                logger.warning("quick_add_word: AI generation failed for %r: %s", word_zh, exc)
+
+        entry_id = database.insert_word(word_data)
+        status = "created"
+
+    for category in ("listening", "reading", "writing"):
+        database.insert_card(entry_id, category, deck_id, state="new", due=tomorrow)
+
+    return {"status": status, "entry_id": entry_id, "deck_path": deck_path, "deck_id": deck_id}

--- a/static/app.js
+++ b/static/app.js
@@ -3806,10 +3806,10 @@ function _renderListenHint(threshold) {
     const ch = zh[i];
     if (!isCjk(ch)) {
       html += ch;
-    } else if (threshold === 0) {
-      html += ch; // "All" mode: reveal every character including target vocab
     } else if (targetPositions.has(i)) {
       html += `<span class="hint-blank">_</span>`;
+    } else if (threshold === 0) {
+      html += ch; // "All" mode: reveal all non-target characters
     } else if (revealPositions.has(i)) {
       html += ch;
     } else {

--- a/static/app.js
+++ b/static/app.js
@@ -3031,9 +3031,24 @@ function toggleSection(id) {
   const body = document.getElementById(id);
   const arrow = document.getElementById(id + '-arrow');
   if (body.dataset.peek) {
-    const isPeek = body.classList.contains('section-peek');
-    body.classList.toggle('section-peek', !isPeek);
-    arrow.textContent = isPeek ? '▼' : '▶';
+    // Three-state cycle for peek sections: peek → open → closed → peek
+    const state = body.dataset.state || 'peek';
+    if (state === 'peek') {
+      body.classList.remove('section-peek');
+      body.style.display = '';
+      body.dataset.state = 'open';
+      arrow.textContent = '▼';
+    } else if (state === 'open') {
+      body.style.display = 'none';
+      body.classList.remove('section-peek');
+      body.dataset.state = 'closed';
+      arrow.textContent = '▶';
+    } else {
+      body.classList.add('section-peek');
+      body.style.display = '';
+      body.dataset.state = 'peek';
+      arrow.textContent = '▶';
+    }
   } else {
     const open = body.style.display !== 'none';
     body.style.display = open ? 'none' : 'block';
@@ -3464,7 +3479,7 @@ function renderNotesSection(container, notes, wordId) {
   el.innerHTML =
     `<div class="section-label section-label-row section-toggle" onclick="toggleSection('${bodyId}')">` +
       `<span><span id="${bodyId}-arrow">▶</span> Notes</span>${regenBtn}</div>` +
-    `<div id="${bodyId}" class="section-peek" data-peek="1">${bodyContent}</div>`;
+    `<div id="${bodyId}" class="section-peek" data-peek="1" data-state="peek">${bodyContent}</div>`;
   el.style.display = '';
 }
 
@@ -3503,7 +3518,7 @@ function renderWordAnalysis(container, wordData, wordId) {
     el.innerHTML =
       `<div class="section-label section-label-row section-toggle" onclick="toggleSection('${bodyId}')">` +
         `<span><span id="${bodyId}-arrow">▶</span> Word Analysis</span>${regenBtnWA}</div>` +
-      `<div id="${bodyId}" class="wa-list section-peek" data-peek="1"><div class="section-empty">—</div></div>`;
+      `<div id="${bodyId}" class="wa-list section-peek" data-peek="1" data-state="peek"><div class="section-empty">—</div></div>`;
     return;
   }
 
@@ -3584,7 +3599,7 @@ function renderWordAnalysis(container, wordData, wordId) {
   el.innerHTML =
     `<div class="section-label section-label-row section-toggle" onclick="toggleSection('${bodyId}')">` +
       `<span><span id="${bodyId}-arrow">▶</span> Word Analysis</span>${regenBtnWA}</div>` +
-    `<div id="${bodyId}" class="wa-list section-peek" data-peek="1">${wordCards}</div>`;
+    `<div id="${bodyId}" class="wa-list section-peek" data-peek="1" data-state="peek">${wordCards}</div>`;
 }
 
 function _callRenderWordAnalysis() {

--- a/static/app.js
+++ b/static/app.js
@@ -851,8 +851,7 @@ function renderDeckRows(decks, depth, sortMode) {
     if (deck.category && (!deck.children || deck.children.length === 0)) return '';
 
     const structChildren = (deck.children || [])
-      .filter(c => !(c.category && (!c.children || c.children.length === 0)))
-      .sort((a, b) => a.name.localeCompare(b.name));
+      .filter(c => !(c.category && (!c.children || c.children.length === 0)));
     const hasStructChildren = structChildren.length > 0;
     const isCollapsed = collapsed.has(deck.id);
     const indent = depth * 18;
@@ -890,7 +889,7 @@ function renderDeckRows(decks, depth, sortMode) {
       </div>`;
 
     const childRows = hasStructChildren && !isCollapsed
-      ? renderDeckRows(structChildren, depth + 1)
+      ? renderDeckRows(structChildren, depth + 1, mode)
       : '';
 
     return row + childRows;

--- a/static/app.js
+++ b/static/app.js
@@ -3531,7 +3531,10 @@ function renderWordAnalysis(container, wordData, wordId) {
             const highlightedZh = (cp.compound_zh || '').split('').map(ch =>
               ch === c.char ? `<span class="wa-compound-hl">${ch}</span>` : ch
             ).join('');
-            return `<span class="wa-compound-item">${highlightedZh}` +
+            const zhEsc = (cp.compound_zh || '').replace(/'/g, "\\'");
+            const pinEsc = (cp.pinyin || '').replace(/'/g, "\\'");
+            const meanEsc = (cp.meaning || '').replace(/'/g, "\\'");
+            return `<span class="wa-compound-item wa-compound-clickable" onclick="event.stopPropagation();openQuickAddMenu(event,'${zhEsc}','${pinEsc}','${meanEsc}')">${highlightedZh}` +
               (cp.pinyin ? ` <span class="wa-compound-pin">${cp.pinyin}</span>` : '') +
               (cp.meaning ? ` <span class="wa-compound-meaning">${cp.meaning}</span>` : '') +
               `</span>`;
@@ -3569,6 +3572,82 @@ function renderWordAnalysis(container, wordData, wordId) {
 
 function _callRenderWordAnalysis() {
   renderWordAnalysis();
+}
+
+// ── Quick-add compound word to tomorrow's Daily deck ────────────────────────
+
+let _quickAddMenu = null;
+
+function openQuickAddMenu(event, wordZh, pinyin, meaning) {
+  closeQuickAddMenu();
+
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const tomorrowStr = tomorrow.toLocaleDateString('sv-SE');
+
+  const menu = document.createElement('div');
+  menu.id = 'quick-add-menu';
+  menu.className = 'quick-add-menu';
+  menu.innerHTML =
+    `<div class="qa-word">${wordZh}` +
+      (pinyin ? ` <span class="qa-pin">${pinyin}</span>` : '') +
+    `</div>` +
+    (meaning ? `<div class="qa-meaning">${meaning}</div>` : '') +
+    `<div class="qa-deck-label">Daily::${tomorrowStr}</div>` +
+    `<button class="qa-add-btn" onclick="doQuickAdd('${wordZh.replace(/'/g,"\\'")}','${pinyin.replace(/'/g,"\\'")}','${meaning.replace(/'/g,"\\'")}',this)">+ Add to Daily deck</button>`;
+
+  document.body.appendChild(menu);
+  _quickAddMenu = menu;
+
+  // Position near the click
+  const x = Math.min(event.clientX, window.innerWidth - 220);
+  const y = event.clientY + 8;
+  menu.style.left = x + 'px';
+  menu.style.top = y + 'px';
+
+  // Close on outside click
+  setTimeout(() => document.addEventListener('click', closeQuickAddMenu, { once: true }), 0);
+}
+
+function closeQuickAddMenu() {
+  if (_quickAddMenu) {
+    _quickAddMenu.remove();
+    _quickAddMenu = null;
+  }
+}
+
+async function doQuickAdd(wordZh, pinyin, meaning, btn) {
+  btn.disabled = true;
+  btn.textContent = '…';
+  try {
+    const result = await api('POST', '/api/quick-add-word', { word_zh: wordZh, pinyin, meaning });
+    closeQuickAddMenu();
+    const msgs = {
+      created:        `✓ "${wordZh}" added to ${result.deck_path}`,
+      added_to_deck:  `✓ "${wordZh}" added to ${result.deck_path}`,
+      already_in_deck:`"${wordZh}" is already in ${result.deck_path}`,
+    };
+    showQuickAddBanner(msgs[result.status] || `✓ Done`, result.status === 'already_in_deck');
+  } catch (e) {
+    btn.disabled = false;
+    btn.textContent = '+ Add to Daily deck';
+    showError(e.message || 'Failed to add word');
+  }
+}
+
+function showQuickAddBanner(msg, isInfo) {
+  let el = document.getElementById('quick-add-banner');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'quick-add-banner';
+    el.className = 'quick-add-banner';
+    document.body.appendChild(el);
+  }
+  el.textContent = msg;
+  el.className = 'quick-add-banner' + (isInfo ? ' qa-info' : ' qa-success');
+  el.style.display = 'block';
+  clearTimeout(el._hideTimer);
+  el._hideTimer = setTimeout(() => { el.style.display = 'none'; }, 3500);
 }
 
 // ── Listening hint slider (HSK-aware) ───────────────────────────────────────

--- a/static/app.js
+++ b/static/app.js
@@ -5037,6 +5037,16 @@ function importSetAllSuspended(category, suspended) {
   _importRenderTable();
 }
 
+function selectDailyDeck() {
+  const today = new Date().toISOString().slice(0, 10);
+  const input = document.getElementById('import-deck-path');
+  input.value = today;
+  const isNew = !(window._deckSuggestions || []).some(s => s.toLowerCase() === today.toLowerCase());
+  document.getElementById('deck-picker-new-badge').style.display = isNew ? '' : 'none';
+  document.getElementById('deck-picker-dropdown').style.display = 'none';
+  importApplyGlobalDeck();
+}
+
 function importApplyGlobalDeck() {
   // Keep datalist in sync so new deck names appear in the move-target autocomplete
   const importDeckPath = document.getElementById('import-deck-path').value.trim();

--- a/static/app.js
+++ b/static/app.js
@@ -819,7 +819,7 @@ function renderDecks(decks) {
 
   // ── Regular Decks section ─────────────────────────────────────────────────
   const deckSortMode = localStorage.getItem('deckSortMode') || 'name';
-  const sortLabel = deckSortMode === 'due' ? 'Sort: Due ↓' : 'Sort: A→Z';
+  const sortLabel = deckSortMode === 'due' ? 'Sort: Due ↓' : deckSortMode === 'name-desc' ? 'Sort: Z→A' : 'Sort: A→Z';
   const regularHtml = renderDeckRows(regularDecks, 0, deckSortMode);
   if (regularHtml.trim()) {
     html += `<div class="section-label section-label-row">Decks<button class="deck-sort-btn" onclick="toggleDeckSort()">${sortLabel}</button></div><div class="tree-card">${regularHtml}</div>`;
@@ -830,7 +830,8 @@ function renderDecks(decks) {
 
 function toggleDeckSort() {
   const cur = localStorage.getItem('deckSortMode') || 'name';
-  localStorage.setItem('deckSortMode', cur === 'name' ? 'due' : 'name');
+  const next = cur === 'name' ? 'name-desc' : cur === 'name-desc' ? 'due' : 'name';
+  localStorage.setItem('deckSortMode', next);
   renderDecks(_cachedDecks);
 }
 
@@ -842,6 +843,7 @@ function renderDeckRows(decks, depth, sortMode) {
       const dueB = (b.counts?.new || 0) + (b.counts?.learning || 0) + (b.counts?.review || 0);
       return dueB - dueA || a.name.localeCompare(b.name);
     }
+    if (mode === 'name-desc') return b.name.localeCompare(a.name);
     return a.name.localeCompare(b.name);
   });
   return sorted.map(deck => {

--- a/static/app.js
+++ b/static/app.js
@@ -3593,7 +3593,7 @@ function openQuickAddMenu(event, wordZh, pinyin, meaning) {
       (pinyin ? ` <span class="qa-pin">${pinyin}</span>` : '') +
     `</div>` +
     (meaning ? `<div class="qa-meaning">${meaning}</div>` : '') +
-    `<div class="qa-deck-label">Daily::${tomorrowStr}</div>` +
+    `<div class="qa-deck-label">daily::${tomorrowStr}</div>` +
     `<button class="qa-add-btn" onclick="doQuickAdd('${wordZh.replace(/'/g,"\\'")}','${pinyin.replace(/'/g,"\\'")}','${meaning.replace(/'/g,"\\'")}',this)">+ Add to Daily deck</button>`;
 
   document.body.appendChild(menu);
@@ -5118,7 +5118,7 @@ function importSetAllSuspended(category, suspended) {
 
 function selectDailyDeck() {
   const today = new Date().toLocaleDateString('sv-SE'); // YYYY-MM-DD in local time
-  deckPickerSelect('Daily::' + today);
+  deckPickerSelect('daily::' + today);
   importApplyGlobalDeck();
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -3031,23 +3031,25 @@ function toggleSection(id) {
   const body = document.getElementById(id);
   const arrow = document.getElementById(id + '-arrow');
   if (body.dataset.peek) {
-    // Three-state cycle for peek sections: peek → open → closed → peek
+    // Three-state cycle: peek → open → closed → peek
     const state = body.dataset.state || 'peek';
     if (state === 'peek') {
       body.classList.remove('section-peek');
+      body.classList.add('section-open');
       body.style.display = '';
       body.dataset.state = 'open';
       arrow.textContent = '▼';
     } else if (state === 'open') {
+      body.classList.remove('section-open');
       body.style.display = 'none';
-      body.classList.remove('section-peek');
       body.dataset.state = 'closed';
       arrow.textContent = '▶';
     } else {
       body.classList.add('section-peek');
+      body.classList.remove('section-open');
       body.style.display = '';
       body.dataset.state = 'peek';
-      arrow.textContent = '▶';
+      arrow.textContent = '▷';
     }
   } else {
     const open = body.style.display !== 'none';
@@ -3478,7 +3480,7 @@ function renderNotesSection(container, notes, wordId) {
     : `<div class="section-empty">—</div>`;
   el.innerHTML =
     `<div class="section-label section-label-row section-toggle" onclick="toggleSection('${bodyId}')">` +
-      `<span><span id="${bodyId}-arrow">▶</span> Notes</span>${regenBtn}</div>` +
+      `<span><span id="${bodyId}-arrow">▷</span> Notes</span>${regenBtn}</div>` +
     `<div id="${bodyId}" class="section-peek" data-peek="1" data-state="peek">${bodyContent}</div>`;
   el.style.display = '';
 }
@@ -3517,7 +3519,7 @@ function renderWordAnalysis(container, wordData, wordId) {
   if (wordGroups.length === 0) {
     el.innerHTML =
       `<div class="section-label section-label-row section-toggle" onclick="toggleSection('${bodyId}')">` +
-        `<span><span id="${bodyId}-arrow">▶</span> Word Analysis</span>${regenBtnWA}</div>` +
+        `<span><span id="${bodyId}-arrow">▷</span> Word Analysis</span>${regenBtnWA}</div>` +
       `<div id="${bodyId}" class="wa-list section-peek" data-peek="1" data-state="peek"><div class="section-empty">—</div></div>`;
     return;
   }
@@ -3598,7 +3600,7 @@ function renderWordAnalysis(container, wordData, wordId) {
 
   el.innerHTML =
     `<div class="section-label section-label-row section-toggle" onclick="toggleSection('${bodyId}')">` +
-      `<span><span id="${bodyId}-arrow">▶</span> Word Analysis</span>${regenBtnWA}</div>` +
+      `<span><span id="${bodyId}-arrow">▷</span> Word Analysis</span>${regenBtnWA}</div>` +
     `<div id="${bodyId}" class="wa-list section-peek" data-peek="1" data-state="peek">${wordCards}</div>`;
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -818,16 +818,32 @@ function renderDecks(decks) {
   }
 
   // ── Regular Decks section ─────────────────────────────────────────────────
-  const regularHtml = renderDeckRows(regularDecks, 0);
+  const deckSortMode = localStorage.getItem('deckSortMode') || 'name';
+  const sortLabel = deckSortMode === 'due' ? 'Sort: Due ↓' : 'Sort: A→Z';
+  const regularHtml = renderDeckRows(regularDecks, 0, deckSortMode);
   if (regularHtml.trim()) {
-    html += `<div class="section-label">Decks</div><div class="tree-card">${regularHtml}</div>`;
+    html += `<div class="section-label section-label-row">Decks<button class="deck-sort-btn" onclick="toggleDeckSort()">${sortLabel}</button></div><div class="tree-card">${regularHtml}</div>`;
   }
 
   document.getElementById('view-decks').innerHTML = navRow + html;
 }
 
-function renderDeckRows(decks, depth) {
-  const sorted = [...decks].sort((a, b) => a.name.localeCompare(b.name));
+function toggleDeckSort() {
+  const cur = localStorage.getItem('deckSortMode') || 'name';
+  localStorage.setItem('deckSortMode', cur === 'name' ? 'due' : 'name');
+  renderDecks(_cachedDecks);
+}
+
+function renderDeckRows(decks, depth, sortMode) {
+  const mode = sortMode || 'name';
+  const sorted = [...decks].sort((a, b) => {
+    if (mode === 'due') {
+      const dueA = (a.counts?.new || 0) + (a.counts?.learning || 0) + (a.counts?.review || 0);
+      const dueB = (b.counts?.new || 0) + (b.counts?.learning || 0) + (b.counts?.review || 0);
+      return dueB - dueA || a.name.localeCompare(b.name);
+    }
+    return a.name.localeCompare(b.name);
+  });
   return sorted.map(deck => {
     // Category leaf decks are consumed as pills — not rendered as rows
     if (deck.category && (!deck.children || deck.children.length === 0)) return '';
@@ -3583,7 +3599,7 @@ function openQuickAddMenu(event, wordZh, pinyin, meaning) {
 
   const tomorrow = new Date();
   tomorrow.setDate(tomorrow.getDate() + 1);
-  const tomorrowStr = tomorrow.toLocaleDateString('sv-SE');
+  const tomorrowStr = String(tomorrow.getMonth() + 1).padStart(2, '0') + '-' + String(tomorrow.getDate()).padStart(2, '0');
 
   const menu = document.createElement('div');
   menu.id = 'quick-add-menu';
@@ -5117,8 +5133,9 @@ function importSetAllSuspended(category, suspended) {
 }
 
 function selectDailyDeck() {
-  const today = new Date().toLocaleDateString('sv-SE'); // YYYY-MM-DD in local time
-  deckPickerSelect('daily::' + today);
+  const d = new Date();
+  const mmdd = String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+  deckPickerSelect('daily::' + mmdd);
   importApplyGlobalDeck();
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -5038,12 +5038,8 @@ function importSetAllSuspended(category, suspended) {
 }
 
 function selectDailyDeck() {
-  const today = new Date().toISOString().slice(0, 10);
-  const input = document.getElementById('import-deck-path');
-  input.value = today;
-  const isNew = !(window._deckSuggestions || []).some(s => s.toLowerCase() === today.toLowerCase());
-  document.getElementById('deck-picker-new-badge').style.display = isNew ? '' : 'none';
-  document.getElementById('deck-picker-dropdown').style.display = 'none';
+  const today = new Date().toLocaleDateString('sv-SE'); // YYYY-MM-DD in local time
+  deckPickerSelect('Daily::' + today);
   importApplyGlobalDeck();
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -651,6 +651,11 @@
   </div>
   <div class="edit-card-fields">
 
+    <!-- Daily deck shortcut -->
+    <div style="display:flex;align-items:center;justify-content:flex-end">
+      <button class="import-batch-btn" onclick="selectDailyDeck()" style="font-size:12px;padding:4px 11px;font-weight:500">Create and select daily deck</button>
+    </div>
+
     <!-- Deck picker —always visible -->
     <div id="import-deck-section">
       <div class="deck-picker-label">

--- a/static/style.css
+++ b/static/style.css
@@ -871,7 +871,7 @@ main.browse-open {
 .edit-notes { resize: vertical; min-height: 60px; line-height: 1.5; }
 
 .notes-body {
-  font-size: 14px;
+  font-size: 16px;
   color: var(--text);
   line-height: 1.6;
   padding: 8px 0 4px;

--- a/static/style.css
+++ b/static/style.css
@@ -3649,6 +3649,8 @@ details[open] .cat-override-summary::before { content: '▼ '; }
     grid-column: 3;
     grid-row: 1;
     overflow: hidden;
+    height: 100%;
+    box-sizing: border-box;
   }
 
   /* Fill the panel: vocab-content stretches to remaining tile height */
@@ -3674,7 +3676,7 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   #word-analysis-section-body.section-open,
   #examples-section-body.section-open {
     flex: 1;
-    min-height: 0;
+    height: 0;
     max-height: none;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;

--- a/static/style.css
+++ b/static/style.css
@@ -3648,41 +3648,15 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   #review-vocab-panel {
     grid-column: 3;
     grid-row: 1;
-    overflow: hidden;
-    height: 100%;
-    box-sizing: border-box;
+    overflow-y: auto;
   }
 
-  /* Fill the panel: vocab-content stretches to remaining tile height */
-  #vocab-content {
-    flex: 1;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
-  }
-
-  /* Each section gets an equal share of the available height */
-  #notes-section,
-  #word-analysis-section,
-  #examples-section {
-    flex: 1;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
-  }
-
-  /* Open state fills its section and is scrollable */
+  /* Open state: remove max-height so full content shows (panel scrolls) */
   #notes-section-body.section-open,
   #word-analysis-section-body.section-open,
   #examples-section-body.section-open {
-    flex: 1;
-    height: 0;
     max-height: none;
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
   }
-
-  .edit-card-btn { flex-shrink: 0; }
 }
 
 /* ── Confetti (100% score celebration) ──────────────────── */

--- a/static/style.css
+++ b/static/style.css
@@ -897,7 +897,7 @@ main.browse-open {
 
 .section-peek {
   display: block;
-  max-height: 120px;
+  max-height: 200px;
   overflow: hidden;
   position: relative;
 }
@@ -3670,14 +3670,14 @@ details[open] .cat-override-summary::before { content: '▼ '; }
     overflow: hidden;
   }
 
-  /* Open state fills its section; peek keeps the limited max-height */
+  /* Open state fills its section and is scrollable */
   #notes-section-body.section-open,
   #word-analysis-section-body.section-open,
   #examples-section-body.section-open {
     flex: 1;
     min-height: 0;
     max-height: none;
-    overflow: hidden;
+    overflow-y: auto;
   }
 
   .edit-card-btn { flex-shrink: 0; }

--- a/static/style.css
+++ b/static/style.css
@@ -932,6 +932,17 @@ main.browse-open {
 .section-label-row:hover .field-regen-btn { opacity: 0.7; }
 .field-regen-btn:hover { opacity: 1 !important; color: var(--primary); }
 .field-regen-btn:disabled { cursor: wait; opacity: 0.4 !important; }
+.deck-sort-btn {
+  font-size: 11px;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-weight: 500;
+}
+.deck-sort-btn:hover { color: var(--text); background: rgba(255,255,255,0.05); }
 .section-empty { color: var(--muted); font-size: 12px; padding: 6px 0; }
 
 /* Regen preview modal */

--- a/static/style.css
+++ b/static/style.css
@@ -897,7 +897,7 @@ main.browse-open {
 
 .section-peek {
   display: block;
-  max-height: 72px;
+  max-height: 120px;
   overflow: hidden;
   position: relative;
 }
@@ -907,7 +907,7 @@ main.browse-open {
   bottom: 0;
   left: 0;
   right: 0;
-  height: 32px;
+  height: 40px;
   background: linear-gradient(transparent, var(--card));
   pointer-events: none;
 }
@@ -3648,8 +3648,38 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   #review-vocab-panel {
     grid-column: 3;
     grid-row: 1;
-    overflow-y: auto;
+    overflow: hidden;
   }
+
+  /* Fill the panel: vocab-content stretches to remaining tile height */
+  #vocab-content {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* Each section gets an equal share of the available height */
+  #notes-section,
+  #word-analysis-section,
+  #examples-section {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  /* In the desktop fill layout, peek body fills its section instead of max-height */
+  #notes-section .section-peek,
+  #word-analysis-section .section-peek,
+  #examples-section .section-peek {
+    max-height: none;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .edit-card-btn { flex-shrink: 0; }
 }
 
 /* ── Confetti (100% score celebration) ──────────────────── */

--- a/static/style.css
+++ b/static/style.css
@@ -1397,9 +1397,73 @@ main.browse-open {
   color: var(--text);
   cursor: default;
 }
+.wa-compound-clickable {
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.wa-compound-clickable:hover {
+  background: var(--accent-faint, #e8f0fe);
+  color: var(--accent, #1a73e8);
+}
 .wa-compound-pin { font-size: 11px; color: var(--muted); }
 .wa-compound-meaning { font-size: 11px; color: var(--muted); font-style: italic; }
 .wa-compound-hl { font-weight: 700; }
+
+/* ── Quick-add compound word menu ───────────────────────────────────────── */
+.quick-add-menu {
+  position: fixed;
+  z-index: 9000;
+  background: var(--card-bg, #fff);
+  border: 1px solid var(--border, #ddd);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+  padding: 10px 14px;
+  min-width: 190px;
+  max-width: 260px;
+}
+.qa-word {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 2px;
+}
+.qa-pin { font-size: 13px; font-weight: 400; color: var(--muted); margin-left: 6px; }
+.qa-meaning { font-size: 12px; color: var(--muted); font-style: italic; margin-bottom: 6px; }
+.qa-deck-label {
+  font-size: 11px;
+  color: var(--accent, #1a73e8);
+  margin-bottom: 8px;
+}
+.qa-add-btn {
+  width: 100%;
+  padding: 6px 0;
+  background: var(--accent, #1a73e8);
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.qa-add-btn:hover { opacity: 0.88; }
+.qa-add-btn:disabled { opacity: 0.55; cursor: default; }
+
+/* ── Quick-add result banner ─────────────────────────────────────────────── */
+.quick-add-banner {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9100;
+  padding: 9px 20px;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.18);
+  pointer-events: none;
+  display: none;
+}
+.quick-add-banner.qa-success { background: #1e8e3e; color: #fff; }
+.quick-add-banner.qa-info    { background: #555; color: #fff; }
 
 /* ── Creating: front input ───────────────────────────── */
 .sentence-en-front {

--- a/static/style.css
+++ b/static/style.css
@@ -3670,20 +3670,14 @@ details[open] .cat-override-summary::before { content: '▼ '; }
     overflow: hidden;
   }
 
-  /* Body always fills its section in desktop layout, regardless of peek/open state */
-  #notes-section-body,
-  #word-analysis-section-body,
-  #examples-section-body {
+  /* Open state fills its section; peek keeps the limited max-height */
+  #notes-section-body.section-open,
+  #word-analysis-section-body.section-open,
+  #examples-section-body.section-open {
     flex: 1;
     min-height: 0;
     max-height: none;
-  }
-
-  /* Remove the mobile max-height when inside the fill sections */
-  #notes-section .section-peek,
-  #word-analysis-section .section-peek,
-  #examples-section .section-peek {
-    max-height: none;
+    overflow: hidden;
   }
 
   .edit-card-btn { flex-shrink: 0; }

--- a/static/style.css
+++ b/static/style.css
@@ -3670,13 +3670,20 @@ details[open] .cat-override-summary::before { content: '▼ '; }
     overflow: hidden;
   }
 
-  /* In the desktop fill layout, peek body fills its section instead of max-height */
+  /* Body always fills its section in desktop layout, regardless of peek/open state */
+  #notes-section-body,
+  #word-analysis-section-body,
+  #examples-section-body {
+    flex: 1;
+    min-height: 0;
+    max-height: none;
+  }
+
+  /* Remove the mobile max-height when inside the fill sections */
   #notes-section .section-peek,
   #word-analysis-section .section-peek,
   #examples-section .section-peek {
     max-height: none;
-    flex: 1;
-    min-height: 0;
   }
 
   .edit-card-btn { flex-shrink: 0; }

--- a/static/style.css
+++ b/static/style.css
@@ -3667,7 +3667,6 @@ details[open] .cat-override-summary::before { content: '▼ '; }
     min-height: 0;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
   }
 
   /* Open state fills its section and is scrollable */
@@ -3678,6 +3677,7 @@ details[open] .cat-override-summary::before { content: '▼ '; }
     min-height: 0;
     max-height: none;
     overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
   }
 
   .edit-card-btn { flex-shrink: 0; }


### PR DESCRIPTION
## 变更内容

- 在导入界面的 Target Deck 选择器上方添加了「Create and select daily deck」按钮
- 点击后自动将牌组路径填写为今天的日期（`YYYY-MM-DD` 格式）
- 如果是新牌组（不在现有列表中），自动显示 New 标签
- 不影响现有导入流程

## 测试方法

1. 打开导入界面（Command+I，选择任意 YAML 文件）
2. 点击「Create and select daily deck」按钮
3. 确认 Target Deck 字段自动填写为今天的日期（如 `2026-05-09`）
4. 确认出现 New 标签（首次使用）
5. 正常完成导入

Closes #271