### PR TITLE
fix: 创建模式词块复现上一张卡的错误句子

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -4010,7 +4010,9 @@ function pickExtraBlankWord(zh, excludeWord) {
 // ── Word bank (creating mode, non-sentence notes) ─────────────────────────
 async function _buildWordBank() {
   const zh = sentence?.sentence_zh;
-  if (!zh || !card?.word_zh) return;
+  // No sentence for this card yet — clear stale state so the previous card's
+  // word bank doesn't linger on screen (renderWordBankUI clears the DOM too).
+  if (!zh || !card?.word_zh) { wordBankOrder = []; wordBankTokens = []; return; }
   const target = card.word_zh;
 
   // Separable words like "由...组成" — split into parts to match independently
@@ -4196,7 +4198,13 @@ function wordBankAddToken(num) {
 
 async function renderWordBankUI() {
   await _buildWordBank();
-  if (!wordBankOrder.length) return; // sentence not loaded yet
+  if (!wordBankOrder.length) {
+    // Sentence not loaded / no match — clear any stale skeleton + tiles from the
+    // previous card instead of leaving them on screen as a wrong sentence.
+    document.getElementById('word-bank-skeleton')?.replaceChildren();
+    document.getElementById('word-bank-tokens')?.replaceChildren();
+    return;
+  }
 
   // Sentence skeleton: pre-placed tokens shown as text, blanks for tiles/target (data-slot for live update)
   const skelEl = document.getElementById('word-bank-skeleton');


### PR DESCRIPTION
## 问题
创建模式词块复习中，当卡片在当前加载的故事里找不到匹配句子时（常见于「All」混合复习里跨天到期的旧卡），界面显示**上一张卡的句子**并套上当前词，看起来像「完全错误的句子」，德语提示也变空。

## 根因
`_buildWordBank()` 在 `sentence` 为 null 时提前返回，**不更新**全局 `wordBankOrder`/`wordBankTokens`，保留上一张卡的数据；`renderWordBankUI()` 因数组非空继续渲染旧骨架与词块 → 残留错句。

## 变更内容
- `_buildWordBank()`：无句子时清空 `wordBankOrder=[]`、`wordBankTokens=[]` 再返回
- `renderWordBankUI()`：`wordBankOrder` 为空时清空 `#word-bank-skeleton` 与 `#word-bank-tokens` DOM

异步加载到正确句子后会再次调用 `renderWordBankUI()` 正常填充。

## 测试方法
1. 从「All」根牌组混合复习，类别 Creating
2. 复习到词不在当前统一故事里的旧到期卡
3. 确认句子区不再显示上一张卡的句子（为空或随后加载出正确句子）

## 备注
更深层的「混合复习为何配不到句子」（回退用 rootDeckId 而非卡片自身牌组）属另一议题，本 PR 只消除残留错句这一可见症状。

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)