### PR TITLE
fix: 间隔显示月份时同时显示剩余天数

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -635,6 +635,90 @@ def _fallback_sentences(cards: list[dict]) -> list[dict]:
     return result
 
 
+_FIX_BATCH = 25  # words per DeepSeek call
+
+
+def _needs_comma_fix(text: str | None) -> bool:
+    if not text or len(text) < 15:
+        return False
+    return "," not in text and ";" not in text and "/" not in text
+
+
+def fix_definition_commas(cards: list[dict]) -> int:
+    """Add missing commas to English/German definitions of today's due words.
+
+    Sends batches to DeepSeek, updates entries in-place and in the DB.
+    Returns the number of entries actually updated.
+    """
+    to_fix = [
+        {"id": c["word_id"], "word_zh": c["word_zh"],
+         "en": c.get("definition"), "de": c.get("definition_de")}
+        for c in cards
+        if _needs_comma_fix(c.get("definition")) or _needs_comma_fix(c.get("definition_de"))
+    ]
+    # deduplicate by word_id
+    seen: set[int] = set()
+    unique: list[dict] = []
+    for item in to_fix:
+        if item["id"] not in seen:
+            seen.add(item["id"])
+            unique.append(item)
+
+    if not unique:
+        return 0
+
+    logger.info("fix_commas  %d entries need comma repair", len(unique))
+    total_fixed = 0
+
+    for i in range(0, len(unique), _FIX_BATCH):
+        batch = unique[i:i + _FIX_BATCH]
+        word_lines = "\n".join(
+            f'{item["word_zh"]} | EN: {item["en"] or ""} | DE: {item["de"] or ""}'
+            for item in batch
+        )
+        prompt = (
+            "The following Chinese vocabulary definitions are missing commas between "
+            "their separate meanings. Add commas (or slashes where a slash is the natural "
+            "separator) to make the meanings clearly distinct. Do not add or remove meanings, "
+            "only insert the missing punctuation.\n\n"
+            "Return ONLY a JSON array. Each element: "
+            '{"word_zh": "...", "en": "fixed English or null", "de": "fixed German or null"}\n\n'
+            f"Words:\n{word_lines}"
+        )
+        try:
+            raw = _call_api("deepseek-v4-flash",
+                            [{"role": "user", "content": prompt}],
+                            max_tokens=2000, purpose="fix_commas")
+            # extract JSON array from response
+            m = re.search(r"\[.*\]", raw, re.DOTALL)
+            if not m:
+                logger.warning("fix_commas  no JSON array in response")
+                continue
+            updates = json.loads(m.group())
+            id_map = {item["word_zh"]: item["id"] for item in batch}
+            for upd in updates:
+                wid = id_map.get(upd.get("word_zh"))
+                if not wid:
+                    continue
+                fields: dict = {}
+                if upd.get("en"):
+                    fields["definition"] = upd["en"]
+                if upd.get("de"):
+                    fields["definition_de"] = upd["de"]
+                if fields:
+                    database.update_word(wid, fields)
+                    # also patch the in-memory card dicts so the story prompt sees new values
+                    for c in cards:
+                        if c.get("word_id") == wid:
+                            c.update(fields)
+                    total_fixed += 1
+        except Exception as e:
+            logger.warning("fix_commas  batch error: %s", e)
+
+    logger.info("fix_commas  updated %d entries", total_fixed)
+    return total_fixed
+
+
 def estimate_story_tokens(num_cards: int) -> int:
     """Rough token estimate for generating a story with num_cards words.
 

--- a/ai.py
+++ b/ai.py
@@ -418,6 +418,7 @@ def regenerate_entry_fields(
         )
 
     if want_chars:
+        n_chars = len(characters)
         char_field_lines = []
         if want_etym:
             char_field_lines.append(
@@ -429,7 +430,11 @@ def regenerate_entry_fields(
                 "  - compounds: 3-5 common compound words using this character. "
                 "Each: {\"simplified\": \"词\", \"pinyin\": \"...\", \"meaning\": \"German (NO colons)\"}"
             )
-        sections.append("CHARACTER DATA: For each character above:\n" + "\n".join(char_field_lines))
+        sections.append(
+            f"CHARACTER DATA: Return EXACTLY {n_chars} object(s) in the \"characters\" array — "
+            f"one per character listed above. Do NOT skip any character.\n"
+            + "\n".join(char_field_lines)
+        )
 
     # --- JSON template ---
     json_keys = []
@@ -453,7 +458,10 @@ def regenerate_entry_fields(
             char_obj_keys += ', "etymology": "..."'
         if want_comp:
             char_obj_keys += ', "compounds": [{"simplified": "...", "pinyin": "...", "meaning": "..."}]'
-        json_keys.append(f'  "characters": [{{{char_obj_keys}}}]')
+        # Show one example object per actual character so the AI knows the expected array length
+        char_example = "{" + char_obj_keys + "}"
+        char_array = ", ".join([char_example] * max(len(characters), 1))
+        json_keys.append(f'  "characters": [{char_array}]')
 
     json_template = "{\n" + ",\n".join(json_keys) + "\n}"
 

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -153,19 +153,37 @@ def _save_regen_result(word_id: int, fields: list, top_result: dict, all_charact
                     position=i,
                 )
 
-    existing_chars = {c["char_id"] for c in database.get_word_characters(word_id)}
+    # Build a map from character string → component word_id so characters get linked
+    # to the correct component word (e.g. for 漏洞: '漏'→12175, '洞'→12176).
+    # Falls back to the parent word_id for characters without a matching component.
+    components = database.get_note_components(word_id)
+    comp_word_id_by_char = {comp["word_zh"]: comp["id"] for comp in components}
+    # Cache existing chars per target word to avoid redundant DB reads
+    existing_by_word: dict[int, set] = {}
+
     for i, char_data in enumerate(all_characters):
         char_id = char_data.get("char_id")
+        ch = char_data.get("char", "")
         if not char_id:
-            ch = char_data.get("char", "")
             if ch:
                 rec = database.get_character(ch)
                 if rec:
                     char_id = rec["id"]
+                elif ch:
+                    char_id = database.upsert_character({
+                        "char": ch, "traditional": None, "pinyin": None,
+                        "hsk_level": None, "etymology": None, "other_meanings": None,
+                    })
         if not char_id:
             continue
-        if char_id not in existing_chars:
-            database.insert_word_character(word_id, char_id, i, None)
+        target_word_id = comp_word_id_by_char.get(ch, word_id)
+        if target_word_id not in existing_by_word:
+            existing_by_word[target_word_id] = {
+                c["char_id"] for c in database.get_word_characters(target_word_id)
+            }
+        if char_id not in existing_by_word[target_word_id]:
+            database.insert_word_character(target_word_id, char_id, i, None)
+            existing_by_word[target_word_id].add(char_id)
         if "etymology" in fields and char_data.get("etymology"):
             database.update_character(char_id, {"etymology": char_data["etymology"]})
         if "compounds" in fields and char_data.get("compounds"):

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -101,6 +101,27 @@ def _run_regen_ai(word_id: int, word: dict, fields: list) -> tuple[dict, list]:
             comp_fields = [f for f in fields if f in ("etymology", "compounds")]
             for comp in components:
                 comp_chars = database.get_word_characters(comp["id"])
+                if not comp_chars:
+                    # No chars linked yet — infer from the component's word_zh
+                    seen: set = set()
+                    for ch in comp.get("word_zh", ""):
+                        if ch in seen:
+                            continue
+                        seen.add(ch)
+                        basic = database.get_character(ch)
+                        if basic:
+                            full = database.get_character_by_id(basic["id"])
+                            if full:
+                                comp_chars.append({
+                                    "char_id": full["id"], "char": ch,
+                                    "pinyin": full.get("pinyin", ""),
+                                    "hsk_level": full.get("hsk_level", ""),
+                                    "etymology": full.get("etymology", ""),
+                                    "compounds": full.get("compounds", []),
+                                })
+                                continue
+                        comp_chars.append({"char_id": None, "char": ch,
+                                           "pinyin": "", "hsk_level": "", "etymology": "", "compounds": []})
                 result = ai.regenerate_entry_fields(comp, comp_chars, comp_fields)
                 _enrich_chars_with_id(result.get("characters", []), comp_chars, all_characters)
     else:
@@ -153,11 +174,14 @@ def _save_regen_result(word_id: int, fields: list, top_result: dict, all_charact
                     position=i,
                 )
 
-    # Build a map from character string → component word_id so characters get linked
-    # to the correct component word (e.g. for 漏洞: '漏'→12175, '洞'→12176).
-    # Falls back to the parent word_id for characters without a matching component.
+    # Build a map from individual character → component word_id.
+    # For a component like '田园', both '田' and '园' map to that component's word_id.
+    # Falls back to the parent word_id for characters with no matching component.
     components = database.get_note_components(word_id)
-    comp_word_id_by_char = {comp["word_zh"]: comp["id"] for comp in components}
+    comp_word_id_by_char: dict[str, int] = {}
+    for comp in components:
+        for ch in comp["word_zh"]:
+            comp_word_id_by_char.setdefault(ch, comp["id"])
     # Cache existing chars per target word to avoid redundant DB reads
     existing_by_word: dict[int, set] = {}
 

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -157,6 +157,12 @@ def _save_regen_result(word_id: int, fields: list, top_result: dict, all_charact
     for i, char_data in enumerate(all_characters):
         char_id = char_data.get("char_id")
         if not char_id:
+            ch = char_data.get("char", "")
+            if ch:
+                rec = database.get_character(ch)
+                if rec:
+                    char_id = rec["id"]
+        if not char_id:
             continue
         if char_id not in existing_chars:
             database.insert_word_character(word_id, char_id, i, None)

--- a/routes/story.py
+++ b/routes/story.py
@@ -147,6 +147,7 @@ def get_story(deck_id: int, category: str,
     logger.info("story  GENERATE deck=%d cat=%s due_cards=%d topic=%r max_hsk=%d model=%s mode=%s",
                 deck_id, category, len(cards), topic, max_hsk, chosen_model, mode)
     if cards:
+        ai.fix_definition_commas(cards)
         progress_key = f"{deck_id}/{category}"
         ai._story_progress[progress_key] = {"phase": "starting", "msg": "Starting…", "percent": 5}
         last_error = None
@@ -197,6 +198,7 @@ def regenerate_story(deck_id: int, category: str,
                 deck_id, category, len(cards), topic, max_hsk, chosen_model, mode)
     if not cards:
         return None
+    ai.fix_definition_commas(cards)
     progress_key = f"{deck_id}/{category}"
     ai._story_progress[progress_key] = {"phase": "starting", "msg": "Starting…", "percent": 5}
     last_error = None

--- a/srs.py
+++ b/srs.py
@@ -78,8 +78,11 @@ def _fmt_day(days: int) -> str:
         return "1d"
     if days < 31:
         return f"{days}d"
-    months = round(days / 30)
-    if months < 12:
+    if days < 365:
+        months = days // 30
+        remaining = days % 30
+        if remaining > 0:
+            return f"{months}mo {remaining}d"
         return f"{months}mo"
     return f"{round(days / 365)}y"
 

--- a/static/app.js
+++ b/static/app.js
@@ -3319,6 +3319,7 @@ function _showRegenPreviewModal(previewData) {
       <button onclick="_closeRegenPreviewModal()">×</button>
     </div>
     <div class="regen-preview-body">${bodyHtml}</div>
+    <div id="regen-modal-error" style="display:none;color:#b91c1c;background:#fef2f2;border:1px solid #fecaca;border-radius:6px;padding:8px 12px;margin:8px 16px;font-size:13px"></div>
     <div class="regen-preview-footer">
       <button class="regen-btn regen-btn-regenerate" id="regen-btn-regen" onclick="_rerunRegen()">↺ Regenerate</button>
       <button class="regen-btn regen-btn-reject" onclick="_closeRegenPreviewModal()">✗ Reject</button>
@@ -3469,7 +3470,9 @@ async function _applyRegenResult() {
       }
     }
   } catch (e) {
-    showError('Apply failed: ' + e.message);
+    const modalErr = document.getElementById('regen-modal-error');
+    if (modalErr) { modalErr.textContent = 'Apply failed: ' + e.message; modalErr.style.display = 'block'; }
+    else showError('Apply failed: ' + e.message);
     if (applyBtn) applyBtn.disabled = false;
     if (regenBtn) regenBtn.disabled = false;
   }

--- a/static/app.js
+++ b/static/app.js
@@ -3216,6 +3216,14 @@ function regenAllFields(wordId) {
   regenFields(wordId, allFields, 'wd-all');
 }
 
+function regenAllFieldsFromReview() {
+  const wordId = _getActiveWordId();
+  if (!wordId) return showError('No active word');
+  const allFields = ['definition', 'definition_zh', 'definition_de', 'definition_fr', 'pos',
+                     'notes', 'examples', 'etymology', 'compounds'];
+  regenFields(wordId, allFields, 'review-regen-all');
+}
+
 async function regenFields(wordId, fields, containerId) {
   const el = document.getElementById(containerId);
   const btn = el?.querySelector('.field-regen-btn');
@@ -3422,7 +3430,12 @@ async function _applyRegenResult() {
     const DEF_FIELDS = ['definition', 'definition_zh', 'definition_de', 'definition_fr', 'pos'];
     const isDefRegen = fields.some(f => DEF_FIELDS.includes(f));
     console.log('[apply] wordId=', wordId, '_currentWordId=', _currentWordId, 'fields=', fields, 'containerId=', containerId, 'isDefRegen=', isDefRegen);
-    if (containerId === 'wd-all' && _currentWordId === wordId) {
+    if (containerId === 'review-regen-all') {
+      // Re-render all review side-panel sections
+      renderNotesSection(null, updated.notes, wordId);
+      renderWordAnalysis(null, updated, wordId);
+      renderVocabDetail(null, updated.examples, wordId);
+    } else if (containerId === 'wd-all' && _currentWordId === wordId) {
       updated.cards = wordDetails?.cards || [];
       renderWordDetail(updated);
     } else if (isDefRegen && _currentWordId === wordId) {

--- a/static/app.js
+++ b/static/app.js
@@ -3394,9 +3394,10 @@ function _getRegenResultFromModal() {
   if (fields.includes('etymology') || fields.includes('compounds')) {
     const charGroups = document.querySelectorAll('#regen-chars-list .regen-char-group');
     result.characters = Array.from(charGroups).map(group => {
+      const rawId = parseInt(group.dataset.charId);
       const charResult = {
         char:    group.dataset.char,
-        char_id: parseInt(group.dataset.charId) || undefined,
+        char_id: isNaN(rawId) ? null : rawId,
       };
       if (fields.includes('etymology')) {
         charResult.etymology = group.querySelector('[data-field="etymology"]')?.value?.trim() || '';

--- a/static/app.js
+++ b/static/app.js
@@ -6133,6 +6133,8 @@ document.addEventListener('keydown', async e => {
       e.preventDefault(); _toggleSuspendCat('listening');
     } else if (e.key === 'c') {
       e.preventDefault(); _toggleSuspendCat('creating');
+    } else if (e.key === 'C') {
+      e.preventDefault(); regenAllFieldsFromReview();
     } else if (e.key === 'D') {
       e.preventDefault();
       if (await showConfirm('Delete this card?')) reviewCardAction('delete');
@@ -6154,6 +6156,8 @@ document.addEventListener('keydown', async e => {
       e.preventDefault(); _toggleAndScroll('wd-word-analysis-section-body', 'wd-word-analysis-section', 'end');
     } else if (e.key === 'c') {
       e.preventDefault(); _toggleAllChars();
+    } else if (e.key === 'C') {
+      e.preventDefault(); if (_currentWordId) regenAllFields(_currentWordId);
     } else if (e.key === 'r') {
       e.preventDefault(); _toggleAndScroll('wd-relations-body', 'wd-relations-section');
     }

--- a/static/app.js
+++ b/static/app.js
@@ -3652,11 +3652,7 @@ function renderWordAnalysis(container, wordData, wordId) {
     return `<div class="wa-word-card">` +
       `<div class="wa-word-header">${header}</div>` +
       (mwHtml ? `<div class="wa-word-extra">${mwHtml}</div>` : '') +
-      (hasChars
-        ? `<div class="wa-chars-toggle section-toggle" onclick="toggleSection('${charBodyId}')">` +
-            `<span id="${charBodyId}-arrow">▼</span> Characters</div>` +
-          `<div id="${charBodyId}" class="wa-chars-list">${charBody}</div>`
-        : '') +
+      (hasChars ? `<div class="wa-chars-list">${charBody}</div>` : '') +
       `</div>`;
   }).join('');
 
@@ -6084,18 +6080,6 @@ document.addEventListener('keydown', async e => {
       document.getElementById(containerId)?.scrollIntoView({ behavior: 'smooth', block });
   };
 
-  const _toggleAllChars = () => {
-    const charLists = document.querySelectorAll('.wa-chars-list');
-    if (!charLists.length) return;
-    const opening = charLists[0].style.display === 'none';
-    charLists.forEach(el => {
-      const arrow = document.getElementById(el.id + '-arrow');
-      el.style.display = opening ? 'block' : 'none';
-      if (arrow) arrow.textContent = opening ? '▼' : '▶';
-    });
-    if (opening) charLists[charLists.length - 1].scrollIntoView({ behavior: 'smooth', block: 'end' });
-  };
-
   // Review shortcuts
   const reviewView = document.getElementById('view-review');
   if (reviewView && reviewView.style.display !== 'none') {
@@ -6121,8 +6105,6 @@ document.addEventListener('keydown', async e => {
       e.preventDefault(); _toggleAndScroll('notes-section-body', 'notes-section');
     } else if (backVisible && e.key === 'w') {
       e.preventDefault(); _toggleAndScroll('word-analysis-section-body', 'word-analysis-section', 'end');
-    } else if (backVisible && e.key === 'h') {
-      e.preventDefault(); _toggleAllChars();
     } else if (e.key === 'q') {
       e.preventDefault(); _adjustListenHintSlider(-1);
     } else if (e.key === 'w') {
@@ -6154,8 +6136,6 @@ document.addEventListener('keydown', async e => {
       e.preventDefault(); _toggleAndScroll('wd-notes-section-body', 'wd-notes-section');
     } else if (e.key === 'w') {
       e.preventDefault(); _toggleAndScroll('wd-word-analysis-section-body', 'wd-word-analysis-section', 'end');
-    } else if (e.key === 'c') {
-      e.preventDefault(); _toggleAllChars();
     } else if (e.key === 'C') {
       e.preventDefault(); if (_currentWordId) regenAllFields(_currentWordId);
     } else if (e.key === 'r') {

--- a/static/app.js
+++ b/static/app.js
@@ -3597,7 +3597,11 @@ function renderWordAnalysis(container, wordData, wordId) {
     let header = zhSpan;
     if (comp.pinyin)     header += `<span class="wa-word-pin">${comp.pinyin}</span>`;
     if (comp.hsk_level)  header += `<span class="wa-hsk-badge">HSK ${comp.hsk_level}</span>`;
-    if (comp.definition) header += `<span class="wa-word-def">${comp.definition}</span>`;
+    const compDef = comp.definition || (() => {
+      try { const m = JSON.parse(comp.characters?.[0]?.other_meanings || '[]'); return m.slice(0, 2).join('; '); }
+      catch { return ''; }
+    })();
+    if (compDef) header += `<span class="wa-word-def">${compDef}</span>`;
 
     // Measure words row
     let mwHtml = '';

--- a/static/app.js
+++ b/static/app.js
@@ -1546,6 +1546,8 @@ async function openWordDetail(wordId) {
 
 function renderWordDetail(word) {
   document.getElementById('wd-edit-btn').onclick = () => openWordEditModal(word);
+  const regenAllBtn = document.getElementById('wd-regen-all-btn');
+  if (regenAllBtn) regenAllBtn.onclick = () => word.id && regenAllFields(word.id);
   document.getElementById('wd-hanzi').textContent = word.word_zh || '';
   document.getElementById('wd-pinyin').textContent = word.pinyin || '';
   document.getElementById('wd-def').textContent = word.definition || '';
@@ -3208,6 +3210,12 @@ function _getActiveWordId() {
 // ── Regen preview modal ──────────────────────────────────────────────────────
 let _regenState = null; // { wordId, fields, containerId }
 
+function regenAllFields(wordId) {
+  const allFields = ['definition', 'definition_zh', 'definition_de', 'definition_fr', 'pos',
+                     'notes', 'examples', 'etymology', 'compounds'];
+  regenFields(wordId, allFields, 'wd-all');
+}
+
 async function regenFields(wordId, fields, containerId) {
   const el = document.getElementById(containerId);
   const btn = el?.querySelector('.field-regen-btn');
@@ -3414,7 +3422,10 @@ async function _applyRegenResult() {
     const DEF_FIELDS = ['definition', 'definition_zh', 'definition_de', 'definition_fr', 'pos'];
     const isDefRegen = fields.some(f => DEF_FIELDS.includes(f));
     console.log('[apply] wordId=', wordId, '_currentWordId=', _currentWordId, 'fields=', fields, 'containerId=', containerId, 'isDefRegen=', isDefRegen);
-    if (isDefRegen && _currentWordId === wordId) {
+    if (containerId === 'wd-all' && _currentWordId === wordId) {
+      updated.cards = wordDetails?.cards || [];
+      renderWordDetail(updated);
+    } else if (isDefRegen && _currentWordId === wordId) {
       // Definition/POS regen: full re-render is safe (header is always visible)
       updated.cards = wordDetails?.cards || [];
       renderWordDetail(updated);

--- a/static/app.js
+++ b/static/app.js
@@ -3581,8 +3581,8 @@ function renderWordAnalysis(container, wordData, wordId) {
   if (wordGroups.length === 0) {
     el.innerHTML =
       `<div class="section-label section-label-row section-toggle" onclick="toggleSection('${bodyId}')">` +
-        `<span><span id="${bodyId}-arrow">▷</span> Word Analysis</span>${regenBtnWA}</div>` +
-      `<div id="${bodyId}" class="wa-list section-peek" data-peek="1" data-state="peek"><div class="section-empty">—</div></div>`;
+        `<span><span id="${bodyId}-arrow">▼</span> Word Analysis</span>${regenBtnWA}</div>` +
+      `<div id="${bodyId}" class="wa-list section-open" data-peek="1" data-state="open"><div class="section-empty">—</div></div>`;
     return;
   }
 
@@ -3658,8 +3658,8 @@ function renderWordAnalysis(container, wordData, wordId) {
 
   el.innerHTML =
     `<div class="section-label section-label-row section-toggle" onclick="toggleSection('${bodyId}')">` +
-      `<span><span id="${bodyId}-arrow">▷</span> Word Analysis</span>${regenBtnWA}</div>` +
-    `<div id="${bodyId}" class="wa-list section-peek" data-peek="1" data-state="peek">${wordCards}</div>`;
+      `<span><span id="${bodyId}-arrow">▼</span> Word Analysis</span>${regenBtnWA}</div>` +
+    `<div id="${bodyId}" class="wa-list section-open" data-peek="1" data-state="open">${wordCards}</div>`;
 }
 
 function _callRenderWordAnalysis() {

--- a/static/app.js
+++ b/static/app.js
@@ -3873,7 +3873,7 @@ function _renderListenHint(threshold) {
     if (!isCjk(ch)) {
       html += ch;
     } else if (targetPositions.has(i)) {
-      html += `<span class="hint-blank">_</span>`;
+      html += `<span class="hint-blank hint-blank-target">_</span>`;
     } else if (threshold === 0) {
       html += ch; // "All" mode: reveal all non-target characters
     } else if (revealPositions.has(i)) {

--- a/static/app.js
+++ b/static/app.js
@@ -3624,8 +3624,12 @@ function renderWordAnalysis(container, wordData, wordId) {
         const charEsc = (c.char || '').replace(/'/g, "\\'");
         const pinEsc  = (c.pinyin || '').replace(/'/g, "\\'");
         let right = '';
-        if (c.pinyin)             right += `<span class="wa-char-pin">${c.pinyin}</span>`;
-        if (c.meaning_in_context) right += `<span class="wa-char-ctx">${c.meaning_in_context}</span>`;
+        if (c.pinyin) right += `<span class="wa-char-pin">${c.pinyin}</span>`;
+        const charMeaning = c.meaning_in_context || (() => {
+          try { const m = JSON.parse(c.other_meanings || '[]'); return m.slice(0, 2).join('; '); }
+          catch { return ''; }
+        })();
+        if (charMeaning) right += `<span class="wa-char-ctx">${charMeaning}</span>`;
         if (c.compounds?.length) {
           const cps = c.compounds.map(cp => {
             const highlightedZh = (cp.compound_zh || '').split('').map(ch =>

--- a/static/app.js
+++ b/static/app.js
@@ -3547,6 +3547,18 @@ function renderWordAnalysis(container, wordData, wordId) {
   let wordGroups = [];
   if (isMultiWord) {
     wordGroups = wd?.components || [];
+    // chengyu/sentence with no components: fall back to characters linked directly to the entry
+    if (wordGroups.length === 0 && wd?.characters?.length > 0) {
+      wordGroups = [{
+        id: wd.id,
+        word_zh:       wd.word_zh    || card?.word_zh,
+        pinyin:        wd.pinyin     || card?.pinyin,
+        hsk_level:     wd.hsk_level  || card?.hsk_level,
+        definition:    wd.definition || card?.definition,
+        measure_words: wd.measure_words || [],
+        characters:    wd.characters || [],
+      }];
+    }
   } else if (wd?.components?.length > 0) {
     // New-format vocabulary: word_analyses stored as components (each with own characters)
     wordGroups = wd.components;

--- a/static/index.html
+++ b/static/index.html
@@ -220,7 +220,10 @@
           <div id="notes-section"></div>
           <div id="word-analysis-section"></div>
           <div id="examples-section"></div>
-          <button class="edit-card-btn" id="edit-card-btn" onclick="openEditCard()">Edit card</button>
+          <div style="display:flex;gap:8px;justify-content:center">
+            <button class="edit-card-btn" id="edit-card-btn" onclick="openEditCard()">Edit card</button>
+            <button class="edit-card-btn" id="review-regen-all-btn" onclick="regenAllFieldsFromReview()" title="Regenerate all fields with AI">↺ All</button>
+          </div>
         </div>
       </div>
 

--- a/static/index.html
+++ b/static/index.html
@@ -330,6 +330,7 @@
         <div class="wd-def-de" id="wd-def-de" style="display:none"></div>
       </div>
       <button class="wd-edit-btn" id="wd-edit-btn">Edit</button>
+      <button class="wd-edit-btn wd-regen-all-btn" id="wd-regen-all-btn" title="Regenerate all fields">↺ All</button>
       <button class="wd-back-review-btn" id="wd-back-review-btn" style="display:none" onclick="goBack()">← Review</button>
     </div>
     <div class="wd-body">

--- a/static/style.css
+++ b/static/style.css
@@ -453,6 +453,7 @@ main.browse-open {
 }
 .listen-hint-sentence .hint-blank {
   color: var(--text-muted, #aaa);
+  margin: 0 1px;
 }
 .listen-hint-sentence .hint-blank-target {
   color: var(--primary, #4a90d9);

--- a/static/style.css
+++ b/static/style.css
@@ -454,6 +454,9 @@ main.browse-open {
 .listen-hint-sentence .hint-blank {
   color: var(--text-muted, #aaa);
 }
+.listen-hint-sentence .hint-blank-target {
+  color: var(--primary, #4a90d9);
+}
 .listen-hint-slider-row {
   display: flex;
   align-items: center;

--- a/static/style.css
+++ b/static/style.css
@@ -2377,6 +2377,7 @@ main.browse-open {
   transition: border-color 0.12s, color 0.12s;
 }
 .wd-edit-btn:hover { border-color: var(--primary); color: var(--primary); }
+.wd-regen-all-btn { margin-left: 6px; }
 .wd-hanzi  { font-size: 44px; font-weight: 700; line-height: 1.1; }
 .wd-pinyin { font-size: 16px; color: var(--muted); margin: 4px 0 8px; }
 .wd-pos-def-row {


### PR DESCRIPTION
## 变更内容
- 修改 `srs.py` 的 `_fmt_day` 函数
- 显示月份时加上剩余天数，例如 `1mo 3d` 而不是只显示 `1mo`
- 整除时仍只显示月份，例如 60天 → `2mo`

## 测试方法
- 复习一张 interval 在 31–364 天之间的卡片，确认 Easy/Good/Hard 按钮下方显示 `Xmo Yd` 格式