### PR TITLE
fix: 恢复故事句子的法语翻译（#292 回归 bug）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -598,7 +598,7 @@ Return ONLY valid JSON, no explanation, no markdown:
 # ---------------------------------------------------------------------------
 
 def _fill_translations(sentences: list[dict], progress_key: str | None = None) -> None:
-    """Translate sentence_zh → sentence_de in-place using Google Translate."""
+    """Translate sentence_zh → sentence_de + sentence_fr in-place using Google Translate."""
     try:
         import translator as _t
         texts = [s.get("sentence_zh", "") for s in sentences]
@@ -610,16 +610,17 @@ def _fill_translations(sentences: list[dict], progress_key: str | None = None) -
 
         t0 = time.time()
         de_results = _t.translate_batch(texts, target="de")
-        logger.info("translate DE done in %.1fs (%d sentences)", time.time() - t0, total)
+        fr_results = _t.translate_batch(texts, target="fr")
+        logger.info("translate DE+FR done in %.1fs (%d sentences)", time.time() - t0, total)
 
         if progress_key and total > 0:
             _set_progress(progress_key, phase="translating",
                           msg=f"Translating… {total}/{total}", percent=92)
 
-        for s, de in zip(sentences, de_results):
+        for s, de, fr in zip(sentences, de_results, fr_results):
             s["sentence_de"] = de
+            s["sentence_fr"] = fr
             s.setdefault("sentence_en", "")
-            s.setdefault("sentence_fr", "")
     except Exception as e:
         err = str(e)
         vpn_hint = " (VPN issue?)" if any(k in err.lower() for k in ("eof", "connect", "timeout", "proxy", "ssl")) else ""


### PR DESCRIPTION
## 问题
复习卡片不再显示整句的**法语**翻译（`sentence_fr` 为空）。

## 根因
PR #292（Kahneman 模式）重构 `ai.py` 的 `_fill_translations()` 时误删了法语翻译调用：
```diff
         de_results = _t.translate_batch(texts, target="de")
-        fr_results = _t.translate_batch(texts, target="fr")
```
导致 06-04 之后生成的所有故事（普通 + Kahneman）只填德语、不填法语。

## 变更内容
- `_fill_translations()` 恢复法语翻译（`target="fr"`），与德语并行
- 结果写回 `sentence_fr`；异常回退分支不变

## 测试方法
1. `DISABLE_AI=0` 重新生成一篇故事，确认 `story_sentences.sentence_fr` 被填充
2. 复习卡背显示 🇫🇷 法语整句翻译

## 备注
已有的 06-04 之后故事仍缺法语，可后续单独脚本回填（本 PR 只修代码）。

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)