### PR TITLE
feat: 添加快速复习模式（⚡，跳过 AI 故事生成）

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -1142,6 +1142,134 @@ def toggle_category_suspension(deck_id: int, category: str) -> dict:
     return {"all_suspended": not has_active}
 
 
+def count_due_all_decks() -> dict:
+    """Bulk count due cards for ALL decks in 4 queries instead of ~4 per deck.
+
+    Returns {(deck_id, category): {new, learning, review, learning_future}}.
+    Also returns suspension flags as a second dict:
+    {(deck_id, category): all_suspended_bool}.
+    """
+    today = anki_today().isoformat()
+    now = datetime.now().isoformat(timespec="seconds")
+    today_end = (anki_today() + timedelta(days=1)).isoformat()
+
+    conn = get_db()
+
+    # 1. Due cards grouped by (deck_id, category, state)
+    due_rows = conn.execute(
+        """SELECT c.deck_id, c.category, c.state, COUNT(*) AS cnt
+           FROM cards c
+           WHERE c.state != 'suspended'
+             AND c.deleted_at IS NULL
+             AND (c.buried_until IS NULL OR c.buried_until < ?)
+             AND (
+               (c.state IN ('learning', 'relearn') AND c.due <= ?)
+               OR (c.state = 'review' AND c.due <= ?)
+               OR (c.state = 'new' AND c.due <= ?)
+             )
+           GROUP BY c.deck_id, c.category, c.state""",
+        (today, now, today, today),
+    ).fetchall()
+
+    # 2. Future learning cards grouped by (deck_id, category)
+    future_rows = conn.execute(
+        """SELECT deck_id, category, COUNT(*) AS cnt
+           FROM cards
+           WHERE state IN ('learning', 'relearn')
+             AND due > ?
+             AND deleted_at IS NULL
+             AND (buried_until IS NULL OR buried_until < ?)
+           GROUP BY deck_id, category""",
+        (now, today),
+    ).fetchall()
+
+    # 3. New cards introduced today grouped by (deck_id, category)
+    new_today_rows = conn.execute(
+        """SELECT c.deck_id, c.category, COUNT(DISTINCT c.id) AS cnt
+           FROM cards c
+           WHERE EXISTS (
+               SELECT 1 FROM review_log rl
+               WHERE rl.card_id = c.id
+                 AND rl.reviewed_at >= ?
+                 AND rl.reviewed_at < ?
+           )
+           AND NOT EXISTS (
+               SELECT 1 FROM review_log rl
+               WHERE rl.card_id = c.id
+                 AND rl.reviewed_at < ?
+           )
+           GROUP BY c.deck_id, c.category""",
+        (today, today_end, today),
+    ).fetchall()
+
+    # 4. new_per_day limit per (deck_id, category) with category overrides
+    limit_rows = conn.execute(
+        """SELECT d.id AS deck_id, d.category,
+                  COALESCE(pco.new_per_day, p.new_per_day, 20) AS new_per_day
+           FROM decks d
+           JOIN deck_presets p ON p.id = d.preset_id
+           LEFT JOIN preset_category_overrides pco
+             ON pco.preset_id = d.preset_id AND pco.category = d.category
+           WHERE d.deleted_at IS NULL""",
+    ).fetchall()
+
+    # 5. Suspension flags: all cards suspended per (deck_id, category)?
+    susp_rows = conn.execute(
+        """SELECT c.deck_id, c.category,
+                  COUNT(*) AS total,
+                  SUM(CASE WHEN c.state = 'suspended' THEN 1 ELSE 0 END) AS suspended_count
+           FROM cards c
+           JOIN entries e ON e.id = c.word_id
+           WHERE c.deleted_at IS NULL
+             AND e.note_type != 'sentence'
+           GROUP BY c.deck_id, c.category""",
+    ).fetchall()
+
+    conn.close()
+
+    # Build counts dict
+    counts: dict[tuple, dict] = {}
+    for row in due_rows:
+        key = (row["deck_id"], row["category"])
+        if key not in counts:
+            counts[key] = {"new_raw": 0, "learning": 0, "review": 0, "learning_future": 0}
+        s = row["state"]
+        if s in ("learning", "relearn"):
+            counts[key]["learning"] += row["cnt"]
+        elif s == "review":
+            counts[key]["review"] += row["cnt"]
+        elif s == "new":
+            counts[key]["new_raw"] += row["cnt"]
+
+    for row in future_rows:
+        key = (row["deck_id"], row["category"])
+        if key not in counts:
+            counts[key] = {"new_raw": 0, "learning": 0, "review": 0, "learning_future": 0}
+        counts[key]["learning_future"] = row["cnt"]
+
+    new_today: dict[tuple, int] = {
+        (r["deck_id"], r["category"]): r["cnt"] for r in new_today_rows
+    }
+    new_limits: dict[tuple, int] = {
+        (r["deck_id"], r["category"]): r["new_per_day"] for r in limit_rows
+    }
+
+    for key, c in counts.items():
+        limit = new_limits.get(key, 20)
+        done = new_today.get(key, 0)
+        c["new"] = min(c.pop("new_raw", 0), max(0, limit - done))
+
+    # Build suspension flags dict
+    susp_flags: dict[tuple, bool] = {}
+    for row in susp_rows:
+        key = (row["deck_id"], row["category"])
+        total = row["total"] or 0
+        suspended = row["suspended_count"] or 0
+        susp_flags[key] = total > 0 and total == suspended
+
+    return counts, susp_flags
+
+
 def get_deck_all_suspended(deck_id: int) -> bool:
     """Return True if ALL non-sentence cards in deck and all descendant decks are suspended."""
     conn = get_db()

