### PR TITLE
fix: 复习时未来日期只剩当前类别到期不再显示空灰色方块

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -161,21 +161,23 @@ function _renderCal() {
       const isToday = dateStr === todayStr;
       const info = dayMap[dateStr];
 
-      // Only count future dues that will actually render a chip — the current
-      // category's chip is suppressed below, so a date whose only due is the
-      // current category must not get the grey "has-future" background.
-      const hasFutureDue = dateStr > todayStr
-        && (info?.dues || []).some(f => f.category !== _calCategory);
+      // The current category's chip is suppressed (we're already reviewing it),
+      // so only ratings + other-category dues count as visible content. A date
+      // whose only due is the current category must render like an empty day:
+      // no grey "has-future" background, and its day number must still show.
+      const ratings     = info?.ratings || [];
+      const visibleDues = (info?.dues || []).filter(f => f.category !== _calCategory);
+      const hasVisible   = ratings.length > 0 || visibleDues.length > 0;
+      const hasFutureDue = dateStr > todayStr && visibleDues.length > 0;
       html += `<div class="cal-cell${isToday ? ' cal-today' : ''}${hasFutureDue ? ' cal-has-future' : ''}">`;
-      if (info) {
+      if (hasVisible) {
         html += '<div class="cal-chips">';
-        for (const r of info.ratings) {
+        for (const r of ratings) {
           const rCls = _RATING_CLASS[r.rating] || 'good';
           const letter = _CAT_LETTER[r.category] || '?';
           html += `<span class="cal-chip cal-chip-${rCls}" title="${r.category}: ${rCls}">${letter}</span>`;
         }
-        for (const f of info.dues) {
-          if (f.category === _calCategory) continue;
+        for (const f of visibleDues) {
           const cCls = _CAT_CLASS[f.category] || '';
           const letter = _CAT_LETTER[f.category] || '?';
           html += `<span class="cal-chip cal-chip-due-${cCls}" title="${f.category} due">${letter}</span>`;

--- a/static/app.js
+++ b/static/app.js
@@ -161,7 +161,11 @@ function _renderCal() {
       const isToday = dateStr === todayStr;
       const info = dayMap[dateStr];
 
-      const hasFutureDue = dateStr > todayStr && info?.dues?.length > 0;
+      // Only count future dues that will actually render a chip — the current
+      // category's chip is suppressed below, so a date whose only due is the
+      // current category must not get the grey "has-future" background.
+      const hasFutureDue = dateStr > todayStr
+        && (info?.dues || []).some(f => f.category !== _calCategory);
       html += `<div class="cal-cell${isToday ? ' cal-today' : ''}${hasFutureDue ? ' cal-has-future' : ''}">`;
       if (info) {
         html += '<div class="cal-chips">';


### PR DESCRIPTION
## 变更内容
修复日历上**空的灰色方块**问题：复习某类别（如 Listening）时，未来日期若唯一到期就是当前类别，徽章被隐藏（#289 的修复）但灰色背景仍保留，剩下一个空灰方块。

现在 `hasFutureDue` 只在存在**其他类别**到期时才为真，与徽章渲染逻辑保持一致。

## 测试方法
- 复习一个 Listening 卡片，打开日历
- 确认未来日期不再出现没有徽章的空灰色方块
- 确认有读/创等其他类别到期的未来日期仍正常显示灰色背景和徽章

Closes #294