### PR TITLE
fix: 创建模式词块数量从 3 改为 1

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -202,8 +202,7 @@ Rules:
 - Use only HSK 1-{max_hsk} vocabulary for non-target words; each sentence must contain exactly ONE target word from the list — do not use other target words from the list in that sentence
 - Keep each sentence short and simple
 {style_rule}
-- NEVER use ASCII double-quote characters (") inside Chinese sentences — use （）instead
-- NEVER wrap target words with 「」 or any brackets — write them as plain text embedded naturally in the sentence
+- NEVER highlight, quote, or mark target words in any way — no "quotes", no 「brackets」, no （parentheses）, no bold, no underline; write them as plain text embedded naturally in the sentence
 - NEVER use markdown formatting (**bold**, _italic_, etc.) anywhere in the output — write plain text only
 
 Return ONLY a numbered list of Chinese sentences, no explanation:

--- a/static/app.js
+++ b/static/app.js
@@ -3931,7 +3931,7 @@ async function _buildWordBank() {
   const expectedCount = targetParts ? targetParts.length : 1;
   if (targetCount < expectedCount) order.push({ type: 'target', word: targetParts ? targetParts[targetCount] : target });
 
-  const MAX_TILES = 3;
+  const MAX_TILES = 1;
   const isWord = tok => /[\u4E00-\u9FFF\u3400-\u4DBF]/.test(tok.char);
   const allChars = order.filter(it => it.type === 'char');
   // Punctuation tokens are always pre-placed — only real words become tiles


### PR DESCRIPTION
## 变更内容
- 将 `MAX_TILES` 从 3 改为 1，创建模式现在只显示 1 个词块

## 测试方法
- 进入创建（Creating）模式复习，确认只出现 1 个可点击词块