### PR TITLE
feat: 添加「始终显示翻译」开关（复习卡背）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3543,8 +3543,14 @@ function revealAnswer() {
     _sentFrEl.textContent = sentence?.sentence_fr || '';
     _sentDeEl.textContent = sentence?.sentence_de || '';
   }
-  _sentFrEl.style.display = 'none';
-  _sentDeEl.style.display = 'none';
+  // Default visibility: shown when "always show translation" is on, else hidden (press u to toggle).
+  _sentFrEl.style.display = (_alwaysTranslation && _sentFrEl.textContent) ? '' : 'none';
+  _sentDeEl.style.display = (_alwaysTranslation && _sentDeEl.textContent) ? '' : 'none';
+  // Show the toggle only when this card actually has a translation.
+  const _alwaysToggle = document.getElementById('always-trans-toggle');
+  const _hasTranslation = !!(_sentFrEl.textContent || _sentDeEl.textContent);
+  _alwaysToggle.style.display = _hasTranslation ? 'flex' : 'none';
+  document.getElementById('always-trans-checkbox').checked = _alwaysTranslation;
 
   // Kahneman concept box (compact: part + chapter title only) + reasoning light bulb
   const _conceptRow = document.getElementById('sentence-concept-row');
@@ -4973,6 +4979,19 @@ function toggleTranslation() {
   const show = !anyVisible;
   fr.style.display = (show && fr.textContent) ? '' : 'none';
   de.style.display = (show && de.textContent) ? '' : 'none';
+}
+
+// Persistent "always show translation" preference (survives across sessions).
+let _alwaysTranslation = localStorage.getItem('alwaysTranslation') === '1';
+
+function setAlwaysTranslation(on) {
+  _alwaysTranslation = !!on;
+  localStorage.setItem('alwaysTranslation', _alwaysTranslation ? '1' : '0');
+  // Apply immediately to the card currently on screen.
+  const fr = document.getElementById('sentence-fr');
+  const de = document.getElementById('sentence-de');
+  fr.style.display = (_alwaysTranslation && fr.textContent) ? '' : 'none';
+  de.style.display = (_alwaysTranslation && de.textContent) ? '' : 'none';
 }
 
 // ── Story error modal ─────────────────────────────────────────────────────────

