### PR TITLE
feat: 难词（leech）自动暂停 + 浏览器难词分区 + 可调阈值

### DIFF
--- a/database/browse.py
+++ b/database/browse.py
@@ -13,6 +13,7 @@ def get_words_for_browse() -> list[dict]:
         SELECT w.id, w.word_zh, w.pinyin, w.definition, w.definition_de, w.pos, w.hsk_level, w.note_type,
                c.id as card_id, c.category, c.state, c.interval, c.ease,
                c.due, c.lapses, c.step_index, c.deck_id,
+               c.is_leech, c.learning_again_count,
                d.name as deck_name
         FROM entries w
         LEFT JOIN cards c ON c.word_id = w.id AND c.deleted_at IS NULL
@@ -49,6 +50,8 @@ def get_words_for_browse() -> list[dict]:
                 "lapses": r["lapses"],
                 "step_index": r["step_index"],
                 "deck_id": r["deck_id"],
+                "is_leech": r["is_leech"],
+                "learning_again_count": r["learning_again_count"],
                 "deck_name": r["deck_name"],
             })
     return list(words.values())
@@ -100,19 +103,44 @@ def get_cards_for_word(word_id: int) -> list[dict]:
 
 
 def suspend_card(card_id: int) -> None:
-    """Unconditionally suspend a card (used by leech detection)."""
+    """Unconditionally suspend a card."""
     conn = get_db()
     conn.execute("UPDATE cards SET state='suspended' WHERE id=?", (card_id,))
     conn.commit()
     conn.close()
 
 
-def toggle_card_suspension(card_id: int) -> dict:
-    """Toggle a card between suspended and new."""
+def mark_leech_suspend(card_id: int) -> None:
+    """Suspend a card flagged as a leech, preserving its prior state for restore."""
     conn = get_db()
-    cur = conn.execute("SELECT state FROM cards WHERE id=?", (card_id,)).fetchone()
-    new_state = "new" if cur and cur["state"] == "suspended" else "suspended"
-    conn.execute("UPDATE cards SET state=? WHERE id=?", (new_state, card_id))
+    conn.execute(
+        """UPDATE cards
+              SET pre_suspend_state = state, state = 'suspended', is_leech = 1
+            WHERE id = ? AND state != 'suspended'""",
+        (card_id,),
+    )
+    conn.commit()
+    conn.close()
+
+
+def toggle_card_suspension(card_id: int) -> dict:
+    """Toggle a card between suspended and new.
+
+    Unsuspending a leech clears its leech flag and resets the Again counters,
+    giving the card a fresh start instead of immediately re-triggering.
+    """
+    conn = get_db()
+    cur = conn.execute("SELECT state, is_leech FROM cards WHERE id=?", (card_id,)).fetchone()
+    if cur and cur["state"] == "suspended":
+        if cur["is_leech"]:
+            conn.execute(
+                "UPDATE cards SET state='new', is_leech=0, lapses=0, learning_again_count=0 WHERE id=?",
+                (card_id,),
+            )
+        else:
+            conn.execute("UPDATE cards SET state='new' WHERE id=?", (card_id,))
+    else:
+        conn.execute("UPDATE cards SET state='suspended' WHERE id=?", (card_id,))
     conn.commit()
     conn.close()
     return get_card(card_id)
@@ -123,7 +151,8 @@ def reset_card(card_id: int) -> dict:
     conn = get_db()
     conn.execute(
         """UPDATE cards SET state='new', step_index=0, interval=1,
-                            ease=2.5, lapses=0, due=date('now'), buried_until=NULL
+                            ease=2.5, lapses=0, learning_again_count=0, is_leech=0,
+                            due=date('now'), buried_until=NULL
            WHERE id=?""",
         (card_id,),
     )
@@ -297,6 +326,8 @@ def get_all_cards_for_browse(filters: dict | None = None) -> list[dict]:
         if filters.get("state"):
             where.append("c.state = ?")
             params.append(filters["state"])
+        if filters.get("leech"):
+            where.append("c.is_leech = 1")
         if filters.get("search_text"):
             where.append("(w.word_zh LIKE ? OR w.definition LIKE ? OR w.pinyin LIKE ?)")
             q = f"%{filters['search_text']}%"

--- a/database/cards.py
+++ b/database/cards.py
@@ -1376,3 +1376,94 @@ def get_card_calendar_data(card_id: int) -> dict:
     }
 
 
+def get_card_timeline_data(card_id: int) -> dict:
+    """Per-card interval timeline for all category cards of the same word.
+
+    review_log does not store intervals, so the y-value of each point is the
+    real elapsed time since the previous review (in days, 0 for the first
+    review). The card's state at each point is replayed with the SM-2 state
+    machine (see stats._next_state); recorded review_log.state values
+    recalibrate the replay and the card's current state pins the end.
+
+    Each card gets a final scheduled point at its due date with the current
+    interval, so the graph extends into the future.
+    """
+    from .stats import _next_state, _EVOLUTION_STATES
+
+    conn = get_db()
+    word_row = conn.execute("SELECT word_id FROM cards WHERE id = ?", (card_id,)).fetchone()
+    if not word_row:
+        conn.close()
+        return {"cards": []}
+
+    cards = conn.execute(
+        """SELECT c.id, c.deck_id, c.category, c.state, c.pre_suspend_state,
+                  c.interval, c.due
+           FROM cards c
+           WHERE c.word_id = ? AND c.deleted_at IS NULL
+           ORDER BY c.category""",
+        (word_row["word_id"],),
+    ).fetchall()
+
+    result = []
+    for c in cards:
+        rows = conn.execute(
+            """SELECT datetime(reviewed_at, 'localtime') AS at, rating, state
+               FROM review_log WHERE card_id = ? ORDER BY reviewed_at""",
+            (c["id"],),
+        ).fetchall()
+
+        preset = get_preset_for_deck(c["deck_id"], c["category"]) or {}
+        n_learn = max(1, len(str(preset.get("learning_steps", "1 10")).split()))
+        n_relearn = max(1, len(str(preset.get("relearning_steps", "10")).split()))
+
+        final = c["state"]
+        if final == "suspended":
+            final = c["pre_suspend_state"]
+
+        points = []
+        state, step = "new", 0
+        prev_dt = None
+        for r in rows:
+            if r["state"] in _EVOLUTION_STATES and r["state"] != state:
+                state, step = r["state"], 0  # recalibrate from recorded truth
+            state, step = _next_state(state, step, r["rating"], n_learn, n_relearn)
+            dt = datetime.fromisoformat(r["at"])
+            gap = (dt - prev_dt).total_seconds() / 86400 if prev_dt else 0.0
+            points.append({
+                "at": r["at"],
+                "gap": round(gap, 2),
+                "rating": r["rating"],
+                "state": state,
+            })
+            prev_dt = dt
+        if points and final in _EVOLUTION_STATES:
+            points[-1]["state"] = final  # pin the end to the card's real state
+
+        # Scheduled point: where the card is due next (skip new/suspended cards)
+        scheduled = None
+        if points and c["state"] in ("learning", "relearn", "review"):
+            due_raw = c["due"]
+            due_dt = datetime.fromisoformat(due_raw) if len(due_raw) > 10 \
+                else datetime.fromisoformat(due_raw + "T04:00:00")
+            gap = max(0.0, (due_dt - prev_dt).total_seconds() / 86400)
+            scheduled = {
+                "at": due_dt.isoformat(sep=" "),
+                "gap": round(c["interval"], 2) if c["state"] == "review" else round(gap, 2),
+                "state": c["state"],
+            }
+
+        result.append({
+            "card_id": c["id"],
+            "category": c["category"],
+            "state": c["state"],
+            "interval": c["interval"],
+            "due": c["due"],
+            "points": points,
+            "scheduled": scheduled,
+        })
+
+    conn.close()
+    return {"cards": result}
+
+

--- a/database/cards.py
+++ b/database/cards.py
@@ -1376,19 +1376,107 @@ def get_card_calendar_data(card_id: int) -> dict:
     }
 
 
+def _parse_step_minutes(steps_str: str) -> list[float]:
+    """Parse a learning/relearning step string to minutes.
+
+    Mirrors srs._parse_steps: plain numbers and "m" are minutes, "d" is days
+    (×1440). Malformed tokens are skipped; empty input falls back to [1].
+    """
+    out = []
+    for s in str(steps_str).strip().split():
+        try:
+            if s.endswith("d"):
+                out.append(float(s[:-1]) * 1440)
+            elif s.endswith("m"):
+                out.append(float(s[:-1]))
+            else:
+                out.append(float(s))
+        except ValueError:
+            continue
+    return out or [1.0]
+
+
+def _replay_schedule_step(state, step, interval, ease, rating, P):
+    """Pure SM-2 replay of one review (no fuzz, no DB).
+
+    Returns (new_state, new_step, new_interval, new_ease, gap_days) where
+    gap_days is the scheduled delay until the card's next due — i.e. the
+    interval the scheduler assigned. Learning/relearn steps are sub-day
+    (minutes/1440); review intervals are whole days.
+    """
+    ls, rs = P["learning_steps"], P["relearning_steps"]
+
+    if state in ("new", "learning"):
+        if rating == 4:                         # Easy → graduate
+            return ("review", 0, P["easy_interval"], ease, float(P["easy_interval"]))
+        if rating == 1:                         # Again → back to step 0
+            return ("learning", 0, interval, ease, ls[0] / 1440)
+        if rating == 2:                         # Hard → repeat step
+            if step == 0 and len(ls) > 1:
+                delay = (ls[0] + ls[1]) / 2
+            elif len(ls) == 1:
+                delay = ls[0] * 1.5
+            else:
+                delay = ls[step]
+            return ("learning", step, interval, ease, delay / 1440)
+        if step >= len(ls) - 1:                 # Good on last step → graduate
+            return ("review", 0, P["graduating_interval"], ease, float(P["graduating_interval"]))
+        return ("learning", step + 1, interval, ease, ls[step + 1] / 1440)
+
+    if state == "review":
+        if rating == 1:                         # Again → lapse + relearn
+            ne = max(1.3, ease - 0.20)
+            iv = max(P["minimum_interval"], int(interval * 0.5))
+            return ("relearn", 0, iv, ne, rs[0] / 1440)
+        if rating == 2:                         # Hard
+            ne = max(1.3, ease - 0.15)
+            iv = max(P["minimum_interval"], int(interval * 1.2))
+            return ("review", 0, iv, ne, float(iv))
+        if rating == 3:                         # Good
+            iv = max(P["minimum_interval"], int(interval * ease))
+            return ("review", 0, iv, ease, float(iv))
+        ne = ease + 0.15                        # Easy
+        iv = max(P["minimum_interval"], int(interval * ne * 1.3))
+        return ("review", 0, iv, ne, float(iv))
+
+    if state == "relearn":
+        if rating == 1:
+            return ("relearn", 0, interval, ease, rs[0] / 1440)
+        if rating == 2:
+            if step == 0 and len(rs) > 1:
+                delay = (rs[0] + rs[1]) / 2
+            elif len(rs) == 1:
+                delay = rs[0] * 1.5
+            else:
+                delay = rs[step]
+            return ("relearn", step, interval, ease, delay / 1440)
+        if rating == 4:                         # Easy → review
+            iv = max(P["minimum_interval"], int(interval * ease))
+            return ("review", 0, iv, ease, float(iv))
+        if step >= len(rs) - 1:                 # Good on last step → review
+            iv = max(P["minimum_interval"], interval)
+            return ("review", 0, iv, ease, float(iv))
+        return ("relearn", step + 1, interval, ease, rs[step + 1] / 1440)
+
+    return (state, step, interval, ease, float(interval))
+
+
 def get_card_timeline_data(card_id: int) -> dict:
     """Per-card interval timeline for all category cards of the same word.
 
-    review_log does not store intervals, so the y-value of each point is the
-    real elapsed time since the previous review (in days, 0 for the first
-    review). The card's state at each point is replayed with the SM-2 state
-    machine (see stats._next_state); recorded review_log.state values
-    recalibrate the replay and the card's current state pins the end.
+    The y-value of each point is the *scheduled* SRS interval the card was
+    given after that review (whole days for review cards, sub-day for
+    learning/relearn steps), reconstructed by replaying the full SM-2
+    scheduler over the rating history (review_log stores ratings, not
+    intervals). This is what Anki's card-info graph shows and — unlike the
+    raw elapsed time between reviews — diverges per card by ease/rating even
+    when several cards are studied together on the same days.
 
-    Each card gets a final scheduled point at its due date with the current
-    interval, so the graph extends into the future.
+    Recorded review_log.state values recalibrate the replayed state, and the
+    card's current state pins the end. Each card gets a final dashed point at
+    its real due date with the current interval.
     """
