### PR TITLE
feat: 复习汇总图——本次复习所有卡片叠加，悬停看词、点击进浏览

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -1571,3 +1571,91 @@ def get_card_timeline_data(card_id: int) -> dict:
     return {"cards": result}
 
 
+def get_session_timelines(card_ids: list[int]) -> dict:
+    """Interval timelines for an explicit list of cards (one review session).
+
+    Like get_card_timeline_data but keyed by card id (not word) and tagged with
+    each card's word label, so the session summary graph can show which card a
+    line is and link to it. Cards with no reviews yet are skipped.
+    """
+    from .stats import _EVOLUTION_STATES
+
+    if not card_ids:
+        return {"cards": []}
+
+    conn = get_db()
+    ph = ",".join("?" * len(card_ids))
+    cards = conn.execute(
+        f"""SELECT c.id, c.word_id, c.deck_id, c.category, c.state,
+                   c.pre_suspend_state, c.interval, c.due,
+                   w.word_zh, w.pinyin
+            FROM cards c JOIN entries w ON w.id = c.word_id
+            WHERE c.id IN ({ph}) AND c.deleted_at IS NULL""",
+        card_ids,
+    ).fetchall()
+
+    result = []
+    for c in cards:
+        rows = conn.execute(
+            """SELECT datetime(reviewed_at, 'localtime') AS at, rating, state
+               FROM review_log WHERE card_id = ? ORDER BY reviewed_at""",
+            (c["id"],),
+        ).fetchall()
+        if not rows:
+            continue
+
+        preset = get_preset_for_deck(c["deck_id"], c["category"]) or {}
+        P = {
+            "learning_steps":      _parse_step_minutes(preset.get("learning_steps", "1 10")),
+            "relearning_steps":    _parse_step_minutes(preset.get("relearning_steps", "10")),
+            "graduating_interval": preset.get("graduating_interval", 1),
+            "easy_interval":       preset.get("easy_interval", 4),
+            "minimum_interval":    preset.get("minimum_interval", 1),
+        }
+
+        final = c["state"]
+        if final == "suspended":
+            final = c["pre_suspend_state"]
+
+        points = []
+        state, step, interval, ease = "new", 0, 0, 2.5
+        for r in rows:
+            if r["state"] in _EVOLUTION_STATES and r["state"] != state:
+                state, step = r["state"], 0
+            state, step, interval, ease, gap = _replay_schedule_step(
+                state, step, interval, ease, r["rating"], P)
+            points.append({"at": r["at"], "gap": round(gap, 3),
+                           "rating": r["rating"], "state": state})
+        if points and final in _EVOLUTION_STATES:
+            points[-1]["state"] = final
+
+        scheduled = None
+        if points and c["state"] in ("learning", "relearn", "review"):
+            due_raw = c["due"]
+            due_dt = datetime.fromisoformat(due_raw) if len(due_raw) > 10 \
+                else datetime.fromisoformat(due_raw + "T04:00:00")
+            if c["state"] == "review":
+                gap = float(c["interval"])
+            else:
+                last_dt = datetime.fromisoformat(rows[-1]["at"])
+                gap = max(0.0, (due_dt - last_dt).total_seconds() / 86400)
+            scheduled = {"at": due_dt.isoformat(sep=" "), "gap": round(gap, 3),
+                         "state": c["state"]}
+
+        result.append({
+            "card_id":  c["id"],
+            "word_id":  c["word_id"],
+            "word_zh":  c["word_zh"],
+            "pinyin":   c["pinyin"],
+            "category": c["category"],
+            "state":    c["state"],
+            "interval": c["interval"],
+            "due":      c["due"],
+            "points":   points,
+            "scheduled": scheduled,
+        })
+
+    conn.close()
+    return {"cards": result}
+
+

--- a/routes/review.py
+++ b/routes/review.py
@@ -331,3 +331,10 @@ def get_card_calendar(card_id: int):
 @router.get("/api/cards/{card_id}/timeline")
 def get_card_timeline(card_id: int):
     return database.get_card_timeline_data(card_id)
