### PR TITLE
feat: 卡片状态跃迁时弹出中文动画提示

### DIFF
--- a/routes/review.py
+++ b/routes/review.py
@@ -244,7 +244,15 @@ def submit_review(card_id: int, rating: int, user_response: str | None = None,
             "Card #%d %s SUSPENDED (lapses=%d)",
             card_before["id"], card_before["word_zh"], updated["lapses"],
         )
-    return {"next_card": next_card, "counts": counts}
+    state_from = card_before["state"]
+    state_to   = updated["state"]
+    transition = {
+        "from":    state_from,
+        "to":      state_to,
+        "changed": state_from != state_to,
+        "leech":   bool(updated.get("is_leech")) and state_to == "suspended",
+    }
+    return {"next_card": next_card, "counts": counts, "transition": transition}
 
 
 

--- a/static/app.js
+++ b/static/app.js
@@ -308,6 +308,30 @@ const _STATE_COLOR = {
   relearn:  '#CC79A7',  // magenta / reddish purple
 };
 const _CGRAPH_COLOR = _STATE_COLOR;
+
+// Chinese label + colour shown when a card's state changes during review.
+// 'suspended' here always means a leech (review can only suspend via leech).
+const _STATE_ANIM = {
+  new:       { text: '新词',     color: _STATE_COLOR.new },
+  learning:  { text: '学习中',   color: _STATE_COLOR.learning },
+  review:    { text: '学会了',   color: _STATE_COLOR.review },
+  relearn:   { text: '重新学习', color: _STATE_COLOR.relearn },
+  suspended: { text: '难词！',   color: '#b45309' },
+};
+
+// Floating Chinese state-change cue: fades + scales in, drifts up, removes itself.
+function showStateChangeAnim(transition) {
+  const info = _STATE_ANIM[transition?.to];
+  if (!info) return;
+  const el = document.createElement('div');
+  el.className = 'state-anim';
+  el.textContent = info.text;
+  el.style.color = info.color;
+  document.body.appendChild(el);
+  el.addEventListener('animationend', () => el.remove(), { once: true });
+  // Safety net in case animationend never fires (e.g. reduced-motion)
+  setTimeout(() => el.remove(), 2000);
+}
 const _CGRAPH_LABEL = { new: 'New', learning: 'Learning', review: 'Learnt', relearn: 'Relearn' };
 const _CGRAPH_RATING = { 1: 'Again', 2: 'Hard', 3: 'Good', 4: 'Easy' };
 
@@ -4551,6 +4575,7 @@ async function rate(rating) {
     else if (deckId) url += `&parent_deck_id=${deckId}`;
     const result = await api('POST', url);
     _sessionReviewedCount++;
+    if (result.transition?.changed) showStateChangeAnim(result.transition);
     if (typeof invalidateHomeCalendar === 'function') invalidateHomeCalendar();
     if (typeof invalidateHomeEvolution === 'function') invalidateHomeEvolution();
     api('GET', '/api/retention?days=0').then(r => {

--- a/static/style.css
+++ b/static/style.css
@@ -3586,6 +3586,34 @@ details[open] .cat-override-summary::before { content: '▼ '; }
 .cal-leg-filled { background: var(--muted, #94a3b8); border: 2px solid var(--muted, #94a3b8); }
 .cal-leg-hollow { background: var(--card, #fff);     border: 2px solid var(--muted, #94a3b8); }
 .cal-leg-sep { width: 1px; align-self: stretch; background: var(--border, #e5e7eb); margin: 0 2px; }
+
+/* ── State-change cue (issue #329) ──────────────────────────────────────────
+   Floating Chinese word announcing a card's new state during review. */
+.state-anim {
+  position: fixed;
+  top: 28%;
+  left: 50%;
+  z-index: 9999;
+  pointer-events: none;
+  font-size: 2.6rem;
+  font-weight: 800;
+  letter-spacing: 2px;
+  white-space: nowrap;
+  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.9), 0 2px 10px rgba(0, 0, 0, 0.18);
+  transform: translate(-50%, -50%) scale(0.6);
+  opacity: 0;
+  animation: state-anim-pop 1.3s cubic-bezier(0.2, 0.8, 0.3, 1) forwards;
+}
+@keyframes state-anim-pop {
+  0%   { opacity: 0;   transform: translate(-50%, -50%) scale(0.6); }
+  18%  { opacity: 1;   transform: translate(-50%, -50%) scale(1.12); }
+  34%  { opacity: 1;   transform: translate(-50%, -50%) scale(1); }
+  70%  { opacity: 1;   transform: translate(-50%, -90%) scale(1); }
+  100% { opacity: 0;   transform: translate(-50%, -150%) scale(0.96); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .state-anim { animation-duration: 0.9s; }
+}
 .cal-today-dot {
   width: 5px;
   height: 5px;


### PR DESCRIPTION
## 变更内容
复习时卡片状态改变，屏幕浮现一个状态中文词动画，用对应状态色显示，让你一眼知道发生了什么。

- 后端 `POST /api/review` 新增返回 `transition: {from, to, changed, leech}`
- 前端 `rate()` 在 `changed=true` 时调用动画
- 中文词 + 色盲安全配色：
  - 学习中（learning）橙
  - 学会了（review/Learnt）深蓝
  - 重新学习（relearn）品红
  - 新词（new）浅蓝
  - 难词！（leech 暂停）警示棕
- 动画：淡入放大 → 上浮淡出，约 1.3s，纯 CSS，结束自动移除，含 reduced-motion 兜底

## 测试方法
- 新卡首次 Good → 浮现「学习中」
- 学习毕业（Easy/最后一步 Good）→「学会了」（已用临时库验证 learning→review）
- 复习点 Again → 「重新学习」
- 触发难词阈值 →「难词！」

注：链式分支，base 为 `feat/327-calendar-redesign`，包含日历与难词改动。

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)