-    from .stats import _next_state, _EVOLUTION_STATES
+    from .stats import _EVOLUTION_STATES
 
     conn = get_db()
     word_row = conn.execute("SELECT word_id FROM cards WHERE id = ?", (card_id,)).fetchone()
@@ -1414,42 +1502,48 @@ def get_card_timeline_data(card_id: int) -> dict:
         ).fetchall()
 
         preset = get_preset_for_deck(c["deck_id"], c["category"]) or {}
-        n_learn = max(1, len(str(preset.get("learning_steps", "1 10")).split()))
-        n_relearn = max(1, len(str(preset.get("relearning_steps", "10")).split()))
+        P = {
+            "learning_steps":      _parse_step_minutes(preset.get("learning_steps", "1 10")),
+            "relearning_steps":    _parse_step_minutes(preset.get("relearning_steps", "10")),
+            "graduating_interval": preset.get("graduating_interval", 1),
+            "easy_interval":       preset.get("easy_interval", 4),
+            "minimum_interval":    preset.get("minimum_interval", 1),
+        }
 
         final = c["state"]
         if final == "suspended":
             final = c["pre_suspend_state"]
 
         points = []
-        state, step = "new", 0
-        prev_dt = None
+        state, step, interval, ease = "new", 0, 0, 2.5
         for r in rows:
             if r["state"] in _EVOLUTION_STATES and r["state"] != state:
                 state, step = r["state"], 0  # recalibrate from recorded truth
-            state, step = _next_state(state, step, r["rating"], n_learn, n_relearn)
-            dt = datetime.fromisoformat(r["at"])
-            gap = (dt - prev_dt).total_seconds() / 86400 if prev_dt else 0.0
+            state, step, interval, ease, gap = _replay_schedule_step(
+                state, step, interval, ease, r["rating"], P)
             points.append({
                 "at": r["at"],
-                "gap": round(gap, 2),
+                "gap": round(gap, 3),
                 "rating": r["rating"],
                 "state": state,
             })
-            prev_dt = dt
         if points and final in _EVOLUTION_STATES:
             points[-1]["state"] = final  # pin the end to the card's real state
 
-        # Scheduled point: where the card is due next (skip new/suspended cards)
+        # Final dashed point: the card's real current interval, plotted at its due date
         scheduled = None
         if points and c["state"] in ("learning", "relearn", "review"):
             due_raw = c["due"]
             due_dt = datetime.fromisoformat(due_raw) if len(due_raw) > 10 \
                 else datetime.fromisoformat(due_raw + "T04:00:00")
-            gap = max(0.0, (due_dt - prev_dt).total_seconds() / 86400)
+            if c["state"] == "review":
+                gap = float(c["interval"])
+            else:
+                last_dt = datetime.fromisoformat(rows[-1]["at"])
+                gap = max(0.0, (due_dt - last_dt).total_seconds() / 86400)
             scheduled = {
                 "at": due_dt.isoformat(sep=" "),
-                "gap": round(c["interval"], 2) if c["state"] == "review" else round(gap, 2),
+                "gap": round(gap, 3),
                 "state": c["state"],
             }
 

--- a/database/cards.py
+++ b/database/cards.py
@@ -128,7 +128,7 @@ def get_card(card_id: int) -> dict | None:
                   p.id AS preset_id,
                   p.learning_steps, p.graduating_interval, p.easy_interval,
                   p.relearning_steps, p.minimum_interval,
-                  p.leech_threshold, p.leech_action,
+                  p.leech_threshold, p.learning_leech_threshold, p.leech_action,
                   p.new_per_day, p.reviews_per_day
            FROM cards c
            JOIN entries w ON w.id = c.word_id
@@ -487,14 +487,24 @@ def update_word(word_id: int, fields: dict) -> None:
 
 def update_card(card_id: int, *, state: str, due: str,
                 step_index: int, interval: int,
-                ease: float, repetitions: int, lapses: int) -> None:
+                ease: float, repetitions: int, lapses: int,
+                learning_again_count: int | None = None) -> None:
     conn = get_db()
-    conn.execute(
-        """UPDATE cards SET state=?, due=?, step_index=?, interval=?,
-                            ease=?, repetitions=?, lapses=?
-           WHERE id=?""",
-        (state, due, step_index, interval, ease, repetitions, lapses, card_id),
-    )
+    if learning_again_count is None:
+        conn.execute(
+            """UPDATE cards SET state=?, due=?, step_index=?, interval=?,
+                                ease=?, repetitions=?, lapses=?
+               WHERE id=?""",
+            (state, due, step_index, interval, ease, repetitions, lapses, card_id),
+        )
+    else:
+        conn.execute(
+            """UPDATE cards SET state=?, due=?, step_index=?, interval=?,
+                                ease=?, repetitions=?, lapses=?, learning_again_count=?
+               WHERE id=?""",
+            (state, due, step_index, interval, ease, repetitions, lapses,
+             learning_again_count, card_id),
+        )
     conn.commit()
     conn.close()
 

--- a/database/core.py
+++ b/database/core.py
@@ -207,6 +207,14 @@ def init_db() -> None:
         conn.execute("ALTER TABLE cards ADD COLUMN deleted_at TEXT")
     if "pre_suspend_state" not in card_cols:
         conn.execute("ALTER TABLE cards ADD COLUMN pre_suspend_state TEXT")
+    # Leech tracking: Again presses during learning, + a flag marking leech suspends.
+    # Absence of is_leech signals a fresh install of this feature → run the one-time
+    # historical backfill below (after preset thresholds are migrated).
+    need_leech_backfill = "is_leech" not in card_cols
+    if "learning_again_count" not in card_cols:
+        conn.execute("ALTER TABLE cards ADD COLUMN learning_again_count INTEGER NOT NULL DEFAULT 0")
+    if "is_leech" not in card_cols:
+        conn.execute("ALTER TABLE cards ADD COLUMN is_leech INTEGER NOT NULL DEFAULT 0")
 
     # review_log: per-review timing + card state at review time (for calendar heatmap stats)
     rl_cols = {r["name"] for r in conn.execute("PRAGMA table_info(review_log)").fetchall()}
@@ -250,6 +258,11 @@ def init_db() -> None:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN sibling_separation INTEGER NOT NULL DEFAULT 3")
     if "sibling_factor" not in preset_cols:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN sibling_factor REAL NOT NULL DEFAULT 0.2")
+    if "learning_leech_threshold" not in preset_cols:
+        conn.execute("ALTER TABLE deck_presets ADD COLUMN learning_leech_threshold INTEGER NOT NULL DEFAULT 6")
+        # Lower the review-leech threshold from the legacy default (8) to the new
+        # default (3) for presets that never tuned it away from 8.
+        conn.execute("UPDATE deck_presets SET leech_threshold = 3 WHERE leech_threshold = 8")
 
     conn.execute("""CREATE TABLE IF NOT EXISTS preset_category_overrides (
         id                  INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -263,9 +276,41 @@ def init_db() -> None:
         relearning_steps    TEXT,
         minimum_interval    INTEGER,
         leech_threshold     INTEGER,
+        learning_leech_threshold INTEGER,
         leech_action        TEXT CHECK(leech_action IN ('suspend', 'tag')),
         UNIQUE(preset_id, category)
     )""")
+    override_cols = {r["name"] for r in conn.execute("PRAGMA table_info(preset_category_overrides)").fetchall()}
+    if "learning_leech_threshold" not in override_cols:
+        conn.execute("ALTER TABLE preset_category_overrides ADD COLUMN learning_leech_threshold INTEGER")
+
+    # ── One-time historical leech backfill ─────────────────────────────────────
+    # Retroactively flag cards that already exceed their deck's leech thresholds,
+    # so past Again presses count too. Runs once, when is_leech is first added.
+    if need_leech_backfill:
+        # Reconstruct learning Again presses from the review log (rating=1 while the
+        # card was in new/learning/relearn). Logs with NULL state can't be classified
+        # and are skipped — review-state lapses are already tracked in cards.lapses.
+        conn.execute(
+            """UPDATE cards SET learning_again_count = (
+                   SELECT COUNT(*) FROM review_log r
+                   WHERE r.card_id = cards.id AND r.rating = 1
+                     AND r.state IN ('new', 'learning', 'relearn')
+               )"""
+        )
+        # Suspend + flag every active card already over either threshold.
+        conn.execute(
+            """UPDATE cards
+                  SET pre_suspend_state = state, state = 'suspended', is_leech = 1
+                WHERE state != 'suspended' AND deleted_at IS NULL
+                  AND id IN (
+                      SELECT c.id FROM cards c
+                      JOIN decks d ON d.id = c.deck_id
+                      JOIN deck_presets p ON p.id = d.preset_id
+                      WHERE c.lapses >= p.leech_threshold
+                         OR c.learning_again_count >= p.learning_leech_threshold
+                  )"""
+        )
 
     # Normalize legacy due values: learning/relearn cards whose due datetime
     # falls on a future Anki day should store just the date (no time component).

--- a/database/presets.py
+++ b/database/presets.py
@@ -19,7 +19,8 @@ def default_preset() -> dict:
         "insertion_order": "sequential",
         "bury_siblings": 1,
         "randomize_story_order": 0,
-        "leech_threshold": 8,
+        "leech_threshold": 3,
+        "learning_leech_threshold": 6,
         "leech_action": "suspend",
         "new_gather_order": "ascending_position",
         "new_sort_order": "card_type_gathered",
@@ -132,7 +133,7 @@ def get_preset_for_deck(deck_id: int, category: str | None = None) -> dict:
 _OVERRIDE_FIELDS = {
     "new_per_day", "reviews_per_day", "learning_steps",
     "graduating_interval", "easy_interval", "relearning_steps",
-    "minimum_interval", "leech_threshold", "leech_action",
+    "minimum_interval", "leech_threshold", "learning_leech_threshold", "leech_action",
 }
 
 
