### PR TITLE
feat: 后台生成故事 — 生成期间可离开去看统计/复习别的牌组

### DIFF
--- a/routes/story.py
+++ b/routes/story.py
@@ -3,6 +3,7 @@ import logging
 import math
 import os
 import random
+import threading
 
 import jieba
 import database
@@ -67,6 +68,12 @@ def _add_tokens(sentences: list[dict]) -> list[dict]:
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+# In-flight background story generations, keyed by f"{deck_id}/{category}".
+# Guards against starting a second generation for the same deck+category while
+# one is already running (e.g. the frontend polling repeatedly in background mode).
+_generating: set[str] = set()
+_gen_lock = threading.Lock()
 
 
 def _log_story(story: dict) -> None:
@@ -157,6 +164,82 @@ def _validated_model(model: str | None) -> str:
     return DEFAULT_MODEL
 
 
+def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
+                        topic, max_hsk, model, grammar_focus, grammar_pct, mode,
+                        chapter_ids, progress_key) -> dict | None:
+    """Generate a story for `cards`, persist it, and return the stored story
+    (with sentences) — or an error dict on failure, or None if there is nothing
+    to generate. Shared by the synchronous GET, the background thread, and regenerate.
+
+    Sets ai._story_progress[progress_key] to a "starting" state up front; the
+    generate functions update it during the run. Callers own terminal cleanup.
+    """
+    if not cards:
+        return None
+    ai.fix_definition_commas(cards)
+    ai._story_progress[progress_key] = {"phase": "starting", "msg": "Starting…", "percent": 5}
+    try:
+        if mode == "kahneman":
+            parsed_chapter_ids = [int(x) for x in chapter_ids.split(",") if x.strip()] if chapter_ids else []
+            sentences, prompt_text = _generate_kahneman_story_sentences(
+                cards, parsed_chapter_ids, model=model, progress_key=progress_key)
+        else:
+            sentences, prompt_text = _generate_story_sentences(
+                cards, topic=topic, max_hsk=max_hsk, model=model,
+                progress_key=progress_key, grammar_focus=grammar_focus,
+                grammar_pct=grammar_pct, mode=mode)
+        for i, s in enumerate(sentences):
+            s["position"] = i
+        database.create_story(today, category, deck_id, sentences, prompt_text, topic)
+        story = database.get_active_story(today, category, deck_id)
+    except Exception as e:
+        logger.error("story  generation error: %s", e)
+        return {
+            "error": True,
+            "reason": str(e),
+            "model": model,
+            "has_history": database.has_story_history(deck_id, category),
+        }
+    if story:
+        story["sentences"] = _add_tokens(database.get_story_sentences(story["id"]))
+        logger.info("story  SAVED   deck=%d cat=%s sentences=%d",
+                    deck_id, category, len(story["sentences"]))
+        _log_story(story)
+    return story
+
+
+def _start_background_generation(deck_id: int, category: str, today: str, cards: list, *,
+                                 topic, max_hsk, model, grammar_focus, grammar_pct,
+                                 mode, chapter_ids, progress_key) -> None:
+    """Spawn a daemon thread that generates+stores a story, recording a terminal
+    progress state (done/error) the frontend can poll. De-duped by progress_key."""
+    def _run() -> None:
+        logger.info("story  BG-START deck=%d cat=%s model=%s", deck_id, category, model)
+        try:
+            result = _generate_and_store(
+                deck_id, category, today, cards,
+                topic=topic, max_hsk=max_hsk, model=model,
+                grammar_focus=grammar_focus, grammar_pct=grammar_pct,
+                mode=mode, chapter_ids=chapter_ids, progress_key=progress_key)
+            if isinstance(result, dict) and result.get("error"):
+                ai._story_progress[progress_key] = {
+                    "phase": "error", "percent": 0, "msg": result.get("reason", "Generation failed")}
+                logger.warning("story  BG-ERROR deck=%d cat=%s: %s",
+                               deck_id, category, result.get("reason"))
+            else:
+                ai._story_progress[progress_key] = {
+                    "phase": "done", "percent": 100, "msg": "Story ready!"}
+                logger.info("story  BG-DONE  deck=%d cat=%s", deck_id, category)
+        except Exception as e:
+            ai._story_progress[progress_key] = {"phase": "error", "percent": 0, "msg": str(e)}
+            logger.warning("story  BG-ERROR deck=%d cat=%s: %s", deck_id, category, e)
+        finally:
+            with _gen_lock:
+                _generating.discard(progress_key)
+
+    threading.Thread(target=_run, daemon=True).start()
+
+
 @router.get("/api/story/{deck_id}/{category}")
 def get_story(deck_id: int, category: str,
               topic: str | None = None, max_hsk: int = 3,
@@ -164,11 +247,24 @@ def get_story(deck_id: int, category: str,
               grammar_focus: str | None = None, grammar_pct: int = 75,
               mode: str = "story",
               chapter_ids: str | None = None,
-              no_generate: bool = False):
+              no_generate: bool = False,
+              background: bool = False):
+    """Return today's story for (deck_id, category).
+
+    background=False (default): generate synchronously and return the story
+      (or an error dict). Used by regenerate flows and callers that block.
+    background=True: never block — return the cached story if ready, else kick
+      off generation in a daemon thread and return {"generating": True}. The
+      frontend polls this endpoint (and /api/story-progress) until the story is
+      ready, and can navigate away meanwhile. A failed background run is sticky
+      (returns the error dict) so polling stops instead of restarting forever.
+    """
     if database.is_sentences_deck(deck_id):
         return None
 
     today = database.anki_today().isoformat()
