### PR TITLE
feat: 日历回退为彩色方块版，去汉字，激活类别全彩/其他更透明

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -1571,3 +1571,91 @@ def get_card_timeline_data(card_id: int) -> dict:
     return {"cards": result}
 
 
+def get_session_timelines(card_ids: list[int]) -> dict:
+    """Interval timelines for an explicit list of cards (one review session).
+
+    Like get_card_timeline_data but keyed by card id (not word) and tagged with
+    each card's word label, so the session summary graph can show which card a
+    line is and link to it. Cards with no reviews yet are skipped.
+    """
+    from .stats import _EVOLUTION_STATES
+
+    if not card_ids:
+        return {"cards": []}
+
+    conn = get_db()
+    ph = ",".join("?" * len(card_ids))
+    cards = conn.execute(
+        f"""SELECT c.id, c.word_id, c.deck_id, c.category, c.state,
+                   c.pre_suspend_state, c.interval, c.due,
+                   w.word_zh, w.pinyin
+            FROM cards c JOIN entries w ON w.id = c.word_id
+            WHERE c.id IN ({ph}) AND c.deleted_at IS NULL""",
+        card_ids,
+    ).fetchall()
+
+    result = []
+    for c in cards:
+        rows = conn.execute(
+            """SELECT datetime(reviewed_at, 'localtime') AS at, rating, state
+               FROM review_log WHERE card_id = ? ORDER BY reviewed_at""",
+            (c["id"],),
+        ).fetchall()
+        if not rows:
+            continue
+
+        preset = get_preset_for_deck(c["deck_id"], c["category"]) or {}
+        P = {
+            "learning_steps":      _parse_step_minutes(preset.get("learning_steps", "1 10")),
+            "relearning_steps":    _parse_step_minutes(preset.get("relearning_steps", "10")),
+            "graduating_interval": preset.get("graduating_interval", 1),
+            "easy_interval":       preset.get("easy_interval", 4),
+            "minimum_interval":    preset.get("minimum_interval", 1),
+        }
+
+        final = c["state"]
+        if final == "suspended":
+            final = c["pre_suspend_state"]
+
+        points = []
+        state, step, interval, ease = "new", 0, 0, 2.5
+        for r in rows:
+            if r["state"] in _EVOLUTION_STATES and r["state"] != state:
+                state, step = r["state"], 0
+            state, step, interval, ease, gap = _replay_schedule_step(
+                state, step, interval, ease, r["rating"], P)
+            points.append({"at": r["at"], "gap": round(gap, 3),
+                           "rating": r["rating"], "state": state})
+        if points and final in _EVOLUTION_STATES:
+            points[-1]["state"] = final
+
+        scheduled = None
+        if points and c["state"] in ("learning", "relearn", "review"):
+            due_raw = c["due"]
+            due_dt = datetime.fromisoformat(due_raw) if len(due_raw) > 10 \
+                else datetime.fromisoformat(due_raw + "T04:00:00")
+            if c["state"] == "review":
+                gap = float(c["interval"])
+            else:
+                last_dt = datetime.fromisoformat(rows[-1]["at"])
+                gap = max(0.0, (due_dt - last_dt).total_seconds() / 86400)
+            scheduled = {"at": due_dt.isoformat(sep=" "), "gap": round(gap, 3),
+                         "state": c["state"]}
+
+        result.append({
+            "card_id":  c["id"],
+            "word_id":  c["word_id"],
+            "word_zh":  c["word_zh"],
+            "pinyin":   c["pinyin"],
+            "category": c["category"],
+            "state":    c["state"],
+            "interval": c["interval"],
+            "due":      c["due"],
+            "points":   points,
+            "scheduled": scheduled,
+        })
+
+    conn.close()
+    return {"cards": result}
+
+

--- a/routes/review.py
+++ b/routes/review.py
@@ -331,3 +331,10 @@ def get_card_calendar(card_id: int):
 @router.get("/api/cards/{card_id}/timeline")
 def get_card_timeline(card_id: int):
     return database.get_card_timeline_data(card_id)
