### PR TITLE
feat: 词语分析中点击复合词快速添加到明日每日牌组

### DIFF
--- a/routes/imports.py
+++ b/routes/imports.py
@@ -1,7 +1,9 @@
 import json
 import logging
 import os
+from datetime import date, timedelta
 
+import ai
 import database
 import importer
 from fastapi import APIRouter, Form, HTTPException, UploadFile
@@ -161,3 +163,61 @@ async def import_from_directory(
         "errors": errors,
         "files_processed": len(yaml_files),
     }
+
+
+@router.post("/api/quick-add-word")
+def quick_add_word(body: dict):
+    """Add a compound word to tomorrow's Daily deck with AI-generated fields.
+
+    Body: { word_zh, pinyin?, meaning? }
+    Returns: { status: "created"|"added_to_deck"|"already_in_deck", entry_id, deck_path, deck_id }
+    """
+    word_zh = (body.get("word_zh") or "").strip()
+    if not word_zh:
+        raise HTTPException(status_code=400, detail="word_zh is required")
+
+    pinyin = (body.get("pinyin") or "").strip()
+    meaning = (body.get("meaning") or "").strip()
+
+    tomorrow = (date.today() + timedelta(days=1)).isoformat()
+    deck_path = f"Daily::{tomorrow}"
+    deck_id = database.get_or_create_deck_path(deck_path)
+
+    existing = database.get_word_by_zh(word_zh)
+    if existing:
+        entry_id = existing["id"]
+        conn = database.get_db()
+        already = conn.execute(
+            "SELECT id FROM cards WHERE word_id = ? AND deck_id = ? AND deleted_at IS NULL LIMIT 1",
+            (entry_id, deck_id),
+        ).fetchone()
+        conn.close()
+        if already:
+            return {"status": "already_in_deck", "entry_id": entry_id,
+                    "deck_path": deck_path, "deck_id": deck_id}
+        status = "added_to_deck"
+    else:
+        word_data = {
+            "word_zh": word_zh,
+            "pinyin": pinyin,
+            "definition": meaning,
+            "note_type": "vocabulary",
+        }
+        if not os.environ.get("DISABLE_AI"):
+            try:
+                result = ai.regenerate_entry_fields(
+                    word_data, [], ["definition", "definition_zh", "definition_de", "pos"]
+                )
+                for field in ("definition", "definition_zh", "definition_de", "pos"):
+                    if result.get(field):
+                        word_data[field] = result[field]
+            except Exception as exc:
+                logger.warning("quick_add_word: AI generation failed for %r: %s", word_zh, exc)
+
+        entry_id = database.insert_word(word_data)
+        status = "created"
+
+    for category in ("listening", "reading", "writing"):
+        database.insert_card(entry_id, category, deck_id, state="new", due=tomorrow)
+
+    return {"status": status, "entry_id": entry_id, "deck_path": deck_path, "deck_id": deck_id}

