### PR TITLE
chore: 数据库备份保留份数 30 → 120（历史窗口延长到约30天）

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Daily SQLite backup — keeps last 30 snapshots, then auto-prunes.
+# SQLite backup (runs every 6h via launchd) — keeps last 120 snapshots (~30 days), then auto-prunes.
+# Backs up the database only; TTS audio in data/tts/ is intentionally NOT backed up.
 
 DB="/Users/daniel/Documents/AnkiAdvanced/data/srs.db"
 BACKUP_DIR="/Users/daniel/Documents/AnkiAdvanced/data/backups"
@@ -14,5 +15,5 @@ sqlite3 "$DB" ".backup '$DEST'"
 
 echo "[$(date)] Backed up to $DEST"
 
-# Keep only the 30 most recent backups
-ls -t "$BACKUP_DIR"/srs_*.db | tail -n +31 | xargs rm -f
+# Keep only the 120 most recent backups (~30 days at one snapshot per 6h)
+ls -t "$BACKUP_DIR"/srs_*.db | tail -n +121 | xargs rm -f


### PR DESCRIPTION
## 变更内容
- `backup.sh`：保留份数 30 → **120**（每 6 小时一次 × 120 ≈ 30 天历史）
- 仅备份 `data/srs.db`，**不含语音文件 `data/tts/`**（按 Daniel 要求）

## 测试方法
- `bash -n backup.sh` 语法通过
- 合并到 main 后，launchd 下次运行即保留最近 120 份

Closes #310