+
+
+@router.post("/api/session-timelines")
+def session_timelines(body: dict):
+    """Interval timelines for the cards reviewed in one session (summary graph)."""
+    ids = [int(i) for i in body.get("ids", [])]
+    return database.get_session_timelines(ids)

--- a/static/app.js
+++ b/static/app.js
@@ -46,6 +46,7 @@ let wordDetails = null;   // full word data: examples + characters
 let _currentWordId = null; // word ID open in word-detail view
 let _prevView = null;      // view we came from before opening word-detail
 let _sessionReviewedCount = 0; // cards rated this session (for clap animation)
+let _sessionReviewedIds = [];  // card ids reviewed this session (for summary graph)
 let userInput   = '';     // creating category: what the user typed
 let clozeExtraWord = ''; // extra word blanked in cloze front (revealed on back)
 let wordBankTokens = [];  // [{char, num}] shuffled non-target tokens
@@ -63,6 +64,7 @@ let _retentionData = null;  // cached result from GET /api/retention
 let _cachedDecks = null;       // last fetched deck tree (for toggle re-renders)
 let _timerInterval = null;
 let _timerStart = null;
+const _TIMER_CAP_MS = 40000;  // beyond this the user is likely doing something else
 let _sessionTotalMs = 0;
 let _sessionRatedCount = 0;
 
