### PR TITLE
feat: 主页添加卡片状态发展图表（New/Learning/Learnt/Relearn）

### DIFF
--- a/database/stats.py
+++ b/database/stats.py
@@ -289,6 +289,170 @@ def get_calendar_stats(days: int = 365, deck_id: int | None = None) -> dict:
     }
 
 
+_EVOLUTION_STATES = ("new", "learning", "review", "relearn")
+
+
+def _next_state(state: str, step: int, rating: int,
+                n_learn: int, n_relearn: int) -> tuple[str, int]:
+    """SM-2 state transition for one review (states only, no intervals)."""
+    if state in ("new", "learning"):
+        if rating == 1:
+            return ("learning", 0)
+        if rating == 2:
+            return ("learning", step)
+        if rating == 3:
+            if step + 1 >= n_learn:
+                return ("review", 0)
+            return ("learning", step + 1)
+        return ("review", 0)  # Easy graduates immediately
+    if state == "review":
+        return ("relearn", 0) if rating == 1 else ("review", 0)
+    if state == "relearn":
+        if rating == 1:
+            return ("relearn", 0)
+        if rating == 2:
+            return ("relearn", step)
+        if rating == 3:
+            if step + 1 >= n_relearn:
+                return ("review", 0)
+            return ("relearn", step + 1)
+        return ("review", 0)
+    return (state, step)
+
+
+def get_card_evolution(days: int = 365, deck_id: int | None = None) -> dict:
+    """Per-day card-state counts over time, reconstructed from review_log.
+
+    Most legacy review rows have NULL state, so the history is rebuilt by
+    replaying the SM-2 state machine over each card's rating sequence (using
+    the deck preset's learning/relearning step counts). Rows that *do* record
+    a state recalibrate the replay, and the card's current state pins the end
+    of the timeline. Before the first review a card is 'new' (from the
+    entry's date_added). Suspended cards count under their pre_suspend_state
+    (or stay in their last replayed state when that is unset).
+
+    Days use the Anki boundary (local time, 4am cutoff) like get_calendar_stats.
+
+    Returns:
+        {
+          "days": int, "today": "YYYY-MM-DD",
+          "dates": ["YYYY-MM-DD", ...],            # oldest → today, len == days
+          "series": {category: {state: [int, ...]}}  # aligned with dates
+        }
+    """
+    conn = get_db()
+    today = anki_today()
+    dates = [(today - _dt.timedelta(days=days - 1 - i)).isoformat()
+             for i in range(days)]
+
+    deck_filter = "AND c.deck_id = ?" if deck_id else ""
+    params = [deck_id] if deck_id else []
+    day_of = "date(datetime({col}, 'localtime', '-4 hours'))"
+
+    cards = conn.execute(
+        f"""SELECT c.id, c.deck_id, c.category, c.state, c.pre_suspend_state,
+                   {day_of.format(col='e.date_added')} AS created
+            FROM cards c JOIN entries e ON e.id = c.word_id
+            WHERE c.deleted_at IS NULL {deck_filter}""",
+        params,
+    ).fetchall()
+
+    reviews = conn.execute(
+        f"""SELECT rl.card_id, {day_of.format(col='rl.reviewed_at')} AS d,
+                   rl.state, rl.rating
+            FROM review_log rl
+            JOIN cards c ON c.id = rl.card_id
+            WHERE c.deleted_at IS NULL {deck_filter}
+            ORDER BY rl.card_id, rl.reviewed_at""",
+        params,
+    ).fetchall()
+
+    # Learning/relearning step counts per deck (category override wins)
+    preset_rows = conn.execute(
+        """SELECT d.id AS deck_id,
+                  p.learning_steps, p.relearning_steps,
+                  o.learning_steps AS o_ls, o.relearning_steps AS o_rs
+           FROM decks d
+           JOIN deck_presets p ON p.id = d.preset_id
+           LEFT JOIN preset_category_overrides o
+                  ON o.preset_id = d.preset_id AND o.category = d.category"""
+    ).fetchall()
+    conn.close()
+
+    steps_by_deck = {
+        r["deck_id"]: (
+            max(1, len((r["o_ls"] or r["learning_steps"]).split())),
+            max(1, len((r["o_rs"] or r["relearning_steps"]).split())),
+        )
+        for r in preset_rows
+    }
+
+    revs_by_card: dict[int, list] = {}
+    for r in reviews:
+        revs_by_card.setdefault(r["card_id"], []).append(
+            (r["d"], r["state"], r["rating"]))
+
+    # deltas[category][day][state] — state-count changes taking effect that day
+    deltas: dict[str, dict[str, dict[str, int]]] = {}
+    for c in cards:
+        final = c["state"]
+        if final == "suspended":
+            final = c["pre_suspend_state"]
+        n_learn, n_relearn = steps_by_deck.get(c["deck_id"], (2, 1))
+        rl = revs_by_card.get(c["id"], [])
+
+        # Checkpoints: (day, state the card holds from the end of that day on)
+        seq = [(c["created"], "new")]
+        state, step = "new", 0
+        for day, recorded, rating in rl:
+            if recorded in _EVOLUTION_STATES and recorded != state:
+                state, step = recorded, 0  # recalibrate from recorded truth
+            state, step = _next_state(state, step, rating, n_learn, n_relearn)
+            seq.append((day, state))
+        if rl and final in _EVOLUTION_STATES:
+            seq[-1] = (seq[-1][0], final)  # pin the end to the card's real state
+
+        # Several checkpoints on one day: the last one wins
+        last_for_day: dict[str, str] = {}
+        for day, st in seq:
+            last_for_day[day] = st
+
+        cat_deltas = deltas.setdefault(c["category"], {})
+        prev = None
+        for day in sorted(last_for_day):
+            st = last_for_day[day]
+            if st == prev:
+                continue
+            d = cat_deltas.setdefault(day, {})
+            if prev is not None:
+                d[prev] = d.get(prev, 0) - 1
+            d[st] = d.get(st, 0) + 1
+            prev = st
+
+    # Accumulate deltas into daily series (deltas before the window roll into day 0)
+    series: dict[str, dict[str, list[int]]] = {}
+    for cat, cat_deltas in deltas.items():
+        running = dict.fromkeys(_EVOLUTION_STATES, 0)
+        out = {s: [] for s in _EVOLUTION_STATES}
+        delta_days = sorted(cat_deltas)
+        idx = 0
+        for date_str in dates:
+            while idx < len(delta_days) and delta_days[idx] <= date_str:
+                for s, n in cat_deltas[delta_days[idx]].items():
+                    running[s] += n
+                idx += 1
+            for s in _EVOLUTION_STATES:
+                out[s].append(running[s])
+        series[cat] = out
+
+    return {
+        "days": days,
+        "today": today.isoformat(),
+        "dates": dates,
+        "series": series,
+    }
+
+
 def _calc_streak(conn: sqlite3.Connection, deck_id: int | None) -> int:
     deck_filter = "AND c.deck_id = ?" if deck_id else ""
     params = [deck_id] if deck_id else []

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -481,6 +481,11 @@ def get_calendar_stats(days: int = 365, deck_id: int | None = None):
     return database.get_calendar_stats(days, deck_id)
 
 
