### PR TITLE
feat: Kahneman 章节显示书的「部分」分组（章节选择/概念框/弹出框）

### DIFF
--- a/routes/story.py
+++ b/routes/story.py
@@ -15,6 +15,36 @@ from .utils import DISABLE_AI, leaf_ids
 
 KAHNEMAN_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "kahneman_chapters.json")
 
+# 《思考，快与慢》原书的 5 个部分（Part）—— 按章节号区间划分。
+# 数据文件不存部分信息，统一在此按章节号计算，保证一致性。
+_KAHNEMAN_PARTS = [
+    (1, 9, 1, "两个系统", "Two Systems"),
+    (10, 18, 2, "启发法与偏见", "Heuristics and Biases"),
+    (19, 24, 3, "过度自信", "Overconfidence"),
+    (25, 34, 4, "选择", "Choices"),
+    (35, 38, 5, "两个自我", "Two Selves"),
+]
+
+# 部分序号 → 中文数字（用于「第一部分」等标签）
+_PART_CN_NUM = {1: "一", 2: "二", 3: "三", 4: "四", 5: "五"}
+# 部分序号 → 罗马数字（原书英文用「Part I.」格式）
+_PART_ROMAN = {1: "I", 2: "II", 3: "III", 4: "IV", 5: "V"}
+
+
+def _attach_part(chapter: dict) -> dict:
+    """Return a copy of `chapter` with part_number / part_zh / part_en attached."""
+    num = chapter.get("number")
+    for lo, hi, pnum, pzh, pen in _KAHNEMAN_PARTS:
+        if num is not None and lo <= num <= hi:
+            return {
+                **chapter,
+                "part_number": pnum,
+                "part_zh": f"第{_PART_CN_NUM[pnum]}部分 {pzh}",
+                "part_en": f"Part {_PART_ROMAN[pnum]}. {pen}",
+            }
+    return dict(chapter)
+
+
 # Suppress jieba's startup log messages
 jieba.setLogLevel(logging.ERROR)
 
@@ -279,7 +309,7 @@ def kahneman_chapters():
     with open(KAHNEMAN_PATH, encoding="utf-8") as f:
         data = json.load(f)
     chapters = [
-        {k: v for k, v in ch.items() if k != "examples_zh"}
+        _attach_part({k: v for k, v in ch.items() if k != "examples_zh"})
         for ch in data.get("chapters", [])
     ]
     return {"chapters": chapters, "available": True}
@@ -291,7 +321,7 @@ def kahneman_chapter(number: int):
     ch = _load_kahneman_chapter(number)
     if ch is None:
         return {"chapter": None, "available": False}
-    return {"chapter": ch, "available": True}
+    return {"chapter": _attach_part(ch), "available": True}
 
 
 def _load_kahneman_chapter(chapter_id: int) -> dict | None:

