### PR TITLE
feat: 拼词填空目标词空格内浅色显示德语翻译提示

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -36,6 +36,41 @@ def insert_card(word_id: int, category: str, deck_id: int,
     return row["id"]
 
 
+def promote_saved_word(word_id: int, target_deck_id: int,
+                       saved_deck_id: int, due: str) -> int:
+    """Move a saved word's suspended cards out of the Saved deck into target_deck_id
+    as fresh 'new' cards due on `due`, clearing any scheduling state.
+
+    Returns the number of cards promoted.
+    """
+    conn = get_db()
+    cur = conn.execute(
+        """UPDATE cards
+           SET deck_id=?, state='new', due=?, step_index=0, interval=0,
+               ease=2.5, repetitions=0, lapses=0, stability=NULL, difficulty=NULL,
+               last_review=NULL, learning_again_count=0, is_leech=0,
+               buried_until=NULL, pre_suspend_state=NULL
+           WHERE word_id=? AND deck_id=? AND deleted_at IS NULL""",
+        (target_deck_id, due, word_id, saved_deck_id),
+    )
+    conn.commit()
+    count = cur.rowcount
+    conn.close()
+    return count
+
+
+def set_card_note(card_id: int, note: str | None) -> None:
+    """Store (or clear) the free-text 'note for next time' on a card.
+
+    Empty/blank strings are stored as NULL so the card shows no note next time.
+    """
+    note = (note or "").strip() or None
+    conn = get_db()
+    conn.execute("UPDATE cards SET next_note=? WHERE id=?", (note, card_id))
+    conn.commit()
+    conn.close()
+
+
 def move_card_to_deck(card_id: int, deck_id: int) -> bool:
     conn = get_db()
     cur = conn.execute(
@@ -131,7 +166,7 @@ def get_card(card_id: int) -> dict | None:
                   p.relearning_steps, p.minimum_interval,
                   p.leech_threshold, p.learning_leech_threshold, p.leech_action,
                   p.desired_retention, p.maximum_interval, p.fsrs_weights, p.enable_fsrs,
-                  p.learning_hard_1d,
+                  p.learning_hard_1d, p.learning_hard_days,
                   p.new_per_day, p.reviews_per_day
            FROM cards c
            JOIN entries w ON w.id = c.word_id

--- a/database/cards.py
+++ b/database/cards.py
@@ -906,44 +906,81 @@ def count_due_deduped(leaf_pairs: list[tuple[int, str]]) -> dict:
     return {"new": new_count, "learning": learning_count, "review": review_count}
 
 
-def count_unfinished() -> dict:
-    """Count learning/relearn cards due right now across all decks and categories."""
+def _unfinished_where(scope: str) -> tuple[str, list]:
+    """Build the WHERE clause + params for the unfinished virtual deck.
+
+    scope='unfinished' (default): only learning/relearn cards due right now.
+    scope='all': every card still due today (new + review + learning/relearn).
+    """
     now = datetime.now().isoformat(timespec="seconds")
-    conn = get_db()
-    learning = conn.execute(
-        """SELECT COUNT(*) FROM cards
-           WHERE state IN ('learning', 'relearn') AND due <= ?
-             AND (buried_until IS NULL OR buried_until < date('now'))""",
-        (now,),
-    ).fetchone()[0]
-    conn.close()
-    return {"new": 0, "learning": learning, "review": 0}
+    if scope == "all":
+        today = anki_today().isoformat()
+        tomorrow = (date.fromisoformat(today) + timedelta(days=1)).isoformat()
+        clause = (
+            "state != 'suspended' AND deleted_at IS NULL "
+            "AND (buried_until IS NULL OR buried_until < ?) "
+            "AND ("
+            "  (state IN ('learning', 'relearn') AND due < ?)"
+            "  OR (state = 'review' AND due <= ?)"
+            "  OR (state = 'new' AND due <= ?)"
+            ")"
+        )
+        return clause, [today, tomorrow, today, today]
+    clause = (
+        "state IN ('learning', 'relearn') AND due <= ? "
+        "AND deleted_at IS NULL "
+        "AND (buried_until IS NULL OR buried_until < date('now'))"
+    )
+    return clause, [now]
 
 
-def get_unfinished_deck_categories() -> list[dict]:
-    """Return distinct (deck_id, category) pairs that have unfinished cards due now."""
-    now = datetime.now().isoformat(timespec="seconds")
+def count_unfinished(scope: str = "unfinished") -> dict:
+    """Count cards on the unfinished virtual deck, grouped by state."""
+    clause, params = _unfinished_where(scope)
     conn = get_db()
     rows = conn.execute(
-        """SELECT DISTINCT deck_id, category FROM cards
-           WHERE state IN ('learning', 'relearn') AND due <= ?
-             AND (buried_until IS NULL OR buried_until < date('now'))""",
-        (now,),
+        f"SELECT state, COUNT(*) AS n FROM cards WHERE {clause} GROUP BY state",
+        params,
+    ).fetchall()
+    conn.close()
+    counts = {"new": 0, "learning": 0, "review": 0}
+    for r in rows:
+        if r["state"] in ("learning", "relearn"):
+            counts["learning"] += r["n"]
+        elif r["state"] == "review":
+            counts["review"] += r["n"]
+        elif r["state"] == "new":
+            counts["new"] += r["n"]
+    return counts
+
+
+def get_unfinished_deck_categories(scope: str = "unfinished") -> list[dict]:
+    """Return distinct (deck_id, category) pairs that have unfinished cards due now."""
+    clause, params = _unfinished_where(scope)
+    conn = get_db()
+    rows = conn.execute(
+        f"SELECT DISTINCT deck_id, category FROM cards WHERE {clause}",
+        params,
     ).fetchall()
     conn.close()
     return [{"deck_id": r["deck_id"], "category": r["category"]} for r in rows]
 
 
-def get_next_unfinished_card() -> dict | None:
-    """Highest-priority learning/relearn card due right now across all decks/categories."""
-    now = datetime.now().isoformat(timespec="seconds")
+def get_next_unfinished_card(scope: str = "unfinished") -> dict | None:
+    """Highest-priority card on the unfinished virtual deck.
+
+    Learning/relearn first (time-sensitive), then review, then new; each by due ASC.
+    """
+    clause, params = _unfinished_where(scope)
     conn = get_db()
     row = conn.execute(
-        """SELECT id FROM cards
-           WHERE state IN ('learning', 'relearn') AND due <= ?
-             AND (buried_until IS NULL OR buried_until < date('now'))
-           ORDER BY due ASC LIMIT 1""",
-        (now,),
+        f"""SELECT id FROM cards WHERE {clause}
+           ORDER BY CASE state
+                      WHEN 'learning' THEN 0 WHEN 'relearn' THEN 0
+                      WHEN 'review' THEN 1 ELSE 2 END,
+                    due ASC
+           LIMIT 1""",
+        params,
     ).fetchone()
     conn.close()
     return get_card(row["id"]) if row else None

--- a/database/core.py
+++ b/database/core.py
@@ -225,6 +225,8 @@ def init_db() -> None:
         conn.execute("ALTER TABLE cards ADD COLUMN difficulty REAL")
     if "last_review" not in card_cols:
         conn.execute("ALTER TABLE cards ADD COLUMN last_review TEXT")
+    if "next_note" not in card_cols:
+        conn.execute("ALTER TABLE cards ADD COLUMN next_note TEXT")
 
     # review_log: per-review timing + card state at review time (for calendar heatmap stats)
     rl_cols = {r["name"] for r in conn.execute("PRAGMA table_info(review_log)").fetchall()}
@@ -283,6 +285,8 @@ def init_db() -> None:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN enable_fsrs INTEGER NOT NULL DEFAULT 1")
     if "learning_hard_1d" not in preset_cols:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN learning_hard_1d INTEGER NOT NULL DEFAULT 1")
+    if "learning_hard_days" not in preset_cols:
+        conn.execute("ALTER TABLE deck_presets ADD COLUMN learning_hard_days REAL NOT NULL DEFAULT 1")
 
     conn.execute("""CREATE TABLE IF NOT EXISTS preset_category_overrides (
         id                  INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/database/decks.py
+++ b/database/decks.py
@@ -263,6 +263,12 @@ def get_or_create_deck_path(path: str) -> int:
     return parent_id
 
 
+def get_or_create_saved_deck() -> int:
+    """The fixed 'Saved' staging deck: holds suspended compound words the user
+    set aside for later (see /api/save-word). Promoting moves them to a Daily deck."""
+    return get_or_create_deck_path("Saved")
+
+
 def get_word_deck_names(word_id: int) -> list[str]:
     """Return the unique deck names (leaf only) where cards for this word live."""
     conn = get_db()

--- a/database/presets.py
+++ b/database/presets.py
@@ -27,6 +27,7 @@ def default_preset() -> dict:
         "fsrs_weights": None,
         "enable_fsrs": 1,
         "learning_hard_1d": 1,
+        "learning_hard_days": 1,
         "new_gather_order": "ascending_position",
         "new_sort_order": "card_type_gathered",
         "new_review_order": "mixed",
@@ -205,6 +206,7 @@ def insert_preset(preset: dict) -> int:
     preset.setdefault("fsrs_weights", None)
     preset.setdefault("enable_fsrs", 1)
     preset.setdefault("learning_hard_1d", 1)
+    preset.setdefault("learning_hard_days", 1)
     conn = get_db()
     cur = conn.execute(
         """INSERT INTO deck_presets
@@ -212,7 +214,7 @@ def insert_preset(preset: dict) -> int:
             learning_steps, graduating_interval, easy_interval,
             relearning_steps, minimum_interval, insertion_order,
             bury_siblings, randomize_story_order, leech_threshold, learning_leech_threshold, leech_action,
-            desired_retention, maximum_interval, fsrs_weights, enable_fsrs, learning_hard_1d,
+            desired_retention, maximum_interval, fsrs_weights, enable_fsrs, learning_hard_1d, learning_hard_days,
             new_gather_order, new_sort_order, new_review_order,
             interday_learning_review_order, review_sort_order,
             bury_new_siblings, bury_review_siblings, bury_interday_siblings,
@@ -221,7 +223,7 @@ def insert_preset(preset: dict) -> int:
                    :learning_steps, :graduating_interval, :easy_interval,
                    :relearning_steps, :minimum_interval, :insertion_order,
                    :bury_siblings, :randomize_story_order, :leech_threshold, :learning_leech_threshold, :leech_action,
-                   :desired_retention, :maximum_interval, :fsrs_weights, :enable_fsrs, :learning_hard_1d,
+                   :desired_retention, :maximum_interval, :fsrs_weights, :enable_fsrs, :learning_hard_1d, :learning_hard_days,
                    :new_gather_order, :new_sort_order, :new_review_order,
                    :interday_learning_review_order, :review_sort_order,
                    :bury_new_siblings, :bury_review_siblings, :bury_interday_siblings,
@@ -240,7 +242,7 @@ def update_preset(preset_id: int, fields: dict) -> None:
         "learning_steps", "graduating_interval", "easy_interval",
         "relearning_steps", "minimum_interval", "insertion_order",
         "bury_siblings", "randomize_story_order", "leech_threshold", "learning_leech_threshold", "leech_action",
-        "desired_retention", "maximum_interval", "fsrs_weights", "enable_fsrs", "learning_hard_1d",
+        "desired_retention", "maximum_interval", "fsrs_weights", "enable_fsrs", "learning_hard_1d", "learning_hard_days",
         "new_gather_order", "new_sort_order", "new_review_order",
         "interday_learning_review_order", "review_sort_order",
         "bury_new_siblings", "bury_review_siblings", "bury_interday_siblings",

--- a/routes/decks.py
+++ b/routes/decks.py
@@ -72,7 +72,7 @@ def _attach_counts(flat_decks: list) -> None:
 # ---------------------------------------------------------------------------
 
 @router.get("/api/decks")
-def get_decks():
+def get_decks(unfinished_scope: str = "unfinished"):
     tree = database.get_deck_tree()
     flat = _flatten(tree)
     _attach_counts(flat)
@@ -84,8 +84,8 @@ def get_decks():
         deck["bury_mode"] = deck.get("bury_quick_mode", "all")
         deck["new_review_order_override"] = deck.get("new_review_order_override")
         deck["category_order"] = p.get("category_order", "listening,reading,creating")
-    unfinished = database.count_unfinished()
-    if unfinished["learning"] > 0:
+    unfinished = database.count_unfinished(unfinished_scope)
+    if sum(unfinished.values()) > 0:
         tree.insert(0, {
             "id": "unfinished",
             "name": "Unfinished Cards",

--- a/routes/imports.py
+++ b/routes/imports.py
@@ -217,7 +217,72 @@ def quick_add_word(body: dict):
         entry_id = database.insert_word(word_data)
         status = "created"
 
-    for category in ("listening", "reading", "writing"):
+    for category in ("listening", "reading", "creating"):
         database.insert_card(entry_id, category, deck_id, state="new", due=tomorrow)
 
     return {"status": status, "entry_id": entry_id, "deck_path": deck_path, "deck_id": deck_id}
+
+
+@router.post("/api/save-word")
+def save_word(body: dict):
+    """Stage a compound word in the fixed 'Saved' deck as suspended cards.
+
+    Unlike /api/quick-add-word this does NOT call the AI and does NOT activate
+    the cards — content is generated later on demand, and the word only enters
+    the study algorithm when promoted to a Daily deck (see /api/saved/{id}/promote).
+
+    Body: { word_zh, pinyin?, meaning? }
+    Returns: { status: "saved"|"already_saved"|"exists_elsewhere", entry_id, saved_deck_id }
+    """
+    word_zh = (body.get("word_zh") or "").strip()
+    if not word_zh:
+        raise HTTPException(status_code=400, detail="word_zh is required")
+
+    pinyin = (body.get("pinyin") or "").strip()
+    meaning = (body.get("meaning") or "").strip()
+
+    saved_deck_id = database.get_or_create_saved_deck()
+
+    existing = database.get_word_by_zh(word_zh)
+    if existing:
+        entry_id = existing["id"]
+        conn = database.get_db()
+        deck_ids = {
+            r["deck_id"] for r in conn.execute(
+                "SELECT deck_id FROM cards WHERE word_id=? AND deleted_at IS NULL",
+                (entry_id,),
+            ).fetchall()
+        }
+        conn.close()
+        if saved_deck_id in deck_ids:
+            return {"status": "already_saved", "entry_id": entry_id, "saved_deck_id": saved_deck_id}
+        if deck_ids:
+            # Word already lives in a real deck — nothing to stage.
+            return {"status": "exists_elsewhere", "entry_id": entry_id, "saved_deck_id": saved_deck_id}
+    else:
+        entry_id = database.insert_word({
+            "word_zh": word_zh,
+            "pinyin": pinyin,
+            "definition": meaning,
+            "note_type": "vocabulary",
+        })
+
+    for category in ("listening", "reading", "creating"):
+        database.insert_card(entry_id, category, saved_deck_id, state="suspended")
+
+    return {"status": "saved", "entry_id": entry_id, "saved_deck_id": saved_deck_id}
+
+
+@router.post("/api/saved/{word_id}/promote")
+def promote_saved(word_id: int):
+    """Move a saved word's suspended cards into tomorrow's Daily deck as active new cards."""
+    saved_deck_id = database.get_or_create_saved_deck()
+    tomorrow = (date.today() + timedelta(days=1)).isoformat()
+    deck_path = f"Daily::{tomorrow}"
+    daily_deck_id = database.get_or_create_deck_path(deck_path)
+
+    count = database.promote_saved_word(word_id, daily_deck_id, saved_deck_id, tomorrow)
+    if not count:
+        raise HTTPException(status_code=404, detail="No saved cards found for this word")
+
+    return {"status": "promoted", "count": count, "deck_path": deck_path, "deck_id": daily_deck_id}

--- a/routes/review.py
+++ b/routes/review.py
@@ -76,17 +76,17 @@ def get_today(deck_id: int, category: str):
 
 
 @router.get("/api/today-unfinished")
-def get_today_unfinished():
-    card = database.get_next_unfinished_card()
+def get_today_unfinished(scope: str = "unfinished"):
+    card = database.get_next_unfinished_card(scope)
     if card:
         card["intervals"] = srs.preview_intervals(card)
         card["fsrs"] = srs.explain_card(card)
-    return {"card": card, "counts": database.count_unfinished()}
+    return {"card": card, "counts": database.count_unfinished(scope)}
 
 
 @router.get("/api/today-unfinished-decks")
-def get_today_unfinished_decks():
-    return database.get_unfinished_deck_categories()
+def get_today_unfinished_decks(scope: str = "unfinished"):
+    return database.get_unfinished_deck_categories(scope)
 
 
 @router.get("/api/today-mixed/{deck_id}")
@@ -102,7 +102,7 @@ def get_today_mixed(deck_id: int):
 def submit_review(card_id: int, rating: int, user_response: str | None = None,
                   root_deck_id: int | None = None, unfinished_mode: bool = False,
                   parent_deck_id: int | None = None, duration_ms: int | None = None,
-                  next_note: str | None = None):
+                  next_note: str | None = None, unfinished_scope: str = "unfinished"):
     card_before = database.get_card(card_id)
     # Persist the free-text "note for next time" the user left on this card
     # (None means "leave the existing note untouched"; "" clears it).
@@ -198,17 +198,18 @@ def submit_review(card_id: int, rating: int, user_response: str | None = None,
         "root_deck_id":       root_deck_id,
         "parent_deck_id":     parent_deck_id,
         "unfinished_mode":    unfinished_mode,
+        "unfinished_scope":   unfinished_scope,
         "deck_id":            deck_id,
         "category":           cat,
         "siblings_snapshot":  siblings_snapshot,
     })
 
     if unfinished_mode:
-        next_card = database.get_next_unfinished_card()
+        next_card = database.get_next_unfinished_card(unfinished_scope)
         if next_card:
             next_card["intervals"] = srs.preview_intervals(next_card)
             next_card["fsrs"] = srs.explain_card(next_card)
-        counts = database.count_unfinished()
+        counts = database.count_unfinished(unfinished_scope)
     elif root_deck_id:
         _queue_mgr.after_review(queue_key, card_id, updated, newly_buried)
         next_card = _next_card_from_queue(queue_key, build_fn)
@@ -308,7 +309,7 @@ def undo_review():
     parent_deck_id  = entry.get("parent_deck_id")
 
     if unfinished_mode:
-        counts = database.count_unfinished()
+        counts = database.count_unfinished(entry.get("unfinished_scope", "unfinished"))
     elif root_deck_id:
         counts = database.count_due_any_cat(root_deck_id)
     elif parent_deck_id:

--- a/routes/review.py
+++ b/routes/review.py
@@ -101,8 +101,13 @@ def get_today_mixed(deck_id: int):
 @router.post("/api/review")
 def submit_review(card_id: int, rating: int, user_response: str | None = None,
                   root_deck_id: int | None = None, unfinished_mode: bool = False,
-                  parent_deck_id: int | None = None, duration_ms: int | None = None):
+                  parent_deck_id: int | None = None, duration_ms: int | None = None,
+                  next_note: str | None = None):
     card_before = database.get_card(card_id)
+    # Persist the free-text "note for next time" the user left on this card
+    # (None means "leave the existing note untouched"; "" clears it).
+    if next_note is not None:
+        database.set_card_note(card_id, next_note)
     updated, log_id = srs.apply_review(card_id, rating, user_response=user_response,
                                        duration_ms=duration_ms)
     deck_id = updated["deck_id"]

--- a/routes/story.py
+++ b/routes/story.py
@@ -163,7 +163,8 @@ def get_story(deck_id: int, category: str,
               model: str | None = None,
               grammar_focus: str | None = None, grammar_pct: int = 75,
               mode: str = "story",
-              chapter_ids: str | None = None):
+              chapter_ids: str | None = None,
+              no_generate: bool = False):
     if database.is_sentences_deck(deck_id):
         return None
 
@@ -176,6 +177,12 @@ def get_story(deck_id: int, category: str,
                     deck_id, category, len(story["sentences"]), story["id"])
         _log_story(story)
         return story
+
+    # Caller only wants an already-generated story (e.g. "use existing" mode):
+    # no cached story → return nothing instead of generating a new one.
+    if no_generate:
+        logger.info("story  NO-GEN (no_generate=1) deck=%d cat=%s — no cached story", deck_id, category)
+        return None
 
     if DISABLE_AI:
         logger.info("story  DISABLED (DISABLE_AI=1) deck=%d cat=%s", deck_id, category)

--- a/schema.sql
+++ b/schema.sql
@@ -35,9 +35,13 @@ CREATE TABLE IF NOT EXISTS deck_presets (
     maximum_interval        INTEGER NOT NULL DEFAULT 36500,
     fsrs_weights            TEXT,
     enable_fsrs             INTEGER NOT NULL DEFAULT 1,
-    -- When 1, a single-step learning/relearn card's "Hard" schedules ~1 day
-    -- instead of step×1.5, so a half-remembered card returns tomorrow.
+    -- When 1, a single-step learning/relearn card's "Hard" schedules
+    -- learning_hard_days (default 1 day) instead of step×1.5, so a
+    -- half-remembered card returns after that many days.
     learning_hard_1d        INTEGER NOT NULL DEFAULT 1,
+    -- How many days "Hard" delays a learning/relearn card when learning_hard_1d
+    -- is on. Fractional allowed (e.g. 0.5 = half a day).
+    learning_hard_days      REAL NOT NULL DEFAULT 1,
 
     -- New card insertion order (legacy; superseded by new_gather_order)
     insertion_order         TEXT NOT NULL DEFAULT 'sequential'
@@ -285,6 +289,9 @@ CREATE TABLE IF NOT EXISTS cards (
 
     -- saved before suspension so it can be restored on unsuspend
     pre_suspend_state TEXT,
+
+    -- free-text note the user leaves for the next time this card comes up
+    next_note TEXT,
 
     UNIQUE(word_id, category)
 );

--- a/srs.py
+++ b/srs.py
@@ -373,6 +373,7 @@ def apply_review(card_id: int, rating: int,
         "fsrs_weights":        card.get("fsrs_weights"),
         "enable_fsrs":         card.get("enable_fsrs", 1),
         "learning_hard_1d":    card.get("learning_hard_1d", 1),
+        "learning_hard_days":  card.get("learning_hard_days", 1),
     }
 
     if card["state"] in ("new", "learning"):

--- a/srs.py
+++ b/srs.py
@@ -35,6 +35,19 @@ def _hard_1d_enabled(card: dict) -> bool:
     return bool(val) if val is not None else True
 
 
+def _hard_minutes(card: dict) -> int:
+    """Minutes that "Hard" delays a learning/relearn card when learning_hard_1d
+    is on — learning_hard_days (default 1 day), fractional days allowed."""
+    days = card.get("learning_hard_days", 1)
+    if days is None:
+        days = 1
+    try:
+        days = float(days)
+    except (TypeError, ValueError):
+        days = 1.0
+    return max(1, round(days * 1440))
+
+
 def _elapsed_days(card: dict) -> int:
     """Days since the previous review, for computing retrievability.
 
@@ -103,7 +116,7 @@ def preview_intervals(card: dict) -> dict:
         si = min(step_index, len(l_steps) - 1)
         again = _fmt_min(l_steps[0])
         if _hard_1d_enabled(card):
-            hard = _fmt_min(LEARNING_HARD_SINGLE_STEP_MINUTES)
+            hard = _fmt_min(_hard_minutes(card))
         elif si == 0 and len(l_steps) > 1:
             hard = _fmt_min((l_steps[0] + l_steps[1]) / 2)
         elif len(l_steps) == 1:
@@ -136,7 +149,7 @@ def preview_intervals(card: dict) -> dict:
         si = min(step_index, len(r_steps) - 1)
         again = _fmt_min(r_steps[0])
         if _hard_1d_enabled(card):
-            hard = _fmt_min(LEARNING_HARD_SINGLE_STEP_MINUTES)
+            hard = _fmt_min(_hard_minutes(card))
         elif si == 0 and len(r_steps) > 1:
             hard = _fmt_min((r_steps[0] + r_steps[1]) / 2)
         elif len(r_steps) == 1:
@@ -434,7 +447,7 @@ def _handle_learning(card: dict, preset: dict, rating: int) -> dict:
         c["state"] = "learning"
         idx = c["step_index"]
         if _hard_1d_enabled(preset):
-            delay = LEARNING_HARD_SINGLE_STEP_MINUTES
+            delay = _hard_minutes(preset)
         elif idx == 0 and len(steps) > 1:
             delay = (steps[0] + steps[1]) / 2
         elif len(steps) == 1:
@@ -538,7 +551,7 @@ def _handle_relearn(card: dict, preset: dict, rating: int) -> dict:
         c["state"] = "relearn"
         idx = c["step_index"]
         if _hard_1d_enabled(preset):
-            delay = LEARNING_HARD_SINGLE_STEP_MINUTES
+            delay = _hard_minutes(preset)
         elif idx == 0 and len(steps) > 1:
             delay = (steps[0] + steps[1]) / 2
         elif len(steps) == 1:

--- a/static/app.js
+++ b/static/app.js
@@ -1445,7 +1445,7 @@ async function openQuickAddCard() {
 let _browseSearchTimer = null;
 let _browseMode       = 'notes';   // 'notes' | 'hanzi'
 let _browseFilter     = 'all';     // note_type or 'all'; for hanzi mode: 'all'
-let _browseCardStatus = 'all';     // 'all' | 'learning' | 'reference'
+let _browseCardStatus = 'all';     // 'all' | 'learning' | 'leech' | 'reference' | 'saved'
 let _browseDeckId     = null;      // deck filter (notes mode only)
 let _allHanzi         = [];        // cache
 
@@ -1494,6 +1494,7 @@ function _filteredBrowseWords() {
   if (_browseCardStatus === 'learning')   words = words.filter(w => w.cards.length > 0);
   if (_browseCardStatus === 'leech')      words = words.filter(w => w.cards.some(c => c.is_leech));
   if (_browseCardStatus === 'reference')  words = words.filter(w => w.cards.length === 0);
+  if (_browseCardStatus === 'saved')      words = words.filter(w => w.cards.some(c => c.deck_name === 'Saved'));
   return words;
 }
 
@@ -1662,7 +1663,11 @@ function _wordRow(w) {
   const def = (w.definition || '').slice(0, 60) + ((w.definition || '').length > 60 ? '…' : '');
   const sel = _browseSelected.has(w.id) ? ' bw-row-selected' : '';
   let rightHtml;
-  if (w.cards.length === 0) {
+  if (_browseCardStatus === 'saved') {
+    rightHtml =
+      `<button class="bw-saved-btn" onclick="event.stopPropagation();savedGenerate(${w.id},this)" title="Generate content with AI">✨ Generate</button>` +
+      `<button class="bw-saved-btn bw-saved-promote" onclick="event.stopPropagation();savedPromote(${w.id},this)" title="Add to tomorrow's Daily deck">→ Add to Daily</button>`;
+  } else if (w.cards.length === 0) {
     rightHtml = `<button class="bw-add-btn" onclick="openAddToDeckModal(event,${w.id})" title="添加到牌组">＋ 添加</button>`;
   } else {
     const CAT_LETTER = { listening: 'L', reading: 'R', creating: 'C' };
@@ -1687,6 +1692,38 @@ function _wordRow(w) {
       </div>
       <div class="bw-right">${rightHtml}</div>
     </div>`;
+}
+
+// Generate AI content for a saved word (stays in the Saved list, now filled in).
+async function savedGenerate(wordId, btn) {
+  btn.disabled = true;
+  const orig = btn.textContent;
+  btn.textContent = '…';
+  try {
+    await api('POST', `/api/word/${wordId}/ai-enrich`);
+    await _browseReload();
+    showQuickAddBanner('✨ Content generated', false);
+  } catch (e) {
+    btn.disabled = false;
+    btn.textContent = orig;
+    showError('Generate failed: ' + e.message);
+  }
+}
+
+// Promote a saved word into tomorrow's Daily deck (leaves the Saved list).
+async function savedPromote(wordId, btn) {
+  btn.disabled = true;
+  const orig = btn.textContent;
+  btn.textContent = '…';
+  try {
+    const r = await api('POST', `/api/saved/${wordId}/promote`);
+    await _browseReload();
+    showQuickAddBanner(`→ Added to ${r.deck_path}`, false);
+  } catch (e) {
+    btn.disabled = false;
+    btn.textContent = orig;
+    showError('Add to Daily failed: ' + e.message);
+  }
 }
 
 function onBrowseRowClick(e, wordId) {
@@ -2476,8 +2513,10 @@ function applySchedulerVisibility() {
 const INFO_TEXT = {
   enable_fsrs: ['Enable FSRS',
     'FSRS is a modern scheduler that models each card with Stability and Difficulty to predict the best review time. Turn it off to fall back to the legacy SM-2 (ease-factor) algorithm. Switching hides the fields that don\'t apply to the chosen scheduler.'],
-  hard_1d: ['Hard = 1 day',
-    'While a card is still in learning or relearning, pressing Hard sends it to tomorrow (1 day) instead of repeating in a few minutes. Applies to both schedulers.'],
+  hard_1d: ['Hard = fixed days',
+    'While a card is still in learning or relearning, pressing Hard sends it forward by a fixed number of days (set below) instead of repeating in a few minutes. Applies to both schedulers.'],
+  hard_days: ['Hard delay (days)',
+    'How many days Hard pushes a learning/relearning card forward when "Hard = fixed days" is enabled. Fractional values allowed (e.g. 0.5 = half a day).'],
   learning_steps: ['Learning steps',
     'The sub-day intervals (in minutes) a new card steps through before it graduates to review. Example: "10m" means one 10-minute step. Used by both schedulers.'],
   graduating_interval: ['Graduating interval (SM-2 only)',
@@ -2547,6 +2586,7 @@ function loadPresetFields(preset) {
   document.getElementById('opt-sibling-factor').value  = preset.sibling_factor ?? 0.2;
   document.getElementById('opt-enable-fsrs').checked   = preset.enable_fsrs == null ? true : !!preset.enable_fsrs;
   document.getElementById('opt-hard-1d').checked       = preset.learning_hard_1d == null ? true : !!preset.learning_hard_1d;
+  document.getElementById('opt-hard-days').value       = preset.learning_hard_days == null ? 1 : preset.learning_hard_days;
   document.getElementById('opt-desired-retention').value = Math.round((preset.desired_retention ?? 0.9) * 100);
   document.getElementById('opt-max-int').value         = preset.maximum_interval ?? 36500;
   applySchedulerVisibility();
@@ -2713,15 +2753,11 @@ async function saveOptions() {
     sibling_factor:         parseFloat(document.getElementById('opt-sibling-factor').value) || 0.2,
     enable_fsrs:            document.getElementById('opt-enable-fsrs').checked ? 1 : 0,
     learning_hard_1d:       document.getElementById('opt-hard-1d').checked ? 1 : 0,
+    learning_hard_days:     Math.max(0.1, parseFloat(document.getElementById('opt-hard-days').value) || 1),
     desired_retention:      Math.min(0.99, Math.max(0.70, (parseInt(document.getElementById('opt-desired-retention').value) || 90) / 100)),
     maximum_interval:       Math.max(1, parseInt(document.getElementById('opt-max-int').value) || 36500),
     category_order: _getCategoryOrderUI(),
   };
-  // Warn if a story for today already exists — order settings change would cause mismatch
-  if (story !== null) {
-    const ok = confirm('You have an active story. Changing sort settings will affect card order and may no longer match the story. Continue?');
-    if (!ok) return;
-  }
   try {
     const [savedPreset] = await Promise.all([
       api('PUT', `/api/decks/${optDeckId}/preset`, fields),
@@ -3076,6 +3112,13 @@ function loadCard(c, counts) {
   [1, 2, 3, 4].forEach(r => {
     document.getElementById(`int-${r}`).textContent = iv[r] || '';
   });
+
+  // Pre-fill the "note for next time" left on this card last time (if any)
+  const noteInput = document.getElementById('next-note-input');
+  if (noteInput) {
+    noteInput.value = card.next_note || '';
+    noteInput.classList.toggle('has-note', !!(card.next_note || '').trim());
+  }
 
   // Find sentence for this card's word in the story.
   // If no match, leave sentence null — renderSentence() will show just the word.
@@ -4206,13 +4249,17 @@ function openQuickAddMenu(event, wordZh, pinyin, meaning) {
   const menu = document.createElement('div');
   menu.id = 'quick-add-menu';
   menu.className = 'quick-add-menu';
+  const wEsc = wordZh.replace(/'/g, "\\'");
+  const pEsc = pinyin.replace(/'/g, "\\'");
+  const mEsc = meaning.replace(/'/g, "\\'");
   menu.innerHTML =
     `<div class="qa-word">${wordZh}` +
       (pinyin ? ` <span class="qa-pin">${pinyin}</span>` : '') +
     `</div>` +
     (meaning ? `<div class="qa-meaning">${meaning}</div>` : '') +
-    `<div class="qa-deck-label">daily::${tomorrowStr}</div>` +
-    `<button class="qa-add-btn" onclick="doQuickAdd('${wordZh.replace(/'/g,"\\'")}','${pinyin.replace(/'/g,"\\'")}','${meaning.replace(/'/g,"\\'")}',this)">+ Add to Daily deck</button>`;
+    `<button class="qa-add-btn qa-save-btn" onclick="doSaveWord('${wEsc}','${pEsc}','${mEsc}',this)">★ Save for later</button>` +
+    `<div class="qa-deck-label">or add now to daily::${tomorrowStr}</div>` +
+    `<button class="qa-add-btn" onclick="doQuickAdd('${wEsc}','${pEsc}','${mEsc}',this)">+ Add to Daily deck</button>`;
 
   document.body.appendChild(menu);
   _quickAddMenu = menu;
@@ -4231,6 +4278,25 @@ function closeQuickAddMenu() {
   if (_quickAddMenu) {
     _quickAddMenu.remove();
     _quickAddMenu = null;
+  }
+}
+
+async function doSaveWord(wordZh, pinyin, meaning, btn) {
+  btn.disabled = true;
+  btn.textContent = '…';
+  try {
+    const result = await api('POST', '/api/save-word', { word_zh: wordZh, pinyin, meaning });
+    closeQuickAddMenu();
+    const msgs = {
+      saved:            `★ "${wordZh}" saved for later`,
+      already_saved:    `"${wordZh}" is already saved`,
+      exists_elsewhere: `"${wordZh}" is already in a deck`,
+    };
+    showQuickAddBanner(msgs[result.status] || '★ Saved', result.status !== 'saved');
+  } catch (e) {
+    btn.disabled = false;
+    btn.textContent = '★ Save for later';
+    showError(e.message || 'Failed to save word');
   }
 }
 
@@ -4767,6 +4833,8 @@ async function rate(rating) {
   try {
     let url = `/api/review?card_id=${card.id}&rating=${rating}`;
     if (_cardMs != null) url += `&duration_ms=${_cardMs}`;
+    const noteInput = document.getElementById('next-note-input');
+    if (noteInput) url += `&next_note=${encodeURIComponent(noteInput.value)}`;
     if (unfinishedMode) url += `&unfinished_mode=true`;
     else if (rootDeckId) url += `&root_deck_id=${rootDeckId}`;
     else if (deckId) url += `&parent_deck_id=${deckId}`;

--- a/static/app.js
+++ b/static/app.js
@@ -3535,17 +3535,16 @@ function revealAnswer() {
   // Sentence notes have no story — hide story button; show German/French translation
   const _sentFrEl = document.getElementById('sentence-fr');
   const _sentDeEl = document.getElementById('sentence-de');
+  // Fill in the translation text but keep it hidden by default — press u to toggle.
   if (isSentenceNote) {
     _sentFrEl.textContent = '';
-    _sentFrEl.style.display = 'none';
     _sentDeEl.textContent = card.definition || '';
-    _sentDeEl.style.display = card.definition ? '' : 'none';
   } else {
     _sentFrEl.textContent = sentence?.sentence_fr || '';
-    _sentFrEl.style.display = sentence?.sentence_fr ? '' : 'none';
     _sentDeEl.textContent = sentence?.sentence_de || '';
-    _sentDeEl.style.display = sentence?.sentence_de ? '' : 'none';
   }
+  _sentFrEl.style.display = 'none';
+  _sentDeEl.style.display = 'none';
 
   // Kahneman concept box (compact: part + chapter title only) + reasoning light bulb
   const _conceptRow = document.getElementById('sentence-concept-row');
@@ -4961,6 +4960,19 @@ async function togglePinyin() {
   if (!text) return;
   await _loadPinyinRow(text);
   row.classList.toggle('pinyin-revealed');
+}
+
+// ── Translation toggle (German/French sentence translation) ───────────────────
+// Hidden by default to save space; press u to show/hide. Only elements that
+// actually have text participate, and they toggle together as one group.
+function toggleTranslation() {
+  const fr = document.getElementById('sentence-fr');
+  const de = document.getElementById('sentence-de');
+  const anyVisible = (fr.textContent && fr.style.display !== 'none') ||
+                     (de.textContent && de.style.display !== 'none');
+  const show = !anyVisible;
+  fr.style.display = (show && fr.textContent) ? '' : 'none';
+  de.style.display = (show && de.textContent) ? '' : 'none';
 }
 
 // ── Story error modal ─────────────────────────────────────────────────────────
@@ -7072,8 +7084,10 @@ document.addEventListener('keydown', async e => {
       e.preventDefault(); location.reload();
     } else if (e.key === 'r') {
       e.preventDefault(); playSentence();
-    } else if (e.key === 't') {
+    } else if (e.key === 'p') {
       e.preventDefault(); togglePinyin();
+    } else if (e.key === 'u') {
+      e.preventDefault(); toggleTranslation();
     } else if (e.key === ' ') {
       e.preventDefault(); if (!backVisible) revealAnswer();
     } else if (['1','2','3','4'].includes(e.key) && backVisible) {

--- a/static/app.js
+++ b/static/app.js
@@ -36,6 +36,9 @@ function renderMarkdown(text) {
 let deckId      = null;
 let rootDeckId      = null;   // set when studying all categories (mixed mode)
 let unfinishedMode  = false;  // set when studying the "Unfinished Cards" virtual deck
+// Unfinished-deck options. Scope persists; story mode is re-chosen each session.
+let _unfinishedScope     = localStorage.getItem('unfinishedScope') || 'unfinished'; // 'unfinished' | 'all'
+let _unfinishedStoryMode = localStorage.getItem('unfinishedStoryMode') || 'existing'; // 'existing' | 'new'
 let quickMode       = false;  // set when reviewing without AI story generation
 let deckName    = '';
 let category    = '';
@@ -887,7 +890,7 @@ async function loadDecks() {
   setLoading('Loading decks…');
   try {
     const [decks, retention] = await Promise.all([
-      api('GET', '/api/decks'),
+      api('GET', `/api/decks?unfinished_scope=${_unfinishedScope}`),
       api('GET', '/api/retention?days=0').catch(() => null),
     ]);
     _cachedDecks = decks;
@@ -1137,10 +1140,11 @@ function renderDecks(decks) {
   for (const vd of virtualDecks) {
     if (vd.id === 'unfinished') {
       const c = vd.counts;
+      const total = (c.new || 0) + (c.learning || 0) + (c.review || 0);
       filteredHtml += `
-        <div class="filtered-row unfinished-entry" onclick="startReviewUnfinished()">
+        <div class="filtered-row unfinished-entry" onclick="openUnfinishedModal()">
           <span class="filtered-name">${vd.name}</span>
-          <span class="filtered-count">${c.learning}</span>
+          <span class="filtered-count">${total}</span>
         </div>`;
     }
   }
@@ -3015,6 +3019,29 @@ async function _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPc
   }
 }
 
+// ── Unfinished-deck start modal (scope + story choice) ───────────────────────
+function openUnfinishedModal() {
+  // Pre-select the persisted scope and last story mode
+  document.querySelector(`input[name="unf-scope"][value="${_unfinishedScope}"]`).checked = true;
+  document.querySelector(`input[name="unf-story"][value="${_unfinishedStoryMode}"]`).checked = true;
+  document.getElementById('unfinished-modal-overlay').style.display = 'block';
+  document.getElementById('unfinished-modal').style.display = 'flex';
+}
+
+function closeUnfinishedModal() {
+  document.getElementById('unfinished-modal-overlay').style.display = 'none';
+  document.getElementById('unfinished-modal').style.display = 'none';
+}
+
+function confirmUnfinishedStart() {
+  _unfinishedScope     = document.querySelector('input[name="unf-scope"]:checked')?.value || 'unfinished';
+  _unfinishedStoryMode = document.querySelector('input[name="unf-story"]:checked')?.value || 'existing';
+  localStorage.setItem('unfinishedScope', _unfinishedScope);
+  localStorage.setItem('unfinishedStoryMode', _unfinishedStoryMode);
+  closeUnfinishedModal();
+  startReviewUnfinished();
+}
+
 // ── Start "Unfinished Cards" review session ───────────────────────────────────
 async function startReviewUnfinished() {
   deckName = 'Unfinished Cards';
@@ -3024,7 +3051,7 @@ async function startReviewUnfinished() {
   _sessionRatedCount = 0;
   _updateAvgTimeBadge();
   try {
-    const counts = await api('GET', '/api/today-unfinished');
+    const counts = await api('GET', `/api/today-unfinished?scope=${_unfinishedScope}`);
     if (!counts.card) {
       showView('done');
       return;
@@ -3039,10 +3066,12 @@ async function startReviewUnfinished() {
 async function _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', chapterIds = null) {
   unfinishedMode = true;
   setLoading('Loading cards…');
+  // In "existing" story mode, never trigger generation — fetch cached stories only.
+  const noGen = _unfinishedStoryMode === 'existing';
   try {
     const [combos, todayData] = await Promise.all([
-      api('GET', '/api/today-unfinished-decks'),
-      api('GET', '/api/today-unfinished'),
+      api('GET', `/api/today-unfinished-decks?scope=${_unfinishedScope}`),
+      api('GET', `/api/today-unfinished?scope=${_unfinishedScope}`),
     ]);
     if (!todayData.card) {
       unfinishedMode = false;
@@ -3051,11 +3080,13 @@ async function _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, gram
     }
     category = todayData.card.category;
     const firstDeckId = todayData.card.deck_id;
-    // Load a single unified story for the first card's deck
+    // Load the first card's deck story (generate only when story mode = "new")
     try {
-      story = await api('GET', `/api/story/${firstDeckId}/unified` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds));
+      let url = `/api/story/${firstDeckId}/unified` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds);
+      if (noGen) url += (url.includes('?') ? '&' : '?') + 'no_generate=true';
+      story = await api('GET', url);
     } catch (_) {}
-    fetch(`/api/preload-session/${firstDeckId}/unified`, { method: 'POST' }).catch(() => {});
+    if (!noGen) fetch(`/api/preload-session/${firstDeckId}/unified`, { method: 'POST' }).catch(() => {});
     showView('review');
     loadCard(todayData.card, todayData.counts);
   } catch (e) {
@@ -3154,11 +3185,14 @@ function loadCard(c, counts) {
         if (inp.style.display !== 'none') inp.textContent = sentence.sentence_de || sentence.sentence_fr || '';
       }
     };
-    fetch(`/api/story/${storyDeckId}/unified`)
+    // In unfinished "existing story" mode, only fetch a cached story (never generate).
+    const unfNoGen = unfinishedMode && _unfinishedStoryMode === 'existing';
+    const storyUrl = `/api/story/${storyDeckId}/unified` + (unfNoGen ? '?no_generate=true' : '');
+    fetch(storyUrl)
       .then(r => r.ok ? r.json() : null)
       .then(s => {
         if (card !== snap) return;
-        fetch(`/api/preload-session/${storyDeckId}/unified`, { method: 'POST' }).catch(() => {});
+        if (!unfNoGen) fetch(`/api/preload-session/${storyDeckId}/unified`, { method: 'POST' }).catch(() => {});
         if (s?.sentences) {
           story    = s;
           sentence = story.sentences.find(s => s.word_ids?.includes(card.word_id)) || null;
@@ -4849,7 +4883,7 @@ async function rate(rating) {
     if (_cardMs != null) url += `&duration_ms=${_cardMs}`;
     const noteInput = document.getElementById('next-note-input');
     if (noteInput) url += `&next_note=${encodeURIComponent(noteInput.value)}`;
-    if (unfinishedMode) url += `&unfinished_mode=true`;
+    if (unfinishedMode) url += `&unfinished_mode=true&unfinished_scope=${_unfinishedScope}`;
     else if (rootDeckId) url += `&root_deck_id=${rootDeckId}`;
     else if (deckId) url += `&parent_deck_id=${deckId}`;
     const reviewedId = card.id;
@@ -5494,7 +5528,7 @@ async function reviewCardAction(action) {
     if (action === 'leech') showStateChangeAnim({ to: 'suspended' });
     let nextData;
     if (unfinishedMode) {
-      nextData = await api('GET', '/api/today-unfinished');
+      nextData = await api('GET', `/api/today-unfinished?scope=${_unfinishedScope}`);
     } else if (rootDeckId) {
       nextData = await api('GET', `/api/today-mixed/${rootDeckId}`);
     } else {
@@ -5533,7 +5567,7 @@ async function editModalCardAction(action) {
     // Advance to next card
     let nextData;
     if (unfinishedMode) {
-      nextData = await api('GET', '/api/today-unfinished');
+      nextData = await api('GET', `/api/today-unfinished?scope=${_unfinishedScope}`);
     } else if (rootDeckId) {
       nextData = await api('GET', `/api/today-mixed/${rootDeckId}`);
     } else {

--- a/static/app.js
+++ b/static/app.js
@@ -4643,7 +4643,11 @@ function updateWordBankPreview(text) {
   // Walk wordBankOrder to assign values to numbered slots
   let rawIdx = 0, slotIdx = 0;
   const usedNums = new Set();
-  document.querySelectorAll('.wb-skel-blank[data-slot]').forEach(span => span.textContent = '＿');
+  // Reset: empty target slot falls back to its faint German hint, others to ＿
+  document.querySelectorAll('.wb-skel-blank[data-slot]').forEach(span => {
+    if (span.dataset.de) { span.textContent = span.dataset.de; span.classList.add('wb-de-hint'); }
+    else span.textContent = '＿';
+  });
 
   for (const tok of wordBankOrder) {
     if (tok.type === 'pre') continue;
@@ -4656,7 +4660,8 @@ function updateWordBankPreview(text) {
       if (tile) { usedNums.add(tile.num); if (span) span.textContent = tile.char; }
       else if (span) span.textContent = part;
     } else {
-      if (span) span.textContent = part; // target word
+      // target word filled: replace faint German hint with the typed text
+      if (span) { span.textContent = part; span.classList.remove('wb-de-hint'); }
     }
   }
 
@@ -4688,10 +4693,19 @@ async function renderWordBankUI() {
   // Sentence skeleton: pre-placed tokens shown as text, blanks for tiles/target (data-slot for live update)
   const skelEl = document.getElementById('word-bank-skeleton');
   if (skelEl) {
+    const escAttr = s => String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    // German hint shown faintly inside the target word's blank (first target only)
+    const deHint = (card.definition_de || '').trim();
+    let deShown = false;
     let slotIdx = 0;
     skelEl.innerHTML = wordBankOrder.map(tok => {
       if (tok.type === 'pre') return `<span class="wb-skel-pre">${tok.char}</span>`;
-      return `<span class="wb-skel-blank" data-slot="${slotIdx++}">＿</span>`;
+      const slot = slotIdx++;
+      if (tok.type === 'target' && deHint && !deShown) {
+        deShown = true;
+        return `<span class="wb-skel-blank wb-de-hint" data-slot="${slot}" data-de="${escAttr(deHint)}">${escAttr(deHint)}</span>`;
+      }
+      return `<span class="wb-skel-blank" data-slot="${slot}">＿</span>`;
     }).join('');
   }
 

--- a/static/index.html
+++ b/static/index.html
@@ -694,6 +694,31 @@
   </div>
 </div>
 
+<!-- Unfinished-deck start modal: pick card scope + story mode each time -->
+<div id="unfinished-modal-overlay" onclick="closeUnfinishedModal()" style="display:none"></div>
+<div id="unfinished-modal" style="display:none">
+  <div class="edit-modal-header">
+    <span class="edit-modal-title">Unfinished Cards</span>
+    <button class="edit-modal-close" onclick="closeUnfinishedModal()">✕</button>
+  </div>
+  <div class="edit-card-fields">
+    <div class="unf-group">
+      <div class="unf-group-label">Cards to include</div>
+      <label class="unf-radio"><input type="radio" name="unf-scope" value="unfinished"><span>Only unfinished <small>(learning / relearn due now)</small></span></label>
+      <label class="unf-radio"><input type="radio" name="unf-scope" value="all"><span>All due today <small>(includes new &amp; review)</small></span></label>
+    </div>
+    <div class="unf-group">
+      <div class="unf-group-label">Story</div>
+      <label class="unf-radio"><input type="radio" name="unf-story" value="existing"><span>Use existing story <small>(just the word if a card has none)</small></span></label>
+      <label class="unf-radio"><input type="radio" name="unf-story" value="new"><span>Generate a new story</span></label>
+    </div>
+  </div>
+  <div class="edit-card-actions">
+    <button class="edit-cancel-btn" onclick="closeUnfinishedModal()">Cancel</button>
+    <button class="edit-save-btn" onclick="confirmUnfinishedStart()">Start</button>
+  </div>
+</div>
+
 <!-- Cost modal -->
 <div id="cost-modal-overlay" onclick="closeCostModal()" style="display:none"></div>
 <div id="cost-modal" style="display:none">

--- a/static/index.html
+++ b/static/index.html
@@ -203,6 +203,11 @@
               <button class="r-btn r-good"  onclick="rate(3)">Good<small id="int-3"></small></button>
               <button class="r-btn r-easy"  onclick="rate(4)">Easy<small id="int-4"></small></button>
             </div>
+            <!-- Free-text note carried over to the next time this card is seen -->
+            <div class="next-note-row" id="next-note-row">
+              <textarea id="next-note-input" class="next-note-input" rows="1"
+                        placeholder="Note for next time… (optional)"></textarea>
+            </div>
             <!-- FSRS scheduler inspector trigger (Shift+S) -->
             <div class="fsrs-inspect-row">
               <button class="fsrs-inspect-btn" onclick="toggleFsrsInspector()" title="复习调度详情 / FSRS scheduler (Shift+S)">🔬 Scheduler</button>
@@ -296,6 +301,7 @@
         <button class="bs-status-item" id="bss-learning"  onclick="setBrowseStatusFilter('learning')">Learning</button>
         <button class="bs-status-item" id="bss-leech"     onclick="setBrowseStatusFilter('leech')">Leeched</button>
         <button class="bs-status-item" id="bss-reference" onclick="setBrowseStatusFilter('reference')">Reference</button>
+        <button class="bs-status-item" id="bss-saved"     onclick="setBrowseStatusFilter('saved')">★ Saved</button>
       </div>
       <div class="bs-section">
         <div class="bs-section-head">Hanzi</div>
@@ -428,8 +434,12 @@
         <input type="checkbox" id="opt-enable-fsrs" style="width:18px;height:18px;cursor:pointer" onchange="applySchedulerVisibility()">
       </div>
       <div class="opt-row">
-        <span class="opt-label">Hard = 1 day <span class="info-i" data-info="hard_1d">i</span><br><span style="font-weight:400;font-size:11px;color:var(--muted)">learning Hard returns tomorrow instead of minutes</span></span>
+        <span class="opt-label">Hard = fixed days <span class="info-i" data-info="hard_1d">i</span><br><span style="font-weight:400;font-size:11px;color:var(--muted)">learning Hard returns after N days instead of minutes</span></span>
         <input type="checkbox" id="opt-hard-1d" style="width:18px;height:18px;cursor:pointer">
+      </div>
+      <div class="opt-row">
+        <span class="opt-label">Hard delay (days) <span class="info-i" data-info="hard_days">i</span><br><span style="font-weight:400;font-size:11px;color:var(--muted)">how many days Hard delays (when enabled above)</span></span>
+        <input class="opt-input" id="opt-hard-days" type="number" min="0.1" step="0.5">
       </div>
       <div class="opt-row sched-fsrs"><span class="opt-label">Desired retention (%) <span class="info-i" data-info="desired_retention">i</span><br><span style="font-weight:400;font-size:11px;color:var(--muted)">target recall; higher = shorter intervals</span></span><input class="opt-input" id="opt-desired-retention" type="number" min="70" max="99" step="1"></div>
       <div class="opt-row sched-fsrs"><span class="opt-label">Maximum interval (days) <span class="info-i" data-info="maximum_interval">i</span><br><span style="font-weight:400;font-size:11px;color:var(--muted)">cap on how far out a review is scheduled</span></span><input class="opt-input" id="opt-max-int" type="number" min="1" step="1"></div>

--- a/static/index.html
+++ b/static/index.html
@@ -180,16 +180,16 @@
               </div>
             </div>
 
-            <!-- 1. Sentence (listening/reading back; hidden for creating) -->
-            <div class="sentence-row" id="sentence-row-back">
-              <div class="sentence" id="sentence-back"></div>
-            </div>
-
-            <!-- 2. Pinyin row (blurred by default, p to reveal) -->
+            <!-- 1. Pinyin row (blurred by default, p to reveal) -->
             <div class="pinyin-row" id="pinyin-row"></div>
             <!-- French and German translation of the sentence -->
             <div class="sentence-fr" id="sentence-fr"></div>
             <div class="sentence-de" id="sentence-de"></div>
+
+            <!-- 2. Sentence (listening/reading back; hidden for creating) — placed below the translation -->
+            <div class="sentence-row" id="sentence-row-back">
+              <div class="sentence" id="sentence-back"></div>
+            </div>
             <!-- Kahneman chapter concept + reasoning light bulb (Kahneman-mode only) -->
             <div id="sentence-concept-row" class="sentence-concept-row" style="display:none">
               <div id="sentence-concept" class="sentence-concept-section"></div>

--- a/static/index.html
+++ b/static/index.html
@@ -180,16 +180,16 @@
               </div>
             </div>
 
-            <!-- 1. Pinyin row (blurred by default, p to reveal) -->
-            <div class="pinyin-row" id="pinyin-row"></div>
-            <!-- French and German translation of the sentence -->
-            <div class="sentence-fr" id="sentence-fr"></div>
-            <div class="sentence-de" id="sentence-de"></div>
-
-            <!-- 2. Sentence (listening/reading back; hidden for creating) — placed below the translation -->
+            <!-- 1. Sentence (listening/reading back; hidden for creating) -->
             <div class="sentence-row" id="sentence-row-back">
               <div class="sentence" id="sentence-back"></div>
             </div>
+
+            <!-- 2. Pinyin row (hidden by default; press p to toggle) -->
+            <div class="pinyin-row" id="pinyin-row"></div>
+            <!-- French and German translation (hidden by default; press u to toggle) -->
+            <div class="sentence-fr" id="sentence-fr"></div>
+            <div class="sentence-de" id="sentence-de"></div>
             <!-- Kahneman chapter concept + reasoning light bulb (Kahneman-mode only) -->
             <div id="sentence-concept-row" class="sentence-concept-row" style="display:none">
               <div id="sentence-concept" class="sentence-concept-section"></div>

--- a/static/style.css
+++ b/static/style.css
@@ -1597,6 +1597,7 @@ main.browse-open {
   padding: 6px 0;
   flex-wrap: wrap;
   display: flex;
+  align-items: center;
   gap: 2px;
 }
 .wb-skel-pre { color: #000; }
@@ -1617,7 +1618,6 @@ main.browse-open {
   font-size: 14px;
   font-style: italic;
   letter-spacing: 0;
-  vertical-align: baseline;
 }
 .word-bank-tokens {
   display: flex;

--- a/static/style.css
+++ b/static/style.css
@@ -1274,10 +1274,21 @@ main.browse-open {
 .sentence-fr {
   flex: 1;
   text-align: center;
-  font-size: 14px;
+  font-size: 12px;
   color: var(--muted);
   font-style: italic;
   min-height: 18px;
+  /* De-emphasised so the eye is drawn to the Chinese, not the translation.
+     Still readable, and fully clears on hover/focus. */
+  opacity: 0.4;
+  filter: blur(1.1px);
+  letter-spacing: 0.2px;
+  transition: opacity 0.15s, filter 0.15s;
+}
+.sentence-de:hover,
+.sentence-fr:hover {
+  opacity: 0.9;
+  filter: none;
 }
 
 .char-row:last-child { border-bottom: none; }
@@ -1497,14 +1508,23 @@ main.browse-open {
 
 /* ── Creating: front input ───────────────────────────── */
 .sentence-en-front {
-  font-size: 15px;
+  font-size: 13px;
   line-height: 1.6;
   text-align: center;
-  color: var(--text);
+  color: var(--muted);
   min-height: 60px;
   display: flex;
   align-items: center;
   justify-content: center;
+  /* De-emphasised translation: present but not eye-catching, clears on hover. */
+  opacity: 0.4;
+  filter: blur(1.1px);
+  letter-spacing: 0.2px;
+  transition: opacity 0.15s, filter 0.15s;
+}
+.sentence-en-front:hover {
+  opacity: 0.9;
+  filter: none;
 }
 .creating-word-def {
   font-size: 17px;
@@ -2272,6 +2292,25 @@ main.browse-open {
   white-space: nowrap;
 }
 .bw-add-btn:hover { background: #dbeafe; }
+
+/* Saved-list per-row actions: Generate content / Add to Daily */
+.bw-saved-btn {
+  font-size: 11px;
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  border-radius: 4px;
+  padding: 2px 7px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.bw-saved-btn:hover { background: var(--bg); }
+.bw-saved-btn:disabled { opacity: 0.55; cursor: default; }
+.bw-saved-promote { border-color: var(--primary); color: var(--primary); }
+.bw-saved-promote:hover { background: #dbeafe; }
+
+/* "Save for later" button in the compound quick-add menu */
+.qa-save-btn { background: #f59e0b; margin-bottom: 6px; }
 
 /* ── Browse action bar ─────────────────────────────── */
 #browse-action-bar {
@@ -4289,3 +4328,19 @@ table.fsrs-table td.ivl { font-weight: 700; }
 }
 #info-pop-title { font-weight: 700; font-size: 13px; margin-bottom: 5px; }
 #info-pop-body  { font-size: 12px; line-height: 1.55; color: var(--muted); }
+
+/* ── "Note for next time" field under the rating buttons ─────────────────── */
+.next-note-row { margin: 10px auto 0; max-width: 520px; }
+.next-note-input {
+  width: 100%; box-sizing: border-box; resize: vertical;
+  min-height: 34px; padding: 7px 10px;
+  font: inherit; font-size: 13px; line-height: 1.4;
+  color: var(--text); background: var(--card);
+  border: 1px solid var(--border); border-radius: 8px;
+}
+.next-note-input::placeholder { color: var(--muted); }
+.next-note-input:focus { outline: none; border-color: #6366f1; }
+/* Highlight when a note was carried over from last time */
+.next-note-input.has-note {
+  border-color: #f59e0b; background: #fffbeb;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1283,20 +1283,16 @@ main.browse-open {
 }
 .pinyin-btn:hover, .pinyin-btn.active { border-color: var(--primary); color: var(--primary); }
 .pinyin-row {
-  display: flex;
+  /* Hidden entirely by default (no space taken); press p to toggle. */
+  display: none;
   flex-wrap: wrap;
   gap: 2px 6px;
   font-size: 14px;
   justify-content: center;
-  filter: blur(4px);
-  opacity: 0.35;
-  transition: filter 0.2s ease, opacity 0.2s ease;
-  user-select: none;
+  user-select: text;
 }
 .pinyin-row.pinyin-revealed {
-  filter: none;
-  opacity: 1;
-  user-select: text;
+  display: flex;
 }
 .py-char {
   display: flex;
@@ -1310,23 +1306,14 @@ main.browse-open {
 .py-target .py-zh  { color: var(--primary); font-weight: 700; }
 .sentence-de,
 .sentence-fr {
+  /* Hidden entirely by default (no space taken); press u to toggle.
+     When shown, fully readable — visibility is controlled from JS. */
   flex: 1;
   text-align: center;
   font-size: 12px;
   color: var(--muted);
   font-style: italic;
-  min-height: 18px;
-  /* Fully blurred so the translation is completely unreadable by default.
-     Clears only on hover/focus when you explicitly want to check it. */
-  opacity: 0.35;
-  filter: blur(7px);
   letter-spacing: 0.2px;
-  transition: opacity 0.15s, filter 0.15s;
-}
-.sentence-de:hover,
-.sentence-fr:hover {
-  opacity: 0.9;
-  filter: none;
 }
 
 .char-row:last-child { border-bottom: none; }

--- a/static/style.css
+++ b/static/style.css
@@ -1316,10 +1316,10 @@ main.browse-open {
   color: var(--muted);
   font-style: italic;
   min-height: 18px;
-  /* De-emphasised so the eye is drawn to the Chinese, not the translation.
-     Still readable, and fully clears on hover/focus. */
-  opacity: 0.4;
-  filter: blur(1.1px);
+  /* Fully blurred so the translation is completely unreadable by default.
+     Clears only on hover/focus when you explicitly want to check it. */
+  opacity: 0.35;
+  filter: blur(7px);
   letter-spacing: 0.2px;
   transition: opacity 0.15s, filter 0.15s;
 }
@@ -1554,9 +1554,10 @@ main.browse-open {
   display: flex;
   align-items: center;
   justify-content: center;
-  /* De-emphasised translation: present but not eye-catching, clears on hover. */
-  opacity: 0.4;
-  filter: blur(1.1px);
+  /* Fully blurred so the translation is completely unreadable by default.
+     Clears only on hover when you explicitly want to check it. */
+  opacity: 0.35;
+  filter: blur(7px);
   letter-spacing: 0.2px;
   transition: opacity 0.15s, filter 0.15s;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -1081,11 +1081,49 @@ main.browse-open {
 }
 
 /* ── Story setup modal ───────────────────────────────── */
-#setup-modal-overlay {
+#setup-modal-overlay,
+#unfinished-modal-overlay {
   position: fixed; inset: 0;
   background: rgba(0,0,0,0.4);
   z-index: 100;
 }
+#unfinished-modal {
+  position: fixed;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 101;
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 40px rgba(0,0,0,0.18);
+  width: min(420px, 92vw);
+  display: flex;
+  flex-direction: column;
+  padding: 20px 24px 24px;
+  gap: 16px;
+}
+.unf-group { display: flex; flex-direction: column; gap: 8px; }
+.unf-group-label {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted, #888);
+}
+.unf-radio {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1.5px solid var(--border, #ddd);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 15px;
+  transition: border-color 0.12s, background 0.12s;
+}
+.unf-radio:hover { border-color: var(--primary); }
+.unf-radio input { margin-top: 3px; }
+.unf-radio small { display: block; color: var(--muted, #888); font-size: 12px; font-weight: 400; }
+.unf-radio:has(input:checked) { border-color: var(--primary); background: var(--bg); }
 #setup-modal {
   position: fixed;
   top: 50%; left: 50%;

--- a/static/style.css
+++ b/static/style.css
@@ -1618,6 +1618,10 @@ main.browse-open {
   font-size: 14px;
   font-style: italic;
   letter-spacing: 0;
+  white-space: normal;
+  max-width: 13em;
+  line-height: 1.2;
+  text-align: center;
 }
 .word-bank-tokens {
   display: flex;

--- a/static/style.css
+++ b/static/style.css
@@ -1610,6 +1610,15 @@ main.browse-open {
   font-weight: 700;
   letter-spacing: -2px;
 }
+/* Faint German translation shown inside the target word's blank as a hint */
+.wb-skel-blank.wb-de-hint {
+  color: #c2c2c2;
+  font-weight: 400;
+  font-size: 14px;
+  font-style: italic;
+  letter-spacing: 0;
+  vertical-align: baseline;
+}
 .word-bank-tokens {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## 变更内容
- 拼词（word bank）填空界面中，目标词所在的空格用浅色（淡灰、14px、斜体）字体直接显示该词的德语翻译（`card.definition_de`）。
- 仅作用于第一个目标词空格；打乱的单字提示空格保持 ＿（单字无独立翻译）。
- 用户填入目标词后，浅色德语提示被替换为输入文字；`updateWordBankPreview` 重置时空目标空格回退为浅色德语提示。
- 无德语翻译时回退为普通 ＿。

## 涉及文件
- `static/app.js` — `renderWordBankUI`（骨架渲染加德语提示）、`updateWordBankPreview`（重置/填入逻辑）
- `static/style.css` — 新增 `.wb-skel-blank.wb-de-hint` 浅色样式

## 测试方法
1. 进入某牌组「创建」类别、非句子词条、非快速模式（触发 word bank 填空）
2. 确认目标词的空格里显示浅色斜体德语翻译
3. 按提示输入目标词，确认浅色提示被替换为输入文字
4. 清空输入，确认目标空格恢复浅色德语提示

Closes #348