### PR TITLE
feat: 《思考，快与慢》Kahneman 模式——心理偏误风格句子生成

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -598,7 +598,7 @@ Return ONLY valid JSON, no explanation, no markdown:
 # ---------------------------------------------------------------------------
 
 def _fill_translations(sentences: list[dict], progress_key: str | None = None) -> None:
-    """Translate sentence_zh → sentence_de and sentence_fr in-place using Google Translate."""
+    """Translate sentence_zh → sentence_de in-place using Google Translate."""
     try:
         import translator as _t
         texts = [s.get("sentence_zh", "") for s in sentences]
@@ -612,18 +612,14 @@ def _fill_translations(sentences: list[dict], progress_key: str | None = None) -
         de_results = _t.translate_batch(texts, target="de")
         logger.info("translate DE done in %.1fs (%d sentences)", time.time() - t0, total)
 
-        t1 = time.time()
-        fr_results = _t.translate_batch(texts, target="fr")
-        logger.info("translate FR done in %.1fs (%d sentences)", time.time() - t1, total)
-
         if progress_key and total > 0:
             _set_progress(progress_key, phase="translating",
                           msg=f"Translating… {total}/{total}", percent=92)
 
-        for s, de, fr in zip(sentences, de_results, fr_results):
+        for s, de in zip(sentences, de_results):
             s["sentence_de"] = de
-            s["sentence_fr"] = fr
             s.setdefault("sentence_en", "")
+            s.setdefault("sentence_fr", "")
     except Exception as e:
         err = str(e)
         vpn_hint = " (VPN issue?)" if any(k in err.lower() for k in ("eof", "connect", "timeout", "proxy", "ssl")) else ""

--- a/ai.py
+++ b/ai.py
@@ -736,6 +736,129 @@ def fix_definition_commas(cards: list[dict]) -> int:
     return total_fixed
 
 
