### PR TITLE
feat: 同字词暂存区 + 复习/选项四项改进

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -36,6 +36,41 @@ def insert_card(word_id: int, category: str, deck_id: int,
     return row["id"]
 
 
+def promote_saved_word(word_id: int, target_deck_id: int,
+                       saved_deck_id: int, due: str) -> int:
+    """Move a saved word's suspended cards out of the Saved deck into target_deck_id
+    as fresh 'new' cards due on `due`, clearing any scheduling state.
+
+    Returns the number of cards promoted.
+    """
+    conn = get_db()
+    cur = conn.execute(
+        """UPDATE cards
+           SET deck_id=?, state='new', due=?, step_index=0, interval=0,
+               ease=2.5, repetitions=0, lapses=0, stability=NULL, difficulty=NULL,
+               last_review=NULL, learning_again_count=0, is_leech=0,
+               buried_until=NULL, pre_suspend_state=NULL
+           WHERE word_id=? AND deck_id=? AND deleted_at IS NULL""",
+        (target_deck_id, due, word_id, saved_deck_id),
+    )
+    conn.commit()
+    count = cur.rowcount
+    conn.close()
+    return count
+
+
+def set_card_note(card_id: int, note: str | None) -> None:
+    """Store (or clear) the free-text 'note for next time' on a card.
+
+    Empty/blank strings are stored as NULL so the card shows no note next time.
+    """
+    note = (note or "").strip() or None
+    conn = get_db()
+    conn.execute("UPDATE cards SET next_note=? WHERE id=?", (note, card_id))
+    conn.commit()
+    conn.close()
+
+
 def move_card_to_deck(card_id: int, deck_id: int) -> bool:
     conn = get_db()
     cur = conn.execute(
@@ -131,7 +166,7 @@ def get_card(card_id: int) -> dict | None:
                   p.relearning_steps, p.minimum_interval,
                   p.leech_threshold, p.learning_leech_threshold, p.leech_action,
                   p.desired_retention, p.maximum_interval, p.fsrs_weights, p.enable_fsrs,
-                  p.learning_hard_1d,
+                  p.learning_hard_1d, p.learning_hard_days,
                   p.new_per_day, p.reviews_per_day
            FROM cards c
            JOIN entries w ON w.id = c.word_id

--- a/database/core.py
+++ b/database/core.py
@@ -225,6 +225,8 @@ def init_db() -> None:
         conn.execute("ALTER TABLE cards ADD COLUMN difficulty REAL")
     if "last_review" not in card_cols:
         conn.execute("ALTER TABLE cards ADD COLUMN last_review TEXT")
+    if "next_note" not in card_cols:
+        conn.execute("ALTER TABLE cards ADD COLUMN next_note TEXT")
 
     # review_log: per-review timing + card state at review time (for calendar heatmap stats)
     rl_cols = {r["name"] for r in conn.execute("PRAGMA table_info(review_log)").fetchall()}
@@ -283,6 +285,8 @@ def init_db() -> None:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN enable_fsrs INTEGER NOT NULL DEFAULT 1")
     if "learning_hard_1d" not in preset_cols:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN learning_hard_1d INTEGER NOT NULL DEFAULT 1")
+    if "learning_hard_days" not in preset_cols:
+        conn.execute("ALTER TABLE deck_presets ADD COLUMN learning_hard_days REAL NOT NULL DEFAULT 1")
 
     conn.execute("""CREATE TABLE IF NOT EXISTS preset_category_overrides (
         id                  INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/database/decks.py
+++ b/database/decks.py
@@ -263,6 +263,12 @@ def get_or_create_deck_path(path: str) -> int:
     return parent_id
 
 
+def get_or_create_saved_deck() -> int:
+    """The fixed 'Saved' staging deck: holds suspended compound words the user
+    set aside for later (see /api/save-word). Promoting moves them to a Daily deck."""
+    return get_or_create_deck_path("Saved")
+
+
 def get_word_deck_names(word_id: int) -> list[str]:
     """Return the unique deck names (leaf only) where cards for this word live."""
     conn = get_db()

--- a/database/presets.py
+++ b/database/presets.py
@@ -27,6 +27,7 @@ def default_preset() -> dict:
         "fsrs_weights": None,
         "enable_fsrs": 1,
         "learning_hard_1d": 1,
+        "learning_hard_days": 1,
         "new_gather_order": "ascending_position",
         "new_sort_order": "card_type_gathered",
         "new_review_order": "mixed",
@@ -205,6 +206,7 @@ def insert_preset(preset: dict) -> int:
     preset.setdefault("fsrs_weights", None)
     preset.setdefault("enable_fsrs", 1)
     preset.setdefault("learning_hard_1d", 1)
+    preset.setdefault("learning_hard_days", 1)
     conn = get_db()
     cur = conn.execute(
         """INSERT INTO deck_presets
@@ -212,7 +214,7 @@ def insert_preset(preset: dict) -> int:
             learning_steps, graduating_interval, easy_interval,
             relearning_steps, minimum_interval, insertion_order,
             bury_siblings, randomize_story_order, leech_threshold, learning_leech_threshold, leech_action,
-            desired_retention, maximum_interval, fsrs_weights, enable_fsrs, learning_hard_1d,
+            desired_retention, maximum_interval, fsrs_weights, enable_fsrs, learning_hard_1d, learning_hard_days,
             new_gather_order, new_sort_order, new_review_order,
             interday_learning_review_order, review_sort_order,
             bury_new_siblings, bury_review_siblings, bury_interday_siblings,
@@ -221,7 +223,7 @@ def insert_preset(preset: dict) -> int:
                    :learning_steps, :graduating_interval, :easy_interval,
                    :relearning_steps, :minimum_interval, :insertion_order,
                    :bury_siblings, :randomize_story_order, :leech_threshold, :learning_leech_threshold, :leech_action,
-                   :desired_retention, :maximum_interval, :fsrs_weights, :enable_fsrs, :learning_hard_1d,
+                   :desired_retention, :maximum_interval, :fsrs_weights, :enable_fsrs, :learning_hard_1d, :learning_hard_days,
                    :new_gather_order, :new_sort_order, :new_review_order,
                    :interday_learning_review_order, :review_sort_order,
                    :bury_new_siblings, :bury_review_siblings, :bury_interday_siblings,
@@ -240,7 +242,7 @@ def update_preset(preset_id: int, fields: dict) -> None:
         "learning_steps", "graduating_interval", "easy_interval",
         "relearning_steps", "minimum_interval", "insertion_order",
         "bury_siblings", "randomize_story_order", "leech_threshold", "learning_leech_threshold", "leech_action",
-        "desired_retention", "maximum_interval", "fsrs_weights", "enable_fsrs", "learning_hard_1d",
+        "desired_retention", "maximum_interval", "fsrs_weights", "enable_fsrs", "learning_hard_1d", "learning_hard_days",
         "new_gather_order", "new_sort_order", "new_review_order",
         "interday_learning_review_order", "review_sort_order",
         "bury_new_siblings", "bury_review_siblings", "bury_interday_siblings",

--- a/routes/imports.py
+++ b/routes/imports.py
@@ -217,7 +217,72 @@ def quick_add_word(body: dict):
         entry_id = database.insert_word(word_data)
         status = "created"
 
-    for category in ("listening", "reading", "writing"):
+    for category in ("listening", "reading", "creating"):
         database.insert_card(entry_id, category, deck_id, state="new", due=tomorrow)
 
     return {"status": status, "entry_id": entry_id, "deck_path": deck_path, "deck_id": deck_id}
+
+
+@router.post("/api/save-word")
+def save_word(body: dict):
+    """Stage a compound word in the fixed 'Saved' deck as suspended cards.
+
+    Unlike /api/quick-add-word this does NOT call the AI and does NOT activate
+    the cards — content is generated later on demand, and the word only enters
+    the study algorithm when promoted to a Daily deck (see /api/saved/{id}/promote).
+
+    Body: { word_zh, pinyin?, meaning? }
+    Returns: { status: "saved"|"already_saved"|"exists_elsewhere", entry_id, saved_deck_id }
+    """
+    word_zh = (body.get("word_zh") or "").strip()
+    if not word_zh:
+        raise HTTPException(status_code=400, detail="word_zh is required")
+
+    pinyin = (body.get("pinyin") or "").strip()
+    meaning = (body.get("meaning") or "").strip()
+
+    saved_deck_id = database.get_or_create_saved_deck()
+
+    existing = database.get_word_by_zh(word_zh)
+    if existing:
+        entry_id = existing["id"]
+        conn = database.get_db()
+        deck_ids = {
+            r["deck_id"] for r in conn.execute(
+                "SELECT deck_id FROM cards WHERE word_id=? AND deleted_at IS NULL",
+                (entry_id,),
+            ).fetchall()
+        }
+        conn.close()
+        if saved_deck_id in deck_ids:
+            return {"status": "already_saved", "entry_id": entry_id, "saved_deck_id": saved_deck_id}
+        if deck_ids:
+            # Word already lives in a real deck — nothing to stage.
+            return {"status": "exists_elsewhere", "entry_id": entry_id, "saved_deck_id": saved_deck_id}
+    else:
+        entry_id = database.insert_word({
+            "word_zh": word_zh,
+            "pinyin": pinyin,
+            "definition": meaning,
+            "note_type": "vocabulary",
+        })
+
+    for category in ("listening", "reading", "creating"):
+        database.insert_card(entry_id, category, saved_deck_id, state="suspended")
+
+    return {"status": "saved", "entry_id": entry_id, "saved_deck_id": saved_deck_id}
+
+
+@router.post("/api/saved/{word_id}/promote")
+def promote_saved(word_id: int):
+    """Move a saved word's suspended cards into tomorrow's Daily deck as active new cards."""
+    saved_deck_id = database.get_or_create_saved_deck()
+    tomorrow = (date.today() + timedelta(days=1)).isoformat()
+    deck_path = f"Daily::{tomorrow}"
+    daily_deck_id = database.get_or_create_deck_path(deck_path)
+
+    count = database.promote_saved_word(word_id, daily_deck_id, saved_deck_id, tomorrow)
+    if not count:
+        raise HTTPException(status_code=404, detail="No saved cards found for this word")
+
+    return {"status": "promoted", "count": count, "deck_path": deck_path, "deck_id": daily_deck_id}

--- a/routes/review.py
+++ b/routes/review.py
@@ -101,8 +101,13 @@ def get_today_mixed(deck_id: int):
 @router.post("/api/review")
 def submit_review(card_id: int, rating: int, user_response: str | None = None,
                   root_deck_id: int | None = None, unfinished_mode: bool = False,
-                  parent_deck_id: int | None = None, duration_ms: int | None = None):
+                  parent_deck_id: int | None = None, duration_ms: int | None = None,
+                  next_note: str | None = None):
     card_before = database.get_card(card_id)
+    # Persist the free-text "note for next time" the user left on this card
+    # (None means "leave the existing note untouched"; "" clears it).
+    if next_note is not None:
+        database.set_card_note(card_id, next_note)
     updated, log_id = srs.apply_review(card_id, rating, user_response=user_response,
                                        duration_ms=duration_ms)
     deck_id = updated["deck_id"]

--- a/schema.sql
+++ b/schema.sql
@@ -35,9 +35,13 @@ CREATE TABLE IF NOT EXISTS deck_presets (
     maximum_interval        INTEGER NOT NULL DEFAULT 36500,
     fsrs_weights            TEXT,
     enable_fsrs             INTEGER NOT NULL DEFAULT 1,
-    -- When 1, a single-step learning/relearn card's "Hard" schedules ~1 day
-    -- instead of step×1.5, so a half-remembered card returns tomorrow.
+    -- When 1, a single-step learning/relearn card's "Hard" schedules
+    -- learning_hard_days (default 1 day) instead of step×1.5, so a
+    -- half-remembered card returns after that many days.
     learning_hard_1d        INTEGER NOT NULL DEFAULT 1,
+    -- How many days "Hard" delays a learning/relearn card when learning_hard_1d
+    -- is on. Fractional allowed (e.g. 0.5 = half a day).
+    learning_hard_days      REAL NOT NULL DEFAULT 1,
 
     -- New card insertion order (legacy; superseded by new_gather_order)
     insertion_order         TEXT NOT NULL DEFAULT 'sequential'
@@ -285,6 +289,9 @@ CREATE TABLE IF NOT EXISTS cards (
 
     -- saved before suspension so it can be restored on unsuspend
     pre_suspend_state TEXT,
+
+    -- free-text note the user leaves for the next time this card comes up
+    next_note TEXT,
 
     UNIQUE(word_id, category)
 );

--- a/srs.py
+++ b/srs.py
@@ -373,6 +373,7 @@ def apply_review(card_id: int, rating: int,
         "fsrs_weights":        card.get("fsrs_weights"),
         "enable_fsrs":         card.get("enable_fsrs", 1),
         "learning_hard_1d":    card.get("learning_hard_1d", 1),
+        "learning_hard_days":  card.get("learning_hard_days", 1),
     }
 
     if card["state"] in ("new", "learning"):

--- a/srs.py
+++ b/srs.py
@@ -35,6 +35,19 @@ def _hard_1d_enabled(card: dict) -> bool:
     return bool(val) if val is not None else True
 
 
+def _hard_minutes(card: dict) -> int:
+    """Minutes that "Hard" delays a learning/relearn card when learning_hard_1d
+    is on — learning_hard_days (default 1 day), fractional days allowed."""
+    days = card.get("learning_hard_days", 1)
+    if days is None:
+        days = 1
+    try:
+        days = float(days)
+    except (TypeError, ValueError):
+        days = 1.0
+    return max(1, round(days * 1440))
+
+
 def _elapsed_days(card: dict) -> int:
     """Days since the previous review, for computing retrievability.
 
@@ -103,7 +116,7 @@ def preview_intervals(card: dict) -> dict:
         si = min(step_index, len(l_steps) - 1)
         again = _fmt_min(l_steps[0])
         if _hard_1d_enabled(card):
-            hard = _fmt_min(LEARNING_HARD_SINGLE_STEP_MINUTES)
+            hard = _fmt_min(_hard_minutes(card))
         elif si == 0 and len(l_steps) > 1:
             hard = _fmt_min((l_steps[0] + l_steps[1]) / 2)
         elif len(l_steps) == 1:
@@ -136,7 +149,7 @@ def preview_intervals(card: dict) -> dict:
         si = min(step_index, len(r_steps) - 1)
         again = _fmt_min(r_steps[0])
         if _hard_1d_enabled(card):
-            hard = _fmt_min(LEARNING_HARD_SINGLE_STEP_MINUTES)
+            hard = _fmt_min(_hard_minutes(card))
         elif si == 0 and len(r_steps) > 1:
             hard = _fmt_min((r_steps[0] + r_steps[1]) / 2)
         elif len(r_steps) == 1:
@@ -434,7 +447,7 @@ def _handle_learning(card: dict, preset: dict, rating: int) -> dict:
         c["state"] = "learning"
         idx = c["step_index"]
         if _hard_1d_enabled(preset):
-            delay = LEARNING_HARD_SINGLE_STEP_MINUTES
+            delay = _hard_minutes(preset)
         elif idx == 0 and len(steps) > 1:
             delay = (steps[0] + steps[1]) / 2
         elif len(steps) == 1:
@@ -538,7 +551,7 @@ def _handle_relearn(card: dict, preset: dict, rating: int) -> dict:
         c["state"] = "relearn"
         idx = c["step_index"]
         if _hard_1d_enabled(preset):
-            delay = LEARNING_HARD_SINGLE_STEP_MINUTES
+            delay = _hard_minutes(preset)
         elif idx == 0 and len(steps) > 1:
             delay = (steps[0] + steps[1]) / 2
         elif len(steps) == 1:

--- a/static/app.js
+++ b/static/app.js
@@ -1445,7 +1445,7 @@ async function openQuickAddCard() {
 let _browseSearchTimer = null;
 let _browseMode       = 'notes';   // 'notes' | 'hanzi'
 let _browseFilter     = 'all';     // note_type or 'all'; for hanzi mode: 'all'
-let _browseCardStatus = 'all';     // 'all' | 'learning' | 'reference'
+let _browseCardStatus = 'all';     // 'all' | 'learning' | 'leech' | 'reference' | 'saved'
 let _browseDeckId     = null;      // deck filter (notes mode only)
 let _allHanzi         = [];        // cache
 
@@ -1494,6 +1494,7 @@ function _filteredBrowseWords() {
   if (_browseCardStatus === 'learning')   words = words.filter(w => w.cards.length > 0);
   if (_browseCardStatus === 'leech')      words = words.filter(w => w.cards.some(c => c.is_leech));
   if (_browseCardStatus === 'reference')  words = words.filter(w => w.cards.length === 0);
+  if (_browseCardStatus === 'saved')      words = words.filter(w => w.cards.some(c => c.deck_name === 'Saved'));
   return words;
 }
 
@@ -1662,7 +1663,11 @@ function _wordRow(w) {
   const def = (w.definition || '').slice(0, 60) + ((w.definition || '').length > 60 ? '…' : '');
   const sel = _browseSelected.has(w.id) ? ' bw-row-selected' : '';
   let rightHtml;
-  if (w.cards.length === 0) {
+  if (_browseCardStatus === 'saved') {
+    rightHtml =
+      `<button class="bw-saved-btn" onclick="event.stopPropagation();savedGenerate(${w.id},this)" title="Generate content with AI">✨ Generate</button>` +
+      `<button class="bw-saved-btn bw-saved-promote" onclick="event.stopPropagation();savedPromote(${w.id},this)" title="Add to tomorrow's Daily deck">→ Add to Daily</button>`;
+  } else if (w.cards.length === 0) {
     rightHtml = `<button class="bw-add-btn" onclick="openAddToDeckModal(event,${w.id})" title="添加到牌组">＋ 添加</button>`;
   } else {
     const CAT_LETTER = { listening: 'L', reading: 'R', creating: 'C' };
@@ -1687,6 +1692,38 @@ function _wordRow(w) {
       </div>
       <div class="bw-right">${rightHtml}</div>
     </div>`;
+}
+
+// Generate AI content for a saved word (stays in the Saved list, now filled in).
+async function savedGenerate(wordId, btn) {
+  btn.disabled = true;
+  const orig = btn.textContent;
+  btn.textContent = '…';
+  try {
+    await api('POST', `/api/word/${wordId}/ai-enrich`);
+    await _browseReload();
+    showQuickAddBanner('✨ Content generated', false);
+  } catch (e) {
+    btn.disabled = false;
+    btn.textContent = orig;
+    showError('Generate failed: ' + e.message);
+  }
+}
+
+// Promote a saved word into tomorrow's Daily deck (leaves the Saved list).
+async function savedPromote(wordId, btn) {
+  btn.disabled = true;
+  const orig = btn.textContent;
+  btn.textContent = '…';
+  try {
+    const r = await api('POST', `/api/saved/${wordId}/promote`);
+    await _browseReload();
+    showQuickAddBanner(`→ Added to ${r.deck_path}`, false);
+  } catch (e) {
+    btn.disabled = false;
+    btn.textContent = orig;
+    showError('Add to Daily failed: ' + e.message);
+  }
 }
 
 function onBrowseRowClick(e, wordId) {
@@ -2476,8 +2513,10 @@ function applySchedulerVisibility() {
 const INFO_TEXT = {
   enable_fsrs: ['Enable FSRS',
     'FSRS is a modern scheduler that models each card with Stability and Difficulty to predict the best review time. Turn it off to fall back to the legacy SM-2 (ease-factor) algorithm. Switching hides the fields that don\'t apply to the chosen scheduler.'],
-  hard_1d: ['Hard = 1 day',
-    'While a card is still in learning or relearning, pressing Hard sends it to tomorrow (1 day) instead of repeating in a few minutes. Applies to both schedulers.'],
+  hard_1d: ['Hard = fixed days',
+    'While a card is still in learning or relearning, pressing Hard sends it forward by a fixed number of days (set below) instead of repeating in a few minutes. Applies to both schedulers.'],
+  hard_days: ['Hard delay (days)',
+    'How many days Hard pushes a learning/relearning card forward when "Hard = fixed days" is enabled. Fractional values allowed (e.g. 0.5 = half a day).'],
   learning_steps: ['Learning steps',
     'The sub-day intervals (in minutes) a new card steps through before it graduates to review. Example: "10m" means one 10-minute step. Used by both schedulers.'],
   graduating_interval: ['Graduating interval (SM-2 only)',
@@ -2547,6 +2586,7 @@ function loadPresetFields(preset) {
   document.getElementById('opt-sibling-factor').value  = preset.sibling_factor ?? 0.2;
   document.getElementById('opt-enable-fsrs').checked   = preset.enable_fsrs == null ? true : !!preset.enable_fsrs;
   document.getElementById('opt-hard-1d').checked       = preset.learning_hard_1d == null ? true : !!preset.learning_hard_1d;
+  document.getElementById('opt-hard-days').value       = preset.learning_hard_days == null ? 1 : preset.learning_hard_days;
   document.getElementById('opt-desired-retention').value = Math.round((preset.desired_retention ?? 0.9) * 100);
   document.getElementById('opt-max-int').value         = preset.maximum_interval ?? 36500;
   applySchedulerVisibility();
@@ -2713,15 +2753,11 @@ async function saveOptions() {
     sibling_factor:         parseFloat(document.getElementById('opt-sibling-factor').value) || 0.2,
     enable_fsrs:            document.getElementById('opt-enable-fsrs').checked ? 1 : 0,
     learning_hard_1d:       document.getElementById('opt-hard-1d').checked ? 1 : 0,
+    learning_hard_days:     Math.max(0.1, parseFloat(document.getElementById('opt-hard-days').value) || 1),
     desired_retention:      Math.min(0.99, Math.max(0.70, (parseInt(document.getElementById('opt-desired-retention').value) || 90) / 100)),
     maximum_interval:       Math.max(1, parseInt(document.getElementById('opt-max-int').value) || 36500),
     category_order: _getCategoryOrderUI(),
   };
-  // Warn if a story for today already exists — order settings change would cause mismatch
-  if (story !== null) {
-    const ok = confirm('You have an active story. Changing sort settings will affect card order and may no longer match the story. Continue?');
-    if (!ok) return;
-  }
   try {
     const [savedPreset] = await Promise.all([
       api('PUT', `/api/decks/${optDeckId}/preset`, fields),
@@ -3076,6 +3112,13 @@ function loadCard(c, counts) {
   [1, 2, 3, 4].forEach(r => {
     document.getElementById(`int-${r}`).textContent = iv[r] || '';
   });
+
+  // Pre-fill the "note for next time" left on this card last time (if any)
+  const noteInput = document.getElementById('next-note-input');
+  if (noteInput) {
+    noteInput.value = card.next_note || '';
+    noteInput.classList.toggle('has-note', !!(card.next_note || '').trim());
+  }
 
   // Find sentence for this card's word in the story.
   // If no match, leave sentence null — renderSentence() will show just the word.
@@ -4206,13 +4249,17 @@ function openQuickAddMenu(event, wordZh, pinyin, meaning) {
   const menu = document.createElement('div');
   menu.id = 'quick-add-menu';
   menu.className = 'quick-add-menu';
+  const wEsc = wordZh.replace(/'/g, "\\'");
+  const pEsc = pinyin.replace(/'/g, "\\'");
+  const mEsc = meaning.replace(/'/g, "\\'");
   menu.innerHTML =
     `<div class="qa-word">${wordZh}` +
       (pinyin ? ` <span class="qa-pin">${pinyin}</span>` : '') +
     `</div>` +
     (meaning ? `<div class="qa-meaning">${meaning}</div>` : '') +
-    `<div class="qa-deck-label">daily::${tomorrowStr}</div>` +
-    `<button class="qa-add-btn" onclick="doQuickAdd('${wordZh.replace(/'/g,"\\'")}','${pinyin.replace(/'/g,"\\'")}','${meaning.replace(/'/g,"\\'")}',this)">+ Add to Daily deck</button>`;
+    `<button class="qa-add-btn qa-save-btn" onclick="doSaveWord('${wEsc}','${pEsc}','${mEsc}',this)">★ Save for later</button>` +
+    `<div class="qa-deck-label">or add now to daily::${tomorrowStr}</div>` +
+    `<button class="qa-add-btn" onclick="doQuickAdd('${wEsc}','${pEsc}','${mEsc}',this)">+ Add to Daily deck</button>`;
 
   document.body.appendChild(menu);
   _quickAddMenu = menu;
@@ -4231,6 +4278,25 @@ function closeQuickAddMenu() {
   if (_quickAddMenu) {
     _quickAddMenu.remove();
     _quickAddMenu = null;
+  }
+}
+
+async function doSaveWord(wordZh, pinyin, meaning, btn) {
+  btn.disabled = true;
+  btn.textContent = '…';
+  try {
+    const result = await api('POST', '/api/save-word', { word_zh: wordZh, pinyin, meaning });
+    closeQuickAddMenu();
+    const msgs = {
+      saved:            `★ "${wordZh}" saved for later`,
+      already_saved:    `"${wordZh}" is already saved`,
+      exists_elsewhere: `"${wordZh}" is already in a deck`,
+    };
+    showQuickAddBanner(msgs[result.status] || '★ Saved', result.status !== 'saved');
+  } catch (e) {
+    btn.disabled = false;
+    btn.textContent = '★ Save for later';
+    showError(e.message || 'Failed to save word');
   }
 }
 
@@ -4767,6 +4833,8 @@ async function rate(rating) {
   try {
     let url = `/api/review?card_id=${card.id}&rating=${rating}`;
     if (_cardMs != null) url += `&duration_ms=${_cardMs}`;
+    const noteInput = document.getElementById('next-note-input');
+    if (noteInput) url += `&next_note=${encodeURIComponent(noteInput.value)}`;
     if (unfinishedMode) url += `&unfinished_mode=true`;
     else if (rootDeckId) url += `&root_deck_id=${rootDeckId}`;
     else if (deckId) url += `&parent_deck_id=${deckId}`;

--- a/static/index.html
+++ b/static/index.html
@@ -203,6 +203,11 @@
               <button class="r-btn r-good"  onclick="rate(3)">Good<small id="int-3"></small></button>
               <button class="r-btn r-easy"  onclick="rate(4)">Easy<small id="int-4"></small></button>
             </div>
+            <!-- Free-text note carried over to the next time this card is seen -->
+            <div class="next-note-row" id="next-note-row">
+              <textarea id="next-note-input" class="next-note-input" rows="1"
+                        placeholder="Note for next time… (optional)"></textarea>
+            </div>
             <!-- FSRS scheduler inspector trigger (Shift+S) -->
             <div class="fsrs-inspect-row">
               <button class="fsrs-inspect-btn" onclick="toggleFsrsInspector()" title="复习调度详情 / FSRS scheduler (Shift+S)">🔬 Scheduler</button>
@@ -296,6 +301,7 @@
         <button class="bs-status-item" id="bss-learning"  onclick="setBrowseStatusFilter('learning')">Learning</button>
         <button class="bs-status-item" id="bss-leech"     onclick="setBrowseStatusFilter('leech')">Leeched</button>
         <button class="bs-status-item" id="bss-reference" onclick="setBrowseStatusFilter('reference')">Reference</button>
+        <button class="bs-status-item" id="bss-saved"     onclick="setBrowseStatusFilter('saved')">★ Saved</button>
       </div>
       <div class="bs-section">
         <div class="bs-section-head">Hanzi</div>
@@ -428,8 +434,12 @@
         <input type="checkbox" id="opt-enable-fsrs" style="width:18px;height:18px;cursor:pointer" onchange="applySchedulerVisibility()">
       </div>
       <div class="opt-row">
-        <span class="opt-label">Hard = 1 day <span class="info-i" data-info="hard_1d">i</span><br><span style="font-weight:400;font-size:11px;color:var(--muted)">learning Hard returns tomorrow instead of minutes</span></span>
+        <span class="opt-label">Hard = fixed days <span class="info-i" data-info="hard_1d">i</span><br><span style="font-weight:400;font-size:11px;color:var(--muted)">learning Hard returns after N days instead of minutes</span></span>
         <input type="checkbox" id="opt-hard-1d" style="width:18px;height:18px;cursor:pointer">
+      </div>
+      <div class="opt-row">
+        <span class="opt-label">Hard delay (days) <span class="info-i" data-info="hard_days">i</span><br><span style="font-weight:400;font-size:11px;color:var(--muted)">how many days Hard delays (when enabled above)</span></span>
+        <input class="opt-input" id="opt-hard-days" type="number" min="0.1" step="0.5">
       </div>
       <div class="opt-row sched-fsrs"><span class="opt-label">Desired retention (%) <span class="info-i" data-info="desired_retention">i</span><br><span style="font-weight:400;font-size:11px;color:var(--muted)">target recall; higher = shorter intervals</span></span><input class="opt-input" id="opt-desired-retention" type="number" min="70" max="99" step="1"></div>
       <div class="opt-row sched-fsrs"><span class="opt-label">Maximum interval (days) <span class="info-i" data-info="maximum_interval">i</span><br><span style="font-weight:400;font-size:11px;color:var(--muted)">cap on how far out a review is scheduled</span></span><input class="opt-input" id="opt-max-int" type="number" min="1" step="1"></div>

--- a/static/style.css
+++ b/static/style.css
@@ -1274,10 +1274,21 @@ main.browse-open {
 .sentence-fr {
   flex: 1;
   text-align: center;
-  font-size: 14px;
+  font-size: 12px;
   color: var(--muted);
   font-style: italic;
   min-height: 18px;
+  /* De-emphasised so the eye is drawn to the Chinese, not the translation.
+     Still readable, and fully clears on hover/focus. */
+  opacity: 0.4;
+  filter: blur(1.1px);
+  letter-spacing: 0.2px;
+  transition: opacity 0.15s, filter 0.15s;
+}
+.sentence-de:hover,
+.sentence-fr:hover {
+  opacity: 0.9;
+  filter: none;
 }
 
 .char-row:last-child { border-bottom: none; }
@@ -1497,14 +1508,23 @@ main.browse-open {
 
 /* ── Creating: front input ───────────────────────────── */
 .sentence-en-front {
-  font-size: 15px;
+  font-size: 13px;
   line-height: 1.6;
   text-align: center;
-  color: var(--text);
+  color: var(--muted);
   min-height: 60px;
   display: flex;
   align-items: center;
   justify-content: center;
+  /* De-emphasised translation: present but not eye-catching, clears on hover. */
+  opacity: 0.4;
+  filter: blur(1.1px);
+  letter-spacing: 0.2px;
+  transition: opacity 0.15s, filter 0.15s;
+}
+.sentence-en-front:hover {
+  opacity: 0.9;
+  filter: none;
 }
 .creating-word-def {
   font-size: 17px;
@@ -2272,6 +2292,25 @@ main.browse-open {
   white-space: nowrap;
 }
 .bw-add-btn:hover { background: #dbeafe; }
+
+/* Saved-list per-row actions: Generate content / Add to Daily */
+.bw-saved-btn {
+  font-size: 11px;
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  border-radius: 4px;
+  padding: 2px 7px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.bw-saved-btn:hover { background: var(--bg); }
+.bw-saved-btn:disabled { opacity: 0.55; cursor: default; }
+.bw-saved-promote { border-color: var(--primary); color: var(--primary); }
+.bw-saved-promote:hover { background: #dbeafe; }
+
+/* "Save for later" button in the compound quick-add menu */
+.qa-save-btn { background: #f59e0b; margin-bottom: 6px; }
 
 /* ── Browse action bar ─────────────────────────────── */
 #browse-action-bar {
@@ -4289,3 +4328,19 @@ table.fsrs-table td.ivl { font-weight: 700; }
 }
 #info-pop-title { font-weight: 700; font-size: 13px; margin-bottom: 5px; }
 #info-pop-body  { font-size: 12px; line-height: 1.55; color: var(--muted); }
+
+/* ── "Note for next time" field under the rating buttons ─────────────────── */
+.next-note-row { margin: 10px auto 0; max-width: 520px; }
+.next-note-input {
+  width: 100%; box-sizing: border-box; resize: vertical;
+  min-height: 34px; padding: 7px 10px;
+  font: inherit; font-size: 13px; line-height: 1.4;
+  color: var(--text); background: var(--card);
+  border: 1px solid var(--border); border-radius: 8px;
+}
+.next-note-input::placeholder { color: var(--muted); }
+.next-note-input:focus { outline: none; border-color: #6366f1; }
+/* Highlight when a note was carried over from last time */
+.next-note-input.has-note {
+  border-color: #f59e0b; background: #fffbeb;
+}


### PR DESCRIPTION
## 变更内容

本 PR 打包了 Daniel 一次性提出的五项改进（两个 Issue），因为它们交织在 app.js / index.html / schema.sql 等同一批文件里，拆成多个分支会反复冲突。提交按后端 / 前端两个自洽节点组织。

### 同字词暂存区（Closes #345）
- 同字词菜单新增「★ Save for later」→ 存进固定的 Saved 牌组，建 3 张暂停卡，不调 AI、不进入学习算法
- 浏览区新增「★ Saved」状态筛选；列表每行有「✨ Generate」（AI 生成内容）和「→ Add to Daily」（移到 Daily::明天、激活为 new 卡）
- 新接口：POST /api/save-word、POST /api/saved/{word_id}/promote
- 修复 quick_add_word 的 writing→creating 类别 bug（旧值违反 CHECK 约束导致 500，这正是原功能不工作的原因）

### 复习与选项四项改进（Closes #346）
1. Hard 延迟天数可自由配置（新预设字段 learning_hard_days，选项弹窗加数字输入框）
2. 卡片「下次备注」字段（评分按钮下方文本框，下次回填、可编辑；cards 新增 next_note 列）
3. 去掉保存牌组选项时的「active story」排序确认弹窗
4. 弱化句子翻译显示（更小 / 半透明 / 轻微模糊，hover 恢复清晰）

## 数据库
- 两个新列均带迁移：deck_presets.learning_hard_days（REAL，默认 1）、cards.next_note（TEXT）
- 无破坏性变更；不需要重建数据库

## 测试方法
- Python 语法 + 导入检查已通过（DISABLE_AI=1 下 import database/srs/routes 正常）
- 手动验证：
  1. 词语分析里点同字词 → ★ Save for later → 浏览区「★ Saved」能看到该词（暂停态）
  2. 在 Saved 列表点 Generate 填充内容；点 Add to Daily 后该词从 Saved 消失、出现在明天的 Daily 牌组
  3. 选项弹窗设「Hard delay (days)」为 2，复习时学习卡 Hard 预览显示约 2d；保存不再弹确认框
  4. 复习时在评分下方写备注、评分；下次该卡出现备注回填
  5. 复习时翻译变淡变模糊，鼠标悬停后清晰

Closes #345
Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)