+
+
+@router.post("/api/session-timelines")
+def session_timelines(body: dict):
+    """Interval timelines for the cards reviewed in one session (summary graph)."""
+    ids = [int(i) for i in body.get("ids", [])]
+    return database.get_session_timelines(ids)

--- a/static/app.js
+++ b/static/app.js
@@ -46,6 +46,7 @@ let wordDetails = null;   // full word data: examples + characters
 let _currentWordId = null; // word ID open in word-detail view
 let _prevView = null;      // view we came from before opening word-detail
 let _sessionReviewedCount = 0; // cards rated this session (for clap animation)
+let _sessionReviewedIds = [];  // card ids reviewed this session (for summary graph)
 let userInput   = '';     // creating category: what the user typed
 let clozeExtraWord = ''; // extra word blanked in cloze front (revealed on back)
 let wordBankTokens = [];  // [{char, num}] shuffled non-target tokens
@@ -418,6 +419,106 @@ function _cardGraphHtml(card) {
       <svg class="cgraph-svg" viewBox="0 0 ${W} ${H}">${svg}</svg>
       <div class="cgraph-xaxis">${xlabels}</div>
       <div class="cgraph-legend">${legend}<span class="evo-leg">╌╌ scheduled</span></div>
+    </div>`;
+}
+
+// ── Session summary graph (issue #337) ───────────────────────────────────────
+// Overlays every reviewed card's interval timeline. Hover a line → its word;
+// click → open that card's browse (word detail).
+
+// Distinct line colours, cycled per card. Chosen to stay separable for Daniel's
+// red-green CB (no red/green pairs adjacent; spans blue↔orange↔purple).
+const _SUMMARY_PALETTE = [
+  '#0072B2', '#E69F00', '#CC79A7', '#56B4E9',
+  '#9467bd', '#8c564b', '#117733', '#882255',
+];
+
+async function openSessionSummary() {
+  const ids = [...new Set(_sessionReviewedIds)];
+  const body = document.getElementById('session-summary-body');
+  document.getElementById('session-summary-overlay').style.display = 'block';
+  document.getElementById('session-summary-modal').style.display = 'block';
+  if (!ids.length) {
+    body.innerHTML = '<div class="cgraph-empty">No cards reviewed yet this session.</div>';
+    return;
+  }
+  body.innerHTML = '<div class="cgraph-empty">Loading…</div>';
+  try {
+    const data = await api('POST', '/api/session-timelines', { ids });
+    body.innerHTML = _sessionSummaryHtml(data.cards || []);
+  } catch (e) {
+    body.innerHTML = `<div class="cgraph-empty">Failed to load: ${e.message}</div>`;
+  }
+}
+
+function closeSessionSummary() {
+  document.getElementById('session-summary-overlay').style.display = 'none';
+  document.getElementById('session-summary-modal').style.display = 'none';
+}
+
+function sumLineClick(wordId) {
+  closeSessionSummary();
+  openWordDetail(wordId);
+}
+
+function _sessionSummaryHtml(cards) {
+  // Keep only cards that actually have a line to draw
+  const drawn = cards.filter(c => (c.points || []).length);
+  if (!drawn.length) return '<div class="cgraph-empty">No interval history yet for these cards.</div>';
+
+  const W = 600, H = 340, PT = 14, PB = 20, PL = 30, PR = 14;
+  const t = s => new Date(s.replace(' ', 'T')).getTime();
+
+  // Each card's full point list (reviews + the scheduled due point)
+  const series = drawn.map(c => {
+    const pts = (c.points || []).slice();
+    if (c.scheduled) pts.push({ ...c.scheduled, scheduled: true });
+    return { card: c, pts };
+  });
+
+  const allPts = series.flatMap(s => s.pts);
+  let t0 = Math.min(...allPts.map(p => t(p.at)));
+  let t1 = Math.max(...allPts.map(p => t(p.at)));
+  if (t1 <= t0) t1 = t0 + 86400000;
+  const ymax = Math.max(1, ...allPts.map(p => p.gap));
+
+  const x = p => PL + (t(p.at) - t0) / (t1 - t0) * (W - PL - PR);
+  // sqrt scale on y so short and long intervals are both legible
+  const y = p => PT + (1 - Math.sqrt(p.gap) / Math.sqrt(ymax)) * (H - PT - PB);
+
+  // Horizontal gridlines + interval labels at a few sqrt-spaced levels
+  let svg = '';
+  const yTicks = [0, ymax * 0.25, ymax * 0.5, ymax].map(v => Math.round(v));
+  for (const v of [...new Set(yTicks)]) {
+    const gy = (PT + (1 - Math.sqrt(v) / Math.sqrt(ymax)) * (H - PT - PB)).toFixed(1);
+    svg += `<line x1="${PL}" y1="${gy}" x2="${W - PR}" y2="${gy}" stroke="var(--border)" stroke-width="0.6"/>`;
+    svg += `<text x="${PL - 4}" y="${(+gy + 3).toFixed(1)}" text-anchor="end" font-size="9" fill="var(--muted)">${v}d</text>`;
+  }
+
+  // One group per card: polyline (+dashed scheduled tail), hover shows the word
+  series.forEach((s, i) => {
+    const color = _SUMMARY_PALETTE[i % _SUMMARY_PALETTE.length];
+    const real = s.card.points.map(p => `${x(p).toFixed(1)},${y(p).toFixed(1)}`).join(' ');
+    let body = `<polyline points="${real}" fill="none" stroke="${color}"/>`;
+    if (s.card.scheduled && s.card.points.length) {
+      const a = s.card.points[s.card.points.length - 1], b = s.card.scheduled;
+      body += `<line x1="${x(a).toFixed(1)}" y1="${y(a).toFixed(1)}" x2="${x(b).toFixed(1)}" y2="${y(b).toFixed(1)}"
+                 stroke="${color}" stroke-dasharray="4 3"/>`;
+    }
+    body += s.pts.map(p => `<circle cx="${x(p).toFixed(1)}" cy="${y(p).toFixed(1)}" r="2.5" fill="${color}"/>`).join('');
+    const label = `${s.card.word_zh}${s.card.pinyin ? ' ' + s.card.pinyin : ''} · ${_CGRAPH_LABEL[s.card.state] || s.card.state}`;
+    svg += `<g class="sum-card" onclick="sumLineClick(${s.card.word_id})"><title>${label}</title>${body}</g>`;
+  });
+
+  const fmtD = s => { const [m, d] = s.slice(5, 10).split('-'); return `${+m}/${+d}`; };
+  const d0 = new Date(t0), d1 = new Date(t1);
+  const iso = dt => dt.toISOString().slice(0, 10);
+
+  return `
+    <div class="session-summary-info">${drawn.length} cards · y = scheduled interval (days) · hover a line to see the word, click to open it</div>
+    <div class="cgraph-wrap">
+      <svg class="session-summary-svg" viewBox="0 0 ${W} ${H}">${svg}</svg>
+      <div class="hcal-graph-axis"><span>${fmtD(iso(d0))}</span><span>${fmtD(iso(d1))}</span></div>
     </div>`;
 }
 
@@ -2584,6 +2685,7 @@ async function startReview(id, cat, name, noStory = false, quick = false) {
   category = cat;
   deckName = name;
   _sessionReviewedCount = 0;
+  _sessionReviewedIds = [];
   _sessionTotalMs = 0;
   _sessionRatedCount = 0;
   _updateAvgTimeBadge();
@@ -2702,6 +2804,7 @@ async function startReviewMixed(id, name, noStory = false, quick = false) {
   deckName   = name;
   story      = null;
   _sessionReviewedCount = 0;
+  _sessionReviewedIds = [];
   _sessionTotalMs = 0;
   _sessionRatedCount = 0;
   _updateAvgTimeBadge();
@@ -4585,8 +4688,10 @@ async function rate(rating) {
     if (unfinishedMode) url += `&unfinished_mode=true`;
     else if (rootDeckId) url += `&root_deck_id=${rootDeckId}`;
     else if (deckId) url += `&parent_deck_id=${deckId}`;
+    const reviewedId = card.id;
     const result = await api('POST', url);
     _sessionReviewedCount++;
+    if (reviewedId != null) _sessionReviewedIds.push(reviewedId);
     if (result.transition?.changed) showStateChangeAnim(result.transition);
     if (typeof invalidateHomeCalendar === 'function') invalidateHomeCalendar();
     if (typeof invalidateHomeEvolution === 'function') invalidateHomeEvolution();
@@ -6549,6 +6654,7 @@ function _hasOpenModal() {
     'hanzi-edit-modal-overlay',
     'conflict-modal-overlay',
     'kahneman-examples-overlay',
+    'session-summary-overlay',
   ];
   return modalIds.some(_isVisible);
 }
@@ -6557,6 +6663,12 @@ document.addEventListener('keydown', async e => {
   const inInput = _isEditableFocusTarget(document.activeElement);
 
   if (e.key === 'Escape') {
+    const sessOverlay = document.getElementById('session-summary-overlay');
+    if (sessOverlay && sessOverlay.style.display !== 'none') {
+      e.preventDefault();
+      closeSessionSummary();
+      return;
+    }
     const kahnemanOverlay = document.getElementById('kahneman-examples-overlay');
     if (kahnemanOverlay && kahnemanOverlay.style.display !== 'none') {
       e.preventDefault();

--- a/static/app.js
+++ b/static/app.js
@@ -64,6 +64,7 @@ let _retentionData = null;  // cached result from GET /api/retention
 let _cachedDecks = null;       // last fetched deck tree (for toggle re-renders)
 let _timerInterval = null;
 let _timerStart = null;
+const _TIMER_CAP_MS = 40000;  // beyond this the user is likely doing something else
 let _sessionTotalMs = 0;
 let _sessionRatedCount = 0;
 
@@ -587,10 +588,19 @@ function _startTimer() {
   _stopTimer();
   _timerStart = Date.now();
   const el = document.getElementById('card-timer');
+  el.classList.remove('card-timer-capped');
   el.textContent = '0s';
   el.style.display = 'block';
   _timerInterval = setInterval(() => {
-    const s = Math.floor((Date.now() - _timerStart) / 1000);
+    const ms = Date.now() - _timerStart;
+    if (ms >= _TIMER_CAP_MS) {
+      // Freeze at the cap — the time past 40s won't count toward the average.
+      el.textContent = '40s';
+      el.classList.add('card-timer-capped');
+      clearInterval(_timerInterval); _timerInterval = null;
+      return;
+    }
+    const s = Math.floor(ms / 1000);
     el.textContent = s < 60 ? `${s}s` : `${Math.floor(s / 60)}m${s % 60}s`;
   }, 1000);
 }
@@ -3271,7 +3281,7 @@ function diffAnswer(userInput, correct, wordZh) {
 
 // ── Back of card ────────────────────────────────────────────────────────────
 function revealAnswer() {
-  _stopTimer();
+  // Keep the timer running on the back side (it freezes at the 40s cap).
   const isCreating = category === 'creating';
 
   // Capture user input before hiding front
@@ -4677,7 +4687,8 @@ async function rate(rating) {
   document.querySelectorAll('.r-btn').forEach(b => b.disabled = true);
   let _cardMs = null;
   if (_timerStart) {
-    _cardMs = Date.now() - _timerStart;
+    // Cap at 40s: time spent past that likely isn't real study time.
+    _cardMs = Math.min(Date.now() - _timerStart, _TIMER_CAP_MS);
     _sessionTotalMs += _cardMs;
     _sessionRatedCount++;
     _updateAvgTimeBadge();

--- a/static/index.html
+++ b/static/index.html
@@ -47,6 +47,7 @@
     <span id="review-rr-badge" class="review-rr-badge" style="display:none" title="Daily retention rate"></span>
     <span id="avg-time-badge" class="review-rr-badge" style="display:none" title="Average time per card this session"></span>
     <button class="undo-btn" id="undo-btn" onclick="undoReview()" title="Undo last rating [Z]" disabled>↩ Undo</button>
+    <button class="undo-btn" id="session-graph-btn" onclick="openSessionSummary()" title="Graph of cards reviewed this session">📈 Session</button>
   </div>
   <div class="header-right">
     <button id="header-regen-btn" onclick="regenerateStory()" title="Regenerate story" style="display:none">↺</button>
@@ -270,6 +271,7 @@
     <p>暂时没有需要复习的卡片了。</p>
     <div style="display:flex;flex-direction:column;gap:12px;align-items:center">
       <button id="done-story-btn" class="btn-primary" onclick="openStoryModal()">View Full Story</button>
+      <button class="btn-secondary" onclick="openSessionSummary()">📈 Session Graph</button>
       <button class="btn-secondary" onclick="goBack()">Back to Decks</button>
     </div>
   </div>
@@ -856,6 +858,16 @@
     <button class="edit-modal-close" onclick="closeReasoning()">✕</button>
   </div>
   <div id="reasoning-body" class="reasoning-body"></div>
+</div>
+
+<!-- Session summary graph modal: interval timelines of all cards reviewed -->
+<div id="session-summary-overlay" onclick="closeSessionSummary()" style="display:none"></div>
+<div id="session-summary-modal" style="display:none">
+  <div class="edit-modal-header">
+    <span class="edit-modal-title">📈 Session — reviewed cards</span>
+    <button class="edit-modal-close" onclick="closeSessionSummary()">✕</button>
+  </div>
+  <div id="session-summary-body" class="session-summary-body"></div>
 </div>
 
 <!-- Hanzi regenerate confirm modal -->

--- a/static/style.css
+++ b/static/style.css
@@ -334,6 +334,8 @@ main.browse-open {
   min-width: 24px;
   text-align: right;
 }
+/* Capped at 40s — amber to signal the timer (and average) stopped counting */
+#card-timer.card-timer-capped { color: #b45309; opacity: 1; }
 .card-deck-path {
   width: 100%;
   font-size: 11px;

--- a/static/style.css
+++ b/static/style.css
@@ -4138,6 +4138,31 @@ details[open] .cat-override-summary::before { content: '▼ '; }
 }
 .cgraph-empty { color: var(--muted); font-size: 12px; padding: 8px 2px; }
 
+/* ── Session summary graph (issue #337) ─────────────────────────────────────*/
+#session-summary-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.45); z-index: 100; }
+#session-summary-modal {
+  position: fixed;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 101;
+  background: var(--card);
+  border-radius: 18px;
+  box-shadow: 0 12px 48px rgba(0,0,0,0.22);
+  width: min(680px, 94vw);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  padding: 14px 18px 18px;
+}
+.session-summary-body { overflow: auto; }
+.session-summary-info { font-size: 11px; color: var(--muted); margin: 2px 0 8px; }
+.session-summary-svg { display: block; width: 100%; height: auto; }
+/* Each card is one group: dimmed by default, full opacity + thicker on hover */
+.sum-card { opacity: 0.42; cursor: pointer; transition: opacity 0.1s; }
+.sum-card:hover { opacity: 1; }
+.sum-card polyline, .sum-card line { stroke-width: 2; fill: none; }
+.sum-card:hover polyline, .sum-card:hover line { stroke-width: 3.6; }
+
 /* Graph sits above the calendar in the same tile — separate them */
 #card-graph, #wd-tile-graph {
   padding-bottom: 12px;


### PR DESCRIPTION
## 变更内容
复习时或之后，点按钮打开**本次会话复习过的所有卡片**的间隔图叠加视图。

- **后端**：`get_session_timelines(ids)` + `POST /api/session-timelines`，按 card_id 重放 SM-2 间隔时间线，附词标签（word_zh/pinyin/word_id）
- **前端**：会话期间记录 `_sessionReviewedIds`（会话重置时清空）
- **图**：modal 内多线 SVG，每卡一条线（**sqrt y 轴** + 虚线 scheduled 尾），默认半透明；**悬停整条高亮**并用原生 title 显示词；**点击跳到该卡的浏览**（`openWordDetail(word_id)`）
- **入口**：复习计数栏「📈 Session」按钮 + done 视图「📈 Session Graph」按钮
- Esc / 点遮罩关闭

## 测试方法（后端已用临时库验证）
- 复习几张卡后点「📈 Session」→ 多条线叠加
- 悬停某条线 → 显示词与状态
- 点击某条线 → 进入该词详情（即该卡浏览）

注：链式分支，base 为 `feat/335-calendar-revert-tweak`。

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)