@@ -200,7 +201,7 @@ def insert_preset(preset: dict) -> int:
            (name, new_per_day, reviews_per_day,
             learning_steps, graduating_interval, easy_interval,
             relearning_steps, minimum_interval, insertion_order,
-            bury_siblings, randomize_story_order, leech_threshold, leech_action,
+            bury_siblings, randomize_story_order, leech_threshold, learning_leech_threshold, leech_action,
             new_gather_order, new_sort_order, new_review_order,
             interday_learning_review_order, review_sort_order,
             bury_new_siblings, bury_review_siblings, bury_interday_siblings,
@@ -208,7 +209,7 @@ def insert_preset(preset: dict) -> int:
            VALUES (:name, :new_per_day, :reviews_per_day,
                    :learning_steps, :graduating_interval, :easy_interval,
                    :relearning_steps, :minimum_interval, :insertion_order,
-                   :bury_siblings, :randomize_story_order, :leech_threshold, :leech_action,
+                   :bury_siblings, :randomize_story_order, :leech_threshold, :learning_leech_threshold, :leech_action,
                    :new_gather_order, :new_sort_order, :new_review_order,
                    :interday_learning_review_order, :review_sort_order,
                    :bury_new_siblings, :bury_review_siblings, :bury_interday_siblings,
@@ -226,7 +227,7 @@ def update_preset(preset_id: int, fields: dict) -> None:
         "name", "new_per_day", "reviews_per_day",
         "learning_steps", "graduating_interval", "easy_interval",
         "relearning_steps", "minimum_interval", "insertion_order",
-        "bury_siblings", "randomize_story_order", "leech_threshold", "leech_action",
+        "bury_siblings", "randomize_story_order", "leech_threshold", "learning_leech_threshold", "leech_action",
         "new_gather_order", "new_sort_order", "new_review_order",
         "interday_learning_review_order", "review_sort_order",
         "bury_new_siblings", "bury_review_siblings", "bury_interday_siblings",

--- a/database/stats.py
+++ b/database/stats.py
@@ -289,6 +289,170 @@ def get_calendar_stats(days: int = 365, deck_id: int | None = None) -> dict:
     }
 
 
+_EVOLUTION_STATES = ("new", "learning", "review", "relearn")
+
+
+def _next_state(state: str, step: int, rating: int,
+                n_learn: int, n_relearn: int) -> tuple[str, int]:
+    """SM-2 state transition for one review (states only, no intervals)."""
+    if state in ("new", "learning"):
+        if rating == 1:
+            return ("learning", 0)
+        if rating == 2:
+            return ("learning", step)
+        if rating == 3:
+            if step + 1 >= n_learn:
+                return ("review", 0)
+            return ("learning", step + 1)
+        return ("review", 0)  # Easy graduates immediately
+    if state == "review":
+        return ("relearn", 0) if rating == 1 else ("review", 0)
+    if state == "relearn":
+        if rating == 1:
+            return ("relearn", 0)
+        if rating == 2:
+            return ("relearn", step)
+        if rating == 3:
+            if step + 1 >= n_relearn:
+                return ("review", 0)
+            return ("relearn", step + 1)
+        return ("review", 0)
+    return (state, step)
+
+
+def get_card_evolution(days: int = 365, deck_id: int | None = None) -> dict:
+    """Per-day card-state counts over time, reconstructed from review_log.
+
+    Most legacy review rows have NULL state, so the history is rebuilt by
+    replaying the SM-2 state machine over each card's rating sequence (using
+    the deck preset's learning/relearning step counts). Rows that *do* record
+    a state recalibrate the replay, and the card's current state pins the end
+    of the timeline. Before the first review a card is 'new' (from the
+    entry's date_added). Suspended cards count under their pre_suspend_state
+    (or stay in their last replayed state when that is unset).
+
+    Days use the Anki boundary (local time, 4am cutoff) like get_calendar_stats.
+
+    Returns:
+        {
+          "days": int, "today": "YYYY-MM-DD",
+          "dates": ["YYYY-MM-DD", ...],            # oldest → today, len == days
+          "series": {category: {state: [int, ...]}}  # aligned with dates
+        }
+    """
+    conn = get_db()
+    today = anki_today()
+    dates = [(today - _dt.timedelta(days=days - 1 - i)).isoformat()
+             for i in range(days)]
+
+    deck_filter = "AND c.deck_id = ?" if deck_id else ""
+    params = [deck_id] if deck_id else []
+    day_of = "date(datetime({col}, 'localtime', '-4 hours'))"
+
+    cards = conn.execute(
+        f"""SELECT c.id, c.deck_id, c.category, c.state, c.pre_suspend_state,
+                   {day_of.format(col='e.date_added')} AS created
+            FROM cards c JOIN entries e ON e.id = c.word_id
+            WHERE c.deleted_at IS NULL {deck_filter}""",
+        params,
+    ).fetchall()
+
+    reviews = conn.execute(
+        f"""SELECT rl.card_id, {day_of.format(col='rl.reviewed_at')} AS d,
+                   rl.state, rl.rating
+            FROM review_log rl
+            JOIN cards c ON c.id = rl.card_id
+            WHERE c.deleted_at IS NULL {deck_filter}
+            ORDER BY rl.card_id, rl.reviewed_at""",
+        params,
+    ).fetchall()
+
+    # Learning/relearning step counts per deck (category override wins)
+    preset_rows = conn.execute(
+        """SELECT d.id AS deck_id,
+                  p.learning_steps, p.relearning_steps,
+                  o.learning_steps AS o_ls, o.relearning_steps AS o_rs
+           FROM decks d
+           JOIN deck_presets p ON p.id = d.preset_id
+           LEFT JOIN preset_category_overrides o
+                  ON o.preset_id = d.preset_id AND o.category = d.category"""
+    ).fetchall()
+    conn.close()
+
+    steps_by_deck = {
+        r["deck_id"]: (
+            max(1, len((r["o_ls"] or r["learning_steps"]).split())),
+            max(1, len((r["o_rs"] or r["relearning_steps"]).split())),
+        )
+        for r in preset_rows
+    }
+
+    revs_by_card: dict[int, list] = {}
+    for r in reviews:
+        revs_by_card.setdefault(r["card_id"], []).append(
+            (r["d"], r["state"], r["rating"]))
+
+    # deltas[category][day][state] — state-count changes taking effect that day
+    deltas: dict[str, dict[str, dict[str, int]]] = {}
+    for c in cards:
+        final = c["state"]
+        if final == "suspended":
+            final = c["pre_suspend_state"]
+        n_learn, n_relearn = steps_by_deck.get(c["deck_id"], (2, 1))
+        rl = revs_by_card.get(c["id"], [])
+
+        # Checkpoints: (day, state the card holds from the end of that day on)
+        seq = [(c["created"], "new")]
+        state, step = "new", 0
+        for day, recorded, rating in rl:
+            if recorded in _EVOLUTION_STATES and recorded != state:
+                state, step = recorded, 0  # recalibrate from recorded truth
+            state, step = _next_state(state, step, rating, n_learn, n_relearn)
+            seq.append((day, state))
+        if rl and final in _EVOLUTION_STATES:
+            seq[-1] = (seq[-1][0], final)  # pin the end to the card's real state
+
+        # Several checkpoints on one day: the last one wins
+        last_for_day: dict[str, str] = {}
+        for day, st in seq:
+            last_for_day[day] = st
+
+        cat_deltas = deltas.setdefault(c["category"], {})
+        prev = None
+        for day in sorted(last_for_day):
+            st = last_for_day[day]
+            if st == prev:
+                continue
+            d = cat_deltas.setdefault(day, {})
+            if prev is not None:
+                d[prev] = d.get(prev, 0) - 1
+            d[st] = d.get(st, 0) + 1
+            prev = st
+
+    # Accumulate deltas into daily series (deltas before the window roll into day 0)
+    series: dict[str, dict[str, list[int]]] = {}
+    for cat, cat_deltas in deltas.items():
+        running = dict.fromkeys(_EVOLUTION_STATES, 0)
+        out = {s: [] for s in _EVOLUTION_STATES}
+        delta_days = sorted(cat_deltas)
+        idx = 0
+        for date_str in dates:
+            while idx < len(delta_days) and delta_days[idx] <= date_str:
+                for s, n in cat_deltas[delta_days[idx]].items():
+                    running[s] += n
+                idx += 1
+            for s in _EVOLUTION_STATES:
+                out[s].append(running[s])
+        series[cat] = out
+
+    return {
+        "days": days,
+        "today": today.isoformat(),
+        "dates": dates,
+        "series": series,
+    }
+
+
 def _calc_streak(conn: sqlite3.Connection, deck_id: int | None) -> int:
     deck_filter = "AND c.deck_id = ?" if deck_id else ""
     params = [deck_id] if deck_id else []

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -481,6 +481,11 @@ def get_calendar_stats(days: int = 365, deck_id: int | None = None):
     return database.get_calendar_stats(days, deck_id)
 
 
+@router.get("/api/card-evolution")
+def get_card_evolution(days: int = 365, deck_id: int | None = None):
+    return database.get_card_evolution(days, deck_id)
+
+
 @router.get("/api/costs")
 def get_api_costs():
     return database.get_api_costs()

--- a/routes/review.py
+++ b/routes/review.py
@@ -318,3 +318,8 @@ def unbury_card(card_id: int):
 @router.get("/api/cards/{card_id}/calendar")
 def get_card_calendar(card_id: int):
     return database.get_card_calendar_data(card_id)
+
+
+@router.get("/api/cards/{card_id}/timeline")
+def get_card_timeline(card_id: int):
+    return database.get_card_timeline_data(card_id)

--- a/schema.sql
+++ b/schema.sql
@@ -40,7 +40,10 @@ CREATE TABLE IF NOT EXISTS deck_presets (
     randomize_story_order   INTEGER NOT NULL DEFAULT 0,
 
     -- Leech settings
-    leech_threshold         INTEGER NOT NULL DEFAULT 8,
+    -- leech_threshold: review-state lapses before a card is flagged as a leech
+    leech_threshold         INTEGER NOT NULL DEFAULT 3,
+    -- learning_leech_threshold: Again presses in learning/relearn before flagging
+    learning_leech_threshold INTEGER NOT NULL DEFAULT 6,
     leech_action            TEXT NOT NULL DEFAULT 'suspend'
                                 CHECK(leech_action IN ('suspend', 'tag')),
 
@@ -250,6 +253,12 @@ CREATE TABLE IF NOT EXISTS cards (
     repetitions INTEGER NOT NULL DEFAULT 0,
     lapses      INTEGER NOT NULL DEFAULT 0,
 
+    -- Again presses while in new/learning/relearn (drives the learning leech check)
+    learning_again_count INTEGER NOT NULL DEFAULT 0,
+
+    -- set to 1 when the card was suspended by leech detection (vs. manual suspend)
+    is_leech    INTEGER NOT NULL DEFAULT 0,
+
     -- Temporary burial: card is hidden until this date (resets automatically next day)
     buried_until TEXT,
 
@@ -432,6 +441,7 @@ CREATE TABLE IF NOT EXISTS preset_category_overrides (
     relearning_steps    TEXT,
     minimum_interval    INTEGER,
     leech_threshold     INTEGER,
+    learning_leech_threshold INTEGER,
     leech_action        TEXT CHECK(leech_action IN ('suspend', 'tag')),
     UNIQUE(preset_id, category)
 );

--- a/srs.py
+++ b/srs.py
@@ -211,6 +211,7 @@ def apply_review(card_id: int, rating: int,
         "relearning_steps":    card["relearning_steps"],
         "minimum_interval":    card["minimum_interval"],
         "leech_threshold":     card["leech_threshold"],
+        "learning_leech_threshold": card["learning_leech_threshold"],
         "leech_action":        card["leech_action"],
     }
 
@@ -233,6 +234,7 @@ def apply_review(card_id: int, rating: int,
         ease=updated["ease"],
         repetitions=updated["repetitions"],
         lapses=updated["lapses"],
+        learning_again_count=updated.get("learning_again_count"),
     )
     log_id = database.insert_review(
         card_id, rating, user_response=user_response,
@@ -258,6 +260,8 @@ def _handle_learning(card: dict, preset: dict, rating: int) -> dict:
         c["state"] = "learning"
         c["step_index"] = 0
         c["due"] = next_learning_due(steps, 0)
+        c["learning_again_count"] = c.get("learning_again_count", 0) + 1
+        _check_learning_leech(c, preset)
         return c
 
     if rating == 2:  # Hard — stay on current step, slow delay
@@ -325,6 +329,8 @@ def _handle_relearn(card: dict, preset: dict, rating: int) -> dict:
         c["state"] = "relearn"
         c["step_index"] = 0
         c["due"] = next_learning_due(steps, 0)
+        c["learning_again_count"] = c.get("learning_again_count", 0) + 1
+        _check_learning_leech(c, preset)
         return c
 
     if rating == 2:  # Hard — repeat current step
@@ -364,8 +370,19 @@ def _handle_relearn(card: dict, preset: dict, rating: int) -> dict:
 
 
 def _check_leech(card: dict, preset: dict) -> None:
-    """Suspend card if lapses >= leech_threshold."""
+    """Flag a review-state leech once lapses reach leech_threshold."""
     if card["lapses"] >= preset["leech_threshold"]:
-        if preset["leech_action"] == "suspend":
-            database.suspend_card(card["id"])
-            card["state"] = "suspended"
+        _apply_leech(card, preset)
+
+
+def _check_learning_leech(card: dict, preset: dict) -> None:
+    """Flag a learning/relearn leech once Again presses reach the threshold."""
+    if card.get("learning_again_count", 0) >= preset["learning_leech_threshold"]:
+        _apply_leech(card, preset)
+
+
+def _apply_leech(card: dict, preset: dict) -> None:
+    """Suspend + flag the card when leech_action is 'suspend'."""
+    if preset["leech_action"] == "suspend":
+        database.mark_leech_suspend(card["id"])
+        card["state"] = "suspended"

--- a/static/app.js
+++ b/static/app.js
@@ -239,10 +239,9 @@ async function _loadCardTile(cardId, category) {
   } catch (e) { /* silently skip if unavailable */ }
 }
 
-// ── Card interval graph + graph/calendar tile toggle (issue #323) ───────────
+// ── Card interval graph + calendar (issue #323) — graph on top, calendar below
 let _ctlData     = null;   // {cards} from /api/cards/{id}/timeline (review view)
 let _ctlCategory = null;   // category of the card being reviewed
-let _cardTileMode = localStorage.getItem('cardTileMode') || 'graph';
 
 const _CGRAPH_COLOR = {
   new: 'var(--primary)', learning: 'var(--hard)',
@@ -251,33 +250,15 @@ const _CGRAPH_COLOR = {
 const _CGRAPH_LABEL = { new: 'New', learning: 'Learning', review: 'Learnt', relearn: 'Relearn' };
 const _CGRAPH_RATING = { 1: 'Again', 2: 'Hard', 3: 'Good', 4: 'Easy' };
 
-function setCardTileMode(m) {
-  _cardTileMode = m;
-  localStorage.setItem('cardTileMode', m);
-  _renderCardTile();
-  _wdRenderCardTile();
-}
-
-// Review-view tile: switch between interval graph and calendar
+// Review-view tile: interval graph stacked above the calendar
 function _renderCardTile() {
   const g = document.getElementById('card-graph');
-  const c = document.getElementById('card-calendar');
-  if (!g || !c) return;
-  const bg = document.getElementById('ctile-btn-graph');
-  const bc = document.getElementById('ctile-btn-calendar');
-  if (bg) bg.classList.toggle('active', _cardTileMode === 'graph');
-  if (bc) bc.classList.toggle('active', _cardTileMode !== 'graph');
-  if (_cardTileMode === 'graph') {
-    c.style.display = 'none';
-    g.style.display = '';
+  if (g) {
     const cards = _ctlData?.cards || [];
     const card = cards.find(k => k.category === _ctlCategory) || cards[0];
     g.innerHTML = _cardGraphHtml(card);
-  } else {
-    g.style.display = 'none';
-    c.style.display = '';
-    if (_calData) _renderCal();
   }
+  if (_calData) _renderCal();
 }
 
 // Shared SVG renderer: x = time, y = interval (days), colored by card state
@@ -360,29 +341,21 @@ function wdSetTileCat(cat) { _wdCat = cat; _wdRenderCardTile(); }
 function _wdRenderCardTile() {
   const el = document.getElementById('wd-card-tile-section');
   if (!el || !_wdTlData) return;
-  const isGraph = _cardTileMode === 'graph';
   const catBtns = (_wdTlData.cards || []).map(c =>
     `<button class="hcal-seg-btn ${c.category === _wdCat ? 'active' : ''}"
              onclick="wdSetTileCat('${c.category}')">${_CAT_LETTER[c.category] || c.category}</button>`).join('');
+  const cards = _wdTlData.cards || [];
+  const card = cards.find(c => c.category === _wdCat) || cards[0];
   el.innerHTML = `
     <div class="section-label">Schedule</div>
     <div class="wd-card-tile">
       <div class="card-tile-head">
-        <div class="hcal-seg">
-          <button class="hcal-seg-btn ${isGraph ? 'active' : ''}" onclick="setCardTileMode('graph')">Graph</button>
-          <button class="hcal-seg-btn ${!isGraph ? 'active' : ''}" onclick="setCardTileMode('calendar')">Calendar</button>
-        </div>
-        ${isGraph ? `<div class="hcal-seg">${catBtns}</div>` : ''}
+        <div class="hcal-seg">${catBtns}</div>
       </div>
-      <div id="wd-tile-body"></div>
+      <div id="wd-tile-graph">${_cardGraphHtml(card)}</div>
+      <div class="card-calendar wd-cal-scroll" id="wd-cal-scroll"><div id="wd-cal-timeline"></div></div>
     </div>`;
-  const body = document.getElementById('wd-tile-body');
-  if (isGraph) {
-    const cards = _wdTlData.cards || [];
-    const card = cards.find(c => c.category === _wdCat) || cards[0];
-    body.innerHTML = _cardGraphHtml(card);
-  } else {
-    body.innerHTML = `<div class="card-calendar wd-cal-scroll" id="wd-cal-scroll"><div id="wd-cal-timeline"></div></div>`;
+  if (_wdCalData) {
     const saved = _calData, savedCat = _calCategory;
     _calData = _wdCalData;
     _calCategory = null;

--- a/static/app.js
+++ b/static/app.js
@@ -102,8 +102,8 @@ function _buildCalDayMap() {
   return map;
 }
 
-function _renderCal() {
-  const timelineEl = document.getElementById('cal-timeline');
+function _renderCal(timelineId = 'cal-timeline', panelId = 'review-cal-panel') {
+  const timelineEl = document.getElementById(timelineId);
   if (!timelineEl) return;
 
   const today = new Date();
@@ -203,9 +203,9 @@ function _renderCal() {
 
   // Scroll to first reviewed month (or today if no history)
   const scrollTargetId = firstMonthId || todayMonthId;
-  if (scrollTargetId) {
+  if (scrollTargetId && panelId) {
     requestAnimationFrame(() => {
-      const panel = document.getElementById('review-cal-panel');
+      const panel = document.getElementById(panelId);
       const el    = document.getElementById(scrollTargetId);
       if (panel && el) {
         const panelRect = panel.getBoundingClientRect();
@@ -216,21 +216,180 @@ function _renderCal() {
   }
 }
 
-async function _loadCardCalendar(cardId, category) {
+async function _loadCardTile(cardId, category) {
   const panel = document.getElementById('review-cal-panel');
   _calData     = null;
+  _ctlData     = null;
   _calCategory = category || null;
+  _ctlCategory = category || null;
   if (panel) panel.style.display = 'none';
   try {
-    const data = await api('GET', `/api/cards/${cardId}/calendar`);
-    if (!data) return;
-    _calData = data;
+    const [cal, tl] = await Promise.all([
+      api('GET', `/api/cards/${cardId}/calendar`),
+      api('GET', `/api/cards/${cardId}/timeline`).catch(() => null),
+    ]);
+    if (!cal && !tl) return;
+    _calData = cal;
+    _ctlData = tl;
     const today = new Date();
     _calYear  = today.getFullYear();
     _calMonth = today.getMonth();
-    _renderCal();
+    _renderCardTile();
     if (panel) panel.style.display = '';
   } catch (e) { /* silently skip if unavailable */ }
+}
+
+// ── Card interval graph + graph/calendar tile toggle (issue #323) ───────────
+let _ctlData     = null;   // {cards} from /api/cards/{id}/timeline (review view)
+let _ctlCategory = null;   // category of the card being reviewed
+let _cardTileMode = localStorage.getItem('cardTileMode') || 'graph';
+
+const _CGRAPH_COLOR = {
+  new: 'var(--primary)', learning: 'var(--hard)',
+  review: 'var(--good)', relearn: 'var(--again)',
+};
+const _CGRAPH_LABEL = { new: 'New', learning: 'Learning', review: 'Learnt', relearn: 'Relearn' };
+const _CGRAPH_RATING = { 1: 'Again', 2: 'Hard', 3: 'Good', 4: 'Easy' };
+
+function setCardTileMode(m) {
+  _cardTileMode = m;
+  localStorage.setItem('cardTileMode', m);
+  _renderCardTile();
+  _wdRenderCardTile();
+}
+
+// Review-view tile: switch between interval graph and calendar
+function _renderCardTile() {
+  const g = document.getElementById('card-graph');
+  const c = document.getElementById('card-calendar');
+  if (!g || !c) return;
+  const bg = document.getElementById('ctile-btn-graph');
+  const bc = document.getElementById('ctile-btn-calendar');
+  if (bg) bg.classList.toggle('active', _cardTileMode === 'graph');
+  if (bc) bc.classList.toggle('active', _cardTileMode !== 'graph');
+  if (_cardTileMode === 'graph') {
+    c.style.display = 'none';
+    g.style.display = '';
+    const cards = _ctlData?.cards || [];
+    const card = cards.find(k => k.category === _ctlCategory) || cards[0];
+    g.innerHTML = _cardGraphHtml(card);
+  } else {
+    g.style.display = 'none';
+    c.style.display = '';
+    if (_calData) _renderCal();
+  }
+}
+
+// Shared SVG renderer: x = time, y = interval (days), colored by card state
+function _cardGraphHtml(card) {
+  const pts = (card?.points || []).slice();
+  if (card?.scheduled) pts.push({ ...card.scheduled, scheduled: true });
+  if (!pts.length) return '<div class="cgraph-empty">No reviews yet.</div>';
+
+  const W = 340, H = 150, PT = 8, PB = 6, PL = 6, PR = 8;
+  const t = s => new Date(s.replace(' ', 'T')).getTime();
+  const t0 = t(pts[0].at);
+  let t1 = t(pts[pts.length - 1].at);
+  if (t1 <= t0) t1 = t0 + 86400000;
+  let ymax = Math.max(1, ...pts.map(p => p.gap));
+  ymax = ymax <= 5 ? Math.ceil(ymax) : ymax <= 30 ? Math.ceil(ymax / 5) * 5 : Math.ceil(ymax / 10) * 10;
+
+  const x = p => PL + (t(p.at) - t0) / (t1 - t0) * (W - PL - PR);
+  const y = p => PT + (1 - p.gap / ymax) * (H - PT - PB);
+
+  let svg = [0.5, 1].map(f => {
+    const gy = (PT + (1 - f) * (H - PT - PB)).toFixed(1);
+    return `<line x1="${PL}" y1="${gy}" x2="${W - PR}" y2="${gy}" stroke="var(--border)" stroke-width="0.6"/>`;
+  }).join('');
+  for (let i = 1; i < pts.length; i++) {
+    const a = pts[i - 1], b = pts[i];
+    const color = _CGRAPH_COLOR[b.state] || 'var(--muted)';
+    svg += `<line x1="${x(a).toFixed(1)}" y1="${y(a).toFixed(1)}" x2="${x(b).toFixed(1)}" y2="${y(b).toFixed(1)}"
+              stroke="${color}" stroke-width="1.8" stroke-linecap="round"${b.scheduled ? ' stroke-dasharray="4 3"' : ''}/>`;
+  }
+  svg += pts.map(p => {
+    const color = _CGRAPH_COLOR[p.state] || 'var(--muted)';
+    const day = p.at.slice(0, 10);
+    const tip = p.scheduled
+      ? `${day} · due · interval ${p.gap}d`
+      : `${day} · interval ${p.gap}d · ${_CGRAPH_RATING[p.rating] || ''} · ${_CGRAPH_LABEL[p.state] || p.state}`;
+    return `<circle cx="${x(p).toFixed(1)}" cy="${y(p).toFixed(1)}" r="3"
+              fill="${p.scheduled ? 'var(--card)' : color}" stroke="${color}" stroke-width="1.5"><title>${tip}</title></circle>`;
+  }).join('');
+
+  const legend = Object.keys(_CGRAPH_LABEL).map(k =>
+    `<span class="evo-leg"><span class="hcal-leg-sw" style="background:${_CGRAPH_COLOR[k]}"></span>${_CGRAPH_LABEL[k]}</span>`).join('');
+  const fmtD = s => { const [m, d] = s.slice(5, 10).split('-'); return `${+m}/${+d}`; };
+  return `
+    <div class="cgraph-wrap">
+      <span class="cgraph-ymax">${ymax}d</span>
+      <svg class="cgraph-svg" viewBox="0 0 ${W} ${H}">${svg}</svg>
+      <div class="hcal-graph-axis"><span>${fmtD(pts[0].at)}</span><span>${fmtD(pts[pts.length - 1].at)}</span></div>
+      <div class="cgraph-legend">${legend}<span class="evo-leg">╌╌ scheduled</span></div>
+    </div>`;
+}
+
+// ── Word-detail tile (browse) ────────────────────────────────────────────────
+let _wdTlData  = null;
+let _wdCalData = null;
+let _wdCat     = null;
+
+function _wdLoadCardTile(cards) {
+  const el = document.getElementById('wd-card-tile-section');
+  if (!el) return;
+  _wdTlData = null;
+  _wdCalData = null;
+  const withId = (cards || []).filter(c => c.id);
+  if (!withId.length) { el.innerHTML = ''; return; }
+  _wdCat = withId[0].category;
+  el.innerHTML = '<div class="hcal-loading">Loading schedule…</div>';
+  Promise.all([
+    api('GET', `/api/cards/${withId[0].id}/timeline`),
+    api('GET', `/api/cards/${withId[0].id}/calendar`),
+  ]).then(([tl, cal]) => {
+    _wdTlData = tl;
+    _wdCalData = cal;
+    const withPts = (tl?.cards || []).find(c => c.points.length);
+    if (withPts) _wdCat = withPts.category;
+    _wdRenderCardTile();
+  }).catch(() => { el.innerHTML = ''; });
+}
+
+function wdSetTileCat(cat) { _wdCat = cat; _wdRenderCardTile(); }
+
+function _wdRenderCardTile() {
+  const el = document.getElementById('wd-card-tile-section');
+  if (!el || !_wdTlData) return;
+  const isGraph = _cardTileMode === 'graph';
+  const catBtns = (_wdTlData.cards || []).map(c =>
+    `<button class="hcal-seg-btn ${c.category === _wdCat ? 'active' : ''}"
+             onclick="wdSetTileCat('${c.category}')">${_CAT_LETTER[c.category] || c.category}</button>`).join('');
+  el.innerHTML = `
+    <div class="section-label">Schedule</div>
+    <div class="wd-card-tile">
+      <div class="card-tile-head">
+        <div class="hcal-seg">
+          <button class="hcal-seg-btn ${isGraph ? 'active' : ''}" onclick="setCardTileMode('graph')">Graph</button>
+          <button class="hcal-seg-btn ${!isGraph ? 'active' : ''}" onclick="setCardTileMode('calendar')">Calendar</button>
+        </div>
+        ${isGraph ? `<div class="hcal-seg">${catBtns}</div>` : ''}
+      </div>
+      <div id="wd-tile-body"></div>
+    </div>`;
+  const body = document.getElementById('wd-tile-body');
+  if (isGraph) {
+    const cards = _wdTlData.cards || [];
+    const card = cards.find(c => c.category === _wdCat) || cards[0];
+    body.innerHTML = _cardGraphHtml(card);
+  } else {
+    body.innerHTML = `<div class="card-calendar wd-cal-scroll" id="wd-cal-scroll"><div id="wd-cal-timeline"></div></div>`;
+    const saved = _calData, savedCat = _calCategory;
+    _calData = _wdCalData;
+    _calCategory = null;
+    _renderCal('wd-cal-timeline', 'wd-cal-scroll');
+    _calData = saved;
+    _calCategory = savedCat;
+  }
 }
 
 // ── Card timer ──────────────────────────────────────────────────────────────
@@ -1626,6 +1785,9 @@ function renderWordDetail(word) {
 
   // Cards section
   renderWordDetailCards(word.cards || [], word.id);
+
+  // Schedule tile (interval graph / calendar)
+  _wdLoadCardTile(word.cards || []);
 }
 
 function renderWordDetailCards(cards, wordId) {
@@ -2773,7 +2935,7 @@ function loadCard(c, counts) {
 
   showFront();
   _startTimer();
-  _loadCardCalendar(c.id, c.category);
+  _loadCardTile(c.id, c.category);
 
   // Auto-play audio for the listening category.
   // If sentence is missing and a story fetch is in flight, defer to the fetch callback above.

--- a/static/app.js
+++ b/static/app.js
@@ -74,6 +74,28 @@ let _calCategory = null;   // current card's category — shown on today even if
 let _calTimeline = null;   // {cards} from /api/cards/{id}/timeline — for per-day state borders
 let _calFocusCat = null;   // focus category — its chips stay full, other categories fade
 
+// Fade level for non-focus category chips — user-adjustable, persisted.
+let _calFade = (() => {
+  const v = parseFloat(localStorage.getItem('calFade'));
+  return v >= 0.15 && v <= 1 ? v : 0.55;
+})();
+function _calFadeApply() { document.documentElement.style.setProperty('--cal-fade', _calFade); }
+function setCalFade(v) {
+  _calFade = parseFloat(v);
+  localStorage.setItem('calFade', _calFade);
+  _calFadeApply();
+  document.querySelectorAll('.cal-fade-input').forEach(el => {
+    if (parseFloat(el.value) !== _calFade) el.value = _calFade;
+  });
+}
+function _calFadeSliderHtml() {
+  return `<label class="cal-fade-ctl" title="Other-category opacity">
+    <span>Fade</span>
+    <input type="range" class="cal-fade-input" min="0.15" max="1" step="0.05"
+           value="${_calFade}" oninput="setCalFade(this.value)">
+  </label>`;
+}
+
 const _RATING_CLASS = { 1: 'again', 2: 'hard', 3: 'good', 4: 'easy' };
 const _CAT_CLASS    = { listening: 'listening', reading: 'reading', creating: 'creating' };
 
@@ -107,6 +129,7 @@ function _buildCalDayMap() {
 function _renderCal(timelineId = 'cal-timeline', panelId = 'review-cal-panel') {
   const timelineEl = document.getElementById(timelineId);
   if (!timelineEl) return;
+  _calFadeApply();
 
   // Per-(category, date) card state, for the colored chip borders. Built from
   // the timeline data so each review chip shows the state the card was in then.
@@ -259,14 +282,16 @@ async function _loadCardTile(cardId, category) {
 let _ctlData     = null;   // {cards} from /api/cards/{id}/timeline (review view)
 let _ctlCategory = null;   // category of the card being reviewed
 
-// Colorblind-safe card-state palette (Okabe-Ito based). Avoids the orange/green
-// pairing Daniel can't tell apart: Learning is black (not orange), Relearn is
-// reddish-purple (not red) so it stays distinct from the green "Learnt".
+// Colorblind-safe card-state palette (Okabe-Ito). Avoids the green/red/orange/
+// purple cluster entirely — those mid-tones are unreliable for red-green CB.
+// Instead it separates states on the two axes Daniel can read: blue↔yellow hue
+// and lightness. Learnt vs Relearn = blue vs orange (the safest pairing); New
+// vs Learnt = light blue vs dark blue (separated by lightness); Learning = black.
 const _STATE_COLOR = {
-  new:      '#0072B2',  // blue
-  learning: '#111111',  // black
-  review:   '#009E73',  // bluish green
-  relearn:  '#CC79A7',  // reddish purple
+  new:      '#56B4E9',  // sky blue (light)
+  learning: '#000000',  // black
+  review:   '#0072B2',  // blue (dark)
+  relearn:  '#D55E00',  // vermillion / orange
 };
 const _CGRAPH_COLOR = _STATE_COLOR;
 const _CGRAPH_LABEL = { new: 'New', learning: 'Learning', review: 'Learnt', relearn: 'Relearn' };
@@ -282,6 +307,8 @@ function _renderCardTile() {
   }
   // Scroll the calendar's own container (not the outer panel) so the graph
   // above it stays visible instead of being pushed out of view.
+  const fadeRow = document.getElementById('cal-fade-row');
+  if (fadeRow) fadeRow.innerHTML = _calFadeSliderHtml();
   _calTimeline = _ctlData;
   _calFocusCat = _ctlCategory;
   if (_calData) _renderCal('cal-timeline', 'card-calendar');
@@ -385,6 +412,7 @@ function _wdRenderCardTile() {
     <div class="wd-card-tile">
       <div class="card-tile-head">
         <div class="hcal-seg">${catBtns}</div>
+        ${_calFadeSliderHtml()}
       </div>
       <div id="wd-tile-graph">${_cardGraphHtml(card)}</div>
       <div class="card-calendar wd-cal-scroll" id="wd-cal-scroll"><div id="wd-cal-timeline"></div></div>

--- a/static/app.js
+++ b/static/app.js
@@ -71,6 +71,8 @@ let _calData     = null;   // {history, future} from API
 let _calYear     = null;
 let _calMonth    = null;   // 0-based
 let _calCategory = null;   // current card's category — shown on today even if not in dues
+let _calTimeline = null;   // {cards} from /api/cards/{id}/timeline — for per-day state borders
+let _calFocusCat = null;   // focus category — its chips stay full, other categories fade
 
 const _RATING_CLASS = { 1: 'again', 2: 'hard', 3: 'good', 4: 'easy' };
 const _CAT_CLASS    = { listening: 'listening', reading: 'reading', creating: 'creating' };
@@ -105,6 +107,14 @@ function _buildCalDayMap() {
 function _renderCal(timelineId = 'cal-timeline', panelId = 'review-cal-panel') {
   const timelineEl = document.getElementById(timelineId);
   if (!timelineEl) return;
+
+  // Per-(category, date) card state, for the colored chip borders. Built from
+  // the timeline data so each review chip shows the state the card was in then.
+  const stateByCatDate = {};
+  for (const card of (_calTimeline?.cards || [])) {
+    const m = stateByCatDate[card.category] = {};
+    for (const p of (card.points || [])) m[p.at.slice(0, 10)] = p.state;
+  }
 
   const today = new Date();
   const todayStr = today.toISOString().slice(0, 10);
@@ -175,12 +185,18 @@ function _renderCal(timelineId = 'cal-timeline', panelId = 'review-cal-panel') {
         for (const r of ratings) {
           const rCls = _RATING_CLASS[r.rating] || 'good';
           const letter = _CAT_LETTER[r.category] || '?';
-          html += `<span class="cal-chip cal-chip-${rCls}" title="${r.category}: ${rCls}">${letter}</span>`;
+          const st = stateByCatDate[r.category]?.[dateStr];
+          const faded = (_calFocusCat && r.category !== _calFocusCat) ? ' cal-chip-faded' : '';
+          const cls = `cal-chip cal-chip-${rCls}${st ? ' cal-chip-state' : ''}${faded}`;
+          const style = st ? ` style="border-color:${_STATE_COLOR[st]}"` : '';
+          const stTip = st ? ` · ${_CGRAPH_LABEL[st] || st}` : '';
+          html += `<span class="${cls}"${style} title="${r.category}: ${rCls}${stTip}">${letter}</span>`;
         }
         for (const f of visibleDues) {
           const cCls = _CAT_CLASS[f.category] || '';
           const letter = _CAT_LETTER[f.category] || '?';
-          html += `<span class="cal-chip cal-chip-due-${cCls}" title="${f.category} due">${letter}</span>`;
+          const faded = (_calFocusCat && f.category !== _calFocusCat) ? ' cal-chip-faded' : '';
+          html += `<span class="cal-chip cal-chip-due-${cCls}${faded}" title="${f.category} due">${letter}</span>`;
         }
         html += '</div>';
       } else if (isToday && _calCategory) {
@@ -243,10 +259,16 @@ async function _loadCardTile(cardId, category) {
 let _ctlData     = null;   // {cards} from /api/cards/{id}/timeline (review view)
 let _ctlCategory = null;   // category of the card being reviewed
 
-const _CGRAPH_COLOR = {
-  new: 'var(--primary)', learning: 'var(--hard)',
-  review: 'var(--good)', relearn: 'var(--again)',
+// Colorblind-safe card-state palette (Okabe-Ito based). Avoids the orange/green
+// pairing Daniel can't tell apart: Learning is black (not orange), Relearn is
+// reddish-purple (not red) so it stays distinct from the green "Learnt".
+const _STATE_COLOR = {
+  new:      '#0072B2',  // blue
+  learning: '#111111',  // black
+  review:   '#009E73',  // bluish green
+  relearn:  '#CC79A7',  // reddish purple
 };
+const _CGRAPH_COLOR = _STATE_COLOR;
 const _CGRAPH_LABEL = { new: 'New', learning: 'Learning', review: 'Learnt', relearn: 'Relearn' };
 const _CGRAPH_RATING = { 1: 'Again', 2: 'Hard', 3: 'Good', 4: 'Easy' };
 
@@ -260,6 +282,8 @@ function _renderCardTile() {
   }
   // Scroll the calendar's own container (not the outer panel) so the graph
   // above it stays visible instead of being pushed out of view.
+  _calTimeline = _ctlData;
+  _calFocusCat = _ctlCategory;
   if (_calData) _renderCal('cal-timeline', 'card-calendar');
 }
 
@@ -366,12 +390,16 @@ function _wdRenderCardTile() {
       <div class="card-calendar wd-cal-scroll" id="wd-cal-scroll"><div id="wd-cal-timeline"></div></div>
     </div>`;
   if (_wdCalData) {
-    const saved = _calData, savedCat = _calCategory;
+    const saved = _calData, savedCat = _calCategory, savedTl = _calTimeline, savedFocus = _calFocusCat;
     _calData = _wdCalData;
     _calCategory = null;
+    _calTimeline = _wdTlData;
+    _calFocusCat = _wdCat;
     _renderCal('wd-cal-timeline', 'wd-cal-scroll');
     _calData = saved;
     _calCategory = savedCat;
+    _calTimeline = savedTl;
+    _calFocusCat = savedFocus;
   }
 }
 
@@ -7414,12 +7442,12 @@ let _evoLoading = false;
 let _evoView = localStorage.getItem('evoView') || 'all';
 let _evoCalc = null;           // per-render geometry cache for tooltips
 
-// Stack order: bottom → top
+// Stack order: bottom → top. Colors from the shared colorblind-safe palette.
 const _EVO_STATES = [
-  { key: 'review',   label: 'Learnt',   color: 'var(--good)'    },
-  { key: 'relearn',  label: 'Relearn',  color: 'var(--again)'   },
-  { key: 'learning', label: 'Learning', color: 'var(--hard)'    },
-  { key: 'new',      label: 'New',      color: 'var(--primary)' },
+  { key: 'review',   label: 'Learnt',   color: _STATE_COLOR.review   },
+  { key: 'relearn',  label: 'Relearn',  color: _STATE_COLOR.relearn  },
+  { key: 'learning', label: 'Learning', color: _STATE_COLOR.learning },
+  { key: 'new',      label: 'New',      color: _STATE_COLOR.new      },
 ];
 const _EVO_VIEWS = [['listening', 'Listening'], ['creating', 'Creating'], ['all', 'All']];
 

--- a/static/app.js
+++ b/static/app.js
@@ -1131,6 +1131,7 @@ function _filteredBrowseWords() {
     words = words.filter(w => w.cards.some(c => leafIds.has(c.deck_id)));
   }
   if (_browseCardStatus === 'learning')   words = words.filter(w => w.cards.length > 0);
+  if (_browseCardStatus === 'leech')      words = words.filter(w => w.cards.some(c => c.is_leech));
   if (_browseCardStatus === 'reference')  words = words.filter(w => w.cards.length === 0);
   return words;
 }
@@ -1641,6 +1642,7 @@ function renderWordDetailCards(cards, wordId) {
         <div class="wd-card-head">
           <span class="wd-cat-label">${CAT_FULL[c.category] || c.category}</span>
           <span class="badge badge-${c.state}">${c.state}</span>
+          ${c.is_leech ? '<span class="badge badge-leech" title="Suspended as a leech">leech</span>' : ''}
           ${isBuried ? '<span class="badge badge-buried">buried</span>' : ''}
           <div class="wd-card-menu-wrap">
             <button class="wd-menu-btn" onclick="toggleCardMenu(${c.id}, event)">⋯</button>
@@ -2106,6 +2108,7 @@ function loadPresetFields(preset) {
   document.getElementById('opt-easy-int').value        = preset.easy_interval;
   document.getElementById('opt-relearn-steps').value   = preset.relearning_steps;
   document.getElementById('opt-leech').value           = preset.leech_threshold;
+  document.getElementById('opt-learning-leech').value  = preset.learning_leech_threshold;
   document.getElementById('opt-new-gather-order').value        = preset.new_gather_order                || 'ascending_position';
   document.getElementById('opt-new-sort-order').value          = preset.new_sort_order                  || 'card_type_gathered';
   document.getElementById('opt-new-review-order').value        = preset.new_review_order                || 'mixed';
@@ -2266,6 +2269,7 @@ async function saveOptions() {
     easy_interval:       parseInt(document.getElementById('opt-easy-int').value),
     relearning_steps:    document.getElementById('opt-relearn-steps').value.trim(),
     leech_threshold:     parseInt(document.getElementById('opt-leech').value),
+    learning_leech_threshold: parseInt(document.getElementById('opt-learning-leech').value),
     new_gather_order:               document.getElementById('opt-new-gather-order').value,
     new_sort_order:                 document.getElementById('opt-new-sort-order').value,
     new_review_order:               document.getElementById('opt-new-review-order').value,

--- a/static/app.js
+++ b/static/app.js
@@ -263,6 +263,14 @@ function _renderCardTile() {
   if (_calData) _renderCal('cal-timeline', 'card-calendar');
 }
 
+// Format a scheduled interval (in days) for tooltips: sub-day → min/h, else days.
+function _fmtIval(days) {
+  if (days >= 1) return `${Math.round(days)}d`;
+  const mins = Math.round(days * 1440);
+  if (mins < 60) return `${mins}m`;
+  return `${Math.round(mins / 60)}h`;
+}
+
 // Shared SVG renderer: x = time, y = interval (days), colored by card state
 function _cardGraphHtml(card) {
   const pts = (card?.points || []).slice();
@@ -294,8 +302,8 @@ function _cardGraphHtml(card) {
     const color = _CGRAPH_COLOR[p.state] || 'var(--muted)';
     const day = p.at.slice(0, 10);
     const tip = p.scheduled
-      ? `${day} · due · interval ${p.gap}d`
-      : `${day} · interval ${p.gap}d · ${_CGRAPH_RATING[p.rating] || ''} · ${_CGRAPH_LABEL[p.state] || p.state}`;
+      ? `${day} · due · interval ${_fmtIval(p.gap)}`
+      : `${day} · interval ${_fmtIval(p.gap)} · ${_CGRAPH_RATING[p.rating] || ''} · ${_CGRAPH_LABEL[p.state] || p.state}`;
     return `<circle cx="${x(p).toFixed(1)}" cy="${y(p).toFixed(1)}" r="3"
               fill="${p.scheduled ? 'var(--card)' : color}" stroke="${color}" stroke-width="1.5"><title>${tip}</title></circle>`;
   }).join('');

--- a/static/app.js
+++ b/static/app.js
@@ -282,16 +282,17 @@ async function _loadCardTile(cardId, category) {
 let _ctlData     = null;   // {cards} from /api/cards/{id}/timeline (review view)
 let _ctlCategory = null;   // category of the card being reviewed
 
-// Colorblind-safe card-state palette (Okabe-Ito). Avoids the green/red/orange/
-// purple cluster entirely — those mid-tones are unreliable for red-green CB.
-// Instead it separates states on the two axes Daniel can read: blue↔yellow hue
-// and lightness. Learnt vs Relearn = blue vs orange (the safest pairing); New
-// vs Learnt = light blue vs dark blue (separated by lightness); Learning = black.
+// Colorblind-safe card-state palette (Okabe-Ito). Tuned for Daniel's red-green
+// CB: no green, no red, and — crucially — no black, since black vs dark-blue is
+// the pair he could not tell apart on thin lines. The four states now sit on
+// hues he reads reliably: light sky blue, orange, dark blue, magenta. The two
+// blues are kept far apart in lightness; orange↔magenta differ on the blue↔
+// yellow axis. Every pair is distinguishable under deuteranopia/protanopia.
 const _STATE_COLOR = {
   new:      '#56B4E9',  // sky blue (light)
-  learning: '#000000',  // black
+  learning: '#E69F00',  // orange
   review:   '#0072B2',  // blue (dark)
-  relearn:  '#D55E00',  // vermillion / orange
+  relearn:  '#CC79A7',  // magenta / reddish purple
 };
 const _CGRAPH_COLOR = _STATE_COLOR;
 const _CGRAPH_LABEL = { new: 'New', learning: 'Learning', review: 'Learnt', relearn: 'Relearn' };
@@ -347,7 +348,7 @@ function _cardGraphHtml(card) {
     const a = pts[i - 1], b = pts[i];
     const color = _CGRAPH_COLOR[b.state] || 'var(--muted)';
     svg += `<line x1="${x(a).toFixed(1)}" y1="${y(a).toFixed(1)}" x2="${x(b).toFixed(1)}" y2="${y(b).toFixed(1)}"
-              stroke="${color}" stroke-width="1.8" stroke-linecap="round"${b.scheduled ? ' stroke-dasharray="4 3"' : ''}/>`;
+              stroke="${color}" stroke-width="2.8" stroke-linecap="round"${b.scheduled ? ' stroke-dasharray="5 4"' : ''}/>`;
   }
   svg += pts.map(p => {
     const color = _CGRAPH_COLOR[p.state] || 'var(--muted)';
@@ -355,8 +356,8 @@ function _cardGraphHtml(card) {
     const tip = p.scheduled
       ? `${day} · due · interval ${_fmtIval(p.gap)}`
       : `${day} · interval ${_fmtIval(p.gap)} · ${_CGRAPH_RATING[p.rating] || ''} · ${_CGRAPH_LABEL[p.state] || p.state}`;
-    return `<circle cx="${x(p).toFixed(1)}" cy="${y(p).toFixed(1)}" r="3"
-              fill="${p.scheduled ? 'var(--card)' : color}" stroke="${color}" stroke-width="1.5"><title>${tip}</title></circle>`;
+    return `<circle cx="${x(p).toFixed(1)}" cy="${y(p).toFixed(1)}" r="4"
+              fill="${p.scheduled ? 'var(--card)' : color}" stroke="${color}" stroke-width="2.2"><title>${tip}</title></circle>`;
   }).join('');
 
   const legend = Object.keys(_CGRAPH_LABEL).map(k =>

--- a/static/app.js
+++ b/static/app.js
@@ -258,7 +258,9 @@ function _renderCardTile() {
     const card = cards.find(k => k.category === _ctlCategory) || cards[0];
     g.innerHTML = _cardGraphHtml(card);
   }
-  if (_calData) _renderCal();
+  // Scroll the calendar's own container (not the outer panel) so the graph
+  // above it stays visible instead of being pushed out of view.
+  if (_calData) _renderCal('cal-timeline', 'card-calendar');
 }
 
 // Shared SVG renderer: x = time, y = interval (days), colored by card state

--- a/static/app.js
+++ b/static/app.js
@@ -831,8 +831,10 @@ function renderDecks(decks) {
   }
 
   document.getElementById('view-decks').innerHTML =
-    navRow + '<div id="home-calendar" class="hcal-card"></div>' + html;
+    navRow + '<div id="home-calendar" class="hcal-card"></div>' +
+    '<div id="home-evolution" class="hcal-card"></div>' + html;
   if (typeof initHomeCalendar === 'function') initHomeCalendar();
+  if (typeof initHomeEvolution === 'function') initHomeEvolution();
 }
 
 function toggleDeckSort() {
@@ -4331,6 +4333,7 @@ async function rate(rating) {
     const result = await api('POST', url);
     _sessionReviewedCount++;
     if (typeof invalidateHomeCalendar === 'function') invalidateHomeCalendar();
+    if (typeof invalidateHomeEvolution === 'function') invalidateHomeEvolution();
     api('GET', '/api/retention?days=0').then(r => {
       _retentionData = r;
       _updateReviewRRBadge(deckId);
@@ -7253,4 +7256,177 @@ function _hcalRenderDetail() {
         <td>${totAvg} <span class="hcal-tip-dim">/ ${totTot}</span></td>
       </tr>
     </table>`;
+}
+
+// ============================================================================
+// Home-page card-evolution chart (issue #321)
+// Stacked area chart of card-state counts over time (New / Learning /
+// Learnt / Relearn), with Listening / Creating / All views.
+// ============================================================================
+
+let _evoData = null;           // cached /api/card-evolution response
+let _evoLoading = false;
+let _evoView = localStorage.getItem('evoView') || 'all';
+let _evoCalc = null;           // per-render geometry cache for tooltips
+
+// Stack order: bottom → top
+const _EVO_STATES = [
+  { key: 'review',   label: 'Learnt',   color: 'var(--good)'    },
+  { key: 'relearn',  label: 'Relearn',  color: 'var(--again)'   },
+  { key: 'learning', label: 'Learning', color: 'var(--hard)'    },
+  { key: 'new',      label: 'New',      color: 'var(--primary)' },
+];
+const _EVO_VIEWS = [['listening', 'Listening'], ['creating', 'Creating'], ['all', 'All']];
+
+function initHomeEvolution() {
+  const el = document.getElementById('home-evolution');
+  if (!el) return;
+  if (_evoData) { _evoRender(); return; }
+  if (_evoLoading) return;
+  _evoLoading = true;
+  el.innerHTML = '<div class="hcal-loading">Loading card evolution…</div>';
+  api('GET', '/api/card-evolution?days=365')
+    .then(d => { _evoData = d; _evoLoading = false; _evoRender(); })
+    .catch(err => {
+      _evoLoading = false;
+      el.innerHTML = `<div class="hcal-loading">Card evolution unavailable — ${
+        (err && err.message) || 'failed to load stats'}.</div>`;
+    });
+}
+
+// Force a refetch (e.g. after reviewing). Safe to call even if not mounted.
+function invalidateHomeEvolution() { _evoData = null; }
+
+function evoSetView(v) {
+  _evoView = v; localStorage.setItem('evoView', v); _evoRender();
+}
+
+// Sum the requested categories into one {state: [counts]} object.
+function _evoSeries() {
+  const n = _evoData.dates.length;
+  const out = {};
+  for (const s of _EVO_STATES) out[s.key] = new Array(n).fill(0);
+  const cats = _evoView === 'all' ? Object.keys(_evoData.series) : [_evoView];
+  for (const cat of cats) {
+    const sr = _evoData.series[cat];
+    if (!sr) continue;
+    for (const s of _EVO_STATES) {
+      const arr = sr[s.key] || [];
+      for (let i = 0; i < n; i++) out[s.key][i] += arr[i] || 0;
+    }
+  }
+  return out;
+}
+
+function _evoRender() {
+  const el = document.getElementById('home-evolution');
+  if (!el || !_evoData) return;
+
+  const sr = _evoSeries();
+  const allDates = _evoData.dates;
+  const totalsAll = allDates.map((_, i) =>
+    _EVO_STATES.reduce((a, s) => a + sr[s.key][i], 0));
+
+  // Trim leading days before the first card existed (young collections)
+  let first = totalsAll.findIndex(t => t > 0);
+  if (first < 0) first = 0;
+  first = Math.max(0, first - 1);
+  const dates = allDates.slice(first);
+  const series = {};
+  for (const s of _EVO_STATES) series[s.key] = sr[s.key].slice(first);
+  const n = dates.length;
+
+  const W = 730, H = 190, PAD_T = 10, PAD_B = 2;
+  let ymax = Math.max(1, ...totalsAll);
+  const step = ymax > 200 ? 100 : ymax > 50 ? 25 : 10;
+  ymax = Math.ceil(ymax / step) * step;
+
+  const x = i => (i / Math.max(1, n - 1)) * W;
+  const y = v => PAD_T + (1 - v / ymax) * (H - PAD_T - PAD_B);
+
+  let lower = new Array(n).fill(0);
+  const layers = _EVO_STATES.map(s => {
+    const upper = lower.map((v, i) => v + series[s.key][i]);
+    const top = upper.map((v, i) => `${x(i).toFixed(1)},${y(v).toFixed(1)}`);
+    const bot = lower.map((v, i) => `${x(i).toFixed(1)},${y(v).toFixed(1)}`).reverse();
+    const pts = `${top.join(' ')} ${bot.join(' ')}`;
+    lower = upper;
+    return `<polygon points="${pts}" fill="${s.color}" fill-opacity="0.8"/>`;
+  }).join('');
+
+  const grid = [0.25, 0.5, 0.75, 1].map(f =>
+    `<line x1="0" y1="${y(ymax * f).toFixed(1)}" x2="${W}" y2="${y(ymax * f).toFixed(1)}"
+           stroke="var(--border)" stroke-width="0.6"/>`).join('');
+  const ylabels = [0.5, 1].map(f =>
+    `<span class="evo-ylabel" style="top:${(y(ymax * f) / H * 100).toFixed(2)}%">${
+      Math.round(ymax * f)}</span>`).join('');
+
+  const viewBtns = _EVO_VIEWS.map(([k, lbl]) =>
+    `<button class="hcal-seg-btn ${k === _evoView ? 'active' : ''}"
+             onclick="evoSetView('${k}')">${lbl}</button>`).join('');
+  const legend = _EVO_STATES.slice().reverse().map(s =>
+    `<span class="evo-leg"><span class="hcal-leg-sw" style="background:${s.color}"></span>${s.label}</span>`).join('');
+
+  const fmt = d => { const [, m, dd] = d.split('-'); return `${+m}/${+dd}`; };
+
+  _evoCalc = { dates, series, n };
+
+  el.innerHTML = `
+    <div class="hcal-controls">
+      <div class="hcal-seg">${viewBtns}</div>
+      <div class="evo-legend">${legend}</div>
+    </div>
+    <div class="evo-chart-wrap">
+      ${ylabels}
+      <svg class="evo-svg" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none"
+           onmousemove="evoMove(event)" onmouseleave="evoLeave()">
+        ${grid}${layers}
+        <line id="evo-cursor" x1="0" y1="0" x2="0" y2="${H}"
+              stroke="#1e293b" stroke-width="0.8" style="display:none"/>
+      </svg>
+      <div class="hcal-graph-axis"><span>${fmt(dates[0])}</span><span>${fmt(dates[n - 1])}</span></div>
+    </div>`;
+}
+
+function evoMove(ev) {
+  if (!_evoCalc) return;
+  const svg = ev.currentTarget;
+  const r = svg.getBoundingClientRect();
+  const { dates, series, n } = _evoCalc;
+  const i = Math.max(0, Math.min(n - 1,
+    Math.round((ev.clientX - r.left) / r.width * (n - 1))));
+
+  const cursor = svg.querySelector('#evo-cursor');
+  if (cursor) {
+    const cx = (i / Math.max(1, n - 1)) * 730;
+    cursor.setAttribute('x1', cx); cursor.setAttribute('x2', cx);
+    cursor.style.display = '';
+  }
+
+  const nice = _hcalParse(dates[i]).toLocaleDateString(undefined,
+    { weekday: 'short', month: 'short', day: 'numeric' });
+  let total = 0;
+  const rows = _EVO_STATES.slice().reverse().map(s => {
+    const v = series[s.key][i];
+    total += v;
+    return `<div class="hcal-tip-row"><span class="hcal-leg-sw" style="background:${
+      s.color};margin-right:5px"></span>${s.label}: <b>${v}</b></div>`;
+  }).join('');
+
+  const t = _hcalTip();
+  t.innerHTML = `<div class="hcal-tip-date">${nice}</div>
+                 <div class="hcal-tip-big">${total} cards</div>${rows}`;
+  t.style.display = 'block';
+  let left = ev.pageX - t.offsetWidth / 2;
+  left = Math.max(6, Math.min(left, window.scrollX + window.innerWidth - t.offsetWidth - 6));
+  let top = ev.pageY - t.offsetHeight - 14;
+  if (top < window.scrollY + 4) top = ev.pageY + 14;
+  t.style.left = left + 'px';
+  t.style.top = top + 'px';
+}
+
+function evoLeave() {
+  hcalHideTip();
+  const cursor = document.getElementById('evo-cursor');
+  if (cursor) cursor.style.display = 'none';
 }

--- a/static/index.html
+++ b/static/index.html
@@ -240,16 +240,10 @@
         </div>
       </div>
 
-      <!-- LEFT: Card tile — interval graph / calendar toggle (hidden until data loads) -->
+      <!-- LEFT: Card tile — interval graph on top, calendar below (hidden until data loads) -->
       <div class="review-side-tile review-cal-tile" id="review-cal-panel" style="display:none">
-        <div class="card-tile-head">
-          <div class="hcal-seg">
-            <button class="hcal-seg-btn" id="ctile-btn-graph" onclick="setCardTileMode('graph')">Graph</button>
-            <button class="hcal-seg-btn" id="ctile-btn-calendar" onclick="setCardTileMode('calendar')">Calendar</button>
-          </div>
-        </div>
-        <div id="card-graph" class="card-graph" style="display:none"></div>
-        <div id="card-calendar" class="card-calendar" style="display:none">
+        <div id="card-graph" class="card-graph"></div>
+        <div id="card-calendar" class="card-calendar">
           <div id="cal-timeline"></div>
           <div class="cal-legend">
             <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-again"></span>Again</span>

--- a/static/index.html
+++ b/static/index.html
@@ -285,6 +285,7 @@
         <div class="bs-section-head">Status</div>
         <button class="bs-status-item bs-active" id="bss-all"       onclick="setBrowseStatusFilter('all')">All Entries</button>
         <button class="bs-status-item" id="bss-learning"  onclick="setBrowseStatusFilter('learning')">Learning</button>
+        <button class="bs-status-item" id="bss-leech"     onclick="setBrowseStatusFilter('leech')">Leeched</button>
         <button class="bs-status-item" id="bss-reference" onclick="setBrowseStatusFilter('reference')">Reference</button>
       </div>
       <div class="bs-section">
@@ -413,7 +414,8 @@
     <div class="opt-group">
       <div class="opt-group-label">Lapses</div>
       <div class="opt-row"><span class="opt-label">Relearning steps (minutes)</span><input class="opt-input wide" id="opt-relearn-steps" type="text"></div>
-      <div class="opt-row"><span class="opt-label">Leech threshold (lapses)</span>  <input class="opt-input" id="opt-leech"         type="number" min="1"></div>
+      <div class="opt-row"><span class="opt-label">Leech threshold (review lapses)</span>  <input class="opt-input" id="opt-leech"         type="number" min="1"></div>
+      <div class="opt-row"><span class="opt-label">Learning leech threshold (Again presses)</span>  <input class="opt-input" id="opt-learning-leech" type="number" min="1"></div>
     </div>
 
     <div class="opt-group">

--- a/static/index.html
+++ b/static/index.html
@@ -240,9 +240,16 @@
         </div>
       </div>
 
-      <!-- LEFT: Calendar tile (hidden until data loads; shown on desktop to the left via order) -->
+      <!-- LEFT: Card tile — interval graph / calendar toggle (hidden until data loads) -->
       <div class="review-side-tile review-cal-tile" id="review-cal-panel" style="display:none">
-        <div id="card-calendar" class="card-calendar">
+        <div class="card-tile-head">
+          <div class="hcal-seg">
+            <button class="hcal-seg-btn" id="ctile-btn-graph" onclick="setCardTileMode('graph')">Graph</button>
+            <button class="hcal-seg-btn" id="ctile-btn-calendar" onclick="setCardTileMode('calendar')">Calendar</button>
+          </div>
+        </div>
+        <div id="card-graph" class="card-graph" style="display:none"></div>
+        <div id="card-calendar" class="card-calendar" style="display:none">
           <div id="cal-timeline"></div>
           <div class="cal-legend">
             <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-again"></span>Again</span>
@@ -355,6 +362,7 @@
       <div id="wd-word-analysis-section"></div>
       <div id="wd-examples-section"></div>
       <div id="wd-cards-section"></div>
+      <div id="wd-card-tile-section"></div>
     </div>
   </div>
 

--- a/static/index.html
+++ b/static/index.html
@@ -243,6 +243,7 @@
       <!-- LEFT: Card tile — interval graph on top, calendar below (hidden until data loads) -->
       <div class="review-side-tile review-cal-tile" id="review-cal-panel" style="display:none">
         <div id="card-graph" class="card-graph"></div>
+        <div id="cal-fade-row" class="cal-fade-row"></div>
         <div id="card-calendar" class="card-calendar">
           <div id="cal-timeline"></div>
           <div class="cal-legend">

--- a/static/style.css
+++ b/static/style.css
@@ -4095,6 +4095,16 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   margin-bottom: 12px;
   border-bottom: 1px solid var(--border);
 }
+
+/* Review side panel: pin the graph on top, let only the calendar scroll so
+   the graph never gets pushed out of view by the auto-scroll-to-first-month. */
+#review-cal-panel { overflow-y: hidden; }
+#review-cal-panel #card-graph { flex: 0 0 auto; }
+#review-cal-panel #card-calendar {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
 .wd-card-tile {
   background: var(--card);
   border: 1px solid var(--border);

--- a/static/style.css
+++ b/static/style.css
@@ -3559,8 +3559,16 @@ details[open] .cat-override-summary::before { content: '▼ '; }
 }
 /* Colored border = card state on that day (colorblind-safe palette, see graph) */
 .cal-chip-state { border: 2px solid; }
-/* Non-focus category chips fade so the current category stands out */
-.cal-chip-faded { opacity: 0.3; }
+/* Non-focus category chips fade so the current category stands out.
+   Opacity is user-adjustable via the small slider (CSS var, persisted). */
+.cal-chip-faded { opacity: var(--cal-fade, 0.55); }
+
+.cal-fade-ctl {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 11px; color: var(--muted);
+}
+.cal-fade-ctl input[type="range"] { width: 64px; height: 14px; cursor: pointer; }
+.cal-fade-row { margin: 8px 0 4px; }
 /* Past review chips — background = rating */
 .cal-chip-again { background: #ef4444; }
 .cal-chip-hard  { background: #f97316; }

--- a/static/style.css
+++ b/static/style.css
@@ -2342,6 +2342,7 @@ main.browse-open {
 .badge-relearn  { background: #fee2e2; color: #b91c1c; }
 .badge-suspended{ background: #f1f5f9; color: #64748b; }
 .badge-buried   { background: #e0e7ff; color: #4338ca; }
+.badge-leech    { background: #fde68a; color: #92400e; }
 
 /* ── Word / Hanzi detail views (break out of narrow main) ── */
 #view-word-detail, #view-hanzi-detail {

--- a/static/style.css
+++ b/static/style.css
@@ -4062,6 +4062,19 @@ details[open] .cat-override-summary::before { content: '▼ '; }
 .hcal-tbl td { padding: 4px 8px 4px 0; border-bottom: 1px solid var(--border); color: var(--text); }
 .hcal-tbl-total td { font-weight: 700; border-bottom: none; }
 
+/* ── Card-evolution chart (issue #321) ── */
+.evo-chart-wrap { position: relative; }
+.evo-svg { display: block; width: 100%; height: 190px; }
+.evo-legend {
+  display: inline-flex; align-items: center; gap: 12px;
+  font-size: 11px; color: var(--muted);
+}
+.evo-leg { display: inline-flex; align-items: center; gap: 4px; }
+.evo-ylabel {
+  position: absolute; left: 4px; transform: translateY(2px);
+  font-size: 9px; color: var(--muted); pointer-events: none;
+}
+
 @media (prefers-color-scheme: dark) {
   :root { --hcal-empty: #1f2933; }
   .hcal-seg-btn.active { background: #6366f1; }

--- a/static/style.css
+++ b/static/style.css
@@ -3555,7 +3555,12 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   color: #fff;
   letter-spacing: 0;
   line-height: 1;
+  box-sizing: border-box;
 }
+/* Colored border = card state on that day (colorblind-safe palette, see graph) */
+.cal-chip-state { border: 2px solid; }
+/* Non-focus category chips fade so the current category stands out */
+.cal-chip-faded { opacity: 0.3; }
 /* Past review chips — background = rating */
 .cal-chip-again { background: #ef4444; }
 .cal-chip-hard  { background: #f97316; }

--- a/static/style.css
+++ b/static/style.css
@@ -4088,6 +4088,13 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   margin-top: 6px; font-size: 11px; color: var(--muted);
 }
 .cgraph-empty { color: var(--muted); font-size: 12px; padding: 8px 2px; }
+
+/* Graph sits above the calendar in the same tile — separate them */
+#card-graph, #wd-tile-graph {
+  padding-bottom: 12px;
+  margin-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+}
 .wd-card-tile {
   background: var(--card);
   border: 1px solid var(--border);

--- a/static/style.css
+++ b/static/style.css
@@ -4075,6 +4075,27 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   font-size: 9px; color: var(--muted); pointer-events: none;
 }
 
+/* ── Per-card interval graph + tile toggle (issue #323) ── */
+.card-tile-head {
+  display: flex; justify-content: space-between; align-items: center;
+  gap: 8px; flex-wrap: wrap; margin-bottom: 8px;
+}
+.cgraph-wrap { position: relative; }
+.cgraph-svg { display: block; width: 100%; height: auto; }
+.cgraph-ymax { position: absolute; top: 0; left: 4px; font-size: 9px; color: var(--muted); }
+.cgraph-legend {
+  display: flex; flex-wrap: wrap; gap: 10px;
+  margin-top: 6px; font-size: 11px; color: var(--muted);
+}
+.cgraph-empty { color: var(--muted); font-size: 12px; padding: 8px 2px; }
+.wd-card-tile {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 14px;
+}
+.wd-cal-scroll { max-height: 340px; overflow-y: auto; }
+
 @media (prefers-color-scheme: dark) {
   :root { --hcal-empty: #1f2933; }
   .hcal-seg-btn.active { background: #6366f1; }

--- a/tests/test_srs_logic.py
+++ b/tests/test_srs_logic.py
@@ -24,11 +24,12 @@ DEFAULT_PRESET = {
     "relearning_steps":    "10",
     "minimum_interval":    1,
     "leech_threshold":     8,
+    "learning_leech_threshold": 6,
     "leech_action":        "suspend",
 }
 
 def make_card(state="new", step_index=0, interval=1, ease=2.5, lapses=0,
-              repetitions=0):
+              repetitions=0, learning_again_count=0):
     return {
         "id": 1,
         "state":        state,
@@ -37,6 +38,7 @@ def make_card(state="new", step_index=0, interval=1, ease=2.5, lapses=0,
         "ease":         ease,
         "lapses":       lapses,
         "repetitions":  repetitions,
+        "learning_again_count": learning_again_count,
         "due":          "2026-01-01",
     }
 


### PR DESCRIPTION
## 变更内容
实现难词（leech）自动暂停机制，并可在牌组选项自行调阈值。

**复习态难词**：卡片毕业后累计遗忘（`lapses`）达到 `leech_threshold`（默认 **3**）→ 自动暂停并标记。

**学习态难词**：learning + relearn 状态累计点 Again 达到 `learning_leech_threshold`（默认 **6**）→ 自动暂停并标记。新增 `cards.learning_again_count` 跟踪。

**可调**：两个阈值都在牌组选项中可改（复习阈值标签注明「review lapses」，新增「Learning leech threshold」输入框）。

**回填历史**：迁移时从 `review_log` 重建学习态 Again 计数，并对过去已超阈值的卡片追溯暂停（一次性，guard 在 `is_leech` 列首次添加时）。在真实库副本上验证：追溯标记了 10 张难词。

**浏览器**：侧栏新增「Leeched」状态筛选（按 `is_leech`），卡片详情显示 leech 徽章。

**取消暂停**：手动 unsuspend 某张难词时清除 `is_leech` 并把 `lapses`/`learning_again_count` 清零，给它重新开始的机会。

## 数据库变更
- `cards`：新增 `learning_again_count`、`is_leech`
- `deck_presets`：新增 `learning_leech_threshold`（默认 6）；`leech_threshold` 默认 8→3，并迁移现有仍为 8 的预设为 3
- `preset_category_overrides`：新增 `learning_leech_threshold`（可按类别覆盖）

## 测试方法
- 复习卡 `lapses=2` 上点 Again → 暂停 + leech 标记（已验证）
- 学习卡 `learning_again_count=5` 上点 Again → 暂停 + leech 标记（已验证）
- 浏览器「Leeched」分区列出难词，徽章显示
- 取消暂停后标记清除、计数清零（已验证）
- 重启后历史超阈值卡片被追溯暂停（副本验证：10 张）
- 现有测试套件：我的改动未引入新失败（剩余失败在干净 main 上同样存在）

⚠️ 注意：合并后**首次启动**会运行一次性回填，会追溯暂停你过去已超阈值的卡片（约 10 张）。数据库每 6 小时自动备份，可回滚。

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)