--- a/static/app.js
+++ b/static/app.js
@@ -3031,9 +3031,11 @@ function revealAnswer() {
   const _conceptEl = document.getElementById('sentence-concept');
   if (!isSentenceNote && sentence?.concept_zh) {
     const chNum = sentence.concept_en ? parseInt(sentence.concept_en.match(/Chapter (\d+)/)?.[1]) : null;
-    const renderConcept = (desc) => {
-      _conceptEl.innerHTML = `<span class="concept-chapter-title">${sentence.concept_zh}</span>`
-        + (desc ? `<span class="concept-chapter-desc">${desc}</span>` : '')
+    const renderConcept = (ch) => {
+      _conceptEl.innerHTML =
+          (ch?.part_zh ? `<span class="concept-part-label">${ch.part_zh}</span>` : '')
+        + `<span class="concept-chapter-title">${sentence.concept_zh}</span>`
+        + (ch?.concept_zh ? `<span class="concept-chapter-desc">${ch.concept_zh}</span>` : '')
         + (chNum ? `<span class="concept-chapter-hint">点击查看书中原句 ›</span>` : '');
       _conceptEl.style.display = '';
       if (chNum) {
@@ -3045,11 +3047,11 @@ function revealAnswer() {
       }
     };
     const cachedCh = chNum && _kahnemanChapters ? _kahnemanChapters.find(c => c.number === chNum) : null;
-    renderConcept(cachedCh?.concept_zh || '');
+    renderConcept(cachedCh);
     if (!cachedCh && chNum) {
       _ensureKahnemanChapters().then(() => {
         const ch = _kahnemanChapters?.find(c => c.number === chNum);
-        if (ch?.concept_zh) renderConcept(ch.concept_zh);
+        if (ch) renderConcept(ch);
       });
     }
   } else {
@@ -4573,19 +4575,25 @@ async function openKahnemanExamples(chNum, conceptZh) {
   if (!chapter) {
     try {
       const data = await api('GET', `/api/kahneman/chapter/${chNum}`);
-      chapter = { summary: data.chapter?.concept_zh || '', examples: data.chapter?.examples_zh || [] };
+      chapter = {
+        summary: data.chapter?.concept_zh || '',
+        examples: data.chapter?.examples_zh || [],
+        part: data.chapter?.part_zh || '',
+      };
       _kahnemanExamplesCache[chNum] = chapter;
-    } catch (e) { chapter = { summary: '', examples: [] }; }
+    } catch (e) { chapter = { summary: '', examples: [], part: '' }; }
   }
   if (modal.style.display === 'none') return; // closed while loading
   const esc = s => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const partHtml = chapter.part
+    ? `<div class="kahneman-part-label">${esc(chapter.part)}</div>` : '';
   const summaryHtml = chapter.summary
     ? `<div class="kahneman-summary">${esc(chapter.summary)}</div>` : '';
   const examplesHtml = chapter.examples.length
     ? `<div class="kahneman-examples-label">书中原句</div>`
       + chapter.examples.map(ex => `<p class="kahneman-example">${esc(ex)}</p>`).join('')
     : '<div class="kahneman-examples-loading">本章暂无书中原句。</div>';
-  bodyEl.innerHTML = summaryHtml + examplesHtml;
+  bodyEl.innerHTML = partHtml + summaryHtml + examplesHtml;
 }
 
 function closeKahnemanExamples() {
@@ -4617,14 +4625,23 @@ async function _loadKahnemanChapters() {
 function _renderKahnemanChapters() {
   const container = document.getElementById('setup-kahneman-chapters');
   if (!_kahnemanChapters) return;
-  container.innerHTML = _kahnemanChapters.map(ch => `
+  let lastPart = null;
+  container.innerHTML = _kahnemanChapters.map(ch => {
+    // Insert a part header before the first chapter of each book part.
+    let header = '';
+    if (ch.part_number != null && ch.part_number !== lastPart) {
+      lastPart = ch.part_number;
+      header = `<div class="kahneman-part-header">${ch.part_zh || ''}</div>`;
+    }
+    return header + `
     <label class="kahneman-chapter-row">
       <input type="checkbox" class="kahneman-chapter-cb" value="${ch.number}" onchange="_updateKahnemanCount()">
       <div class="kahneman-chapter-info">
         <span class="kahneman-chapter-title">第${ch.number}章 ${ch.title_zh}</span>
         <span class="kahneman-chapter-concept">${ch.concept_zh}</span>
       </div>
-    </label>`).join('');
+    </label>`;
+  }).join('');
   _updateKahnemanCount();
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -3724,6 +3724,32 @@ details[open] .cat-override-summary::before { content: '▼ '; }
 .kahneman-chapter-title { font-size: 13px; font-weight: 600; color: var(--text, #222); }
 .kahneman-chapter-concept { font-size: 12px; color: var(--muted, #888); line-height: 1.4; }
 
+/* Book-part group header inside the chapter selector list */
+.kahneman-part-header {
+  padding: 8px 12px 5px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  color: #6d28d9;
+  background: #f5f3ff;
+  border-bottom: 1px solid var(--border, #eee);
+}
+.kahneman-part-header:first-child { border-top: none; }
+@media (prefers-color-scheme: dark) {
+  .kahneman-part-header { color: #c4b5fd; background: #1e1b2e; }
+}
+
+/* Part label shown in the chapter-examples popup */
+.kahneman-part-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: #7c3aed;
+  margin-bottom: 6px;
+}
+@media (prefers-color-scheme: dark) {
+  .kahneman-part-label { color: #c4b5fd; }
+}
+
 /* ── Kahneman concept badge in story modal ──────────────── */
 .story-concept-badge {
   display: inline-flex;
@@ -3756,6 +3782,13 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   border-radius: 10px;
   text-align: left;
 }
+.concept-part-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  color: #7c3aed;
+  text-transform: none;
+}
 .concept-chapter-title {
   font-size: 15px;
   font-weight: 700;
@@ -3776,6 +3809,7 @@ details[open] .cat-override-summary::before { content: '▼ '; }
 .sentence-concept-section.concept-clickable:hover { background: #e0d7fb; border-color: #a78bfa; }
 @media (prefers-color-scheme: dark) {
   .sentence-concept-section { background: #2e1065; border-color: #6d28d9; }
+  .concept-part-label { color: #c4b5fd; }
   .concept-chapter-title { color: #c4b5fd; }
   .concept-chapter-desc { color: #a78bfa; }
   .concept-chapter-hint { color: #c4b5fd; }


### PR DESCRIPTION
## 变更内容

为《思考，快与慢》的 Kahneman 模式在三处显示原书的 5 个「部分」（Part）分组：

1. **生成故事视图** —— 章节选择清单按部分分组，每组前加部分标题
2. **复习卡背面的概念框** —— 显示该章所属部分
3. **概念弹出框** —— 显示该章所属部分

部分划分（按原书）：

| 部分 | 章节 | 中文 | 英文 |
|------|------|------|------|
| I | 1–9 | 两个系统 | Two Systems |
| II | 10–18 | 启发法与偏见 | Heuristics and Biases |
| III | 19–24 | 过度自信 | Overconfidence |
| IV | 25–34 | 选择 | Choices |
| V | 35–38 | 两个自我 | Two Selves |

## 实现方式

- 后端在 `routes/story.py` 按章节号区间计算部分，`/api/kahneman/chapters` 与 `/api/kahneman/chapter/{number}` 返回的每个章节附加 `part_number`/`part_zh`/`part_en`。**数据文件无需改动**，保证一致性。
- 前端在三处读取这些字段渲染部分标签，新增对应 CSS（含深色模式）。

## 测试方法

1. 生成故事视图选 Kahneman 模式 → 章节清单出现「第一部分 两个系统」等分组标题
2. 复习一张 Kahneman 卡片揭示答案 → 概念框顶部显示部分
3. 点击概念框 → 弹出框显示部分

已本地验证 API 返回正确的部分字段（章节 9→第一部分、10→第二部分、24→第三部分、25→第四部分）。

Closes #305