--- a/static/app.js
+++ b/static/app.js
@@ -3531,7 +3531,10 @@ function renderWordAnalysis(container, wordData, wordId) {
             const highlightedZh = (cp.compound_zh || '').split('').map(ch =>
               ch === c.char ? `<span class="wa-compound-hl">${ch}</span>` : ch
             ).join('');
-            return `<span class="wa-compound-item">${highlightedZh}` +
+            const zhEsc = (cp.compound_zh || '').replace(/'/g, "\\'");
+            const pinEsc = (cp.pinyin || '').replace(/'/g, "\\'");
+            const meanEsc = (cp.meaning || '').replace(/'/g, "\\'");
+            return `<span class="wa-compound-item wa-compound-clickable" onclick="event.stopPropagation();openQuickAddMenu(event,'${zhEsc}','${pinEsc}','${meanEsc}')">${highlightedZh}` +
               (cp.pinyin ? ` <span class="wa-compound-pin">${cp.pinyin}</span>` : '') +
               (cp.meaning ? ` <span class="wa-compound-meaning">${cp.meaning}</span>` : '') +
               `</span>`;
@@ -3569,6 +3572,82 @@ function renderWordAnalysis(container, wordData, wordId) {
 
 function _callRenderWordAnalysis() {
   renderWordAnalysis();
+}
+
+// ── Quick-add compound word to tomorrow's Daily deck ────────────────────────
+
+let _quickAddMenu = null;
+
+function openQuickAddMenu(event, wordZh, pinyin, meaning) {
+  closeQuickAddMenu();
+
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const tomorrowStr = tomorrow.toLocaleDateString('sv-SE');
+
+  const menu = document.createElement('div');
+  menu.id = 'quick-add-menu';
+  menu.className = 'quick-add-menu';
+  menu.innerHTML =
+    `<div class="qa-word">${wordZh}` +
+      (pinyin ? ` <span class="qa-pin">${pinyin}</span>` : '') +
+    `</div>` +
+    (meaning ? `<div class="qa-meaning">${meaning}</div>` : '') +
+    `<div class="qa-deck-label">Daily::${tomorrowStr}</div>` +
+    `<button class="qa-add-btn" onclick="doQuickAdd('${wordZh.replace(/'/g,"\\'")}','${pinyin.replace(/'/g,"\\'")}','${meaning.replace(/'/g,"\\'")}',this)">+ Add to Daily deck</button>`;
+
+  document.body.appendChild(menu);
+  _quickAddMenu = menu;
+
+  // Position near the click
+  const x = Math.min(event.clientX, window.innerWidth - 220);
+  const y = event.clientY + 8;
+  menu.style.left = x + 'px';
+  menu.style.top = y + 'px';
+
+  // Close on outside click
+  setTimeout(() => document.addEventListener('click', closeQuickAddMenu, { once: true }), 0);
+}
+
+function closeQuickAddMenu() {
+  if (_quickAddMenu) {
+    _quickAddMenu.remove();
+    _quickAddMenu = null;
+  }
+}
+
+async function doQuickAdd(wordZh, pinyin, meaning, btn) {
+  btn.disabled = true;
+  btn.textContent = '…';
+  try {
+    const result = await api('POST', '/api/quick-add-word', { word_zh: wordZh, pinyin, meaning });
+    closeQuickAddMenu();
+    const msgs = {
+      created:        `✓ "${wordZh}" added to ${result.deck_path}`,
+      added_to_deck:  `✓ "${wordZh}" added to ${result.deck_path}`,
+      already_in_deck:`"${wordZh}" is already in ${result.deck_path}`,
+    };
+    showQuickAddBanner(msgs[result.status] || `✓ Done`, result.status === 'already_in_deck');
+  } catch (e) {
+    btn.disabled = false;
+    btn.textContent = '+ Add to Daily deck';
+    showError(e.message || 'Failed to add word');
+  }
+}
+
+function showQuickAddBanner(msg, isInfo) {
+  let el = document.getElementById('quick-add-banner');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'quick-add-banner';
+    el.className = 'quick-add-banner';
+    document.body.appendChild(el);
+  }
+  el.textContent = msg;
+  el.className = 'quick-add-banner' + (isInfo ? ' qa-info' : ' qa-success');
+  el.style.display = 'block';
+  clearTimeout(el._hideTimer);
+  el._hideTimer = setTimeout(() => { el.style.display = 'none'; }, 3500);
 }
 
 // ── Listening hint slider (HSK-aware) ───────────────────────────────────────

--- a/static/style.css
+++ b/static/style.css
@@ -1397,9 +1397,73 @@ main.browse-open {
   color: var(--text);
   cursor: default;
 }
+.wa-compound-clickable {
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.wa-compound-clickable:hover {
+  background: var(--accent-faint, #e8f0fe);
+  color: var(--accent, #1a73e8);
+}
 .wa-compound-pin { font-size: 11px; color: var(--muted); }
 .wa-compound-meaning { font-size: 11px; color: var(--muted); font-style: italic; }
 .wa-compound-hl { font-weight: 700; }
+
+/* ── Quick-add compound word menu ───────────────────────────────────────── */
+.quick-add-menu {
+  position: fixed;
+  z-index: 9000;
+  background: var(--card-bg, #fff);
+  border: 1px solid var(--border, #ddd);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+  padding: 10px 14px;
+  min-width: 190px;
+  max-width: 260px;
+}
+.qa-word {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 2px;
+}
+.qa-pin { font-size: 13px; font-weight: 400; color: var(--muted); margin-left: 6px; }
+.qa-meaning { font-size: 12px; color: var(--muted); font-style: italic; margin-bottom: 6px; }
+.qa-deck-label {
+  font-size: 11px;
+  color: var(--accent, #1a73e8);
+  margin-bottom: 8px;
+}
+.qa-add-btn {
+  width: 100%;
+  padding: 6px 0;
+  background: var(--accent, #1a73e8);
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.qa-add-btn:hover { opacity: 0.88; }
+.qa-add-btn:disabled { opacity: 0.55; cursor: default; }
+
+/* ── Quick-add result banner ─────────────────────────────────────────────── */
+.quick-add-banner {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9100;
+  padding: 9px 20px;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.18);
+  pointer-events: none;
+  display: none;
+}
+.quick-add-banner.qa-success { background: #1e8e3e; color: #fff; }
+.quick-add-banner.qa-info    { background: #555; color: #fff; }
 
 /* ── Creating: front input ───────────────────────────── */
 .sentence-en-front {


### PR DESCRIPTION
## 变更内容

- 后端：新增 `POST /api/quick-add-word` 接口
  - 接受 `{ word_zh, pinyin?, meaning? }` 参数
  - 自动创建/获取 `Daily::YYYY-MM-DD`（明天日期）牌组
  - 调用 AI 生成 definition / definition_zh / definition_de / pos 字段（标准补全，非推理调用）
  - 为听力/阅读/写作三种类别插入新卡片，`state=new`，`due=明天`
  - 若词条已存在：直接添加卡片（不重新生成）
  - 若卡片已在该牌组：返回 `already_in_deck` 状态
  - `DISABLE_AI=1` 时优雅降级（使用现有 pinyin/meaning 创建词条）

- 前端：词语分析（Word Analysis）中的复合词（`.wa-compound-item`）可点击
  - 悬停高亮效果
  - 点击弹出浮动菜单：显示词语 + 拼音 + 含义 + 目标牌组名
  - 点击「Add to Daily deck」按钮 → 调用接口 → 底部显示成功/已存在提示条
  - 菜单点击外部自动关闭

## 测试方法

1. 复习一张词汇卡片，展开 Word Analysis 区域
2. 点击某个汉字下的复合词（例："学习"、"生活"）
3. 确认弹出菜单显示正确的词语信息和明日日期
4. 点击「Add to Daily deck」，等待 AI 生成（约 1-2 秒）
5. 底部出现绿色成功提示：`✓ "XXX" added to Daily::YYYY-MM-DD`
6. 再次点击同一个词，确认提示变为「已存在」

Closes #273