--- a/routes/decks.py
+++ b/routes/decks.py
@@ -34,18 +34,37 @@ def _leaf_pairs(deck: dict) -> list[tuple[int, str]]:
 
 
 def _attach_counts(flat_decks: list) -> None:
-    """Compute due counts for leaf decks; deduplicated aggregate for parents."""
+    """Compute due counts for all decks using bulk queries (O(1) DB round-trips)."""
+    all_counts, susp_flags = database.count_due_all_decks()
+    empty = {"new": 0, "learning": 0, "review": 0, "learning_future": 0}
+
     for deck in flat_decks:
         if not deck.get("children"):
             cat = deck.get("category")
-            deck["counts"] = database.count_due(deck["id"], cat) if cat else {"new": 0, "learning": 0, "review": 0}
-            if cat in ("creating", "listening", "reading"):
-                deck["all_suspended"] = database.get_category_all_suspended(deck["id"], cat)
+            if cat:
+                deck["counts"] = all_counts.get((deck["id"], cat), dict(empty))
+                if cat in ("creating", "listening", "reading"):
+                    deck["all_suspended"] = susp_flags.get((deck["id"], cat), False)
+            else:
+                deck["counts"] = dict(empty)
+
     for deck in reversed(flat_decks):
         if deck.get("children"):
             pairs = _leaf_pairs(deck)
-            deck["counts"] = database.count_due_deduped(pairs) if pairs else {"new": 0, "learning": 0, "review": 0}
-            deck["deck_all_suspended"] = database.get_deck_all_suspended(deck["id"])
+            if pairs:
+                merged: dict = {"new": 0, "learning": 0, "review": 0, "learning_future": 0}
+                for did, cat in pairs:
+                    c = all_counts.get((did, cat), empty)
+                    for k in merged:
+                        merged[k] += c.get(k, 0)
+                deck["counts"] = merged
+                # all_suspended = every leaf's category is fully suspended
+                deck["deck_all_suspended"] = all(
+                    susp_flags.get((did, cat), False) for did, cat in pairs
+                )
+            else:
+                deck["counts"] = dict(empty)
+                deck["deck_all_suspended"] = False
 
 
 # ---------------------------------------------------------------------------

--- a/routes/story.py
+++ b/routes/story.py
@@ -301,7 +301,7 @@ def preload(text: str):
 async def preload_session(deck_id: int, category: str, quick: bool = False):
     progress_key = f"{deck_id}/{category}"
     if quick:
