### PR TITLE
feat: 导入默认改为「听力+创建」激活、阅读暂停，并自动选中每日牌组

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -5231,7 +5231,7 @@ let _conflictEdits = {};       // {word_zh: {field: value}} custom edits
 let _conflictSelections = {};  // {word_zh: "keep"|"update"}
 
 // Default per-category suspension states (creating active, others suspended)
-const IMPORT_DEFAULT_SUSPENDED = { reading: false, listening: false, creating: true };
+const IMPORT_DEFAULT_SUSPENDED = { reading: true, listening: false, creating: false };
 
 const NOTE_TYPE_LABEL = { vocabulary: 'Word', sentence: 'Sentence', chengyu: '成语', expression: 'Expr' };
 const STATUS_ICON  = { ok: '✓', duplicate: '⚠', invalid: '✕' };
@@ -5658,6 +5658,8 @@ async function previewImport(yamlContent) {
 
     // Show deck picker + Import button now that YAML is valid
     document.getElementById('import-deck-section').style.display = '';
+    // Auto-select today's daily deck as the target, unless the user already chose one.
+    if (!document.getElementById('import-deck-path').value.trim()) selectDailyDeck();
     const submitBtn = document.getElementById('import-submit-btn');
     submitBtn.textContent = 'Import';
     submitBtn.onclick = doImport;


### PR DESCRIPTION
## 变更内容
1. 修改 `IMPORT_DEFAULT_SUSPENDED`：新卡片默认 **听力（Listening）+ 创建（Creating）激活，阅读（Reading）暂停**（之前是 Reading/Listening 激活、Creating 暂停）。
2. 导入预览成功后，若 Target Deck 输入框为空，自动填入今天的每日牌组 `daily::MM-DD`。已手动选择的牌组不会被覆盖。

## 测试方法
- 打开导入弹窗，选一个 YAML 文件
- 预览表中每个词：Listen=✓、Create=✓、Read=✕
- Target Deck 自动填入今天的每日牌组（如 `daily::06-09`）
- 手动改 Target Deck 后重新预览，确认不被覆盖

Closes #316