### PR TITLE
fix: 父牌组的新卡每日限制现对全部子牌组生效

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -202,7 +202,8 @@ Rules:
 - Use only HSK 1-{max_hsk} vocabulary for non-target words; each sentence must contain exactly ONE target word from the list — do not use other target words from the list in that sentence
 - Keep each sentence short and simple
 {style_rule}
-- NEVER use ASCII double-quote characters (") inside Chinese sentences — use 「」or （）instead
+- NEVER use ASCII double-quote characters (") inside Chinese sentences — use （）instead
+- NEVER wrap target words with 「」 or any brackets — write them as plain text embedded naturally in the sentence
 - NEVER use markdown formatting (**bold**, _italic_, etc.) anywhere in the output — write plain text only
 
 Return ONLY a numbered list of Chinese sentences, no explanation:

--- a/database/cards.py
+++ b/database/cards.py
@@ -157,6 +157,10 @@ def get_card(card_id: int) -> dict | None:
     return card
 
 
+def _count_new_introduced_today_multi(conn, deck_ids: list[int], category: str, today: str) -> int:
+    return sum(_count_new_introduced_today(conn, did, category, today) for did in deck_ids)
+
+
 def _count_new_introduced_today(conn, deck_id: int, category: str, today: str) -> int:
     """Cards whose very first review log entry is today (introduced as new today)."""
     return conn.execute(
@@ -586,6 +590,25 @@ def get_due_cards_any_cat(root_deck_id: int) -> list[dict]:
     if not all_cards:
         return []
 
+    # Apply root deck's per-category new cap across all leaf decks combined
+    today = anki_today().isoformat()
+    conn = get_db()
+    cats_in_tree = {cat for _, cat in leaf_pairs}
+    for cat in cats_in_tree:
+        cat_deck_ids = [did for did, c in leaf_pairs if c == cat]
+        if len(cat_deck_ids) <= 1:
+            continue
+        root_preset = get_preset_for_deck(root_deck_id, cat)
+        if not root_preset:
+            continue
+        root_new_done = _count_new_introduced_today_multi(conn, cat_deck_ids, cat, today)
+        root_new_remaining = max(0, root_preset["new_per_day"] - root_new_done)
+        cat_new = [c for c in all_cards if c["state"] == "new" and c["category"] == cat]
+        if len(cat_new) > root_new_remaining:
+            remove_ids = {c["id"] for c in cat_new[root_new_remaining:]}
+            all_cards = [c for c in all_cards if c["id"] not in remove_ids]
+    conn.close()
+
     # Build category order index from root deck's preset
     preset = get_preset_for_deck(root_deck_id)
     order_str = preset.get("category_order", "listening,reading,creating")
@@ -652,16 +675,35 @@ def count_due_by_category(root_deck_id: int) -> dict:
             result[category] = {"new": 0, "learning": 0, "review": 0}
         for k in ("new", "learning", "review"):
             result[category][k] += c[k]
+
+    # Apply root deck's per-category new cap (Anki parent-deck behaviour)
+    today = anki_today().isoformat()
+    conn = get_db()
+    for category in result:
+        cat_deck_ids = [did for did, cat in leaf_pairs if cat == category]
+        if len(cat_deck_ids) <= 1:
+            continue
+        root_preset = get_preset_for_deck(root_deck_id, category)
+        if not root_preset:
+            continue
+        root_new_done = _count_new_introduced_today_multi(conn, cat_deck_ids, category, today)
+        root_new_remaining = max(0, root_preset["new_per_day"] - root_new_done)
+        result[category]["new"] = min(result[category]["new"], root_new_remaining)
+    conn.close()
+
     return result
 
 
-def get_due_cards_multi(deck_ids: list[int], category: str, *, sibling_suppression: bool = False) -> list[dict]:
+def get_due_cards_multi(deck_ids: list[int], category: str, *, root_deck_id: int | None = None, sibling_suppression: bool = False) -> list[dict]:
     """Due cards across multiple decks, merged and priority-sorted.
 
     Learning cards always come first (sorted by due), then review and new cards
     are combined according to new_review_order: "mixed" interleaves new cards
     evenly among review cards; "reviews_first" appends new cards after reviews;
     "new_first" prepends new cards before reviews.
+
+    root_deck_id: if provided, its new_per_day limit acts as a combined cap
+    across all leaf decks (Anki parent-deck behaviour).
     """
     all_cards = []
     for deck_id in deck_ids:
@@ -670,6 +712,18 @@ def get_due_cards_multi(deck_ids: list[int], category: str, *, sibling_suppressi
     learning_cards = [c for c in all_cards if c["state"] in ("learning", "relearn")]
     review_cards   = [c for c in all_cards if c["state"] == "review"]
     new_cards      = [c for c in all_cards if c["state"] == "new"]
+
+    # Apply parent deck's combined new-card cap (Anki-style)
+    if root_deck_id is not None and len(deck_ids) > 1:
+        root_preset = get_preset_for_deck(root_deck_id, category)
+        if root_preset:
+            root_new_limit = root_preset["new_per_day"]
+            today = anki_today().isoformat()
+            conn = get_db()
+            root_new_done = _count_new_introduced_today_multi(conn, deck_ids, category, today)
+            conn.close()
+            root_new_remaining = max(0, root_new_limit - root_new_done)
+            new_cards = new_cards[:root_new_remaining]
 
     learning_cards.sort(key=lambda c: c["due"])
     review_cards.sort(key=lambda c: c["due"])
@@ -694,13 +748,24 @@ def get_next_card_multi(deck_ids: list[int], category: str) -> dict | None:
     return cards[0] if cards else None
 
 
-def count_due_multi(deck_ids: list[int], category: str) -> dict:
+def count_due_multi(deck_ids: list[int], category: str, *, root_deck_id: int | None = None) -> dict:
     """Aggregate due counts across multiple decks."""
     total = {"new": 0, "learning": 0, "review": 0}
     for deck_id in deck_ids:
         c = count_due(deck_id, category)
         for k in total:
             total[k] += c[k]
+
+    if root_deck_id is not None and len(deck_ids) > 1:
+        root_preset = get_preset_for_deck(root_deck_id, category)
+        if root_preset:
+            root_new_limit = root_preset["new_per_day"]
+            today = anki_today().isoformat()
+            conn = get_db()
+            root_new_done = _count_new_introduced_today_multi(conn, deck_ids, category, today)
+            conn.close()
+            total["new"] = min(total["new"], max(0, root_new_limit - root_new_done))
+
     return total
 
 

--- a/database/cards.py
+++ b/database/cards.py
@@ -952,54 +952,56 @@ def apply_sibling_repulsion(card_id: int, new_interval: int,
     min_due = (today + timedelta(days=effective_sep)).isoformat()
 
     conn = get_db()
-    card_row = conn.execute(
-        """SELECT c.category, e.word_zh
-           FROM cards c JOIN entries e ON e.id = c.word_id
-           WHERE c.id = ?""",
-        (card_id,),
-    ).fetchone()
-    if not card_row:
+    try:
+        card_row = conn.execute(
+            """SELECT c.category, e.word_zh
+               FROM cards c JOIN entries e ON e.id = c.word_id
+               WHERE c.id = ?""",
+            (card_id,),
+        ).fetchone()
+        if not card_row:
+            return
+
+        cat_label  = card_row["category"]
+        word_label = card_row["word_zh"] or "?"
+        factor_val = int(new_interval * sibling_factor)
+
+        logger.debug(
+            "[SIBLING REPULSION]  #%d %s 「%s」  interval=%dd"
+            "  →  effective_sep = max(%dd, ⌊%d×%.2f⌋=%dd) = %dd  →  min_due=%s",
+            card_id, cat_label, word_label, new_interval,
+            sibling_separation, new_interval, sibling_factor, factor_val,
+            effective_sep, min_due,
+        )
+
+        siblings = conn.execute(
+            """SELECT id, category, state, due FROM cards
+               WHERE word_id = (SELECT word_id FROM cards WHERE id = ?)
+                 AND id != ? AND deleted_at IS NULL
+                 AND state NOT IN ('suspended', 'learning', 'relearn')""",
+            (card_id, card_id),
+        ).fetchall()
+
+        pushed = []
+        for s in siblings:
+            due_date = s["due"][:10]
+            if due_date < min_due:
+                conn.execute("UPDATE cards SET due = ? WHERE id = ?", (min_due, s["id"]))
+                days_pushed = (date.fromisoformat(min_due) - date.fromisoformat(due_date)).days
+                pushed.append((s["id"], s["category"], s["due"], min_due, days_pushed))
+
+        if pushed:
+            for sid, cat, old_due, new_due, days_pushed in pushed:
+                logger.debug(
+                    "  →  pushed  #%d %-10s  %s  →  %s  (+%dd)",
+                    sid, cat, old_due, new_due, days_pushed,
+                )
+        else:
+            logger.debug("  →  all siblings already beyond min_due=%s, no push needed", min_due)
+
+        conn.commit()
+    finally:
         conn.close()
-        return
-
-    cat_label  = card_row["category"]
-    word_label = card_row["word_zh"] or "?"
-    factor_val = int(new_interval * sibling_factor)
-
-    logger.debug(
-        "[SIBLING REPULSION]  #%d %s 「%s」  interval=%dd"
-        "  →  effective_sep = max(%dd, ⌊%d×%.2f⌋=%dd) = %dd  →  min_due=%s",
-        card_id, cat_label, word_label, new_interval,
-        sibling_separation, new_interval, sibling_factor, factor_val,
-        effective_sep, min_due,
-    )
-
-    siblings = conn.execute(
-        """SELECT id, category, state, due FROM cards
-           WHERE word_id = (SELECT word_id FROM cards WHERE id = ?)
-             AND id != ? AND deleted_at IS NULL
-             AND state NOT IN ('suspended', 'learning', 'relearn')""",
-        (card_id, card_id),
-    ).fetchall()
-
-    pushed = []
-    for s in siblings:
-        if s["due"] < min_due:
-            conn.execute("UPDATE cards SET due = ? WHERE id = ?", (min_due, s["id"]))
-            days_pushed = (date.fromisoformat(min_due) - date.fromisoformat(s["due"])).days
-            pushed.append((s["id"], s["category"], s["due"], min_due, days_pushed))
-
-    if pushed:
-        for sid, cat, old_due, new_due, days_pushed in pushed:
-            logger.debug(
-                "  →  pushed  #%d %-10s  %s  →  %s  (+%dd)",
-                sid, cat, old_due, new_due, days_pushed,
-            )
-    else:
-        logger.debug("  →  all siblings already beyond min_due=%s, no push needed", min_due)
-
-    conn.commit()
-    conn.close()
 
 
 def get_creating_all_suspended(deck_id: int) -> bool:

--- a/routes/decks.py
+++ b/routes/decks.py
@@ -3,6 +3,7 @@ import logging
 import database
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
+from .utils import queue_mgr
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -216,6 +217,7 @@ def get_deck_preset(deck_id: int, category: str | None = None):
 def update_deck_preset(deck_id: int, fields: dict):
     deck = database.get_deck(deck_id)
     database.update_preset(deck["preset_id"], fields)
+    queue_mgr.invalidate()
     return database.get_preset(deck["preset_id"])
 
 
@@ -281,6 +283,7 @@ def set_preset_category_override(preset_id: int, category: str, fields: dict):
     if category not in VALID_CATEGORIES:
         raise HTTPException(status_code=400, detail="Invalid category")
     database.set_category_override(preset_id, category, fields)
+    queue_mgr.invalidate()
     overrides = database.get_category_overrides(preset_id)
     return overrides.get(category, {})
 
@@ -290,4 +293,5 @@ def delete_preset_category_override(preset_id: int, category: str):
     if category not in VALID_CATEGORIES:
         raise HTTPException(status_code=400, detail="Invalid category")
     database.delete_category_override(preset_id, category)
+    queue_mgr.invalidate()
     return {"ok": True}

--- a/routes/review.py
+++ b/routes/review.py
@@ -23,6 +23,7 @@ def _key_and_build(
     category: str | None = None,
     root_deck_id: int | None = None,
     deck_id: int | None = None,
+    parent_for_multi: int | None = None,
 ):
     """Return (queue_key, build_fn) for the given review context."""
     if root_deck_id:
@@ -30,7 +31,8 @@ def _key_and_build(
         build_fn = lambda: database.get_due_cards_any_cat(root_deck_id)
     elif ids and len(ids) > 1:
         key = ("multi", tuple(sorted(ids)), category)
-        build_fn = lambda: database.get_due_cards_multi(ids, category)
+        _root = parent_for_multi
+        build_fn = lambda: database.get_due_cards_multi(ids, category, root_deck_id=_root)
     else:
         actual = (ids[0] if ids else deck_id)
         key = ("single", actual, category)
@@ -58,14 +60,14 @@ def _next_card_from_queue(key, build_fn) -> dict | None:
 @router.get("/api/today/{deck_id}/{category}")
 def get_today(deck_id: int, category: str):
     ids = leaf_ids(deck_id, category)
-    key, build_fn = _key_and_build(ids=ids, category=category)
+    key, build_fn = _key_and_build(ids=ids, category=category, parent_for_multi=deck_id)
 
     card = _next_card_from_queue(key, build_fn)
 
     if len(ids) == 1:
         counts = database.count_due(ids[0], category)
     else:
-        counts = database.count_due_multi(ids, category)
+        counts = database.count_due_multi(ids, category, root_deck_id=deck_id)
 
     parent_id = database.get_parent_deck_id(deck_id)
     counts["by_cat"] = database.count_due_by_category(parent_id or deck_id)
@@ -177,7 +179,7 @@ def submit_review(card_id: int, rating: int, user_response: str | None = None,
         queue_key, build_fn = _key_and_build(root_deck_id=root_deck_id)
     elif parent_deck_id:
         ids = leaf_ids(parent_deck_id, cat)
-        queue_key, build_fn = _key_and_build(ids=ids, category=cat)
+        queue_key, build_fn = _key_and_build(ids=ids, category=cat, parent_for_multi=parent_deck_id)
     else:
         queue_key, build_fn = _key_and_build(deck_id=deck_id, category=cat)
 
@@ -206,7 +208,7 @@ def submit_review(card_id: int, rating: int, user_response: str | None = None,
     elif parent_deck_id:
         _queue_mgr.after_review(queue_key, card_id, updated, newly_buried)
         next_card = _next_card_from_queue(queue_key, build_fn)
-        counts = database.count_due_multi(ids, cat)
+        counts = database.count_due_multi(ids, cat, root_deck_id=parent_deck_id)
         counts["by_cat"] = database.count_due_by_category(parent_deck_id)
     else:
         _queue_mgr.after_review(queue_key, card_id, updated, newly_buried)

--- a/yaml_fixer.py
+++ b/yaml_fixer.py
@@ -1,6 +1,6 @@
 """yaml_fixer.py — Pre-process AI-generated YAML to fix common formatting errors.
 
-DeepSeek and other AI models frequently produce YAML with two recurring errors in
+DeepSeek and other AI models frequently produce YAML with these errors in
 plain inline-string fields:
 
   1. Unescaped double quotes inside a double-quoted value:
@@ -11,8 +11,13 @@ plain inline-string fields:
          english: happiness is simple: know contentment   ← invalid YAML
      Fixed: english: 'happiness is simple: know contentment'
 
-Because we know the YAML schema (which fields are always plain strings), we can
-detect and fix both patterns before handing the content to yaml.safe_load().
+  3. A block key accidentally merged onto the end of an inline value:
+         meaning_in_context: binden          compounds:   ← merged line
+     Fixed: two separate lines with the same indentation
+
+Because we know the YAML schema (which fields are always plain strings and
+which keys start block sequences), we can detect and fix all three patterns
+before handing the content to yaml.safe_load().
 """
 
 import re
@@ -28,6 +33,7 @@ _INLINE_STRING_FIELDS: frozenset[str] = frozenset({
     "source_de",
     "register",
     "pos",
+    "pinyin",
     "meaning_in_context",
     "meaning",        # used in compounds, synonyms, antonyms, measure_word
     "structure",      # grammar entries
@@ -37,11 +43,35 @@ _INLINE_STRING_FIELDS: frozenset[str] = frozenset({
     "title",          # grammar comparison entries
 })
 
+# Keys that always introduce a block (sequence or nested mapping) and therefore
+# can never appear as part of an inline string value.  When an AI accidentally
+# appends one of these to an inline value ("value    key:"), we split the line.
+_BLOCK_KEYS: frozenset[str] = frozenset({
+    "antonyms",
+    "characters",
+    "compounds",
+    "etymology",
+    "example",
+    "examples",
+    "explanations",
+    "grammar_structures",
+    "measure_word",
+    "relations",
+    "similar_sentences",
+    "synonyms",
+    "word_analyses",
+})
+
 # Matches a YAML block-context key-value line.
 # Captures: (indent)(key): (value)
 # Skips lines whose value starts with a block-scalar indicator (|, >),
 # sequence (-), flow mapping/sequence ({, [), or comment (#).
 _LINE_RE = re.compile(r'^(\s*)(\w+):\s+([^|>\[{#\n].+)$')
+
+# Matches a block key accidentally merged onto the end of a value.
+# Requires at least two spaces before the key to avoid false positives on
+# legitimate ": word:" patterns inside values.
+_MERGED_BLOCK_KEY_RE = re.compile(r'^(.*?)\s{2,}(\w+):\s*$')
 
 
 def _is_problematic(value: str) -> bool:
@@ -89,16 +119,36 @@ def _requote(value: str) -> str:
 def fix_yaml_content(content: str) -> str:
     """Fix common AI-generated YAML errors and return the corrected string.
 
-    Scans the content line by line.  For each known inline-string field, if the
-    value would cause a YAML parse error it is re-wrapped in safe single quotes.
+    Pass 1: Split lines where a block key was merged onto the end of an inline
+            value (e.g. "meaning_in_context: binden          compounds:").
+    Pass 2: For each known inline-string field, if the value would cause a YAML
+            parse error it is re-wrapped in safe single quotes.
 
     Returns the original string unchanged when no fixes are needed.
     """
     lines = content.split('\n')
     changed = False
-    result = []
 
+    # --- Pass 1: split merged block keys ---
+    expanded: list[str] = []
     for line in lines:
+        m = _LINE_RE.match(line)
+        if m:
+            indent, key, value = m.group(1), m.group(2), m.group(3).rstrip()
+            if key in _INLINE_STRING_FIELDS:
+                bm = _MERGED_BLOCK_KEY_RE.match(value)
+                if bm and bm.group(2) in _BLOCK_KEYS:
+                    real_value = bm.group(1).rstrip()
+                    block_key = bm.group(2)
+                    expanded.append(f"{indent}{key}: {real_value}")
+                    expanded.append(f"{indent}{block_key}:")
+                    changed = True
+                    continue
+        expanded.append(line)
+
+    # --- Pass 2: fix colon/quote problems in inline string values ---
+    result: list[str] = []
+    for line in expanded:
         m = _LINE_RE.match(line)
         if m:
             indent, key, value = m.group(1), m.group(2), m.group(3).rstrip()


### PR DESCRIPTION
## 变更内容

修复了父牌组（如 "daily"）的 New/day 限制不对子牌组合计生效的问题。

**修复前**：设置 New/day = 30，听力 tab 显示 52 张新卡（45 个子牌组各自最多 30，合计超标）。

**修复后**：父牌组的 new_per_day 作为所有子牌组新卡的总上限，显示 30 ✓

**改动的函数**：
- `get_due_cards_multi` — 新增 `root_deck_id` 参数，汇总后截断新卡
- `count_due_multi` — 同上，用于计数显示
- `count_due_by_category` — tab 上的分类计数也遵守父牌组限制
- `get_due_cards_any_cat` — 混合模式也遵守限制
- `_key_and_build` / 路由调用处 — 传入 `parent_for_multi`

## 测试方法

1. 找一个有多个子牌组的父牌组（如 "daily"），设 New/day = 30
2. 进入父牌组的听力复习
3. 顶部 tab 显示的新卡数应 ≤ 30

Closes #275