--- a/static/app.js
+++ b/static/app.js
@@ -3546,11 +3546,7 @@ function revealAnswer() {
   // Default visibility: shown when "always show translation" is on, else hidden (press u to toggle).
   _sentFrEl.style.display = (_alwaysTranslation && _sentFrEl.textContent) ? '' : 'none';
   _sentDeEl.style.display = (_alwaysTranslation && _sentDeEl.textContent) ? '' : 'none';
-  // Show the toggle only when this card actually has a translation.
-  const _alwaysToggle = document.getElementById('always-trans-toggle');
-  const _hasTranslation = !!(_sentFrEl.textContent || _sentDeEl.textContent);
-  _alwaysToggle.style.display = _hasTranslation ? 'flex' : 'none';
-  document.getElementById('always-trans-checkbox').checked = _alwaysTranslation;
+  _syncTransEye();
 
   // Kahneman concept box (compact: part + chapter title only) + reasoning light bulb
   const _conceptRow = document.getElementById('sentence-concept-row');
@@ -4979,19 +4975,41 @@ function toggleTranslation() {
   const show = !anyVisible;
   fr.style.display = (show && fr.textContent) ? '' : 'none';
   de.style.display = (show && de.textContent) ? '' : 'none';
+  _syncTransEye();
 }
 
 // Persistent "always show translation" preference (survives across sessions).
 let _alwaysTranslation = localStorage.getItem('alwaysTranslation') === '1';
 
+// The eye icon only appears while the translation is visible; it is highlighted
+// when "always show" is on, grayed out when off.
+function _syncTransEye() {
+  const fr  = document.getElementById('sentence-fr');
+  const de  = document.getElementById('sentence-de');
+  const eye = document.getElementById('always-trans-eye');
+  if (!eye) return;
+  const visible = (fr.textContent && fr.style.display !== 'none') ||
+                  (de.textContent && de.style.display !== 'none');
+  eye.style.display = visible ? '' : 'none';
+  eye.classList.toggle('active', _alwaysTranslation);
+}
+
+function toggleAlwaysTranslation() {
+  setAlwaysTranslation(!_alwaysTranslation);
+}
+
 function setAlwaysTranslation(on) {
   _alwaysTranslation = !!on;
   localStorage.setItem('alwaysTranslation', _alwaysTranslation ? '1' : '0');
-  // Apply immediately to the card currently on screen.
-  const fr = document.getElementById('sentence-fr');
-  const de = document.getElementById('sentence-de');
-  fr.style.display = (_alwaysTranslation && fr.textContent) ? '' : 'none';
-  de.style.display = (_alwaysTranslation && de.textContent) ? '' : 'none';
+  // Turning on reveals the translation immediately so the change is visible;
+  // turning off only changes the default for future cards (leaves the current one).
+  if (_alwaysTranslation) {
+    const fr = document.getElementById('sentence-fr');
+    const de = document.getElementById('sentence-de');
+    if (fr.textContent) fr.style.display = '';
+    if (de.textContent) de.style.display = '';
+  }
+  _syncTransEye();
 }
 
 // ── Story error modal ─────────────────────────────────────────────────────────

--- a/static/app.js
+++ b/static/app.js
@@ -4975,6 +4975,11 @@ function toggleTranslation() {
   const show = !anyVisible;
   fr.style.display = (show && fr.textContent) ? '' : 'none';
   de.style.display = (show && de.textContent) ? '' : 'none';
+  // Hiding the translation with u while "always show" is on deactivates the preference.
+  if (!show && _alwaysTranslation) {
+    _alwaysTranslation = false;
+    localStorage.setItem('alwaysTranslation', '0');
+  }
   _syncTransEye();
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AnkiAdvanced</title>
-  <link rel="stylesheet" href="/static/style.css?v=13">
+  <link rel="stylesheet" href="/static/style.css?v=14">
 </head>
 <body>
 
@@ -582,7 +582,7 @@
 </div>
 
 <div id="word-tip" style="display:none"></div>
-<script src="/static/app.js?v=13"></script>
+<script src="/static/app.js?v=14"></script>
 
 <!-- Edit card modal -->
 <div id="edit-modal-overlay" onclick="closeEditCard()" style="display:none"></div>

--- a/static/index.html
+++ b/static/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AnkiAdvanced</title>
-  <link rel="stylesheet" href="/static/style.css?v=12">
+  <link rel="stylesheet" href="/static/style.css?v=13">
 </head>
 <body>
 
@@ -187,14 +187,16 @@
 
             <!-- 2. Pinyin row (hidden by default; press p to toggle) -->
             <div class="pinyin-row" id="pinyin-row"></div>
-            <!-- French and German translation (hidden by default; press u to toggle) -->
-            <div class="sentence-fr" id="sentence-fr"></div>
-            <div class="sentence-de" id="sentence-de"></div>
-            <!-- Persistent "always show translation" toggle -->
-            <label class="always-trans-toggle" id="always-trans-toggle" style="display:none">
-              <input type="checkbox" id="always-trans-checkbox" onchange="setAlwaysTranslation(this.checked)">
-              <span>Always show translation</span>
-            </label>
+            <!-- French and German translation (hidden by default; press u to toggle).
+                 Eye icon toggles the persistent "always show translation" preference;
+                 it only appears while the translation itself is visible. -->
+            <div class="sentence-trans-row" id="sentence-trans-row">
+              <div class="sentence-fr" id="sentence-fr"></div>
+              <div class="sentence-de" id="sentence-de"></div>
+              <span class="always-trans-eye" id="always-trans-eye" role="button" tabindex="0"
+                    style="display:none" onclick="toggleAlwaysTranslation()"
+                    title="Always show translation">👁</span>
+            </div>
             <!-- Kahneman chapter concept + reasoning light bulb (Kahneman-mode only) -->
             <div id="sentence-concept-row" class="sentence-concept-row" style="display:none">
               <div id="sentence-concept" class="sentence-concept-section"></div>
@@ -580,7 +582,7 @@
 </div>
 
 <div id="word-tip" style="display:none"></div>
-<script src="/static/app.js?v=12"></script>
+<script src="/static/app.js?v=13"></script>
 
 <!-- Edit card modal -->
 <div id="edit-modal-overlay" onclick="closeEditCard()" style="display:none"></div>

--- a/static/index.html
+++ b/static/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AnkiAdvanced</title>
-  <link rel="stylesheet" href="/static/style.css?v=11">
+  <link rel="stylesheet" href="/static/style.css?v=12">
 </head>
 <body>
 
@@ -580,7 +580,7 @@
 </div>
 
 <div id="word-tip" style="display:none"></div>
-<script src="/static/app.js?v=11"></script>
+<script src="/static/app.js?v=12"></script>
 
 <!-- Edit card modal -->
 <div id="edit-modal-overlay" onclick="closeEditCard()" style="display:none"></div>

--- a/static/index.html
+++ b/static/index.html
@@ -190,6 +190,11 @@
             <!-- French and German translation (hidden by default; press u to toggle) -->
             <div class="sentence-fr" id="sentence-fr"></div>
             <div class="sentence-de" id="sentence-de"></div>
+            <!-- Persistent "always show translation" toggle -->
+            <label class="always-trans-toggle" id="always-trans-toggle" style="display:none">
+              <input type="checkbox" id="always-trans-checkbox" onchange="setAlwaysTranslation(this.checked)">
+              <span>Always show translation</span>
+            </label>
             <!-- Kahneman chapter concept + reasoning light bulb (Kahneman-mode only) -->
             <div id="sentence-concept-row" class="sentence-concept-row" style="display:none">
               <div id="sentence-concept" class="sentence-concept-section"></div>

--- a/static/style.css
+++ b/static/style.css
@@ -1316,18 +1316,26 @@ main.browse-open {
   letter-spacing: 0.2px;
 }
 
-.always-trans-toggle {
+.sentence-trans-row {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  margin-top: 6px;
-  font-size: 11px;
-  color: var(--muted);
+  gap: 8px;
+}
+.always-trans-eye {
+  flex: 0 0 auto;
   cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  opacity: 0.3;            /* grayed out = "always show" is off */
+  filter: grayscale(1);
+  transition: opacity 0.15s, filter 0.15s;
   user-select: none;
 }
-.always-trans-toggle input { cursor: pointer; margin: 0; }
+.always-trans-eye.active { /* highlighted = "always show" is on */
+  opacity: 1;
+  filter: none;
+}
 
 .char-row:last-child { border-bottom: none; }
 .char-row-link  { cursor: pointer; }

--- a/static/style.css
+++ b/static/style.css
@@ -1316,6 +1316,19 @@ main.browse-open {
   letter-spacing: 0.2px;
 }
 
+.always-trans-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--muted);
+  cursor: pointer;
+  user-select: none;
+}
+.always-trans-toggle input { cursor: pointer; margin: 0; }
+
 .char-row:last-child { border-bottom: none; }
 .char-row-link  { cursor: pointer; }
 .char-row-link:hover { background: var(--bg); }


### PR DESCRIPTION
## 变更内容
在复习卡背的翻译下方新增一个低调的复选框「Always show translation」：
- **勾选** → 每张卡片翻开后自动显示德语/法语翻译
- **取消** → 恢复现状（默认隐藏，按 `u` 才显示）

偏好用 `localStorage`（键 `alwaysTranslation`）持久保存，跨会话保留。切换开关时当前卡片立即响应；`u` 键手动切换仍可用。只有当卡片确实有翻译时才显示该开关。

## 涉及文件
- `static/index.html` — 开关 HTML
- `static/app.js` — `_alwaysTranslation` 偏好 + `setAlwaysTranslation()` + 卡背渲染默认显隐
- `static/style.css` — `.always-trans-toggle` 样式

## 测试方法
- 翻开一张有翻译的卡片，勾选「Always show translation」→ 翻译立即显示
- 翻到下一张卡片 → 翻译自动显示，无需按 `u`
- 取消勾选 → 翻译隐藏，按 `u` 仍可手动切换
- 刷新页面 → 勾选状态保留

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)