### PR TITLE
feat: Kahneman 章节选择器支持按「部分」整体勾选

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -4627,15 +4627,20 @@ function _renderKahnemanChapters() {
   if (!_kahnemanChapters) return;
   let lastPart = null;
   container.innerHTML = _kahnemanChapters.map(ch => {
-    // Insert a part header before the first chapter of each book part.
+    // Insert a part header (with a select-all checkbox) before the first chapter of each part.
     let header = '';
     if (ch.part_number != null && ch.part_number !== lastPart) {
       lastPart = ch.part_number;
-      header = `<div class="kahneman-part-header">${ch.part_zh || ''}</div>`;
+      header = `
+      <label class="kahneman-part-header">
+        <input type="checkbox" class="kahneman-part-cb" data-part="${ch.part_number}"
+               onchange="_toggleKahnemanPart(${ch.part_number}, this.checked)">
+        <span class="kahneman-part-title">${ch.part_zh || ''}</span>
+      </label>`;
     }
     return header + `
     <label class="kahneman-chapter-row">
-      <input type="checkbox" class="kahneman-chapter-cb" value="${ch.number}" onchange="_updateKahnemanCount()">
+      <input type="checkbox" class="kahneman-chapter-cb" value="${ch.number}" data-part="${ch.part_number}" onchange="_updateKahnemanCount()">
       <div class="kahneman-chapter-info">
         <span class="kahneman-chapter-title">第${ch.number}章 ${ch.title_zh}</span>
         <span class="kahneman-chapter-concept">${ch.concept_zh}</span>
@@ -4645,10 +4650,24 @@ function _renderKahnemanChapters() {
   _updateKahnemanCount();
 }
 
+function _toggleKahnemanPart(partNum, checked) {
+  document.querySelectorAll(`.kahneman-chapter-cb[data-part="${partNum}"]`)
+    .forEach(cb => { cb.checked = checked; });
+  _updateKahnemanCount();
+}
+
 function _updateKahnemanCount() {
   const checked = document.querySelectorAll('.kahneman-chapter-cb:checked').length;
   const countEl = document.getElementById('setup-kahneman-count');
   countEl.textContent = checked ? `(${checked} selected)` : '(none selected → random 5)';
+  // Sync each part checkbox: checked if all chapters selected, indeterminate if some.
+  document.querySelectorAll('.kahneman-part-cb').forEach(partCb => {
+    const part = partCb.dataset.part;
+    const chapters = document.querySelectorAll(`.kahneman-chapter-cb[data-part="${part}"]`);
+    const sel = document.querySelectorAll(`.kahneman-chapter-cb[data-part="${part}"]:checked`).length;
+    partCb.checked = sel > 0 && sel === chapters.length;
+    partCb.indeterminate = sel > 0 && sel < chapters.length;
+  });
 }
 
 function randomKahnemanChapters() {

--- a/static/index.html
+++ b/static/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AnkiAdvanced</title>
-  <link rel="stylesheet" href="/static/style.css?v=4">
+  <link rel="stylesheet" href="/static/style.css?v=5">
 </head>
 <body>
 
@@ -536,7 +536,7 @@
 </div>
 
 <div id="word-tip" style="display:none"></div>
-<script src="/static/app.js?v=4"></script>
+<script src="/static/app.js?v=5"></script>
 
 <!-- Edit card modal -->
 <div id="edit-modal-overlay" onclick="closeEditCard()" style="display:none"></div>

--- a/static/style.css
+++ b/static/style.css
@@ -3726,6 +3726,9 @@ details[open] .cat-override-summary::before { content: '▼ '; }
 
 /* Book-part group header inside the chapter selector list */
 .kahneman-part-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   padding: 8px 12px 5px;
   font-size: 12px;
   font-weight: 700;
@@ -3733,10 +3736,14 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   color: #6d28d9;
   background: #f5f3ff;
   border-bottom: 1px solid var(--border, #eee);
+  cursor: pointer;
 }
+.kahneman-part-header:hover { background: #ede9fe; }
+.kahneman-part-cb { flex-shrink: 0; cursor: pointer; }
 .kahneman-part-header:first-child { border-top: none; }
 @media (prefers-color-scheme: dark) {
   .kahneman-part-header { color: #c4b5fd; background: #1e1b2e; }
+  .kahneman-part-header:hover { background: #2a2540; }
 }
 
 /* Part label shown in the chapter-examples popup */


### PR DESCRIPTION
## 变更内容

在故事设置弹窗的 Kahneman（卡尼曼）章节选择器里，每个「部分」标题现在带一个复选框：
- 勾选 → 选中该部分的所有章节
- 取消 → 取消该部分的所有章节
- 该部分章节全选时复选框为选中态；部分选中时为半选（indeterminate）态

### 前端
- `static/app.js` `_renderKahnemanChapters`：部分标题改为带复选框的可点击行；章节复选框加 `data-part` 标记
- 新增 `_toggleKahnemanPart()`：批量选中/取消该部分章节
- `_updateKahnemanCount()`：同步各部分复选框的选中/半选状态
- `static/style.css`：部分标题 hover 与复选框样式（含深色模式）
- 缓存版本号升到 `v=5`

## 测试方法
- 打开 Kahneman 模式的故事设置，勾选某个部分标题，确认该部分所有章节被选中
- 手动取消其中一章，确认部分标题复选框变为半选态
- 再次勾选部分标题，确认补齐为全选
- 取消部分标题复选框，确认该部分所有章节取消

## 已验证
- `node --check static/app.js` 语法通过

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)