-        ids = leaf_ids(deck_id) or [deck_id]
+        ids = leaf_ids(deck_id, category) or [deck_id]
         cards = database.get_due_cards_multi(ids, category) if len(ids) > 1 else database.get_due_cards(ids[0], category)
         texts = [c["word_zh"] for c in cards if c.get("word_zh")]
         logger.info("tts  quick preloading %d word audio files", len(texts))

--- a/routes/story.py
+++ b/routes/story.py
@@ -298,20 +298,28 @@ def preload(text: str):
 
 
 @router.post("/api/preload-session/{deck_id}/{category}")
-async def preload_session(deck_id: int, category: str):
-    today = database.anki_today().isoformat()
-    story = database.get_active_story(today, category, deck_id)
+async def preload_session(deck_id: int, category: str, quick: bool = False):
     progress_key = f"{deck_id}/{category}"
-    if story:
-        sentences = _add_tokens(database.get_story_sentences(story["id"]))
-        texts = [s["sentence_zh"] for s in sentences if s.get("sentence_zh")]
-        logger.info("tts  preloading %d sentences", len(texts))
+    if quick:
+        cards = database.get_due_cards(deck_id, category)
+        texts = [c["word_zh"] for c in cards if c.get("word_zh")]
+        logger.info("tts  quick preloading %d word audio files", len(texts))
         try:
             await tts.preload_all_async(texts, progress_key=progress_key)
-            logger.info("tts  preload done")
         except Exception as e:
-            logger.warning("tts  preload error: %s", e)
-    # Clear progress entry after completion
+            logger.warning("tts  quick preload error: %s", e)
+    else:
+        today = database.anki_today().isoformat()
+        story = database.get_active_story(today, category, deck_id)
+        if story:
+            sentences = _add_tokens(database.get_story_sentences(story["id"]))
+            texts = [s["sentence_zh"] for s in sentences if s.get("sentence_zh")]
+            logger.info("tts  preloading %d sentences", len(texts))
+            try:
+                await tts.preload_all_async(texts, progress_key=progress_key)
+                logger.info("tts  preload done")
+            except Exception as e:
+                logger.warning("tts  preload error: %s", e)
     tts._preload_progress.pop(progress_key, None)
     return {"ok": True}
 

--- a/routes/story.py
+++ b/routes/story.py
@@ -301,7 +301,8 @@ def preload(text: str):
 async def preload_session(deck_id: int, category: str, quick: bool = False):
     progress_key = f"{deck_id}/{category}"
     if quick:
-        cards = database.get_due_cards(deck_id, category)
+        ids = leaf_ids(deck_id) or [deck_id]
+        cards = database.get_due_cards_multi(ids, category) if len(ids) > 1 else database.get_due_cards(ids[0], category)
         texts = [c["word_zh"] for c in cards if c.get("word_zh")]
         logger.info("tts  quick preloading %d word audio files", len(texts))
         try:

--- a/schema.sql
+++ b/schema.sql
@@ -430,3 +430,18 @@ CREATE TABLE IF NOT EXISTS preset_category_overrides (
     leech_action        TEXT CHECK(leech_action IN ('suspend', 'tag')),
     UNIQUE(preset_id, category)
 );
+
+-- ---------------------------------------------------------------------------
+-- Performance indexes
+-- ---------------------------------------------------------------------------
+CREATE INDEX IF NOT EXISTS idx_cards_deck_cat_state
+    ON cards(deck_id, category, state);
+
+CREATE INDEX IF NOT EXISTS idx_cards_word_id
+    ON cards(word_id);
+
+CREATE INDEX IF NOT EXISTS idx_cards_due
+    ON cards(due);
+
+CREATE INDEX IF NOT EXISTS idx_review_log_card_date
+    ON review_log(card_id, reviewed_at);