@@ -421,6 +423,106 @@ function _cardGraphHtml(card) {
     </div>`;
 }
 
+// ── Session summary graph (issue #337) ───────────────────────────────────────
+// Overlays every reviewed card's interval timeline. Hover a line → its word;
+// click → open that card's browse (word detail).
+
+// Distinct line colours, cycled per card. Chosen to stay separable for Daniel's
+// red-green CB (no red/green pairs adjacent; spans blue↔orange↔purple).
+const _SUMMARY_PALETTE = [
+  '#0072B2', '#E69F00', '#CC79A7', '#56B4E9',
+  '#9467bd', '#8c564b', '#117733', '#882255',
+];
+
+async function openSessionSummary() {
+  const ids = [...new Set(_sessionReviewedIds)];
+  const body = document.getElementById('session-summary-body');
+  document.getElementById('session-summary-overlay').style.display = 'block';
+  document.getElementById('session-summary-modal').style.display = 'block';
+  if (!ids.length) {
+    body.innerHTML = '<div class="cgraph-empty">No cards reviewed yet this session.</div>';
+    return;
+  }
+  body.innerHTML = '<div class="cgraph-empty">Loading…</div>';
+  try {
+    const data = await api('POST', '/api/session-timelines', { ids });
+    body.innerHTML = _sessionSummaryHtml(data.cards || []);
+  } catch (e) {
+    body.innerHTML = `<div class="cgraph-empty">Failed to load: ${e.message}</div>`;
+  }
+}
+
+function closeSessionSummary() {
+  document.getElementById('session-summary-overlay').style.display = 'none';
+  document.getElementById('session-summary-modal').style.display = 'none';
+}
+
+function sumLineClick(wordId) {
+  closeSessionSummary();
+  openWordDetail(wordId);
+}
+
+function _sessionSummaryHtml(cards) {
+  // Keep only cards that actually have a line to draw
+  const drawn = cards.filter(c => (c.points || []).length);
+  if (!drawn.length) return '<div class="cgraph-empty">No interval history yet for these cards.</div>';
+
+  const W = 600, H = 340, PT = 14, PB = 20, PL = 30, PR = 14;
+  const t = s => new Date(s.replace(' ', 'T')).getTime();
+
+  // Each card's full point list (reviews + the scheduled due point)
+  const series = drawn.map(c => {
+    const pts = (c.points || []).slice();
+    if (c.scheduled) pts.push({ ...c.scheduled, scheduled: true });
+    return { card: c, pts };
+  });
+
+  const allPts = series.flatMap(s => s.pts);
+  let t0 = Math.min(...allPts.map(p => t(p.at)));
+  let t1 = Math.max(...allPts.map(p => t(p.at)));
+  if (t1 <= t0) t1 = t0 + 86400000;
+  const ymax = Math.max(1, ...allPts.map(p => p.gap));
+
+  const x = p => PL + (t(p.at) - t0) / (t1 - t0) * (W - PL - PR);
+  // sqrt scale on y so short and long intervals are both legible
+  const y = p => PT + (1 - Math.sqrt(p.gap) / Math.sqrt(ymax)) * (H - PT - PB);
+
+  // Horizontal gridlines + interval labels at a few sqrt-spaced levels
+  let svg = '';
+  const yTicks = [0, ymax * 0.25, ymax * 0.5, ymax].map(v => Math.round(v));
+  for (const v of [...new Set(yTicks)]) {
+    const gy = (PT + (1 - Math.sqrt(v) / Math.sqrt(ymax)) * (H - PT - PB)).toFixed(1);
+    svg += `<line x1="${PL}" y1="${gy}" x2="${W - PR}" y2="${gy}" stroke="var(--border)" stroke-width="0.6"/>`;
+    svg += `<text x="${PL - 4}" y="${(+gy + 3).toFixed(1)}" text-anchor="end" font-size="9" fill="var(--muted)">${v}d</text>`;
+  }
+
+  // One group per card: polyline (+dashed scheduled tail), hover shows the word
+  series.forEach((s, i) => {
+    const color = _SUMMARY_PALETTE[i % _SUMMARY_PALETTE.length];
+    const real = s.card.points.map(p => `${x(p).toFixed(1)},${y(p).toFixed(1)}`).join(' ');
+    let body = `<polyline points="${real}" fill="none" stroke="${color}"/>`;
+    if (s.card.scheduled && s.card.points.length) {
+      const a = s.card.points[s.card.points.length - 1], b = s.card.scheduled;
+      body += `<line x1="${x(a).toFixed(1)}" y1="${y(a).toFixed(1)}" x2="${x(b).toFixed(1)}" y2="${y(b).toFixed(1)}"
+                 stroke="${color}" stroke-dasharray="4 3"/>`;
+    }
+    body += s.pts.map(p => `<circle cx="${x(p).toFixed(1)}" cy="${y(p).toFixed(1)}" r="2.5" fill="${color}"/>`).join('');
+    const label = `${s.card.word_zh}${s.card.pinyin ? ' ' + s.card.pinyin : ''} · ${_CGRAPH_LABEL[s.card.state] || s.card.state}`;
+    svg += `<g class="sum-card" onclick="sumLineClick(${s.card.word_id})"><title>${label}</title>${body}</g>`;
+  });
+
+  const fmtD = s => { const [m, d] = s.slice(5, 10).split('-'); return `${+m}/${+d}`; };
+  const d0 = new Date(t0), d1 = new Date(t1);
+  const iso = dt => dt.toISOString().slice(0, 10);
+
+  return `
+    <div class="session-summary-info">${drawn.length} cards · y = scheduled interval (days) · hover a line to see the word, click to open it</div>
+    <div class="cgraph-wrap">
+      <svg class="session-summary-svg" viewBox="0 0 ${W} ${H}">${svg}</svg>
+      <div class="hcal-graph-axis"><span>${fmtD(iso(d0))}</span><span>${fmtD(iso(d1))}</span></div>
+    </div>`;
+}
+
 // ── Word-detail tile (browse) ────────────────────────────────────────────────
 let _wdTlData  = null;
 let _wdCalData = null;
@@ -486,10 +588,19 @@ function _startTimer() {
   _stopTimer();
   _timerStart = Date.now();
   const el = document.getElementById('card-timer');
+  el.classList.remove('card-timer-capped');
   el.textContent = '0s';
   el.style.display = 'block';
   _timerInterval = setInterval(() => {
-    const s = Math.floor((Date.now() - _timerStart) / 1000);
+    const ms = Date.now() - _timerStart;
+    if (ms >= _TIMER_CAP_MS) {
+      // Freeze at the cap — the time past 40s won't count toward the average.
+      el.textContent = '40s';
+      el.classList.add('card-timer-capped');
+      clearInterval(_timerInterval); _timerInterval = null;
+      return;
+    }
+    const s = Math.floor(ms / 1000);
     el.textContent = s < 60 ? `${s}s` : `${Math.floor(s / 60)}m${s % 60}s`;
   }, 1000);
 }
@@ -2584,6 +2695,7 @@ async function startReview(id, cat, name, noStory = false, quick = false) {
   category = cat;
   deckName = name;
   _sessionReviewedCount = 0;
+  _sessionReviewedIds = [];
   _sessionTotalMs = 0;
   _sessionRatedCount = 0;
   _updateAvgTimeBadge();
@@ -2702,6 +2814,7 @@ async function startReviewMixed(id, name, noStory = false, quick = false) {
   deckName   = name;
   story      = null;
   _sessionReviewedCount = 0;
+  _sessionReviewedIds = [];
   _sessionTotalMs = 0;
   _sessionRatedCount = 0;
   _updateAvgTimeBadge();
@@ -3168,7 +3281,7 @@ function diffAnswer(userInput, correct, wordZh) {
 
 // ── Back of card ────────────────────────────────────────────────────────────
 function revealAnswer() {
-  _stopTimer();
+  // Keep the timer running on the back side (it freezes at the 40s cap).
   const isCreating = category === 'creating';
 
   // Capture user input before hiding front
@@ -4574,7 +4687,8 @@ async function rate(rating) {
   document.querySelectorAll('.r-btn').forEach(b => b.disabled = true);
   let _cardMs = null;
   if (_timerStart) {
-    _cardMs = Date.now() - _timerStart;
+    // Cap at 40s: time spent past that likely isn't real study time.
+    _cardMs = Math.min(Date.now() - _timerStart, _TIMER_CAP_MS);
     _sessionTotalMs += _cardMs;
     _sessionRatedCount++;
     _updateAvgTimeBadge();
@@ -4585,8 +4699,10 @@ async function rate(rating) {
     if (unfinishedMode) url += `&unfinished_mode=true`;
     else if (rootDeckId) url += `&root_deck_id=${rootDeckId}`;
     else if (deckId) url += `&parent_deck_id=${deckId}`;
+    const reviewedId = card.id;
     const result = await api('POST', url);
     _sessionReviewedCount++;
+    if (reviewedId != null) _sessionReviewedIds.push(reviewedId);
     if (result.transition?.changed) showStateChangeAnim(result.transition);
     if (typeof invalidateHomeCalendar === 'function') invalidateHomeCalendar();
     if (typeof invalidateHomeEvolution === 'function') invalidateHomeEvolution();
@@ -6549,6 +6665,7 @@ function _hasOpenModal() {
     'hanzi-edit-modal-overlay',
     'conflict-modal-overlay',
     'kahneman-examples-overlay',
+    'session-summary-overlay',
   ];
   return modalIds.some(_isVisible);
 }
@@ -6557,6 +6674,12 @@ document.addEventListener('keydown', async e => {
   const inInput = _isEditableFocusTarget(document.activeElement);
 
   if (e.key === 'Escape') {
+    const sessOverlay = document.getElementById('session-summary-overlay');
+    if (sessOverlay && sessOverlay.style.display !== 'none') {
+      e.preventDefault();
+      closeSessionSummary();
+      return;
+    }
     const kahnemanOverlay = document.getElementById('kahneman-examples-overlay');
     if (kahnemanOverlay && kahnemanOverlay.style.display !== 'none') {
       e.preventDefault();

--- a/static/app.js
+++ b/static/app.js
@@ -77,7 +77,7 @@ let _calFocusCat = null;   // focus category — its chips stay full, other cate
 // Fade level for non-focus category chips — user-adjustable, persisted.
 let _calFade = (() => {
   const v = parseFloat(localStorage.getItem('calFade'));
-  return v >= 0.15 && v <= 1 ? v : 0.55;
+  return v >= 0.15 && v <= 1 ? v : 0.3;
 })();
 function _calFadeApply() { document.documentElement.style.setProperty('--cal-fade', _calFade); }
 function setCalFade(v) {
@@ -89,9 +89,11 @@ function setCalFade(v) {
   });
 }
 function _calFadeSliderHtml() {
-  // The redesigned calendar marks the focus category by enlarging its dot
-  // instead of fading the others, so the opacity slider is no longer needed.
-  return '';
+  return `<label class="cal-fade-ctl" title="Other-category opacity">
+    <span>Fade</span>
+    <input type="range" class="cal-fade-input" min="0.15" max="1" step="0.05"
+           value="${_calFade}" oninput="setCalFade(this.value)">
+  </label>`;
 }
 
 const _RATING_CLASS = { 1: 'again', 2: 'hard', 3: 'good', 4: 'easy' };
@@ -100,25 +102,6 @@ const _CAT_CLASS    = { listening: 'listening', reading: 'reading', creating: 'c
 function _calKey(dateStr) { return dateStr; }  // "YYYY-MM-DD"
 
 const _CAT_LETTER = { listening: '听', reading: '读', creating: '创' };
-
-// Fixed slot order for the calendar dots: position alone encodes the category,
-// so no glyph is needed in the dense grid (listening · reading · creating).
-const _CAL_CATS = ['listening', 'reading', 'creating'];
-
-// Sticky legend shown above the month grid (shared by review + word-detail cals).
-// Dot colour = card state (colorblind-safe); filled = reviewed, hollow = due.
-function _calLegendHtml() {
-  const states = [['new', 'New'], ['learning', 'Learning'], ['review', 'Learnt'], ['relearn', 'Relearn']];
-  const sw = states.map(([k, l]) =>
-    `<span class="cal-leg-item"><span class="cal-leg-dot" style="background:${_STATE_COLOR[k]};border-color:${_STATE_COLOR[k]}"></span>${l}</span>`).join('');
-  return `<div class="cal-legend2">${sw}`
-    + `<span class="cal-leg-sep"></span>`
-    + `<span class="cal-leg-item"><span class="cal-leg-dot cal-leg-filled"></span>done</span>`
-    + `<span class="cal-leg-item"><span class="cal-leg-dot cal-leg-hollow"></span>due</span>`
-    + `<span class="cal-leg-sep"></span>`
-    + `<span class="cal-leg-item">听·读·创 = slots L→R</span>`
-    + `</div>`;
-}
 
 function _buildCalDayMap() {
   // Deduplicate: per (date, category) keep only the last review
@@ -184,7 +167,7 @@ function _renderCal(timelineId = 'cal-timeline', panelId = 'review-cal-panel') {
     }
   }
 
-  let html = _calLegendHtml();
+  let html = '';
   let yr = startDate.getFullYear(), mo = startDate.getMonth();
   const endYr = endDate.getFullYear(), endMo = endDate.getMonth();
   let todayMonthId = null;
@@ -211,36 +194,38 @@ function _renderCal(timelineId = 'cal-timeline', panelId = 'review-cal-panel') {
       const isToday = dateStr === todayStr;
       const info = dayMap[dateStr];
 
-      // Fixed 3-slot dots (listening · reading · creating). The current category's
-      // future due is suppressed except on today (we're already reviewing it).
+      // The current category's chip is suppressed (we're already reviewing it),
+      // so only ratings + other-category dues count as visible content. A date
+      // whose only due is the current category must render like an empty day:
+      // no grey "has-future" background, and its day number must still show.
       const ratings     = info?.ratings || [];
-      const visibleDues = (info?.dues || []).filter(
-        f => f.category !== _calCategory || dateStr === todayStr);
-      const hasVisible  = ratings.length > 0 || visibleDues.length > 0;
-      html += `<div class="cal-cell${isToday ? ' cal-today' : ''}">`;
-      html += `<span class="cal-daynum${isToday ? ' cal-daynum-today' : ''}">${d}</span>`;
+      const visibleDues = (info?.dues || []).filter(f => f.category !== _calCategory);
+      const hasVisible   = ratings.length > 0 || visibleDues.length > 0;
+      const hasFutureDue = dateStr > todayStr && visibleDues.length > 0;
+      html += `<div class="cal-cell${isToday ? ' cal-today' : ''}${hasFutureDue ? ' cal-has-future' : ''}">`;
       if (hasVisible) {
-        html += '<div class="cal-dots">';
-        for (const cat of _CAL_CATS) {
-          const past  = ratings.find(r => r.category === cat);
-          const due   = visibleDues.find(f => f.category === cat);
-          const focus = (cat === _calFocusCat) ? ' cal-dot-focus' : '';
-          const glyph = _CAT_LETTER[cat] || cat;
-          if (past) {
-            const st    = stateByCatDate[cat]?.[dateStr];
-            const color = st ? _STATE_COLOR[st] : 'var(--muted)';
-            const rTip  = _CGRAPH_RATING[past.rating] || '';
-            const stTip = st ? ` · ${_CGRAPH_LABEL[st] || st}` : '';
-            html += `<span class="cal-dot cal-dot-done${focus}" style="background:${color};border-color:${color}" title="${glyph} · ${rTip}${stTip}"></span>`;
-          } else if (due) {
-            const color = due.state ? _STATE_COLOR[due.state] : 'var(--muted)';
-            const stTip = due.state ? ` · ${_CGRAPH_LABEL[due.state] || due.state}` : '';
-            html += `<span class="cal-dot cal-dot-due${focus}" style="border-color:${color}" title="${glyph} · due${stTip}"></span>`;
-          } else {
-            html += '<span class="cal-dot cal-dot-empty"></span>';
-          }
+        html += '<div class="cal-chips">';
+        for (const r of ratings) {
+          const rCls = _RATING_CLASS[r.rating] || 'good';
+          const st = stateByCatDate[r.category]?.[dateStr];
+          const faded = (_calFocusCat && r.category !== _calFocusCat) ? ' cal-chip-faded' : '';
+          const cls = `cal-chip cal-chip-${rCls}${st ? ' cal-chip-state' : ''}${faded}`;
+          const style = st ? ` style="border-color:${_STATE_COLOR[st]}"` : '';
+          const stTip = st ? ` · ${_CGRAPH_LABEL[st] || st}` : '';
+          // No category glyph: the active category shows full colour, others fade.
+          html += `<span class="${cls}"${style} title="${r.category}: ${rCls}${stTip}"></span>`;
+        }
+        for (const f of visibleDues) {
+          const cCls = _CAT_CLASS[f.category] || '';
+          const faded = (_calFocusCat && f.category !== _calFocusCat) ? ' cal-chip-faded' : '';
+          html += `<span class="cal-chip cal-chip-due cal-chip-due-${cCls}${faded}" title="${f.category} due"></span>`;
         }
         html += '</div>';
+      } else if (isToday && _calCategory) {
+        const cCls = _CAT_CLASS[_calCategory] || '';
+        html += `<div class="cal-chips"><span class="cal-chip cal-chip-due cal-chip-due-${cCls}" title="${_calCategory} today"></span></div>`;
+      } else {
+        html += `<span class="cal-day-num${isToday ? ' cal-day-num-today' : ''}">${d}</span>`;
       }
       html += '</div>';
     }

--- a/static/index.html
+++ b/static/index.html
@@ -47,6 +47,7 @@
     <span id="review-rr-badge" class="review-rr-badge" style="display:none" title="Daily retention rate"></span>
     <span id="avg-time-badge" class="review-rr-badge" style="display:none" title="Average time per card this session"></span>
     <button class="undo-btn" id="undo-btn" onclick="undoReview()" title="Undo last rating [Z]" disabled>↩ Undo</button>
+    <button class="undo-btn" id="session-graph-btn" onclick="openSessionSummary()" title="Graph of cards reviewed this session">📈 Session</button>
   </div>
   <div class="header-right">
     <button id="header-regen-btn" onclick="regenerateStory()" title="Regenerate story" style="display:none">↺</button>
@@ -270,6 +271,7 @@
     <p>暂时没有需要复习的卡片了。</p>
     <div style="display:flex;flex-direction:column;gap:12px;align-items:center">
       <button id="done-story-btn" class="btn-primary" onclick="openStoryModal()">View Full Story</button>
+      <button class="btn-secondary" onclick="openSessionSummary()">📈 Session Graph</button>
       <button class="btn-secondary" onclick="goBack()">Back to Decks</button>
     </div>
   </div>
@@ -856,6 +858,16 @@
     <button class="edit-modal-close" onclick="closeReasoning()">✕</button>
   </div>
   <div id="reasoning-body" class="reasoning-body"></div>
+</div>
+
+<!-- Session summary graph modal: interval timelines of all cards reviewed -->
+<div id="session-summary-overlay" onclick="closeSessionSummary()" style="display:none"></div>
+<div id="session-summary-modal" style="display:none">
+  <div class="edit-modal-header">
+    <span class="edit-modal-title">📈 Session — reviewed cards</span>
+    <button class="edit-modal-close" onclick="closeSessionSummary()">✕</button>
+  </div>
+  <div id="session-summary-body" class="session-summary-body"></div>
 </div>
 
 <!-- Hanzi regenerate confirm modal -->

--- a/static/index.html
+++ b/static/index.html
@@ -247,6 +247,16 @@
         <div id="cal-fade-row" class="cal-fade-row"></div>
         <div id="card-calendar" class="card-calendar">
           <div id="cal-timeline"></div>
+          <div class="cal-legend">
+            <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-again"></span>Again</span>
+            <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-hard"></span>Hard</span>
+            <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-good"></span>Good</span>
+            <span class="cal-legend-item"><span class="cal-legend-swatch cal-chip-easy"></span>Easy</span>
+            <span class="cal-legend-sep"></span>
+            <span class="cal-legend-item cal-legend-cat">听 Listening</span>
+            <span class="cal-legend-item cal-legend-cat">读 Reading</span>
+            <span class="cal-legend-item cal-legend-cat">创 Creating</span>
+          </div>
         </div>
       </div><!-- /review-cal-panel -->
 

--- a/static/style.css
+++ b/static/style.css
@@ -3509,84 +3509,28 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   gap: 2px;
 }
 .cal-cell {
-  position: relative;
-  min-height: 40px;
+  min-height: 28px;
   border-radius: 4px;
   border: 1px solid var(--border, #e5e7eb);
   display: flex;
   flex-direction: column;
-  align-items: stretch;
-  justify-content: flex-start;
-  padding: 3px 3px 2px;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 1px;
   gap: 2px;
 }
 .cal-cell.cal-today { outline: 2px solid var(--primary, #6366f1); outline-offset: -2px; border-radius: 4px; }
 .cal-cell.cal-empty { pointer-events: none; border-color: transparent; background: none; }
-/* Day number sits top-left and is always visible */
-.cal-daynum {
-  font-size: 0.62rem;
+.cal-cell.cal-has-future { background: #e5e7eb; }
+.cal-day-num {
+  font-size: 0.65rem;
   color: var(--text-muted);
   line-height: 1;
-  align-self: flex-start;
 }
-.cal-daynum-today {
+.cal-day-num-today {
   color: var(--primary, #6366f1);
   font-weight: 700;
 }
-/* Fixed 3-slot dot row pinned to the bottom of the cell */
-.cal-dots {
-  display: flex;
-  gap: 4px;
-  justify-content: center;
-  align-items: center;
-  margin-top: auto;
-}
-.cal-dot {
-  width: 9px;
-  height: 9px;
-  border-radius: 50%;
-  box-sizing: border-box;
-  flex: 0 0 auto;
-}
-.cal-dot-done { border: 2px solid; }                 /* filled — bg+border set inline */
-.cal-dot-due  { background: var(--card, #fff); border: 2px solid; }  /* hollow ring */
-.cal-dot-empty {
-  width: 5px; height: 5px;
-  background: var(--border, #e5e7eb);
-  opacity: 0.5;
-}
-/* Focus category: enlarge + ring instead of fading the others (CB-friendlier) */
-.cal-dot-focus {
-  transform: scale(1.35);
-  box-shadow: 0 0 0 2px var(--card, #fff), 0 0 0 3px rgba(99, 102, 241, 0.55);
-}
-/* Sticky state legend above the months (shared by both calendars) */
-.cal-legend2 {
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 5px 10px;
-  justify-content: center;
-  padding: 5px 4px;
-  margin-bottom: 4px;
-  background: var(--card, #fff);
-  border-bottom: 1px solid var(--border, #e5e7eb);
-  font-size: 11px;
-  color: var(--muted, #64748b);
-}
-.cal-leg-item { display: inline-flex; align-items: center; gap: 4px; }
-.cal-leg-dot {
-  width: 10px; height: 10px;
-  border-radius: 50%;
-  box-sizing: border-box;
-  flex: 0 0 auto;
-}
-.cal-leg-filled { background: var(--muted, #94a3b8); border: 2px solid var(--muted, #94a3b8); }
-.cal-leg-hollow { background: var(--card, #fff);     border: 2px solid var(--muted, #94a3b8); }
-.cal-leg-sep { width: 1px; align-self: stretch; background: var(--border, #e5e7eb); margin: 0 2px; }
-
 /* ── State-change cue (issue #329) ──────────────────────────────────────────
    Floating Chinese word announcing a card's new state during review. */
 .state-anim {
@@ -3658,10 +3602,8 @@ details[open] .cat-override-summary::before { content: '▼ '; }
 .cal-chip-hard  { background: #f97316; }
 .cal-chip-good  { background: #22c55e; }
 .cal-chip-easy  { background: #3b82f6; }
-/* Future due chips — plain black text, no background, no border */
-.cal-chip-due-listening,
-.cal-chip-due-reading,
-.cal-chip-due-creating  { background: transparent; border: none; color: var(--text, #1f2937); font-weight: 700; }
+/* Future due chips — hollow square (no glyph), category told via tooltip */
+.cal-chip-due { background: transparent; border: 1.5px solid var(--muted, #94a3b8); }
 .cal-legend {
   display: flex;
   gap: 8px;

--- a/static/style.css
+++ b/static/style.css
@@ -334,6 +334,8 @@ main.browse-open {
   min-width: 24px;
   text-align: right;
 }
+/* Capped at 40s — amber to signal the timer (and average) stopped counting */
+#card-timer.card-timer-capped { color: #b45309; opacity: 1; }
 .card-deck-path {
   width: 100%;
   font-size: 11px;
@@ -4137,6 +4139,31 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   margin-top: 6px; font-size: 11px; color: var(--muted);
 }
 .cgraph-empty { color: var(--muted); font-size: 12px; padding: 8px 2px; }
+
+/* ── Session summary graph (issue #337) ─────────────────────────────────────*/
+#session-summary-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.45); z-index: 100; }
+#session-summary-modal {
+  position: fixed;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 101;
+  background: var(--card);
+  border-radius: 18px;
+  box-shadow: 0 12px 48px rgba(0,0,0,0.22);
+  width: min(680px, 94vw);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  padding: 14px 18px 18px;
+}
+.session-summary-body { overflow: auto; }
+.session-summary-info { font-size: 11px; color: var(--muted); margin: 2px 0 8px; }
+.session-summary-svg { display: block; width: 100%; height: auto; }
+/* Each card is one group: dimmed by default, full opacity + thicker on hover */
+.sum-card { opacity: 0.42; cursor: pointer; transition: opacity 0.1s; }
+.sum-card:hover { opacity: 1; }
+.sum-card polyline, .sum-card line { stroke-width: 2; fill: none; }
+.sum-card:hover polyline, .sum-card:hover line { stroke-width: 3.6; }
 
 /* Graph sits above the calendar in the same tile — separate them */
 #card-graph, #wd-tile-graph {


### PR DESCRIPTION
## 变更内容
按 Daniel 要求把日历回退为之前的彩色方块版（撤销 #328 点位重设），并做两处调整：

- `git revert` 点位重设提交（恢复方块日历），解决冲突时保留了 #329 的状态动画样式
- **去掉方块里的类别汉字**（听/读/创）
- **激活类别方块全彩，其他类别更透明**（复用既有 fade 机制，默认透明度 0.55→0.3，滑块仍可调）
- 未来待复习方块改为**空心边框**（去字后仍可见），悬停 tooltip 显示类别

## 说明
方块填充色仍是评分色（Again 红 / Good 绿 …），即一周前的样子。考虑到你的红绿色盲，如需把填充改成色盲安全的状态配色（浅蓝/橙/深蓝/品红）告诉我，一处即可切换。

## 测试方法
- 复习侧栏与单词详情页日历恢复方块样式、无汉字
- 当前复习类别全彩，其他半透明
- 待复习显示为空心方块

注：链式分支，base 为 `feat/333-manual-leech-shortcut`。

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)