### PR TITLE
fix: 复习时隐藏当前类别的日历灰色到期徽章

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -171,6 +171,7 @@ function _renderCal() {
           html += `<span class="cal-chip cal-chip-${rCls}" title="${r.category}: ${rCls}">${letter}</span>`;
         }
         for (const f of info.dues) {
+          if (f.category === _calCategory) continue;
           const cCls = _CAT_CLASS[f.category] || '';
           const letter = _CAT_LETTER[f.category] || '?';
           html += `<span class="cal-chip cal-chip-due-${cCls}" title="${f.category} due">${letter}</span>`;


### PR DESCRIPTION
## 变更内容

- 渲染日历时，跳过当前正在复习的类别（`_calCategory`）的灰色未来到期徽章

## 问题

复习听力时，日历在明天显示灰色"听"徽章（因为卡片毕业后 `due` 变成了明天），用户误以为今天不用复习听力。

## 修复后

- 复习听力时：日历不显示灰色"听"（彩色历史徽章仍然显示）
- 阅读/创建的灰色徽章：仍正常显示（这些对用户有用）

Closes #289