--- a/static/app.js
+++ b/static/app.js
@@ -36,6 +36,7 @@ function renderMarkdown(text) {
 let deckId      = null;
 let rootDeckId      = null;   // set when studying all categories (mixed mode)
 let unfinishedMode  = false;  // set when studying the "Unfinished Cards" virtual deck
+let quickMode       = false;  // set when reviewing without AI story generation
 let deckName    = '';
 let category    = '';
 let card        = null;   // current card dict from API
@@ -366,11 +367,12 @@ function showView(name) {
     name === 'word-detail'  ? 'Word Detail' :
     name === 'hanzi-detail' ? 'Hanzi Detail' :
     name === 'stats'        ? 'Stats' : 'AnkiAdvanced';
+  if (name === 'decks') quickMode = false;
   const headerRegenBtn = document.getElementById('header-regen-btn');
-  if (headerRegenBtn) headerRegenBtn.style.display = (name === 'review' && !unfinishedMode) ? '' : 'none';
+  if (headerRegenBtn) headerRegenBtn.style.display = (name === 'review' && !unfinishedMode && !quickMode) ? '' : 'none';
   if (name === 'review') {
     const regenBtn = document.querySelector('.regen-btn');
-    if (regenBtn) regenBtn.style.display = unfinishedMode ? 'none' : '';
+    if (regenBtn) regenBtn.style.display = (unfinishedMode || quickMode) ? 'none' : '';
   }
 }
 
@@ -730,7 +732,7 @@ function buildCategoryButtons(deck) {
       const pillClass = allSusp ? 'cat-pill cat-pill-dimmed' : 'cat-pill';
       const title = allSusp ? `Unsuspend all ${label} cards` : `Suspend all ${label} cards`;
       const rr = _leavesRR([leaf]);
-      return `<span class="cat-pill-group"><button class="${badgeClass}" onclick="event.stopPropagation();toggleCategorySuspension(${leaf.id},'${cat}')" title="${title}">${badgeIcon}</button><span class="cat-pill-wrap"><button class="${pillClass}" onclick="event.stopPropagation();startReview(${leaf.id},'${cat}','${safeName}',${!!leaf.no_story})"><span class="cat-pill-label">${label}</span><span class="cat-pill-counts">${countHtml(c)}</span>${_catRRSpan(rr)}</button><button class="cat-pill-gear" onclick="event.stopPropagation();openOptions(${leaf.id})" title="Options">⚙</button></span></span>`;
+      return `<span class="cat-pill-group"><button class="${badgeClass}" onclick="event.stopPropagation();toggleCategorySuspension(${leaf.id},'${cat}')" title="${title}">${badgeIcon}</button><span class="cat-pill-wrap"><button class="${pillClass}" onclick="event.stopPropagation();startReview(${leaf.id},'${cat}','${safeName}',${!!leaf.no_story})"><span class="cat-pill-label">${label}</span><span class="cat-pill-counts">${countHtml(c)}</span>${_catRRSpan(rr)}</button><button class="cat-pill-quick" onclick="event.stopPropagation();startReview(${leaf.id},'${cat}','${safeName}',${!!leaf.no_story},true)" title="Quick review — no AI story">⚡</button><button class="cat-pill-gear" onclick="event.stopPropagation();openOptions(${leaf.id})" title="Options">⚙</button></span></span>`;
     }
     const c = aggregateCounts(deck, cat);
     const hasCards = getDeepCategoryLeaves(deck).some(l => l.category === cat);
@@ -742,7 +744,7 @@ function buildCategoryButtons(deck) {
     const pillClass = allSusp ? 'cat-pill cat-pill-dimmed' : 'cat-pill';
     const title = allSusp ? `Unsuspend all ${label} cards` : `Suspend all ${label} cards`;
     const rr = _leavesRR(leaves);
-    return `<span class="cat-pill-group"><button class="${badgeClass}" onclick="event.stopPropagation();toggleCategorySuspension(${deck.id},'${cat}')" title="${title}">${badgeIcon}</button><span class="cat-pill-wrap"><button class="${pillClass}" onclick="event.stopPropagation();startReview(${deck.id},'${cat}','${safeName}',${!!deck.no_story})"><span class="cat-pill-label">${label}</span><span class="cat-pill-counts">${countHtml(c)}</span>${_catRRSpan(rr)}</button><button class="cat-pill-gear" onclick="event.stopPropagation();openOptions(${deck.id})" title="Options">⚙</button></span></span>`;
+    return `<span class="cat-pill-group"><button class="${badgeClass}" onclick="event.stopPropagation();toggleCategorySuspension(${deck.id},'${cat}')" title="${title}">${badgeIcon}</button><span class="cat-pill-wrap"><button class="${pillClass}" onclick="event.stopPropagation();startReview(${deck.id},'${cat}','${safeName}',${!!deck.no_story})"><span class="cat-pill-label">${label}</span><span class="cat-pill-counts">${countHtml(c)}</span>${_catRRSpan(rr)}</button><button class="cat-pill-quick" onclick="event.stopPropagation();startReview(${deck.id},'${cat}','${safeName}',${!!deck.no_story},true)" title="Quick review — no AI story">⚡</button><button class="cat-pill-gear" onclick="event.stopPropagation();openOptions(${deck.id})" title="Options">⚙</button></span></span>`;
   }).join('');
 }
 