+@router.get("/api/card-evolution")
+def get_card_evolution(days: int = 365, deck_id: int | None = None):
+    return database.get_card_evolution(days, deck_id)
+
+
 @router.get("/api/costs")
 def get_api_costs():
     return database.get_api_costs()

--- a/static/app.js
+++ b/static/app.js
@@ -831,8 +831,10 @@ function renderDecks(decks) {
   }
 
   document.getElementById('view-decks').innerHTML =
-    navRow + '<div id="home-calendar" class="hcal-card"></div>' + html;
+    navRow + '<div id="home-calendar" class="hcal-card"></div>' +
+    '<div id="home-evolution" class="hcal-card"></div>' + html;
   if (typeof initHomeCalendar === 'function') initHomeCalendar();
+  if (typeof initHomeEvolution === 'function') initHomeEvolution();
 }
 
 function toggleDeckSort() {
@@ -4331,6 +4333,7 @@ async function rate(rating) {
     const result = await api('POST', url);
     _sessionReviewedCount++;
     if (typeof invalidateHomeCalendar === 'function') invalidateHomeCalendar();
+    if (typeof invalidateHomeEvolution === 'function') invalidateHomeEvolution();
     api('GET', '/api/retention?days=0').then(r => {
       _retentionData = r;
       _updateReviewRRBadge(deckId);
@@ -7253,4 +7256,177 @@ function _hcalRenderDetail() {
         <td>${totAvg} <span class="hcal-tip-dim">/ ${totTot}</span></td>
       </tr>
     </table>`;
+}
+
+// ============================================================================
+// Home-page card-evolution chart (issue #321)
+// Stacked area chart of card-state counts over time (New / Learning /
+// Learnt / Relearn), with Listening / Creating / All views.
+// ============================================================================
+
+let _evoData = null;           // cached /api/card-evolution response
+let _evoLoading = false;
+let _evoView = localStorage.getItem('evoView') || 'all';
+let _evoCalc = null;           // per-render geometry cache for tooltips
+
+// Stack order: bottom → top
+const _EVO_STATES = [
+  { key: 'review',   label: 'Learnt',   color: 'var(--good)'    },
+  { key: 'relearn',  label: 'Relearn',  color: 'var(--again)'   },
+  { key: 'learning', label: 'Learning', color: 'var(--hard)'    },
+  { key: 'new',      label: 'New',      color: 'var(--primary)' },
+];
+const _EVO_VIEWS = [['listening', 'Listening'], ['creating', 'Creating'], ['all', 'All']];
+
+function initHomeEvolution() {
+  const el = document.getElementById('home-evolution');
+  if (!el) return;
+  if (_evoData) { _evoRender(); return; }
+  if (_evoLoading) return;
+  _evoLoading = true;
+  el.innerHTML = '<div class="hcal-loading">Loading card evolution…</div>';
+  api('GET', '/api/card-evolution?days=365')
+    .then(d => { _evoData = d; _evoLoading = false; _evoRender(); })
+    .catch(err => {
+      _evoLoading = false;
+      el.innerHTML = `<div class="hcal-loading">Card evolution unavailable — ${
+        (err && err.message) || 'failed to load stats'}.</div>`;
+    });
+}
+
+// Force a refetch (e.g. after reviewing). Safe to call even if not mounted.
+function invalidateHomeEvolution() { _evoData = null; }
+
+function evoSetView(v) {
+  _evoView = v; localStorage.setItem('evoView', v); _evoRender();
+}
+
+// Sum the requested categories into one {state: [counts]} object.
+function _evoSeries() {
+  const n = _evoData.dates.length;
+  const out = {};
+  for (const s of _EVO_STATES) out[s.key] = new Array(n).fill(0);
+  const cats = _evoView === 'all' ? Object.keys(_evoData.series) : [_evoView];
+  for (const cat of cats) {
+    const sr = _evoData.series[cat];
+    if (!sr) continue;
+    for (const s of _EVO_STATES) {
+      const arr = sr[s.key] || [];
+      for (let i = 0; i < n; i++) out[s.key][i] += arr[i] || 0;
+    }
+  }
+  return out;
+}
+
+function _evoRender() {
+  const el = document.getElementById('home-evolution');
+  if (!el || !_evoData) return;
+
+  const sr = _evoSeries();
+  const allDates = _evoData.dates;
+  const totalsAll = allDates.map((_, i) =>
+    _EVO_STATES.reduce((a, s) => a + sr[s.key][i], 0));
+
+  // Trim leading days before the first card existed (young collections)
+  let first = totalsAll.findIndex(t => t > 0);
+  if (first < 0) first = 0;
+  first = Math.max(0, first - 1);
+  const dates = allDates.slice(first);
+  const series = {};
+  for (const s of _EVO_STATES) series[s.key] = sr[s.key].slice(first);
+  const n = dates.length;
+
+  const W = 730, H = 190, PAD_T = 10, PAD_B = 2;
+  let ymax = Math.max(1, ...totalsAll);
+  const step = ymax > 200 ? 100 : ymax > 50 ? 25 : 10;
+  ymax = Math.ceil(ymax / step) * step;
+
+  const x = i => (i / Math.max(1, n - 1)) * W;
+  const y = v => PAD_T + (1 - v / ymax) * (H - PAD_T - PAD_B);
+
+  let lower = new Array(n).fill(0);
+  const layers = _EVO_STATES.map(s => {
+    const upper = lower.map((v, i) => v + series[s.key][i]);
+    const top = upper.map((v, i) => `${x(i).toFixed(1)},${y(v).toFixed(1)}`);
+    const bot = lower.map((v, i) => `${x(i).toFixed(1)},${y(v).toFixed(1)}`).reverse();
+    const pts = `${top.join(' ')} ${bot.join(' ')}`;
+    lower = upper;
+    return `<polygon points="${pts}" fill="${s.color}" fill-opacity="0.8"/>`;
+  }).join('');
+
+  const grid = [0.25, 0.5, 0.75, 1].map(f =>
+    `<line x1="0" y1="${y(ymax * f).toFixed(1)}" x2="${W}" y2="${y(ymax * f).toFixed(1)}"
+           stroke="var(--border)" stroke-width="0.6"/>`).join('');
+  const ylabels = [0.5, 1].map(f =>
+    `<span class="evo-ylabel" style="top:${(y(ymax * f) / H * 100).toFixed(2)}%">${
+      Math.round(ymax * f)}</span>`).join('');
+
+  const viewBtns = _EVO_VIEWS.map(([k, lbl]) =>
+    `<button class="hcal-seg-btn ${k === _evoView ? 'active' : ''}"
+             onclick="evoSetView('${k}')">${lbl}</button>`).join('');
+  const legend = _EVO_STATES.slice().reverse().map(s =>
+    `<span class="evo-leg"><span class="hcal-leg-sw" style="background:${s.color}"></span>${s.label}</span>`).join('');
+
+  const fmt = d => { const [, m, dd] = d.split('-'); return `${+m}/${+dd}`; };
+
+  _evoCalc = { dates, series, n };
+
+  el.innerHTML = `
+    <div class="hcal-controls">
+      <div class="hcal-seg">${viewBtns}</div>
+      <div class="evo-legend">${legend}</div>
+    </div>
+    <div class="evo-chart-wrap">
+      ${ylabels}
+      <svg class="evo-svg" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none"
+           onmousemove="evoMove(event)" onmouseleave="evoLeave()">
+        ${grid}${layers}
+        <line id="evo-cursor" x1="0" y1="0" x2="0" y2="${H}"
+              stroke="#1e293b" stroke-width="0.8" style="display:none"/>
+      </svg>
+      <div class="hcal-graph-axis"><span>${fmt(dates[0])}</span><span>${fmt(dates[n - 1])}</span></div>
+    </div>`;
+}
+
+function evoMove(ev) {
+  if (!_evoCalc) return;
+  const svg = ev.currentTarget;
+  const r = svg.getBoundingClientRect();
+  const { dates, series, n } = _evoCalc;
+  const i = Math.max(0, Math.min(n - 1,
+    Math.round((ev.clientX - r.left) / r.width * (n - 1))));
+
+  const cursor = svg.querySelector('#evo-cursor');
+  if (cursor) {
+    const cx = (i / Math.max(1, n - 1)) * 730;
+    cursor.setAttribute('x1', cx); cursor.setAttribute('x2', cx);
+    cursor.style.display = '';
+  }
+
+  const nice = _hcalParse(dates[i]).toLocaleDateString(undefined,
+    { weekday: 'short', month: 'short', day: 'numeric' });
+  let total = 0;
+  const rows = _EVO_STATES.slice().reverse().map(s => {
+    const v = series[s.key][i];
+    total += v;
+    return `<div class="hcal-tip-row"><span class="hcal-leg-sw" style="background:${
+      s.color};margin-right:5px"></span>${s.label}: <b>${v}</b></div>`;
+  }).join('');
+
+  const t = _hcalTip();
+  t.innerHTML = `<div class="hcal-tip-date">${nice}</div>
+                 <div class="hcal-tip-big">${total} cards</div>${rows}`;
+  t.style.display = 'block';
+  let left = ev.pageX - t.offsetWidth / 2;
+  left = Math.max(6, Math.min(left, window.scrollX + window.innerWidth - t.offsetWidth - 6));
+  let top = ev.pageY - t.offsetHeight - 14;
+  if (top < window.scrollY + 4) top = ev.pageY + 14;
+  t.style.left = left + 'px';
+  t.style.top = top + 'px';
+}
+
+function evoLeave() {
+  hcalHideTip();
+  const cursor = document.getElementById('evo-cursor');
+  if (cursor) cursor.style.display = 'none';
 }

--- a/static/style.css
+++ b/static/style.css
@@ -4062,6 +4062,19 @@ details[open] .cat-override-summary::before { content: '▼ '; }
 .hcal-tbl td { padding: 4px 8px 4px 0; border-bottom: 1px solid var(--border); color: var(--text); }
 .hcal-tbl-total td { font-weight: 700; border-bottom: none; }
 
+/* ── Card-evolution chart (issue #321) ── */
+.evo-chart-wrap { position: relative; }
+.evo-svg { display: block; width: 100%; height: 190px; }
+.evo-legend {
+  display: inline-flex; align-items: center; gap: 12px;
+  font-size: 11px; color: var(--muted);
+}
+.evo-leg { display: inline-flex; align-items: center; gap: 4px; }
+.evo-ylabel {
+  position: absolute; left: 4px; transform: translateY(2px);
+  font-size: 9px; color: var(--muted); pointer-events: none;
+}
+
 @media (prefers-color-scheme: dark) {
   :root { --hcal-empty: #1f2933; }
   .hcal-seg-btn.active { background: #6366f1; }


### PR DESCRIPTION
## 变更内容
- **后端**：`database/stats.py` 新增 `get_card_evolution()`，`routes/browse.py` 新增 `GET /api/card-evolution?days=365`
  - 90% 的旧复习记录没有 `state` 字段，所以通过**重放 SM-2 状态机**（评分序列 + 牌组预设的学习步骤数）重建每张卡片的历史状态
  - 有记录的 `state` 用于校准重放；卡片当前状态固定时间线末端
  - 暂停卡片按 `pre_suspend_state` 归类（从未复习的暂停卡片算作 New——它们确实还没学）
  - 天数按 Anki 日界（本地时间 4am）分桶，与日历热力图一致
- **前端**：主页日历下方新增堆叠面积图（内联 SVG，无构建步骤）
  - 状态颜色沿用现有主题变量：New 蓝 / Learning 琥珀 / Learnt 绿 / Relearn 红
  - 视图切换：Listening / Creating / All（localStorage 记住选择）
  - 自动裁掉集合创建之前的空白天数（数据从 2026-03-16 开始）
  - 悬停显示垂直游标 + 各状态数量提示框
  - 复习后缓存失效，重新进入主页即刷新

## 测试方法
1. `bash run.sh` 启动后打开主页，日历下方应出现堆叠面积图
2. 切换 Listening / Creating / All，曲线应变化且刷新后记住选择
3. 悬停图表任意位置，提示框显示该天 New/Learning/Learnt/Relearn 数量
4. 今天的数值应与浏览页各状态卡片数一致（暂停卡片归入暂停前状态）
5. 完成一次复习后回到主页，图表应反映新状态

已验证：用真实数据库副本测试，今日重建值与 `cards` 表实际状态一致；历史曲线显示 Learnt 从 0 → 966 稳定增长。

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)