+    progress_key = f"{deck_id}/{category}"
+
     # Always return today's cached story — custom params only apply when generating a new one
     story = database.get_active_story(today, category, deck_id)
     if story:
@@ -176,6 +272,8 @@ def get_story(deck_id: int, category: str,
         logger.info("story  CACHED  deck=%d cat=%s sentences=%d story_id=%d",
                     deck_id, category, len(story["sentences"]), story["id"])
         _log_story(story)
+        if background:
+            ai._story_progress.pop(progress_key, None)  # clear any terminal state
         return story
 
     # Caller only wants an already-generated story (e.g. "use existing" mode):
@@ -189,48 +287,48 @@ def get_story(deck_id: int, category: str,
         return None
 
     chosen_model = _validated_model(model)
-    story = None
-    cards = _get_cards_for_story(deck_id, category)
-    logger.info("story  GENERATE deck=%d cat=%s due_cards=%d topic=%r max_hsk=%d model=%s mode=%s",
-                deck_id, category, len(cards), topic, max_hsk, chosen_model, mode)
-    if cards:
-        ai.fix_definition_commas(cards)
-        progress_key = f"{deck_id}/{category}"
-        ai._story_progress[progress_key] = {"phase": "starting", "msg": "Starting…", "percent": 5}
-        last_error = None
-        try:
-            if mode == "kahneman":
-                parsed_chapter_ids = [int(x) for x in chapter_ids.split(",") if x.strip()] if chapter_ids else []
-                sentences, prompt_text = _generate_kahneman_story_sentences(
-                    cards, parsed_chapter_ids, model=chosen_model, progress_key=progress_key)
-            else:
-                sentences, prompt_text = _generate_story_sentences(
-                    cards, topic=topic, max_hsk=max_hsk, model=chosen_model,
-                    progress_key=progress_key, grammar_focus=grammar_focus,
-                    grammar_pct=grammar_pct, mode=mode)
-            for i, s in enumerate(sentences):
-                s["position"] = i
-            database.create_story(today, category, deck_id, sentences, prompt_text, topic)
-            story = database.get_active_story(today, category, deck_id)
-        except Exception as e:
-            last_error = e
-            logger.error("story  generation error: %s", e)
-        finally:
-            ai._story_progress.pop(progress_key, None)
-        if last_error is not None:
+
+    # ── Background mode: don't block — start a thread and report progress ──────
+    if background:
+        # A finished-with-error background run is sticky so polling stops here
+        # (the user can retry via regenerate, which overwrites the progress state).
+        prog = ai._story_progress.get(progress_key)
+        if prog and prog.get("phase") == "error":
             return {
                 "error": True,
-                "reason": str(last_error),
+                "reason": prog.get("msg", "Generation failed"),
                 "model": chosen_model,
                 "has_history": database.has_story_history(deck_id, category),
             }
+        with _gen_lock:
+            if progress_key in _generating:
+                return {"generating": True}
+            cards = _get_cards_for_story(deck_id, category)
+            if not cards:
+                return None
+            _generating.add(progress_key)
+        logger.info("story  BG-QUEUE deck=%d cat=%s due_cards=%d model=%s mode=%s",
+                    deck_id, category, len(cards), chosen_model, mode)
+        _start_background_generation(
+            deck_id, category, today, cards,
+            topic=topic, max_hsk=max_hsk, model=chosen_model,
+            grammar_focus=grammar_focus, grammar_pct=grammar_pct,
+            mode=mode, chapter_ids=chapter_ids, progress_key=progress_key)
+        return {"generating": True}
 
-    if story:
-        story["sentences"] = _add_tokens(database.get_story_sentences(story["id"]))
-        logger.info("story  SAVED   deck=%d cat=%s sentences=%d",
-                    deck_id, category, len(story["sentences"]))
-        _log_story(story)
-    return story
+    # ── Synchronous mode (default): generate now and return the story ─────────
+    cards = _get_cards_for_story(deck_id, category)
+    logger.info("story  GENERATE deck=%d cat=%s due_cards=%d topic=%r max_hsk=%d model=%s mode=%s",
+                deck_id, category, len(cards), topic, max_hsk, chosen_model, mode)
+    if not cards:
+        return None
+    result = _generate_and_store(
+        deck_id, category, today, cards,
+        topic=topic, max_hsk=max_hsk, model=chosen_model,
+        grammar_focus=grammar_focus, grammar_pct=grammar_pct,
+        mode=mode, chapter_ids=chapter_ids, progress_key=progress_key)
+    ai._story_progress.pop(progress_key, None)
+    return result
 
 
 @router.post("/api/story/{deck_id}/{category}/regenerate")
@@ -246,46 +344,19 @@ def regenerate_story(deck_id: int, category: str,
         return None
     chosen_model = _validated_model(model)
     today = database.anki_today().isoformat()
+    progress_key = f"{deck_id}/{category}"
     cards = _get_cards_for_story(deck_id, category)
     logger.info("regen  deck=%d cat=%s due_cards=%d topic=%r max_hsk=%d model=%s mode=%s",
                 deck_id, category, len(cards), topic, max_hsk, chosen_model, mode)
     if not cards:
         return None
-    ai.fix_definition_commas(cards)
-    progress_key = f"{deck_id}/{category}"
-    ai._story_progress[progress_key] = {"phase": "starting", "msg": "Starting…", "percent": 5}
-    last_error = None
-    try:
-        if mode == "kahneman":
-            parsed_chapter_ids = [int(x) for x in chapter_ids.split(",") if x.strip()] if chapter_ids else []
-            sentences, prompt_text = _generate_kahneman_story_sentences(
-                cards, parsed_chapter_ids, model=chosen_model, progress_key=progress_key)
-        else:
-            sentences, prompt_text = _generate_story_sentences(
-                cards, topic=topic, max_hsk=max_hsk, model=chosen_model,
-                progress_key=progress_key, grammar_focus=grammar_focus,
-                grammar_pct=grammar_pct, mode=mode)
-        for i, s in enumerate(sentences):
-            s["position"] = i
-        database.create_story(today, category, deck_id, sentences, prompt_text, topic)
-        story = database.get_active_story(today, category, deck_id)
-    except Exception as e:
-        last_error = e
-        logger.error("regen  generation error: %s", e)
-    finally:
-        ai._story_progress.pop(progress_key, None)
-    if last_error is not None:
-        return {
-            "error": True,
-            "reason": str(last_error),
-            "model": chosen_model,
-            "has_history": database.has_story_history(deck_id, category),
-        }
-    if story:
-        story["sentences"] = _add_tokens(database.get_story_sentences(story["id"]))
-        logger.info("regen  SAVED sentences=%d", len(story["sentences"]))
-        _log_story(story)
-    return story
+    result = _generate_and_store(
+        deck_id, category, today, cards,
+        topic=topic, max_hsk=max_hsk, model=chosen_model,
+        grammar_focus=grammar_focus, grammar_pct=grammar_pct,
+        mode=mode, chapter_ids=chapter_ids, progress_key=progress_key)
+    ai._story_progress.pop(progress_key, None)
+    return result
 
 
 @router.get("/api/story/{deck_id}/{category}/history")

--- a/static/app.js
+++ b/static/app.js
@@ -2812,6 +2812,18 @@ async function startReview(id, cat, name, noStory = false, quick = false) {
   _updateAvgTimeBadge();
   _updateReviewRRBadge(id);
 
+  // A background story is already generating for this deck/category (the user
+  // clicked "Continue in background"): re-open its loading screen instead of the
+  // setup modal — we must not start a second generation.
+  if (!noStory && !quick) {
+    const bgCtx = _bgStories[`${id}/${cat}`];
+    if (bgCtx) {
+      delete _bgStories[bgCtx.key];
+      _resumeBackgroundReview(bgCtx);
+      return;
+    }
+  }
+
   try {
     if (noStory || quick) {
       await _doStartReview(null, 2);

--- a/static/app.js
+++ b/static/app.js
@@ -2834,6 +2834,89 @@ async function startReview(id, cat, name, noStory = false, quick = false) {
   }
 }
 
+// ── Background story generation ─────────────────────────────────────────────
+// Let the user leave the "Generating story…" screen and do other things (check
+// stats, review another deck) while the story finishes generating server-side,
+// then notify them with a clickable banner when it's ready.
+const _BG_LEFT = Symbol('bg-left');
+let _bgStories = {};            // key → resumeCtx, generating while the user is elsewhere
+let _bgStoryPoller = null;      // interval polling those keys for readiness
+let _bgActiveResume = null;     // resumeCtx for the story currently on the loading screen
+let _bgLeaveRequested = false;  // set when the user clicks "Continue in background"
+
+function _showLoadingBgButton() {
+  const b = document.getElementById('loading-bg-btn');
+  if (b) b.style.display = 'block';
+}
+function _hideLoadingBgButton() {
+  const b = document.getElementById('loading-bg-btn');
+  if (b) b.style.display = 'none';
+}
+
+// Poll the background story endpoint until it returns a story (or an error dict),
+// or the user clicks "Continue in background" (→ resolves to _BG_LEFT).
+async function _pollBackgroundStory(bgUrl) {
+  while (true) {
+    if (_bgLeaveRequested) return _BG_LEFT;
+    const r = await api('GET', bgUrl);
+    if (_bgLeaveRequested) return _BG_LEFT;
+    if (r && r.generating) { await new Promise(res => setTimeout(res, 1500)); continue; }
+    return r;  // story | null | { error }
+  }
+}
+
+// User clicked "Continue in background": register the in-flight story, start the
+// global readiness poller, and return to the deck list. Generation keeps running.
+function _continueStoryInBackground() {
+  if (!_bgActiveResume) return;
+  _bgLeaveRequested = true;
+  _bgStories[_bgActiveResume.key] = _bgActiveResume;
+  _bgActiveResume = null;
+  _stopFakeProgress();
+  _stopStoryProgressPoll();
+  _hideLoadingBgButton();
+  _ensureBgStoryPoller();
+  loadDecks();
+}
+
+// Poll every in-flight background story for readiness; banner the user when ready.
+function _ensureBgStoryPoller() {
+  if (_bgStoryPoller) return;
+  _bgStoryPoller = setInterval(async () => {
+    const keys = Object.keys(_bgStories);
+    if (keys.length === 0) { clearInterval(_bgStoryPoller); _bgStoryPoller = null; return; }
+    for (const key of keys) {
+      const ctx = _bgStories[key];
+      let s = null;
+      try {
+        s = await api('GET', `/api/story/${ctx.storyDeckId}/${ctx.storyCategory}?no_generate=true`);
+      } catch (_) { continue; }
+      if (s && s.sentences) {            // ready
+        delete _bgStories[key];
+        _showStoryReadyBanner(ctx);
+      }
+    }
+  }, 3000);
+}
+
+function _showStoryReadyBanner(ctx) {
+  const el = document.getElementById('bg-story-banner');
+  if (!el) return;
+  el.textContent = `📖 Story ready — ${ctx.deckName} · click to review`;
+  el.style.display = 'block';
+  el.onclick = () => { el.style.display = 'none'; _resumeBackgroundReview(ctx); };
+}
+
+// Resume a session whose background story is now cached → starts instantly.
+function _resumeBackgroundReview(ctx) {
+  deckId     = ctx.deckId;
+  category   = ctx.category;
+  deckName   = ctx.deckName;
+  rootDeckId = ctx.rootDeckId;
+  quickMode  = false;
+  _doStartReview(ctx.topic, ctx.maxHsk, ctx.model, ctx.grammarFocus, ctx.grammarPct, ctx.mode, ctx.chapterIds);
+}
+
 async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', chapterIds = null) {
   if (quickMode) {
     setLoading('Loading audio…', true);
@@ -2858,15 +2941,26 @@ async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mo
     const storyDeckId = rootDeckId || deckId;
     const storyCategory = rootDeckId ? 'unified' : category;
     _startStoryProgressPoll(storyDeckId, storyCategory);
+
+    // Capture enough context to resume this exact session if the user chooses to
+    // let the story finish generating in the background and walk away.
+    const resumeCtx = {
+      key: `${storyDeckId}/${storyCategory}`,
+      deckId, category, deckName, rootDeckId, storyDeckId, storyCategory,
+      topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds,
+    };
+    _bgLeaveRequested = false;
+    _bgActiveResume = resumeCtx;
+    _showLoadingBgButton();
+
     const storyUrl = `/api/story/${storyDeckId}/${storyCategory}` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds);
+    const bgUrl = storyUrl + (storyUrl.includes('?') ? '&' : '?') + 'background=true';
     let todayData, storyData;
     try {
-      [todayData, storyData] = await Promise.all([
-        api('GET', `/api/today/${deckId}/${category}`),
-        api('GET', storyUrl),
-      ]);
+      todayData = await api('GET', `/api/today/${deckId}/${category}`);
+      storyData = await _pollBackgroundStory(bgUrl);  // non-blocking: polls until ready
     } catch (e) {
-      _stopFakeProgress(); _stopStoryProgressPoll();
+      _stopFakeProgress(); _stopStoryProgressPoll(); _hideLoadingBgButton();
       _showLoadingError('AI request failed', e.message);
       await new Promise(r => setTimeout(r, 2500));
       showError('Failed to start session: ' + e.message);
@@ -2874,6 +2968,10 @@ async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mo
       return;
     }
 
+    // User clicked "Continue in background" — we've already returned to the deck list.
+    if (storyData === _BG_LEFT) return;
+
+    _hideLoadingBgButton();
     _stopFakeProgress(); _stopStoryProgressPoll();
     setLoadingStep(65, null, 'Story received, processing…');
     story = await _resolveStory(storyData, storyDeckId, storyCategory, topic, maxHsk, grammarFocus, grammarPct, mode);
@@ -2896,7 +2994,7 @@ async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mo
     showView('review');
     loadCard(todayData.card, todayData.counts);
   } catch (e) {
-    _stopFakeProgress(); _stopStoryProgressPoll();
+    _stopFakeProgress(); _stopStoryProgressPoll(); _hideLoadingBgButton();
     _showLoadingError('Failed to load session', e.message);
     await new Promise(r => setTimeout(r, 2500));
     showError('Failed to start session: ' + e.message);

--- a/static/index.html
+++ b/static/index.html
@@ -56,6 +56,8 @@
 
 <main>
   <div id="error-banner"></div>
+  <!-- Clickable banner shown when a background story finishes generating -->
+  <div id="bg-story-banner" style="display:none"></div>
 
   <!-- Loading -->
   <div id="view-loading">
@@ -65,6 +67,9 @@
       <div id="loading-progress-bar"></div>
     </div>
     <div id="loading-sub"></div>
+    <button id="loading-bg-btn" style="display:none" onclick="_continueStoryInBackground()">
+      Continue in background ⏎
+    </button>
   </div>
 
   <!-- Deck list -->

--- a/static/style.css
+++ b/static/style.css
@@ -132,6 +132,20 @@ main.browse-open {
 #loading-sub.warn  { color: #d97706; font-size: 13px; }
 .spinner.hidden { display: none; }
 
+/* "Continue in background" button on the story-generation loading screen */
+#loading-bg-btn {
+  margin: 20px auto 0;
+  display: block;
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 16px;
+  font-size: 13px;
+  cursor: pointer;
+}
+#loading-bg-btn:hover { color: var(--text); border-color: var(--muted); }
+
 /* ── Error banner ────────────────────────────────────── */
 #error-banner {
   background: #fef2f2;
@@ -143,6 +157,21 @@ main.browse-open {
   font-size: 14px;
   display: none;
 }
+
+/* Clickable banner: a background story finished generating */
+#bg-story-banner {
+  background: #ecfdf5;
+  color: #047857;
+  border: 1px solid #a7f3d0;
+  border-radius: 8px;
+  padding: 10px 14px;
+  margin-bottom: 16px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  display: none;
+}
+#bg-story-banner:hover { background: #d1fae5; }
 
 /* ── Deck list ───────────────────────────────────────── */
 #view-decks { display: none; }


### PR DESCRIPTION
## 变更内容

以前开始一个需要故事的复习时是**整屏阻塞**，后端同步生成，要干等约 2 分钟。现在故事**在后台生成**，期间可以去看统计、复习别的牌组、回牌组列表；故事好了用可点击提示条通知，点一下秒进复习。

**后端（`routes/story.py`）**
- `GET /api/story?background=true`：已缓存返回故事；否则开守护线程生成并立即返回 `{generating: true}`，前端轮询取成品
- 新增在途登记表 `_generating`（`threading.Lock` 保护），同一 (deck, category) 不重复生成
- 把「取词→生成→存库」抽成共享函数 `_generate_and_store`，同步路径 / 后台线程 / `regenerate` 三处复用（消除重复）
- 后台失败状态为**粘性**（返回 error，不无限重启）；成功取到缓存时清理进度
- 全程日志：`BG-QUEUE` / `BG-START` / `BG-DONE` / `BG-ERROR`

**前端（`static/app.js`, `index.html`, `style.css`）**
- `_doStartReview` 改用 `background=true` 轮询，不再阻塞
- 加载屏新增「Continue in background ⏎」按钮：点击后回牌组列表，生成在后台继续
- 全局轮询监测就绪 → 弹出可点击「📖 Story ready — <牌组名>」提示条 → 点击秒进复习（故事已缓存）

## 测试方法
- 开始一个需要生成故事的复习 → 点「Continue in background」→ 回牌组列表，去看统计/复习别的牌组
- 约 2 分钟后出现「Story ready」提示条 → 点击立即进入复习，无需再等
- 生成期间再次进入同一牌组 → 看到进度而非重新生成
- 已有缓存故事的牌组 → 仍然秒进

## 已验证（dev.db，未起 8000 端口服务器）
- 后台流程端到端：首调 `{generating:true}` → 线程生成存库 → 轮询取到缓存故事 → 进度清理
- 错误粘性：生成失败返回 error 且不重启
- `py_compile` 全过、`main` 导入正常、`app.js` / `index.html` 语法有效

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)