### PR TITLE
feat: 重设复习日历为固定三槽点位（更易读、色盲友好）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -89,11 +89,9 @@ function setCalFade(v) {
   });
 }
 function _calFadeSliderHtml() {
-  return `<label class="cal-fade-ctl" title="Other-category opacity">
-    <span>Fade</span>
-    <input type="range" class="cal-fade-input" min="0.15" max="1" step="0.05"
-           value="${_calFade}" oninput="setCalFade(this.value)">
-  </label>`;
+  // The redesigned calendar marks the focus category by enlarging its dot
+  // instead of fading the others, so the opacity slider is no longer needed.
+  return '';
 }
 
 const _RATING_CLASS = { 1: 'again', 2: 'hard', 3: 'good', 4: 'easy' };
@@ -102,6 +100,25 @@ const _CAT_CLASS    = { listening: 'listening', reading: 'reading', creating: 'c
 function _calKey(dateStr) { return dateStr; }  // "YYYY-MM-DD"
 
 const _CAT_LETTER = { listening: '听', reading: '读', creating: '创' };
+
+// Fixed slot order for the calendar dots: position alone encodes the category,
+// so no glyph is needed in the dense grid (listening · reading · creating).
+const _CAL_CATS = ['listening', 'reading', 'creating'];
+
+// Sticky legend shown above the month grid (shared by review + word-detail cals).
+// Dot colour = card state (colorblind-safe); filled = reviewed, hollow = due.
+function _calLegendHtml() {
+  const states = [['new', 'New'], ['learning', 'Learning'], ['review', 'Learnt'], ['relearn', 'Relearn']];
+  const sw = states.map(([k, l]) =>
+    `<span class="cal-leg-item"><span class="cal-leg-dot" style="background:${_STATE_COLOR[k]};border-color:${_STATE_COLOR[k]}"></span>${l}</span>`).join('');
+  return `<div class="cal-legend2">${sw}`
+    + `<span class="cal-leg-sep"></span>`
+    + `<span class="cal-leg-item"><span class="cal-leg-dot cal-leg-filled"></span>done</span>`
+    + `<span class="cal-leg-item"><span class="cal-leg-dot cal-leg-hollow"></span>due</span>`
+    + `<span class="cal-leg-sep"></span>`
+    + `<span class="cal-leg-item">听·读·创 = slots L→R</span>`
+    + `</div>`;
+}
 
 function _buildCalDayMap() {
   // Deduplicate: per (date, category) keep only the last review
@@ -167,7 +184,7 @@ function _renderCal(timelineId = 'cal-timeline', panelId = 'review-cal-panel') {
     }
   }
 
-  let html = '';
+  let html = _calLegendHtml();
   let yr = startDate.getFullYear(), mo = startDate.getMonth();
   const endYr = endDate.getFullYear(), endMo = endDate.getMonth();
   let todayMonthId = null;
@@ -194,40 +211,36 @@ function _renderCal(timelineId = 'cal-timeline', panelId = 'review-cal-panel') {
       const isToday = dateStr === todayStr;
       const info = dayMap[dateStr];
 
-      // The current category's chip is suppressed (we're already reviewing it),
-      // so only ratings + other-category dues count as visible content. A date
-      // whose only due is the current category must render like an empty day:
-      // no grey "has-future" background, and its day number must still show.
+      // Fixed 3-slot dots (listening · reading · creating). The current category's
+      // future due is suppressed except on today (we're already reviewing it).
       const ratings     = info?.ratings || [];
-      const visibleDues = (info?.dues || []).filter(f => f.category !== _calCategory);
-      const hasVisible   = ratings.length > 0 || visibleDues.length > 0;
-      const hasFutureDue = dateStr > todayStr && visibleDues.length > 0;
-      html += `<div class="cal-cell${isToday ? ' cal-today' : ''}${hasFutureDue ? ' cal-has-future' : ''}">`;
+      const visibleDues = (info?.dues || []).filter(
+        f => f.category !== _calCategory || dateStr === todayStr);
+      const hasVisible  = ratings.length > 0 || visibleDues.length > 0;
+      html += `<div class="cal-cell${isToday ? ' cal-today' : ''}">`;
+      html += `<span class="cal-daynum${isToday ? ' cal-daynum-today' : ''}">${d}</span>`;
       if (hasVisible) {
-        html += '<div class="cal-chips">';
-        for (const r of ratings) {
-          const rCls = _RATING_CLASS[r.rating] || 'good';
-          const letter = _CAT_LETTER[r.category] || '?';
-          const st = stateByCatDate[r.category]?.[dateStr];
-          const faded = (_calFocusCat && r.category !== _calFocusCat) ? ' cal-chip-faded' : '';
-          const cls = `cal-chip cal-chip-${rCls}${st ? ' cal-chip-state' : ''}${faded}`;
-          const style = st ? ` style="border-color:${_STATE_COLOR[st]}"` : '';
-          const stTip = st ? ` · ${_CGRAPH_LABEL[st] || st}` : '';
-          html += `<span class="${cls}"${style} title="${r.category}: ${rCls}${stTip}">${letter}</span>`;
-        }
-        for (const f of visibleDues) {
-          const cCls = _CAT_CLASS[f.category] || '';
-          const letter = _CAT_LETTER[f.category] || '?';
-          const faded = (_calFocusCat && f.category !== _calFocusCat) ? ' cal-chip-faded' : '';
-          html += `<span class="cal-chip cal-chip-due-${cCls}${faded}" title="${f.category} due">${letter}</span>`;
+        html += '<div class="cal-dots">';
+        for (const cat of _CAL_CATS) {
+          const past  = ratings.find(r => r.category === cat);
+          const due   = visibleDues.find(f => f.category === cat);
+          const focus = (cat === _calFocusCat) ? ' cal-dot-focus' : '';
+          const glyph = _CAT_LETTER[cat] || cat;
+          if (past) {
+            const st    = stateByCatDate[cat]?.[dateStr];
+            const color = st ? _STATE_COLOR[st] : 'var(--muted)';
+            const rTip  = _CGRAPH_RATING[past.rating] || '';
+            const stTip = st ? ` · ${_CGRAPH_LABEL[st] || st}` : '';
+            html += `<span class="cal-dot cal-dot-done${focus}" style="background:${color};border-color:${color}" title="${glyph} · ${rTip}${stTip}"></span>`;
+          } else if (due) {
+            const color = due.state ? _STATE_COLOR[due.state] : 'var(--muted)';
+            const stTip = due.state ? ` · ${_CGRAPH_LABEL[due.state] || due.state}` : '';
+            html += `<span class="cal-dot cal-dot-due${focus}" style="border-color:${color}" title="${glyph} · due${stTip}"></span>`;
+          } else {
+            html += '<span class="cal-dot cal-dot-empty"></span>';
+          }
         }
         html += '</div>';
-      } else if (isToday && _calCategory) {
-        const letter = _CAT_LETTER[_calCategory] || '?';
-        const cCls   = _CAT_CLASS[_calCategory]  || '';
-        html += `<div class="cal-chips"><span class="cal-chip cal-chip-due-${cCls}" title="${_calCategory} today">${letter}</span></div>`;
-      } else {
-        html += `<span class="cal-day-num${isToday ? ' cal-day-num-today' : ''}">${d}</span>`;
       }
       html += '</div>';
     }

--- a/static/index.html
+++ b/static/index.html
@@ -246,16 +246,6 @@
         <div id="cal-fade-row" class="cal-fade-row"></div>
         <div id="card-calendar" class="card-calendar">
           <div id="cal-timeline"></div>
-          <div class="cal-legend">
-            <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-again"></span>Again</span>
-            <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-hard"></span>Hard</span>
-            <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-good"></span>Good</span>
-            <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-easy"></span>Easy</span>
-            <span class="cal-legend-sep"></span>
-            <span class="cal-legend-item cal-legend-cat">听 Listening</span>
-            <span class="cal-legend-item cal-legend-cat">读 Reading</span>
-            <span class="cal-legend-item cal-legend-cat">创 Creating</span>
-          </div>
         </div>
       </div><!-- /review-cal-panel -->
 

--- a/static/style.css
+++ b/static/style.css
@@ -3509,28 +3509,83 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   gap: 2px;
 }
 .cal-cell {
-  min-height: 28px;
+  position: relative;
+  min-height: 40px;
   border-radius: 4px;
   border: 1px solid var(--border, #e5e7eb);
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 2px 1px;
+  align-items: stretch;
+  justify-content: flex-start;
+  padding: 3px 3px 2px;
   gap: 2px;
 }
 .cal-cell.cal-today { outline: 2px solid var(--primary, #6366f1); outline-offset: -2px; border-radius: 4px; }
 .cal-cell.cal-empty { pointer-events: none; border-color: transparent; background: none; }
-.cal-cell.cal-has-future { background: #e5e7eb; }
-.cal-day-num {
-  font-size: 0.65rem;
+/* Day number sits top-left and is always visible */
+.cal-daynum {
+  font-size: 0.62rem;
   color: var(--text-muted);
   line-height: 1;
+  align-self: flex-start;
 }
-.cal-day-num-today {
+.cal-daynum-today {
   color: var(--primary, #6366f1);
   font-weight: 700;
 }
+/* Fixed 3-slot dot row pinned to the bottom of the cell */
+.cal-dots {
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+  align-items: center;
+  margin-top: auto;
+}
+.cal-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  box-sizing: border-box;
+  flex: 0 0 auto;
+}
+.cal-dot-done { border: 2px solid; }                 /* filled — bg+border set inline */
+.cal-dot-due  { background: var(--card, #fff); border: 2px solid; }  /* hollow ring */
+.cal-dot-empty {
+  width: 5px; height: 5px;
+  background: var(--border, #e5e7eb);
+  opacity: 0.5;
+}
+/* Focus category: enlarge + ring instead of fading the others (CB-friendlier) */
+.cal-dot-focus {
+  transform: scale(1.35);
+  box-shadow: 0 0 0 2px var(--card, #fff), 0 0 0 3px rgba(99, 102, 241, 0.55);
+}
+/* Sticky state legend above the months (shared by both calendars) */
+.cal-legend2 {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px 10px;
+  justify-content: center;
+  padding: 5px 4px;
+  margin-bottom: 4px;
+  background: var(--card, #fff);
+  border-bottom: 1px solid var(--border, #e5e7eb);
+  font-size: 11px;
+  color: var(--muted, #64748b);
+}
+.cal-leg-item { display: inline-flex; align-items: center; gap: 4px; }
+.cal-leg-dot {
+  width: 10px; height: 10px;
+  border-radius: 50%;
+  box-sizing: border-box;
+  flex: 0 0 auto;
+}
+.cal-leg-filled { background: var(--muted, #94a3b8); border: 2px solid var(--muted, #94a3b8); }
+.cal-leg-hollow { background: var(--card, #fff);     border: 2px solid var(--muted, #94a3b8); }
+.cal-leg-sep { width: 1px; align-self: stretch; background: var(--border, #e5e7eb); margin: 0 2px; }
 .cal-today-dot {
   width: 5px;
   height: 5px;


### PR DESCRIPTION
## 变更内容
按已确认方案重设日历（保留月历布局，信息分层下沉）：

- 每格左上常显**日期数字**；底部一排**三个固定点位**（听·读·创，位置即类别，不再用汉字塞格子）
- **● 实心** = 那天复习过，颜色 = 当天**卡片状态**（色盲安全：浅蓝 New / 橙 Learning / 深蓝 Learnt / 品红 Relearn）
- **○ 空心** = 将来待复习，颜色 = 该卡状态
- **空槽** = 那天该类无活动（淡点占位，保持三槽对齐）
- **评分**（Again/Hard/Good/Easy）移到悬停 tooltip：如 `听 · Good · Learnt`
- **焦点类别**用点放大+描环强调（取代透明度淡化，对色盲更友好）
- **今天**整格加环
- 新增 **sticky 状态图例**，复习页与单词详情页两个日历共用
- 移除已失效的淡化滑块与旧评分图例

信息全部保留，只是从「5 维挤一格」拆成「位置 + 实心空心 + 单色 + 悬停」四层。

## 测试方法
- 复习侧栏与单词详情页日历都正确显示三槽点位
- 过去实心 / 未来空心区分清晰，颜色随状态变化
- 今天高亮、焦点类别放大描环
- 悬停看到 类别·评分·状态

注：本分支基于 `feat/325-leech-mode`（按 Daniel 的链式分支工作流），故包含难词功能改动。

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)