+def generate_kahneman_sentences(
+    cards: list[dict],
+    chapter: dict,
+    model: str = DEFAULT_MODEL,
+    progress_key: str | None = None,
+    attempt_label: str = "",
+) -> list[dict]:
+    """Generate sentences in the style of Kahneman's "Speaking of..." chapter endings.
+
+    Each sentence uses one vocabulary word and implicitly reveals the cognitive bias
+    described in `chapter`. Returns list of sentence dicts with concept fields attached.
+
+    cards:   vocab cards assigned to this chapter (word_id, word_zh, pinyin, definition)
+    chapter: {number, title_zh, title_en, concept_zh, concept_en, examples_zh}
+    """
+    if not cards:
+        return []
+
+    def _word_in_sentence(word_zh: str, sentence_zh: str) -> bool:
+        if '...' in word_zh or '…' in word_zh:
+            chars = [c for c in word_zh if c not in '.…']
+            return all(c in sentence_zh for c in chars)
+        return word_zh in sentence_zh
+
+    examples_block = "\n".join(f"  {ex}" for ex in chapter.get("examples_zh", []))
+    word_list = "\n".join(
+        f"{i + 1}. {c['word_zh']}（{c.get('pinyin', '')}）— {c.get('definition', '')}"
+        for i, c in enumerate(cards)
+    )
+    concept_label = f"第{chapter['number']}章《{chapter['title_zh']}》：{chapter['concept_zh']}"
+
+    prompt = f"""任务：模仿《思考，快与慢》每章末尾"示例"部分的风格，写若干中文句子帮助HSK 4-5学习者复习词汇。
+每个句子应该是某人在日常情境中说的一句话，自然地透露出一种认知偏误或心理定势，而不直接点明偏误名称。
+
+本章概念：{concept_label}
+
+风格范例（模仿这种语气和结构）：
+{examples_block}
+
+目标词汇（每句话必须恰好包含其中一个，原文出现）：
+{word_list}
+
+规则：
+- 每句话恰好包含一个目标词汇，词汇必须以原文形式出现
+- 用自然口语风格，隐性透露本章所描述的认知偏误
+- 不要直接提及偏误名称或心理学术语
+- 非目标词汇只用HSK 1-2级词汇
+- 句子要简短（不超过20个字）
+- 不要使用markdown格式
+
+仅返回如下JSON数组，不加任何其他文字：
+[
+  {{"sentence_zh": "句子内容"}},
+  {{"sentence_zh": "句子内容"}}
+]"""
+
+    concept_en = f"Chapter {chapter['number']}: {chapter['title_en']}"
+    concept_zh = f"第{chapter['number']}章：{chapter['title_zh']}"
+
+    _set_progress(progress_key, phase="request", msg=f"生成第{chapter['number']}章句子…{attempt_label}", percent=20)
+
+    for attempt in range(3):
+        raw = _call_api(model, [{"role": "user", "content": prompt}], 4096, purpose="kahneman")
+
+        json_start = raw.find("[")
+        json_end = raw.rfind("]") + 1
+        if json_start == -1 or json_end == 0:
+            logger.warning("kahneman attempt %d: no JSON array found", attempt + 1)
+            continue
+
+        try:
+            items = json.loads(raw[json_start:json_end])
+        except json.JSONDecodeError as e:
+            logger.warning("kahneman attempt %d: JSON parse error: %s", attempt + 1, e)
+            continue
+
+        sentences = []
+        seen: set[int] = set()
+        for item in items:
+            s_zh = item.get("sentence_zh", "").strip()
+            if not s_zh:
+                continue
+            word_ids = []
+            for card in cards:
+                wid = card["word_id"]
+                if wid not in seen and _word_in_sentence(card["word_zh"], s_zh):
+                    word_ids.append(wid)
+                    seen.add(wid)
+                    break
+            sentences.append({
+                "word_ids": word_ids,
+                "sentence_zh": s_zh,
+                "sentence_en": "",
+                "concept_en": concept_en,
+                "concept_zh": concept_zh,
+                "tokens": [],
+            })
+
+        missing = [c["word_zh"] for c in cards if c["word_id"] not in seen]
+        if missing:
+            logger.warning("kahneman attempt %d: missing words: %s", attempt + 1, missing)
+            if attempt < 2:
+                continue
+
+        if sentences:
+            _fill_translations(sentences, progress_key=progress_key)
+            return sentences
+
+    # Fallback: one sentence per card
+    fallback = []
+    for card in cards:
+        fallback.append({
+            "word_ids": [card["word_id"]],
+            "sentence_zh": card.get("source_sentence") or f"我学了{card['word_zh']}这个词。",
+            "sentence_en": "",
+            "concept_en": concept_en,
+            "concept_zh": concept_zh,
+            "tokens": [],
+        })
+    _fill_translations(fallback, progress_key=progress_key)
+    return fallback
+
+
 def estimate_story_tokens(num_cards: int) -> int:
     """Rough token estimate for generating a story with num_cards words.
 

--- a/database/core.py
+++ b/database/core.py
@@ -175,6 +175,10 @@ def init_db() -> None:
         conn.execute("ALTER TABLE story_sentences ADD COLUMN sentence_fr TEXT")
     if "tokens" not in ss_cols:
         conn.execute("ALTER TABLE story_sentences ADD COLUMN tokens TEXT")
+    if "concept_en" not in ss_cols:
+        conn.execute("ALTER TABLE story_sentences ADD COLUMN concept_en TEXT")
+    if "concept_zh" not in ss_cols:
+        conn.execute("ALTER TABLE story_sentences ADD COLUMN concept_zh TEXT")
     if "word_id" in ss_cols:
         _migrate_story_sentences_multi_word(conn)
     existing_tables = {r["name"] for r in conn.execute(

--- a/database/stories.py
+++ b/database/stories.py
@@ -60,10 +60,12 @@ def create_story(date_str: str, category: str, deck_id: int,
     for s in sentences:
         tokens_json = json.dumps(s["tokens"], ensure_ascii=False) if s.get("tokens") else None
         sent_cur = conn.execute(
-            """INSERT INTO story_sentences (story_id, position, sentence_zh, sentence_en, sentence_de, sentence_fr, tokens)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            """INSERT INTO story_sentences
+               (story_id, position, sentence_zh, sentence_en, sentence_de, sentence_fr, tokens, concept_en, concept_zh)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (story_id, s["position"], s["sentence_zh"],
-             s.get("sentence_en", ""), s.get("sentence_de"), s.get("sentence_fr"), tokens_json),
+             s.get("sentence_en", ""), s.get("sentence_de"), s.get("sentence_fr"), tokens_json,
+             s.get("concept_en"), s.get("concept_zh")),
         )
         sentence_id = sent_cur.lastrowid
         for word_id in s.get("word_ids", []):

--- a/extract_kahneman.py
+++ b/extract_kahneman.py
@@ -1,0 +1,138 @@
+"""
+一次性脚本：从《思考，快与慢》中文版 PDF 提取每章"示例"句子，
+保存为 data/kahneman_chapters.json。
+
+运行方式：
+    python extract_kahneman.py
+
+需要环境变量：ANTHROPIC_API_KEY
+"""
+
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+
+import anthropic
+
+_book_dir = Path(__file__).parent / "thinking fast and slow"
+_candidates = list(_book_dir.glob("思考*快与慢*.pdf"))
+PDF_PATH = _candidates[0] if _candidates else _book_dir / "思考.pdf"
+OUTPUT_PATH = Path(__file__).parent / "data" / "kahneman_chapters.json"
+
+PROMPT = """你正在阅读《思考，快与慢》（丹尼尔·卡尼曼著）的中文版PDF。
+
+请提取书中每一章末尾的"示例"部分（有时标注为"关于……的例子"或类似标题）。
+这些示例通常是带引号的短句，是某人在日常情境中说的话，暗示某种认知偏误或心理现象正在发挥作用。
+
+对于书中每一章，请提取：
+1. 章节编号（数字）
+2. 章节标题（中文）
+3. 对应英文标题（如果你知道的话）
+4. 该章核心概念的一句话说明（中文，20-40字）
+5. 对应英文概念说明（一句话，英文）
+6. 该章末尾"示例"部分的所有引用句（中文，保留引号）
+
+请以如下 JSON 格式输出，不要添加任何其他文字：
+
+{
+  "chapters": [
+    {
+      "number": 1,
+      "title_zh": "本书的主角",
+      "title_en": "The Characters of the Story",
+      "concept_zh": "系统1（快速、直觉、自动）与系统2（缓慢、理性、费力）是大脑思考的两套机制",
+      "concept_en": "System 1 (fast, intuitive, automatic) and System 2 (slow, deliberate, effortful) are the two systems of the mind",
+      "examples_zh": [
+        "\"他有印象，只是其中一部分是幻象。\"",
+        "\"这纯粹是系统1的反应，她在意识到危险之前就果断采取了行动。\"",
+        "\"这是你系统1的想法，放慢速度，听听系统2的看法吧。\""
+      ]
+    }
+  ]
+}
+
+注意：
+- 只提取"示例"部分的引用句，不要包含章节正文内容
+- 如果某章没有"示例"部分，跳过该章
+- 引用句保留原文标点和引号
+- 确保 JSON 格式合法，可以直接解析"""
+
+
+def main():
+    if not PDF_PATH.exists():
+        print(f"错误：找不到 PDF 文件：{PDF_PATH}", file=sys.stderr)
+        sys.exit(1)
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("错误：缺少 ANTHROPIC_API_KEY 环境变量", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"读取 PDF：{PDF_PATH.name}")
+    with open(PDF_PATH, "rb") as f:
+        pdf_data = base64.standard_b64encode(f.read()).decode("utf-8")
+    print(f"PDF 大小：{len(pdf_data) * 3 // 4 / 1024 / 1024:.1f} MB（base64编码后）")
+
+    client = anthropic.Anthropic(api_key=api_key)
+
+    print("发送到 Claude API 提取章节数据...")
+    response = client.messages.create(
+        model="claude-opus-4-8",
+        max_tokens=32000,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "document",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "application/pdf",
+                            "data": pdf_data,
+                        },
+                    },
+                    {
+                        "type": "text",
+                        "text": PROMPT,
+                    },
+                ],
+            }
+        ],
+    )
+
+    raw = response.content[0].text.strip()
+    print(f"API 响应：{response.usage.input_tokens} 输入词元，{response.usage.output_tokens} 输出词元")
+
+    # 提取 JSON（有时模型会在 JSON 前后加说明文字）
+    json_start = raw.find("{")
+    json_end = raw.rfind("}") + 1
+    if json_start == -1 or json_end == 0:
+        print("错误：响应中找不到 JSON 数据", file=sys.stderr)
+        print("原始响应：", raw[:500])
+        sys.exit(1)
+
+    json_str = raw[json_start:json_end]
+
+    try:
+        data = json.loads(json_str)
+    except json.JSONDecodeError as e:
+        print(f"错误：JSON 解析失败：{e}", file=sys.stderr)
+        print("原始响应前500字：", raw[:500])
+        sys.exit(1)
+
+    chapters = data.get("chapters", [])
+    print(f"成功提取 {len(chapters)} 个章节")
+    for ch in chapters:
+        n_examples = len(ch.get("examples_zh", []))
+        print(f"  第{ch.get('number', '?')}章：{ch.get('title_zh', '?')}（{n_examples} 条示例）")
+
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(OUTPUT_PATH, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    print(f"\n已保存到：{OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/routes/story.py
+++ b/routes/story.py
@@ -1,4 +1,8 @@
+import json
 import logging
+import math
+import os
+import random
 
 import jieba
 import database
@@ -8,6 +12,8 @@ from fastapi import APIRouter
 from fastapi.responses import FileResponse
 
 from .utils import DISABLE_AI, leaf_ids
+
+KAHNEMAN_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "kahneman_chapters.json")
 
 # Suppress jieba's startup log messages
 jieba.setLogLevel(logging.ERROR)
@@ -123,7 +129,8 @@ def get_story(deck_id: int, category: str,
               topic: str | None = None, max_hsk: int = 3,
               model: str | None = None,
               grammar_focus: str | None = None, grammar_pct: int = 75,
-              mode: str = "story"):
+              mode: str = "story",
+              chapter_ids: str | None = None):
     if database.is_sentences_deck(deck_id):
         return None
 
@@ -152,10 +159,15 @@ def get_story(deck_id: int, category: str,
         ai._story_progress[progress_key] = {"phase": "starting", "msg": "Starting…", "percent": 5}
         last_error = None
         try:
-            sentences, prompt_text = _generate_story_sentences(
-                cards, topic=topic, max_hsk=max_hsk, model=chosen_model,
-                progress_key=progress_key, grammar_focus=grammar_focus,
-                grammar_pct=grammar_pct, mode=mode)
+            if mode == "kahneman":
+                parsed_chapter_ids = [int(x) for x in chapter_ids.split(",") if x.strip()] if chapter_ids else []
+                sentences, prompt_text = _generate_kahneman_story_sentences(
+                    cards, parsed_chapter_ids, model=chosen_model, progress_key=progress_key)
+            else:
+                sentences, prompt_text = _generate_story_sentences(
+                    cards, topic=topic, max_hsk=max_hsk, model=chosen_model,
+                    progress_key=progress_key, grammar_focus=grammar_focus,
+                    grammar_pct=grammar_pct, mode=mode)
             for i, s in enumerate(sentences):
                 s["position"] = i
             database.create_story(today, category, deck_id, sentences, prompt_text, topic)
@@ -186,7 +198,8 @@ def regenerate_story(deck_id: int, category: str,
                      topic: str | None = None, max_hsk: int = 3,
                      model: str | None = None,
                      grammar_focus: str | None = None, grammar_pct: int = 75,
-                     mode: str = "story"):
+                     mode: str = "story",
+                     chapter_ids: str | None = None):
     if database.is_sentences_deck(deck_id):
         return None
     if DISABLE_AI:
@@ -203,10 +216,15 @@ def regenerate_story(deck_id: int, category: str,
     ai._story_progress[progress_key] = {"phase": "starting", "msg": "Starting…", "percent": 5}
     last_error = None
     try:
-        sentences, prompt_text = _generate_story_sentences(
-            cards, topic=topic, max_hsk=max_hsk, model=chosen_model,
-            progress_key=progress_key, grammar_focus=grammar_focus,
-            grammar_pct=grammar_pct, mode=mode)
+        if mode == "kahneman":
+            parsed_chapter_ids = [int(x) for x in chapter_ids.split(",") if x.strip()] if chapter_ids else []
+            sentences, prompt_text = _generate_kahneman_story_sentences(
+                cards, parsed_chapter_ids, model=chosen_model, progress_key=progress_key)
+        else:
+            sentences, prompt_text = _generate_story_sentences(
+                cards, topic=topic, max_hsk=max_hsk, model=chosen_model,
+                progress_key=progress_key, grammar_focus=grammar_focus,
+                grammar_pct=grammar_pct, mode=mode)
         for i, s in enumerate(sentences):
             s["position"] = i
         database.create_story(today, category, deck_id, sentences, prompt_text, topic)
@@ -237,6 +255,72 @@ def get_history_story(deck_id: int, category: str):
     if story:
         story["sentences"] = _add_tokens(database.get_story_sentences(story["id"]))
     return story
+
+
+@router.get("/api/kahneman/chapters")
+def kahneman_chapters():
+    """Return all chapters from kahneman_chapters.json (without examples to reduce payload)."""
+    if not os.path.exists(KAHNEMAN_PATH):
+        return {"chapters": [], "available": False}
+    with open(KAHNEMAN_PATH, encoding="utf-8") as f:
+        data = json.load(f)
+    chapters = [
+        {k: v for k, v in ch.items() if k != "examples_zh"}
+        for ch in data.get("chapters", [])
+    ]
+    return {"chapters": chapters, "available": True}
+
+
+def _load_kahneman_chapter(chapter_id: int) -> dict | None:
+    if not os.path.exists(KAHNEMAN_PATH):
+        return None
+    with open(KAHNEMAN_PATH, encoding="utf-8") as f:
+        data = json.load(f)
+    for ch in data.get("chapters", []):
+        if ch.get("number") == chapter_id:
+            return ch
+    return None
+
+
+def _generate_kahneman_story_sentences(
+    cards: list, chapter_ids: list[int] | None,
+    model: str, progress_key: str | None,
+) -> tuple[list, str]:
+    """Distribute cards across selected chapters, call AI once per chapter, merge results."""
+    if not os.path.exists(KAHNEMAN_PATH):
+        raise RuntimeError("data/kahneman_chapters.json not found. Run python extract_kahneman.py first.")
+
+    with open(KAHNEMAN_PATH, encoding="utf-8") as f:
+        all_chapters = json.load(f).get("chapters", [])
+
+    if not all_chapters:
+        raise RuntimeError("kahneman_chapters.json is empty.")
+
+    if chapter_ids:
+        num_map = {ch["number"]: ch for ch in all_chapters}
+        selected = [num_map[cid] for cid in chapter_ids if cid in num_map]
+    else:
+        selected = random.sample(all_chapters, min(5, len(all_chapters)))
+
+    if not selected:
+        raise RuntimeError("No valid chapters selected.")
+
+    n = len(selected)
+    chunk_size = math.ceil(len(cards) / n)
+    chunks = [cards[i:i + chunk_size] for i in range(0, len(cards), chunk_size)]
+
+    all_sentences: list[dict] = []
+    prompt_summary = f"kahneman mode — {n} chapters"
+    for idx, (chapter, chunk) in enumerate(zip(selected, chunks)):
+        if not chunk:
+            continue
+        label = f" ({idx + 1}/{n})"
+        chapter_sentences = ai.generate_kahneman_sentences(
+            chunk, chapter, model=model, progress_key=progress_key, attempt_label=label
+        )
+        all_sentences.extend(chapter_sentences)
+
+    return all_sentences, prompt_summary
 
 
 @router.get("/api/story/{deck_id}/{category}/count")

--- a/schema.sql
+++ b/schema.sql
@@ -302,6 +302,8 @@ CREATE TABLE IF NOT EXISTS story_sentences (
     sentence_de TEXT,
     sentence_fr TEXT,
     tokens      TEXT,
+    concept_en  TEXT,
+    concept_zh  TEXT,
     UNIQUE(story_id, position)
 );
 

--- a/static/app.js
+++ b/static/app.js
@@ -2346,7 +2346,7 @@ async function startReview(id, cat, name, noStory = false, quick = false) {
   }
 }
 
-async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story') {
+async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', chapterIds = null) {
   if (quickMode) {
     setLoading('Loading audio…', true);
     try {
@@ -2370,7 +2370,7 @@ async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mo
     const storyDeckId = rootDeckId || deckId;
     const storyCategory = rootDeckId ? 'unified' : category;
     _startStoryProgressPoll(storyDeckId, storyCategory);
-    const storyUrl = `/api/story/${storyDeckId}/${storyCategory}` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode);
+    const storyUrl = `/api/story/${storyDeckId}/${storyCategory}` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds);
     let todayData, storyData;
     try {
       [todayData, storyData] = await Promise.all([
@@ -2416,7 +2416,7 @@ async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mo
   }
 }
 
-function _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode) {
+function _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds) {
   const p = new URLSearchParams();
   if (topic)                              p.set('topic', topic);
   if (maxHsk !== 3)                       p.set('max_hsk', maxHsk);
@@ -2424,6 +2424,7 @@ function _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode) {
   if (grammarFocus)                       p.set('grammar_focus', grammarFocus);
   if (grammarFocus && grammarPct !== 75)  p.set('grammar_pct', grammarPct);
   if (mode && mode !== 'story')           p.set('mode', mode);
+  if (chapterIds && chapterIds.length)    p.set('chapter_ids', chapterIds.join(','));
   const s = p.toString();
   return s ? '?' + s : '';
 }
@@ -2468,7 +2469,7 @@ async function startReviewMixed(id, name, noStory = false, quick = false) {
   }
 }
 
-async function _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', noStory = false) {
+async function _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', noStory = false, chapterIds = null) {
   setLoading(noStory ? 'Loading…' : 'Generating stories…', !noStory);
   if (!noStory) {
     setLoadingStep(10, null, 'Sending request to AI…');
@@ -2488,7 +2489,7 @@ async function _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPc
     if (!noStory) {
       // Load a single unified story covering all categories (1 AI call instead of 3)
       try {
-        story = await api('GET', `/api/story/${rootDeckId}/unified` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode));
+        story = await api('GET', `/api/story/${rootDeckId}/unified` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds));
       } catch (e) {
         _stopFakeProgress(); _stopStoryProgressPoll();
         _showLoadingError('AI request failed', e.message);
@@ -2550,7 +2551,7 @@ async function startReviewUnfinished() {
   }
 }
 
-async function _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story') {
+async function _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', chapterIds = null) {
   unfinishedMode = true;
   setLoading('Loading cards…');
   try {
@@ -2567,7 +2568,7 @@ async function _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, gram
     const firstDeckId = todayData.card.deck_id;
     // Load a single unified story for the first card's deck
     try {
-      story = await api('GET', `/api/story/${firstDeckId}/unified` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode));
+      story = await api('GET', `/api/story/${firstDeckId}/unified` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds));
     } catch (_) {}
     fetch(`/api/preload-session/${firstDeckId}/unified`, { method: 'POST' }).catch(() => {});
     showView('review');
@@ -4460,19 +4461,92 @@ function updateSetupMode() {
   const topicLabel = document.getElementById('setup-topic-label');
   const topicInput = document.getElementById('setup-topic');
   const btn = document.getElementById('setup-generate-btn');
+  const kahnemanSection = document.getElementById('setup-kahneman-section');
   if (mode === 'qa') {
     topicLabel.childNodes[0].textContent = 'Question ';
     topicInput.placeholder = 'e.g. How was life in ancient China?';
     btn.textContent = 'Generate answer';
+    topicLabel.style.display = '';
+    kahnemanSection.style.display = 'none';
   } else if (mode === 'expository') {
     topicLabel.childNodes[0].textContent = 'Topic ';
     topicInput.placeholder = 'e.g. The Second World War';
     btn.textContent = 'Generate text';
+    topicLabel.style.display = '';
+    kahnemanSection.style.display = 'none';
+  } else if (mode === 'kahneman') {
+    topicLabel.style.display = 'none';
+    kahnemanSection.style.display = 'block';
+    btn.textContent = 'Generate Kahneman';
+    _loadKahnemanChapters();
   } else {
     topicLabel.childNodes[0].textContent = 'Topic ';
     topicInput.placeholder = 'e.g. a day at a coffee shop';
     btn.textContent = 'Generate story';
+    topicLabel.style.display = '';
+    kahnemanSection.style.display = 'none';
   }
+}
+
+let _kahnemanChapters = null;
+
+async function _loadKahnemanChapters() {
+  const container = document.getElementById('setup-kahneman-chapters');
+  const loading = document.getElementById('setup-kahneman-loading');
+  if (_kahnemanChapters) { _renderKahnemanChapters(); return; }
+  container.style.display = 'none';
+  loading.style.display = 'block';
+  try {
+    const data = await api('GET', '/api/kahneman/chapters');
+    if (!data.available || !data.chapters.length) {
+      loading.textContent = 'No chapters found. Run python extract_kahneman.py first.';
+      return;
+    }
+    _kahnemanChapters = data.chapters;
+    loading.style.display = 'none';
+    container.style.display = 'block';
+    _renderKahnemanChapters();
+  } catch (e) {
+    loading.textContent = 'Failed to load chapters.';
+  }
+}
+
+function _renderKahnemanChapters() {
+  const container = document.getElementById('setup-kahneman-chapters');
+  if (!_kahnemanChapters) return;
+  container.innerHTML = _kahnemanChapters.map(ch => `
+    <label class="kahneman-chapter-row">
+      <input type="checkbox" class="kahneman-chapter-cb" value="${ch.number}" onchange="_updateKahnemanCount()">
+      <div class="kahneman-chapter-info">
+        <span class="kahneman-chapter-title">第${ch.number}章 ${ch.title_zh}</span>
+        <span class="kahneman-chapter-concept">${ch.concept_zh}</span>
+      </div>
+    </label>`).join('');
+  _updateKahnemanCount();
+}
+
+function _updateKahnemanCount() {
+  const checked = document.querySelectorAll('.kahneman-chapter-cb:checked').length;
+  const countEl = document.getElementById('setup-kahneman-count');
+  countEl.textContent = checked ? `(${checked} selected)` : '(none selected → random 5)';
+}
+
+function randomKahnemanChapters() {
+  if (!_kahnemanChapters) return;
+  const all = Array.from(document.querySelectorAll('.kahneman-chapter-cb'));
+  all.forEach(cb => { cb.checked = false; });
+  const indices = [];
+  while (indices.length < Math.min(5, all.length)) {
+    const i = Math.floor(Math.random() * all.length);
+    if (!indices.includes(i)) indices.push(i);
+  }
+  indices.forEach(i => { all[i].checked = true; });
+  _updateKahnemanCount();
+}
+
+function _getSelectedChapterIds() {
+  return Array.from(document.querySelectorAll('.kahneman-chapter-cb:checked'))
+    .map(cb => parseInt(cb.value));
 }
 
 function confirmStorySetup() {
@@ -4482,17 +4556,18 @@ function confirmStorySetup() {
   const grammarFocus = document.getElementById('setup-grammar').value.trim() || null;
   const grammarPct  = parseInt(document.getElementById('setup-grammar-pct').value, 10) || 75;
   const mode        = document.getElementById('setup-mode').value;
+  const chapterIds  = mode === 'kahneman' ? _getSelectedChapterIds() : null;
   _closeSetupModal();
   if (_setupIsDeckListRegen) {
-    _doRegenStoryForDeckList(_deckListRegenId, topic, maxHsk, model, grammarFocus, grammarPct, mode);
+    _doRegenStoryForDeckList(_deckListRegenId, topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds);
   } else if (_setupIsRegen) {
-    _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct, mode);
+    _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds);
   } else if (_setupIsUnfinished) {
-    _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, grammarPct, mode);
+    _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds);
   } else if (_setupIsMixed) {
-    _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPct, mode);
+    _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds);
   } else {
-    _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mode);
+    _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds);
   }
 }
 
@@ -4517,11 +4592,16 @@ function openStoryModal() {
       s.word_zh,
       `<span class="story-target">${s.word_zh}</span>`
     );
-    const esc = encodeURIComponent(s.sentence_zh);
+    const conceptBadge = s.concept_zh
+      ? `<div class="story-concept-badge" title="${s.concept_en || ''}">
+           <span class="concept-name">${s.concept_zh}</span>
+         </div>`
+      : '';
     return `<div class="story-sentence${isCurrent ? ' story-sentence-current' : ''}" data-idx="${s.position}">
       <span class="story-num">${s.position + 1}</span>
       <div class="story-content">
         <div class="story-zh">${highlighted}</div>
+        ${conceptBadge}
         ${s.sentence_fr ? `<div class="story-fr">🇫🇷 ${s.sentence_fr}</div>` : ''}
         ${s.sentence_de ? `<div class="story-de">🇩🇪 ${s.sentence_de}</div>` : ''}
       </div>
@@ -4885,7 +4965,7 @@ async function regenerateStory() {
   }
 }
 
-async function _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story') {
+async function _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', chapterIds = null) {
   setLoading('Regenerating story…', true);
   setLoadingStep(10, null, 'Sending request to AI…');
   _startFakeProgress(10, 55, 45000);
@@ -4895,7 +4975,7 @@ async function _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct
     _startStoryProgressPoll(storyDeckId, storyCategory);
     let storyData;
     try {
-      storyData = await api('POST', `/api/story/${storyDeckId}/${storyCategory}/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode));
+      storyData = await api('POST', `/api/story/${storyDeckId}/${storyCategory}/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds));
     } catch (e) {
       _stopFakeProgress(); _stopStoryProgressPoll();
       _showLoadingError('AI request failed', e.message);
@@ -4957,7 +5037,7 @@ async function regenerateStoryFromList(deckId) {
   document.getElementById('setup-topic').focus();
 }
 
-async function _doRegenStoryForDeckList(deckId, topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story') {
+async function _doRegenStoryForDeckList(deckId, topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', chapterIds = null) {
   setLoading('Regenerating story…', true);
   setLoadingStep(10, null, 'Sending request to AI…');
   _startFakeProgress(10, 55, 45000);
@@ -4965,7 +5045,7 @@ async function _doRegenStoryForDeckList(deckId, topic, maxHsk, model, grammarFoc
   try {
     let storyData;
     try {
-      storyData = await api('POST', `/api/story/${deckId}/unified/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode));
+      storyData = await api('POST', `/api/story/${deckId}/unified/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds));
     } catch (e) {
       _stopFakeProgress(); _stopStoryProgressPoll();
       _showLoadingError('AI request failed', e.message);

--- a/static/app.js
+++ b/static/app.js
@@ -3006,6 +3006,28 @@ function revealAnswer() {
     _sentDeEl.textContent = sentence?.sentence_de || '';
     _sentDeEl.style.display = sentence?.sentence_de ? '' : 'none';
   }
+
+  // Kahneman concept section
+  const _conceptEl = document.getElementById('sentence-concept');
+  if (!isSentenceNote && sentence?.concept_zh) {
+    const chNum = sentence.concept_en ? parseInt(sentence.concept_en.match(/Chapter (\d+)/)?.[1]) : null;
+    const renderConcept = (desc) => {
+      _conceptEl.innerHTML = `<span class="concept-chapter-title">${sentence.concept_zh}</span>`
+        + (desc ? `<span class="concept-chapter-desc">${desc}</span>` : '');
+      _conceptEl.style.display = '';
+    };
+    const cachedCh = chNum && _kahnemanChapters ? _kahnemanChapters.find(c => c.number === chNum) : null;
+    renderConcept(cachedCh?.concept_zh || '');
+    if (!cachedCh && chNum) {
+      _ensureKahnemanChapters().then(() => {
+        const ch = _kahnemanChapters?.find(c => c.number === chNum);
+        if (ch?.concept_zh) renderConcept(ch.concept_zh);
+      });
+    }
+  } else {
+    _conceptEl.style.display = 'none';
+    _conceptEl.innerHTML = '';
+  }
   const noteType = wordDetails?.note_type || card.note_type;
   const wordZhEl = document.getElementById('word-zh');
   const isMultiWord = noteType === 'sentence' || noteType === 'chengyu' || noteType === 'expression';
@@ -4489,6 +4511,14 @@ function updateSetupMode() {
 }
 
 let _kahnemanChapters = null;
+
+async function _ensureKahnemanChapters() {
+  if (_kahnemanChapters) return;
+  try {
+    const data = await api('GET', '/api/kahneman/chapters');
+    if (data.available && data.chapters.length) _kahnemanChapters = data.chapters;
+  } catch (e) { /* silent */ }
+}
 
 async function _loadKahnemanChapters() {
   const container = document.getElementById('setup-kahneman-chapters');

--- a/static/index.html
+++ b/static/index.html
@@ -148,6 +148,7 @@
               </div>
               <div class="input-label">Reconstruct the sentence</div>
               <div class="word-bank-skeleton" id="word-bank-skeleton"></div>
+              <div class="creating-word-def" id="creating-word-def-wb" style="display:none"></div>
               <div class="word-bank-tokens" id="word-bank-tokens"></div>
               <input type="text" id="word-bank-input"
                      autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
@@ -585,8 +586,18 @@
         <option value="story">📖 Story — narrative with characters</option>
         <option value="qa">❓ Q&amp;A — answer a question</option>
         <option value="expository">📚 Expository — informative text</option>
+        <option value="kahneman">🧠 Kahneman — cognitive bias style</option>
       </select>
     </label>
+    <!-- Kahneman chapter selector (shown only in kahneman mode) -->
+    <div id="setup-kahneman-section" style="display:none">
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
+        <label class="edit-label" style="margin:0">Chapters <span style="font-weight:400;text-transform:none" id="setup-kahneman-count"></span></label>
+        <button class="edit-cancel-btn" style="padding:4px 10px;font-size:12px" onclick="randomKahnemanChapters()">🎲 Random 5</button>
+      </div>
+      <div id="setup-kahneman-chapters" style="max-height:220px;overflow-y:auto;border:1px solid var(--border,#ddd);border-radius:6px;padding:4px 0"></div>
+      <div id="setup-kahneman-loading" style="display:none;padding:12px;text-align:center;color:var(--muted,#888);font-size:13px">Loading chapters…</div>
+    </div>
     <label class="edit-label" id="setup-topic-label">Topic <span style="font-weight:400;text-transform:none">(optional)</span>
       <input class="edit-input" id="setup-topic" type="text" placeholder="e.g. a day at a coffee shop" onkeydown="if(event.key==='Enter')confirmStorySetup()">
     </label>

--- a/static/index.html
+++ b/static/index.html
@@ -188,6 +188,8 @@
             <!-- French and German translation of the sentence -->
             <div class="sentence-fr" id="sentence-fr"></div>
             <div class="sentence-de" id="sentence-de"></div>
+            <!-- Kahneman chapter concept (shown only for Kahneman-mode sentences) -->
+            <div id="sentence-concept" class="sentence-concept-section" style="display:none"></div>
 
             <!-- 3. Rating buttons (immediately visible after flip) -->
             <div class="rating-row" id="rating-row">

--- a/static/style.css
+++ b/static/style.css
@@ -3706,3 +3706,39 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   z-index: 9999;
   animation: confetti-fall linear forwards;
 }
+
+/* ── Kahneman chapter selector ──────────────────────────── */
+.kahneman-chapter-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 7px 12px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border, #eee);
+  transition: background 0.1s;
+}
+.kahneman-chapter-row:last-child { border-bottom: none; }
+.kahneman-chapter-row:hover { background: var(--hover-bg, #f5f5f5); }
+.kahneman-chapter-row input[type="checkbox"] { margin-top: 2px; flex-shrink: 0; }
+.kahneman-chapter-info { display: flex; flex-direction: column; gap: 2px; }
+.kahneman-chapter-title { font-size: 13px; font-weight: 600; color: var(--text, #222); }
+.kahneman-chapter-concept { font-size: 12px; color: var(--muted, #888); line-height: 1.4; }
+
+/* ── Kahneman concept badge in story modal ──────────────── */
+.story-concept-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 3px;
+  padding: 2px 8px;
+  background: #ede9fe;
+  border: 1px solid #c4b5fd;
+  border-radius: 10px;
+  font-size: 11px;
+  color: #5b21b6;
+}
+@media (prefers-color-scheme: dark) {
+  .story-concept-badge { background: #2e1065; border-color: #6d28d9; color: #c4b5fd; }
+  .kahneman-chapter-row:hover { background: var(--hover-bg, #2a2a2a); }
+}
+.concept-name { font-weight: 500; }

--- a/static/style.css
+++ b/static/style.css
@@ -3757,12 +3757,12 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   text-align: left;
 }
 .concept-chapter-title {
-  font-size: 12px;
+  font-size: 15px;
   font-weight: 700;
   color: #5b21b6;
 }
 .concept-chapter-desc {
-  font-size: 12px;
+  font-size: 14px;
   color: #6d28d9;
   line-height: 1.5;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -3742,3 +3742,32 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   .kahneman-chapter-row:hover { background: var(--hover-bg, #2a2a2a); }
 }
 .concept-name { font-weight: 500; }
+
+/* Kahneman concept block shown on review card back */
+.sentence-concept-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 8px auto 0;
+  max-width: 520px;
+  padding: 8px 12px;
+  background: #ede9fe;
+  border: 1px solid #c4b5fd;
+  border-radius: 10px;
+  text-align: left;
+}
+.concept-chapter-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: #5b21b6;
+}
+.concept-chapter-desc {
+  font-size: 12px;
+  color: #6d28d9;
+  line-height: 1.5;
+}
+@media (prefers-color-scheme: dark) {
+  .sentence-concept-section { background: #2e1065; border-color: #6d28d9; }
+  .concept-chapter-title { color: #c4b5fd; }
+  .concept-chapter-desc { color: #a78bfa; }
+}


### PR DESCRIPTION
## 变更内容

新增"Kahneman"故事生成模式，以《思考，快与慢》的"示例"句子为风格参考：

- **schema.sql + database/core.py**：story_sentences 新增 concept_en/concept_zh 列
- **database/stories.py**：create_story() 支持存储概念标签字段
- **ai.py**：新增 generate_kahneman_sentences()，每章单独一次 AI 请求
- **routes/story.py**：新增 GET /api/kahneman/chapters；故事端点支持 mode=kahneman 和 chapter_ids 参数
- **前端**：设置弹窗新增章节选择器（含随机5章按钮）；故事弹窗每句话显示紫色概念标签
- **extract_kahneman.py**：一次性脚本，用 Claude API 从中文 PDF 提取章节数据

## 前置步骤

运行 `python extract_kahneman.py` 生成 `data/kahneman_chapters.json`

## 测试方法

1. 运行 extract_kahneman.py，确认 JSON 文件包含所有章节
2. 启动服务，打开故事设置弹窗，选"Kahneman"模式
3. 手选2-3章 → 生成 → 每句话下方显示紫色概念标签
4. 点"随机5章" → 确认5个不同章节被选中

Closes #291