@@ -2312,7 +2314,8 @@ async function setDefaultPreset() {
 }
 
 // ── Start review session ────────────────────────────────────────────────────
-async function startReview(id, cat, name, noStory = false) {
+async function startReview(id, cat, name, noStory = false, quick = false) {
+  quickMode = quick;
   deckId   = id;
   category = cat;
   deckName = name;
@@ -2323,7 +2326,7 @@ async function startReview(id, cat, name, noStory = false) {
   _updateReviewRRBadge(id);
 
   try {
-    if (noStory) {
+    if (noStory || quick) {
       await _doStartReview(null, 2);
       return;
     }
@@ -2345,6 +2348,19 @@ async function startReview(id, cat, name, noStory = false) {
 }
 
 async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story') {
+  if (quickMode) {
+    setLoading('Loading…', false);
+    try {
+      const todayData = await api('GET', `/api/today/${deckId}/${category}`);
+      if (!todayData.card) { showView('done'); return; }
+      showView('review');
+      loadCard(todayData.card, todayData.counts);
+    } catch (e) {
+      showError('Failed to start session: ' + e.message);
+      showView('decks');
+    }
+    return;
+  }
   setLoading('Generating story…', true);
   setLoadingStep(10, null, 'Sending request to AI…');
   _startFakeProgress(10, 55, 45000);
@@ -2411,7 +2427,8 @@ function _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode) {
 }
 
 // ── Start mixed (all-category) review session ────────────────────────────────
-async function startReviewMixed(id, name, noStory = false) {
+async function startReviewMixed(id, name, noStory = false, quick = false) {
+  quickMode  = quick;
   rootDeckId = id;
   deckId     = id;
   deckName   = name;
@@ -2428,7 +2445,7 @@ async function startReviewMixed(id, name, noStory = false) {
       showView('done');
       return;
     }
-    if (noStory) {
+    if (noStory || quick) {
       await _doStartReviewMixed(null, 2, null, null, 50, 'story', true);
       return;
     }
@@ -2614,7 +2631,7 @@ function loadCard(c, counts) {
 
   // In unfinished mode or mixed mode: story may be from a different deck/category.
   // Async-load the correct story and update the display when it arrives.
-  if (!sentence && (unfinishedMode || rootDeckId)) {
+  if (!sentence && (unfinishedMode || rootDeckId) && !quickMode) {
     const snap = c;
     const storyDeckId = unfinishedMode ? c.deck_id : rootDeckId;
     fetch(`/api/story/${storyDeckId}/unified`)
@@ -2773,8 +2790,8 @@ function showFront() {
     hintWrap.style.display = 'none';
   }
 
-  // Word bank mode: creating category for non-sentence notes
-  const isCloze = isCreating && !isSentence;
+  // Word bank mode: creating category for non-sentence notes (disabled in quick mode)
+  const isCloze = isCreating && !isSentence && !quickMode;
 
   // Reading only: Chinese sentence on front
   const sentFront = document.getElementById('sentence-front');
@@ -2801,11 +2818,13 @@ function showFront() {
   }
 
   if (isCreating) {
-    if (isSentence) {
-      // Sentence notes: show the German/English source as prompt
-      const prompt = card.source_sentence || card.definition || '';
+    if (isSentence || quickMode) {
+      // Sentence notes or quick mode: text input
+      const prompt = isSentence
+        ? (card.source_sentence || card.definition || '')
+        : (card.definition_de || card.definition || '');
       document.getElementById('sentence-en-front').textContent = prompt;
-      document.getElementById('creating-input-label').textContent = 'Your translation in Chinese';
+      document.getElementById('creating-input-label').textContent = isSentence ? 'Your translation in Chinese' : 'Write the word in Chinese';
       document.getElementById('creating-input').placeholder = 'Type here…';
       const inp = document.getElementById('creating-input');
       inp.value = '';
@@ -2862,7 +2881,7 @@ function revealAnswer() {
 
   // Capture user input before hiding front
   if (isCreating) {
-    const isClozeMode = card.note_type !== 'sentence';
+    const isClozeMode = card.note_type !== 'sentence' && !quickMode;
     if (isClozeMode) {
       // Word bank mode: parse number sequence into reconstructed sentence
       const wbRaw = document.getElementById('word-bank-input').value.trim();

--- a/static/app.js
+++ b/static/app.js
@@ -2353,6 +2353,7 @@ async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mo
     try {
       const todayData = await api('GET', `/api/today/${deckId}/${category}`);
       if (!todayData.card) { showView('done'); return; }
+      fetch(`/api/preload-session/${deckId}/${category}?quick=true`, { method: 'POST' }).catch(() => {});
       showView('review');
       loadCard(todayData.card, todayData.counts);
     } catch (e) {

--- a/static/app.js
+++ b/static/app.js
@@ -2349,11 +2349,13 @@ async function startReview(id, cat, name, noStory = false, quick = false) {
 
 async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story') {
   if (quickMode) {
-    setLoading('Loading…', false);
+    setLoading('Loading audio…', true);
     try {
       const todayData = await api('GET', `/api/today/${deckId}/${category}`);
       if (!todayData.card) { showView('done'); return; }
-      fetch(`/api/preload-session/${deckId}/${category}?quick=true`, { method: 'POST' }).catch(() => {});
+      try {
+        await fetch(`/api/preload-session/${deckId}/${category}?quick=true`, { method: 'POST' });
+      } catch (_) {}
       showView('review');
       loadCard(todayData.card, todayData.counts);
     } catch (e) {

--- a/static/style.css
+++ b/static/style.css
@@ -1750,6 +1750,19 @@ main.browse-open {
   font-weight: 600;
 }
 .cat-pill-counts { font-size: 11px; font-weight: 700; }
+.cat-pill-quick {
+  background: none;
+  border: 1.5px solid var(--border);
+  border-left: none;
+  border-radius: 0;
+  font-size: 11px;
+  padding: 2px 5px;
+  cursor: pointer;
+  color: var(--muted);
+  line-height: 1.4;
+  transition: border-color 0.12s, color 0.12s, background 0.12s;
+}
+.cat-pill-quick:hover { border-color: #f59e0b; color: #f59e0b; background: #fffbeb; }
 .cat-pill-gear {
   background: none;
   border: 1.5px solid var(--border);


### PR DESCRIPTION
## 变更内容

- 每个类别卡片按钮旁新增 ⚡ 按钮（位于主按钮和 ⚙ 按钮之间）
- 点击 ⚡ 后立即进入复习，无需等待 AI 生成故事和 TTS 预加载
- 三个类别行为：
  - **阅读**：正面直接显示高亮词语（`renderSentence()` 在无句子时自动降级）
  - **监听**：自动播放 `word_zh` 音频（`playSentence()` 已有此降级逻辑）
  - **写作**：词块模式降级为文字输入，提示语改为"Write the word in Chinese"
- SRS 调度完全不变
- 返回牌组列表时 `quickMode` 自动重置
- 快速模式下隐藏「重新生成故事」按钮

## 测试方法

1. 启动服务，打开牌组列表
2. 确认每个类别按钮旁出现 ⚡ 按钮（悬停变黄色）
3. 点击 ⚡，确认立即进入复习（无 loading 等待）
4. 分别测试阅读/监听/写作三个类别
5. 评分后确认下一张卡片正常加载
6. 返回牌组列表后再次点击普通按钮，确认标准模式（有故事）仍然正常

Closes #278