### PR TITLE
feat: Kahneman 概念框可点击，弹窗显示书中原句

### DIFF
--- a/routes/story.py
+++ b/routes/story.py
@@ -271,6 +271,15 @@ def kahneman_chapters():
     return {"chapters": chapters, "available": True}
 
 
+@router.get("/api/kahneman/chapter/{number}")
+def kahneman_chapter(number: int):
+    """Return one full chapter (including examples_zh — the book's original quotes)."""
+    ch = _load_kahneman_chapter(number)
+    if ch is None:
+        return {"chapter": None, "available": False}
+    return {"chapter": ch, "available": True}
+
+
 def _load_kahneman_chapter(chapter_id: int) -> dict | None:
     if not os.path.exists(KAHNEMAN_PATH):
         return None

--- a/static/app.js
+++ b/static/app.js
@@ -4528,8 +4528,8 @@ async function _ensureKahnemanChapters() {
   } catch (e) { /* silent */ }
 }
 
-// ── Kahneman examples popup (book's original quotes for a chapter) ──────────────
-const _kahnemanExamplesCache = {}; // chapter number → examples_zh[]
+// ── Kahneman examples popup (chapter summary + book's original quotes) ──────────
+const _kahnemanExamplesCache = {}; // chapter number → { summary, examples }
 
 async function openKahnemanExamples(chNum, conceptZh) {
   const overlay = document.getElementById('kahneman-examples-overlay');
@@ -4541,19 +4541,23 @@ async function openKahnemanExamples(chNum, conceptZh) {
   overlay.style.display = '';
   modal.style.display = '';
 
-  let examples = _kahnemanExamplesCache[chNum];
-  if (!examples) {
+  let chapter = _kahnemanExamplesCache[chNum];
+  if (!chapter) {
     try {
       const data = await api('GET', `/api/kahneman/chapter/${chNum}`);
-      examples = data.chapter?.examples_zh || [];
-      _kahnemanExamplesCache[chNum] = examples;
-    } catch (e) { examples = []; }
+      chapter = { summary: data.chapter?.concept_zh || '', examples: data.chapter?.examples_zh || [] };
+      _kahnemanExamplesCache[chNum] = chapter;
+    } catch (e) { chapter = { summary: '', examples: [] }; }
   }
   if (modal.style.display === 'none') return; // closed while loading
   const esc = s => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  bodyEl.innerHTML = examples.length
-    ? examples.map(ex => `<p class="kahneman-example">${esc(ex)}</p>`).join('')
+  const summaryHtml = chapter.summary
+    ? `<div class="kahneman-summary">${esc(chapter.summary)}</div>` : '';
+  const examplesHtml = chapter.examples.length
+    ? `<div class="kahneman-examples-label">书中原句</div>`
+      + chapter.examples.map(ex => `<p class="kahneman-example">${esc(ex)}</p>`).join('')
     : '<div class="kahneman-examples-loading">本章暂无书中原句。</div>';
+  bodyEl.innerHTML = summaryHtml + examplesHtml;
 }
 
 function closeKahnemanExamples() {

--- a/static/app.js
+++ b/static/app.js
@@ -3013,8 +3013,16 @@ function revealAnswer() {
     const chNum = sentence.concept_en ? parseInt(sentence.concept_en.match(/Chapter (\d+)/)?.[1]) : null;
     const renderConcept = (desc) => {
       _conceptEl.innerHTML = `<span class="concept-chapter-title">${sentence.concept_zh}</span>`
-        + (desc ? `<span class="concept-chapter-desc">${desc}</span>` : '');
+        + (desc ? `<span class="concept-chapter-desc">${desc}</span>` : '')
+        + (chNum ? `<span class="concept-chapter-hint">点击查看书中原句 ›</span>` : '');
       _conceptEl.style.display = '';
+      if (chNum) {
+        _conceptEl.classList.add('concept-clickable');
+        _conceptEl.onclick = () => openKahnemanExamples(chNum, sentence.concept_zh);
+      } else {
+        _conceptEl.classList.remove('concept-clickable');
+        _conceptEl.onclick = null;
+      }
     };
     const cachedCh = chNum && _kahnemanChapters ? _kahnemanChapters.find(c => c.number === chNum) : null;
     renderConcept(cachedCh?.concept_zh || '');
@@ -4518,6 +4526,39 @@ async function _ensureKahnemanChapters() {
     const data = await api('GET', '/api/kahneman/chapters');
     if (data.available && data.chapters.length) _kahnemanChapters = data.chapters;
   } catch (e) { /* silent */ }
+}
+
+// ── Kahneman examples popup (book's original quotes for a chapter) ──────────────
+const _kahnemanExamplesCache = {}; // chapter number → examples_zh[]
+
+async function openKahnemanExamples(chNum, conceptZh) {
+  const overlay = document.getElementById('kahneman-examples-overlay');
+  const modal   = document.getElementById('kahneman-examples-modal');
+  const titleEl = document.getElementById('kahneman-examples-title');
+  const bodyEl  = document.getElementById('kahneman-examples-body');
+  titleEl.textContent = conceptZh || `第${chNum}章`;
+  bodyEl.innerHTML = '<div class="kahneman-examples-loading">加载中…</div>';
+  overlay.style.display = '';
+  modal.style.display = '';
+
+  let examples = _kahnemanExamplesCache[chNum];
+  if (!examples) {
+    try {
+      const data = await api('GET', `/api/kahneman/chapter/${chNum}`);
+      examples = data.chapter?.examples_zh || [];
+      _kahnemanExamplesCache[chNum] = examples;
+    } catch (e) { examples = []; }
+  }
+  if (modal.style.display === 'none') return; // closed while loading
+  const esc = s => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  bodyEl.innerHTML = examples.length
+    ? examples.map(ex => `<p class="kahneman-example">${esc(ex)}</p>`).join('')
+    : '<div class="kahneman-examples-loading">本章暂无书中原句。</div>';
+}
+
+function closeKahnemanExamples() {
+  document.getElementById('kahneman-examples-overlay').style.display = 'none';
+  document.getElementById('kahneman-examples-modal').style.display = 'none';
 }
 
 async function _loadKahnemanChapters() {
@@ -6143,6 +6184,7 @@ function _hasOpenModal() {
     'hanzi-regen-modal-overlay',
     'hanzi-edit-modal-overlay',
     'conflict-modal-overlay',
+    'kahneman-examples-overlay',
   ];
   return modalIds.some(_isVisible);
 }
@@ -6151,6 +6193,12 @@ document.addEventListener('keydown', async e => {
   const inInput = _isEditableFocusTarget(document.activeElement);
 
   if (e.key === 'Escape') {
+    const kahnemanOverlay = document.getElementById('kahneman-examples-overlay');
+    if (kahnemanOverlay && kahnemanOverlay.style.display !== 'none') {
+      e.preventDefault();
+      closeKahnemanExamples();
+      return;
+    }
     const storyOverlay = document.getElementById('story-modal-overlay');
     if (storyOverlay && storyOverlay.style.display !== 'none') {
       e.preventDefault();

--- a/static/index.html
+++ b/static/index.html
@@ -829,6 +829,16 @@
   </div>
 </div>
 
+<!-- Kahneman chapter examples popup (book's original quotes) -->
+<div id="kahneman-examples-overlay" onclick="closeKahnemanExamples()" style="display:none"></div>
+<div id="kahneman-examples-modal" style="display:none">
+  <div class="edit-modal-header">
+    <span class="edit-modal-title" id="kahneman-examples-title"></span>
+    <button class="edit-modal-close" onclick="closeKahnemanExamples()">✕</button>
+  </div>
+  <div id="kahneman-examples-body" class="kahneman-examples-body"></div>
+</div>
+
 <!-- Hanzi regenerate confirm modal -->
 <div id="hanzi-regen-modal-overlay" onclick="closeHanziRegenModal()" style="display:none"></div>
 <div id="hanzi-regen-modal" style="display:none">

--- a/static/style.css
+++ b/static/style.css
@@ -3766,8 +3766,56 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   color: #6d28d9;
   line-height: 1.5;
 }
+.concept-chapter-hint {
+  font-size: 12px;
+  font-weight: 600;
+  color: #7c3aed;
+  margin-top: 2px;
+}
+.sentence-concept-section.concept-clickable { cursor: pointer; transition: background 0.12s, border-color 0.12s; }
+.sentence-concept-section.concept-clickable:hover { background: #e0d7fb; border-color: #a78bfa; }
 @media (prefers-color-scheme: dark) {
   .sentence-concept-section { background: #2e1065; border-color: #6d28d9; }
   .concept-chapter-title { color: #c4b5fd; }
   .concept-chapter-desc { color: #a78bfa; }
+  .concept-chapter-hint { color: #c4b5fd; }
+  .sentence-concept-section.concept-clickable:hover { background: #3b1378; border-color: #7c3aed; }
+}
+
+/* ── Kahneman examples popup (book's original quotes) ──────────────── */
+#kahneman-examples-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.4);
+  z-index: 200;
+}
+#kahneman-examples-modal {
+  position: fixed;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 201;
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 40px rgba(0,0,0,0.18);
+  width: min(480px, 92vw);
+  max-height: 78vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  padding: 20px 24px 24px;
+  gap: 14px;
+}
+.kahneman-examples-body { display: flex; flex-direction: column; gap: 10px; }
+.kahneman-example {
+  margin: 0;
+  padding: 10px 14px;
+  background: #ede9fe;
+  border-left: 3px solid #a78bfa;
+  border-radius: 8px;
+  font-size: 16px;
+  line-height: 1.6;
+  color: #4c1d95;
+}
+.kahneman-examples-loading { color: var(--muted, #888); font-size: 14px; text-align: center; padding: 12px; }
+@media (prefers-color-scheme: dark) {
+  .kahneman-example { background: #2e1065; border-left-color: #7c3aed; color: #ddd6fe; }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -3805,6 +3805,22 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   gap: 14px;
 }
 .kahneman-examples-body { display: flex; flex-direction: column; gap: 10px; }
+.kahneman-summary {
+  font-size: 15px;
+  line-height: 1.6;
+  color: #5b21b6;
+  padding: 10px 14px;
+  background: #f5f3ff;
+  border: 1px solid #ddd6fe;
+  border-radius: 8px;
+}
+.kahneman-examples-label {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--muted, #888);
+  margin-top: 4px;
+}
 .kahneman-example {
   margin: 0;
   padding: 10px 14px;
@@ -3818,4 +3834,5 @@ details[open] .cat-override-summary::before { content: '▼ '; }
 .kahneman-examples-loading { color: var(--muted, #888); font-size: 14px; text-align: center; padding: 12px; }
 @media (prefers-color-scheme: dark) {
   .kahneman-example { background: #2e1065; border-left-color: #7c3aed; color: #ddd6fe; }
+  .kahneman-summary { background: #241047; border-color: #5b21b6; color: #c4b5fd; }
 }


### PR DESCRIPTION
## 变更内容
- 复习卡背的 Kahneman 概念框（`#sentence-concept`）现在可点击
- 点击后弹出小窗，显示该章在 `data/kahneman_chapters.json` 里的 `examples_zh`（《思考，快与慢》书中阐释该偏误的原句引文）
- 按 `Esc` 或点击遮罩层关闭弹窗
- 概念框带手型光标 + "点击查看书中原句 ›" 提示
- 后端新增 `GET /api/kahneman/chapter/{number}`，返回含 `examples_zh` 的完整章节（现有 `/api/kahneman/chapters` 为减小体积去掉了 examples）

## 说明
- 概念框本身只在 Kahneman 模式生成的故事里出现（整篇故事要么全有、要么全无）。普通模式故事的卡片没有概念框，因此也没有点击入口——属预期行为。
- 弹窗结果按章节号缓存，避免重复请求。

## 测试方法
1. 进入一篇 Kahneman 模式生成的牌组，翻开卡片背面，确认概念框显示手型光标与提示文字
2. 点击概念框，确认弹窗显示该章书中原句
3. 按 `Esc` 关闭，再点击遮罩层关闭，确认两种方式都生效
4. 普通模式故事的卡片背面无概念框，确认无影响

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)