### PR TITLE
feat: 复习时 Shift+L 手动标记当前卡为难词

### DIFF
--- a/routes/browse.py
+++ b/routes/browse.py
@@ -382,6 +382,13 @@ def toggle_suspend(card_id: int):
     return database.toggle_card_suspension(card_id)
 
 
+@router.post("/api/cards/{card_id}/leech")
+def leech_card_endpoint(card_id: int):
+    """Manually flag a card as a leech (suspend + is_leech=1)."""
+    database.mark_leech_suspend(card_id)
+    return database.get_card(card_id)
+
+
 @router.post("/api/cards/{card_id}/reset")
 def reset_card_endpoint(card_id: int):
     return database.reset_card(card_id)

--- a/static/app.js
+++ b/static/app.js
@@ -5237,6 +5237,7 @@ async function reviewCardAction(action) {
     } else {
       await api('POST', `/api/cards/${cardId}/${action}`);
     }
+    if (action === 'leech') showStateChangeAnim({ to: 'suspended' });
     let nextData;
     if (unfinishedMode) {
       nextData = await api('GET', '/api/today-unfinished');
@@ -6711,6 +6712,9 @@ document.addEventListener('keydown', async e => {
     } else if (e.key === 'D' || e.key === '7') {
       e.preventDefault();
       reviewCardAction('delete');
+    } else if (e.key === 'L') {
+      e.preventDefault();
+      reviewCardAction('leech');
     } else if (e.key === 'o') {
       e.preventDefault();
       if (deckId) openOptions(deckId);

--- a/static/index.html
+++ b/static/index.html
@@ -101,6 +101,7 @@
                 <div class="wd-card-menu" id="review-card-menu" style="display:none">
                   <button class="wd-menu-item" onclick="reviewCardAction('bury')">Bury until tomorrow</button>
                   <button class="wd-menu-item" id="review-suspend-btn" onclick="reviewCardAction('suspend')">Suspend</button>
+                  <button class="wd-menu-item" onclick="reviewCardAction('leech')">Mark as leech (⇧L)</button>
                   <button class="wd-menu-item wd-menu-item-danger" onclick="reviewCardAction('delete')">Delete card</button>
                 </div>
               </div>


### PR DESCRIPTION
## 变更内容
复习时按 **Shift+L** 把当前卡手动标记为难词（leech）：暂停 + is_leech=1，并自动推进到下一张。

- 后端新增 `POST /api/cards/{card_id}/leech`（复用 `database.mark_leech_suspend`）
- 前端复习键盘处理：`e.key==='L'`（即 Shift+L）→ `reviewCardAction('leech')`
- 手动 leech 时也弹出「难词！」状态动画，反馈一致
- 复习卡操作菜单新增「Mark as leech (⇧L)」项，提升可发现性

被标记的卡会进浏览器的 Leeched 分区；取消暂停会清除标记并重置计数（沿用既有逻辑）。

## 测试方法（已用临时库验证后端）
- 复习中按 Shift+L → 当前卡 state=suspended、is_leech=1，跳到下一张
- 菜单点「Mark as leech」效果相同
- 卡片出现在浏览器 Leeched 分区

注：链式分支，base 为 `feat/331-graph-xaxis-dates`。

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)