### PR TITLE
fix: 修复词语分析「保存到暂存区」报错（insert_word 字段默认值）

### DIFF
--- a/database/entries.py
+++ b/database/entries.py
@@ -20,6 +20,13 @@ def insert_word(word: dict) -> int:
                    :notes, :date_yaml, :source_sentence, :grammar_notes, :register, :definition_de, :definition_fr)""",
         {
             **word,
+            "pinyin":          word.get("pinyin"),
+            "definition":      word.get("definition"),
+            "pos":             word.get("pos"),
+            "hsk_level":       word.get("hsk_level"),
+            "traditional":     word.get("traditional"),
+            "definition_zh":   word.get("definition_zh"),
+            "source":          word.get("source") or "kouyu",
             "note_type":       word.get("note_type", "vocabulary"),
             "notes":           word.get("notes"),
             "date_yaml":       word.get("date_yaml"),


### PR DESCRIPTION
## 变更内容
修复 `POST /api/save-word`（词语分析弹窗「★ Save for later」）调用时崩溃的问题。

`save_word()` 只给 `insert_word()` 传了 4 个字段，而 `insert_word()` 的 SQL 需要 16 个命名参数。原代码漏给 `pos`、`hsk_level`、`traditional`、`definition_zh`、`source` 补默认值：
- 这 5 个缺失字段触发 sqlite3「未提供绑定参数」异常
- `source` 列是 `NOT NULL DEFAULT 'kouyu'`，故缺省回退为 `'kouyu'` 而非 `None`，避免被 `INSERT OR IGNORE` 静默忽略

## 测试方法
- 用临时数据库实测：`insert_word({'word_zh','pinyin','definition','note_type'})` 成功返回 entry_id
- 重复插入幂等，返回同一 id
- 校验写入后 `source='kouyu'`、`note_type='vocabulary'`
- 在词语分析中点「Save for later」，确认词成功存入 Saved 牌组

Closes #354