### PR TITLE
fix: 混合复习跨天卡回退显示自身正确句子（含德语）

### DIFF
--- a/database/stories.py
+++ b/database/stories.py
@@ -92,6 +92,50 @@ def get_sentence_for_word(story_id: int, word_id: int) -> dict | None:
     return dict(row) if row else None
 
 
+def get_latest_sentence_for_word(word_id: int) -> dict | None:
+    """Return the most recent sentence (across all stories) that contains word_id.
+
+    Used as a fallback in mixed/"All" review when a cross-day card's word is not in
+    the currently loaded story. The returned dict matches get_story_sentences() shape
+    (word_ids, words, tokens), so it carries German/French translations too.
+    """
+    conn = get_db()
+    sent_row = conn.execute(
+        """SELECT ss.* FROM story_sentences ss
+           JOIN story_sentence_words sw ON sw.sentence_id = ss.id
+           JOIN stories s ON s.id = ss.story_id
+           WHERE sw.word_id = ?
+           ORDER BY s.generated_at DESC, ss.id DESC
+           LIMIT 1""",
+        (word_id,),
+    ).fetchone()
+    if sent_row is None:
+        conn.close()
+        return None
+
+    word_rows = conn.execute(
+        """SELECT e.id AS word_id, e.word_zh, e.definition
+           FROM story_sentence_words sw
+           JOIN entries e ON e.id = sw.word_id
+           WHERE sw.sentence_id = ?
+           ORDER BY sw.id""",
+        (sent_row["id"],),
+    ).fetchall()
+    conn.close()
+
+    wlist = [{"word_id": w["word_id"], "word_zh": w["word_zh"], "definition": w["definition"]}
+             for w in word_rows]
+    d = dict(sent_row)
+    d["word_ids"] = [w["word_id"] for w in wlist]
+    d["words"] = wlist
+    if wlist:
+        d["word_zh"] = wlist[0]["word_zh"]
+        d["definition"] = wlist[0]["definition"]
+    raw_tokens = d.get("tokens")
+    d["tokens"] = json.loads(raw_tokens) if raw_tokens else []
+    return d
+
+
 def get_story_sentences(story_id: int) -> list[dict]:
     """Return all sentences for a story, each with word_ids and words list."""
     conn = get_db()

--- a/routes/story.py
+++ b/routes/story.py
@@ -257,6 +257,20 @@ def get_history_story(deck_id: int, category: str):
     return story
 
 
+@router.get("/api/sentence-for-word/{word_id}")
+def sentence_for_word(word_id: int):
+    """Return the most recent stored sentence containing this word (with translations).
+
+    Fallback for mixed/"All" review when a cross-day card's word is not in the
+    currently loaded story, so the card still shows its own correct sentence.
+    """
+    sentence = database.get_latest_sentence_for_word(word_id)
+    if sentence is None:
+        return {"sentence": None}
+    _add_tokens([sentence])
+    return {"sentence": sentence}
+
+
 @router.get("/api/kahneman/chapters")
 def kahneman_chapters():
     """Return all chapters from kahneman_chapters.json (without examples to reduce payload)."""

