### PR TITLE
fix: All 全部重新生成时为独立汉字补上翻译字段

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3272,7 +3272,7 @@ let _regenState = null; // { wordId, fields, containerId }
 
 function regenAllFields(wordId) {
   const allFields = ['definition', 'definition_zh', 'definition_de', 'definition_fr', 'pos',
-                     'notes', 'examples', 'etymology', 'compounds'];
+                     'notes', 'examples', 'etymology', 'compounds', 'other_meanings'];
   regenFields(wordId, allFields, 'wd-all');
 }
 
@@ -3280,7 +3280,7 @@ function regenAllFieldsFromReview() {
   const wordId = _getActiveWordId();
   if (!wordId) return showError('No active word');
   const allFields = ['definition', 'definition_zh', 'definition_de', 'definition_fr', 'pos',
-                     'notes', 'examples', 'etymology', 'compounds'];
+                     'notes', 'examples', 'etymology', 'compounds', 'other_meanings'];
   regenFields(wordId, allFields, 'review-regen-all');
 }
 


### PR DESCRIPTION
## 变更内容

`regenAllFields`（行 3273）和 `regenAllFieldsFromReview`（行 3279）的 `allFields` 数组补上了 `'other_meanings'`。

## 问题

点击 "All"（全部重新生成）打开 AI Preview 时，CHARACTERS 部分的每个独立汉字下方缺少翻译/释义（other_meanings）输入框；而单独点击"字词分析"区域的 ↺ 重新生成时却有。原因是两个 allFields 数组遗漏了 `'other_meanings'` 字段。后端已完全支持该字段，仅前端遗漏。

## 测试方法

1. 打开任意词条详情，点击 "All" 全部重新生成
2. 在 AI Preview 的 CHARACTERS 部分，确认每个独立汉字下方都出现翻译/释义输入框
3. 点击 Apply，确认翻译正确保存

Closes #318