### PR TITLE
fix: 导入重复词条默认执行移动到导入牌组操作

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -5423,6 +5423,7 @@ async function previewImport(yamlContent) {
           include: e.status !== 'invalid',
           deck_path: null,
           suspended: { ...IMPORT_DEFAULT_SUSPENDED },
+          ...(e.status === 'duplicate' ? { duplicate_action: 'move_import' } : {}),
         };
       }
     });


### PR DESCRIPTION
## 变更内容

修复导入时重复词条无法移动到导入牌组的问题。

**根本原因：** 初始化 `_cardConfigs` 时，重复词条没有设置 `duplicate_action`，导致提交时以下条件不触发：
```js
if (resolved.duplicate_action === 'move_import') { ... }
```
后端 `card_cfg.get("duplicate_action", "skip")` 默认返回 `"skip"`，卡片不被移动。

**修复：** 对 `status === 'duplicate'` 的词条，初始化时自动设置 `duplicate_action: 'move_import'`。

## 测试方法

1. 导入一个包含已存在词条的 YAML 文件
2. 在预览界面确认重复词条显示为"Move to import deck"
3. 点击导入
4. 确认该词条的卡片已移动到目标牌组（而非被跳过）
5. 确认卡片被取消暂停（unsuspend）

Closes #200