--- a/static/app.js
+++ b/static/app.js
@@ -2637,6 +2637,31 @@ function loadCard(c, counts) {
   if (!sentence && (unfinishedMode || rootDeckId) && !quickMode) {
     const snap = c;
     const storyDeckId = unfinishedMode ? c.deck_id : rootDeckId;
+    // Push the freshly-found `sentence` into the visible UI (reading / cloze / sentence-note).
+    const applySentenceToUI = () => {
+      _updateStoryInfoRow();
+      const isListening  = category === 'listening';
+      const isCreating   = category === 'creating';
+      const isSentenceNt = card.note_type === 'sentence';
+      const isCloze      = isCreating && !isSentenceNt;
+      if (!isListening && !isCreating) {
+        // Reading: update sentence with full highlighted sentence
+        const sentFront = document.getElementById('sentence-front');
+        if (sentFront.style.display !== 'none') sentFront.innerHTML = renderSentence();
+      } else if (isCloze) {
+        // Word bank: sentence just loaded — update hint and rebuild token bank
+        const enFront = document.getElementById('sentence-en-front');
+        enFront.style.display = 'flex';
+        enFront.textContent = sentence.sentence_de || sentence.sentence_fr || '';
+        if (document.getElementById('word-bank-wrap').style.display !== 'none') {
+          renderWordBankUI();
+        }
+      } else if (isCreating && isSentenceNt) {
+        // Sentence notes: update English prompt
+        const inp = document.getElementById('sentence-en-front');
+        if (inp.style.display !== 'none') inp.textContent = sentence.sentence_de || sentence.sentence_fr || '';
+      }
+    };
     fetch(`/api/story/${storyDeckId}/unified`)
       .then(r => r.ok ? r.json() : null)
       .then(s => {
@@ -2645,30 +2670,19 @@ function loadCard(c, counts) {
         if (s?.sentences) {
           story    = s;
           sentence = story.sentences.find(s => s.word_ids?.includes(card.word_id)) || null;
-          if (sentence) {
-            _updateStoryInfoRow();
-            const isListening  = category === 'listening';
-            const isCreating   = category === 'creating';
-            const isSentenceNt = card.note_type === 'sentence';
-            const isCloze      = isCreating && !isSentenceNt;
-            if (!isListening && !isCreating) {
-              // Reading: update sentence with full highlighted sentence
-              const sentFront = document.getElementById('sentence-front');
-              if (sentFront.style.display !== 'none') sentFront.innerHTML = renderSentence();
-            } else if (isCloze) {
-              // Word bank: sentence just loaded — update hint and rebuild token bank
-              const enFront = document.getElementById('sentence-en-front');
-              enFront.style.display = 'flex';
-              enFront.textContent = sentence.sentence_de || sentence.sentence_fr || '';
-              if (document.getElementById('word-bank-wrap').style.display !== 'none') {
-                renderWordBankUI();
-              }
-            } else if (isCreating && isSentenceNt) {
-              // Sentence notes: update English prompt
-              const inp = document.getElementById('sentence-en-front');
-              if (inp.style.display !== 'none') inp.textContent = sentence.sentence_de || sentence.sentence_fr || '';
-            }
-          }
+        }
+        if (sentence) {
+          applySentenceToUI();
+        } else {
+          // Word not in this story (e.g. cross-day card in mixed review): fall back to
+          // the word's own most recent sentence, which carries the German translation.
+          fetch(`/api/sentence-for-word/${card.word_id}`)
+            .then(r => r.ok ? r.json() : null)
+            .then(d => {
+              if (card !== snap || !d?.sentence) return;
+              sentence = d.sentence;
+              applySentenceToUI();
+            }).catch(() => {});
         }
         // Update listening hint now that sentence is loaded
         if (snap.category === 'listening' && document.getElementById('side-back').style.display === 'none') {


### PR DESCRIPTION
## 背景
承接 #300 / #301。「All」混合复习加载单一统一故事；跨天到期旧卡的词常不在该故事里，前端回退又重载根故事，仍配不到句子。#301 已消除残留错句，但这些卡会显示空白，而非自身正确句子。

## 变更内容
- **database/stories.py**：新增 `get_latest_sentence_for_word(word_id)` —— 返回该词在所有故事中**最近一条**句子，结构与 `get_story_sentences` 一致（含 `word_ids`/`words`/`tokens`/`sentence_de`/`sentence_fr`）。
- **routes/story.py**：新增 `GET /api/sentence-for-word/{word_id}`（对句子套用 `_add_tokens` 兜底分词）。
- **static/app.js**：`loadCard` 回退里，统一故事仍配不到时调用该接口取该词自身句子并渲染；句子→UI 的逻辑抽成 `applySentenceToUI()` 复用。

## 验证（已本地测试）
- `get_latest_sentence_for_word(隐喻)` → 「教练的话有一个隐喻。」+ 德语 ✓
- `get_latest_sentence_for_word(地带)` → 「球队在防守地带加强了压力。」+ 德语 ✓
- 不存在的词 → None / `{sentence: null}` ✓
- 端点 jieba 兜底分词把目标词切成独立 token ✓

## 测试方法
1. 「All」混合复习，类别 Creating
2. 复习到词不在当前统一故事里的旧到期卡（如 05-19「隐喻」、05-17「地带」）
3. 确认显示该词自身正确句子及德语提示（不再空白或错句）

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)