### PR TITLE
fix: 修复"添加到明天的牌组"功能（孤儿牌组 + 数量显示 0）

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -36,25 +36,31 @@ def insert_card(word_id: int, category: str, deck_id: int,
     return row["id"]
 
 
-def promote_saved_word(word_id: int, target_deck_id: int,
+def promote_saved_word(word_id: int, target_deck_ids: dict,
                        saved_deck_id: int, due: str) -> int:
-    """Move a saved word's suspended cards out of the Saved deck into target_deck_id
-    as fresh 'new' cards due on `due`, clearing any scheduling state.
+    """Move a saved word's suspended cards out of the Saved deck into the per-category
+    leaf decks as fresh 'new' cards due on `due`, clearing any scheduling state.
+
+    target_deck_ids: {"listening": id, "reading": id, "creating": id} — each card is
+    routed to the leaf deck matching its category, so due counts and review queues
+    (keyed by deck_id, category) pick it up.
 
     Returns the number of cards promoted.
     """
     conn = get_db()
-    cur = conn.execute(
-        """UPDATE cards
-           SET deck_id=?, state='new', due=?, step_index=0, interval=0,
-               ease=2.5, repetitions=0, lapses=0, stability=NULL, difficulty=NULL,
-               last_review=NULL, learning_again_count=0, is_leech=0,
-               buried_until=NULL, pre_suspend_state=NULL
-           WHERE word_id=? AND deck_id=? AND deleted_at IS NULL""",
-        (target_deck_id, due, word_id, saved_deck_id),
-    )
+    count = 0
+    for category, target_deck_id in target_deck_ids.items():
+        cur = conn.execute(
+            """UPDATE cards
+               SET deck_id=?, state='new', due=?, step_index=0, interval=0,
+                   ease=2.5, repetitions=0, lapses=0, stability=NULL, difficulty=NULL,
+                   last_review=NULL, learning_again_count=0, is_leech=0,
+                   buried_until=NULL, pre_suspend_state=NULL
+               WHERE word_id=? AND deck_id=? AND category=? AND deleted_at IS NULL""",
+            (target_deck_id, due, word_id, saved_deck_id, category),
+        )
+        count += cur.rowcount
     conn.commit()
-    count = cur.rowcount
     conn.close()
     return count
 

--- a/database/decks.py
+++ b/database/decks.py
@@ -264,6 +264,28 @@ def get_or_create_deck_path(path: str) -> int:
     return parent_id
 
 
+def get_or_create_category_decks(parent_deck_id: int, parent_name: str) -> dict:
+    """Ensure the three per-category leaf decks exist under a date/daily parent deck,
+    and return {category: deck_id}.
+
+    The rest of the app expects cards to live in these category leaf decks
+    ('<name> · Listening/Reading/Creating', each carrying a `category`), not directly
+    in the category-less parent — due counts and review queues are keyed by
+    (deck_id, category). This is the runtime twin of importer._make_leaf_decks.
+    """
+    return {
+        "listening": get_or_create_deck(
+            f"{parent_name} · Listening", parent_id=parent_deck_id, category="listening"
+        ),
+        "reading": get_or_create_deck(
+            f"{parent_name} · Reading", parent_id=parent_deck_id, category="reading"
+        ),
+        "creating": get_or_create_deck(
+            f"{parent_name} · Creating", parent_id=parent_deck_id, category="creating"
+        ),
+    }
+
+
 def get_or_create_saved_deck() -> int:
     """The fixed 'Saved' staging deck: holds suspended compound words the user
     set aside for later (see /api/save-word). Promoting moves them to a Daily deck."""

--- a/database/decks.py
+++ b/database/decks.py
@@ -192,7 +192,8 @@ def get_or_create_deck(name: str, parent_id: int | None = None,
     """Get deck id by (name, parent_id), creating it if it doesn't exist."""
     conn = get_db()
     row = conn.execute(
-        "SELECT id FROM decks WHERE name = ? AND parent_id IS ?", (name, parent_id)
+        "SELECT id FROM decks WHERE name = ? AND parent_id IS ? AND deleted_at IS NULL",
+        (name, parent_id),
     ).fetchone()
     if row:
         conn.close()

--- a/routes/imports.py
+++ b/routes/imports.py
@@ -182,14 +182,20 @@ def quick_add_word(body: dict):
     tomorrow = (date.today() + timedelta(days=1)).isoformat()
     deck_path = f"Daily::{tomorrow}"
     deck_id = database.get_or_create_deck_path(deck_path)
+    # Cards must live in the per-category leaf decks ('<date> · Listening/Reading/Creating'),
+    # not the category-less parent — otherwise due counts and review queues never see them.
+    leaf_decks = database.get_or_create_category_decks(deck_id, tomorrow)
 
     existing = database.get_word_by_zh(word_zh)
     if existing:
         entry_id = existing["id"]
         conn = database.get_db()
+        leaf_ids = tuple(leaf_decks.values())
+        placeholders = ",".join("?" * len(leaf_ids))
         already = conn.execute(
-            "SELECT id FROM cards WHERE word_id = ? AND deck_id = ? AND deleted_at IS NULL LIMIT 1",
-            (entry_id, deck_id),
+            f"SELECT id FROM cards WHERE word_id = ? AND deck_id IN ({placeholders}) "
+            "AND deleted_at IS NULL LIMIT 1",
+            (entry_id, *leaf_ids),
         ).fetchone()
         conn.close()
         if already:
@@ -218,7 +224,7 @@ def quick_add_word(body: dict):
         status = "created"
 
     for category in ("listening", "reading", "creating"):
-        database.insert_card(entry_id, category, deck_id, state="new", due=tomorrow)
+        database.insert_card(entry_id, category, leaf_decks[category], state="new", due=tomorrow)
 
     return {"status": status, "entry_id": entry_id, "deck_path": deck_path, "deck_id": deck_id}
 
@@ -280,8 +286,9 @@ def promote_saved(word_id: int):
     tomorrow = (date.today() + timedelta(days=1)).isoformat()
     deck_path = f"Daily::{tomorrow}"
     daily_deck_id = database.get_or_create_deck_path(deck_path)
+    leaf_decks = database.get_or_create_category_decks(daily_deck_id, tomorrow)
 
-    count = database.promote_saved_word(word_id, daily_deck_id, saved_deck_id, tomorrow)
+    count = database.promote_saved_word(word_id, leaf_decks, saved_deck_id, tomorrow)
     if not count:
         raise HTTPException(status_code=404, detail="No saved cards found for this word")
 


### PR DESCRIPTION
本 PR 修复"添加到明天的牌组"功能（`quick_add_word` / `promote_saved`）的两个 bug。

## 变更内容

### 1. get_or_create_deck 排除已删除牌组（Closes #359）
`get_or_create_deck`（`database/decks.py`）查找牌组时加上 `AND deleted_at IS NULL`，使其忽略垃圾桶里的同名牌组。此前若垃圾桶中存在同名父牌组 `Daily`，新建的日期子牌组会被挂到已删除的父牌组下，在牌组树中不可见。

### 2. 创建类别子牌组而非扁平牌组（Closes #361）
应用约定卡片必须存在按类别拆分的子叶子牌组（`<日期> · Listening/Reading/Creating`，各带 `category`）；到期数量与复习队列以 `(deck_id, category)` 为键。原先该功能把三类卡片直接塞进无类别的日期牌组，导致数量恒为 `0 0 0`、无法复习。
- 新增 `database.get_or_create_category_decks(parent_id, parent_name)` 创建三个类别子叶子牌组
- `quick_add_word` / `promote_saved` 改为把卡片插入/移动到对应类别子牌组
- `promote_saved_word` 改为接受 `{category: deck_id}` 字典，按类别分流

## 测试方法
- 用该功能添加一个生词，确认日期牌组下出现 3 个类别子牌组，父牌组数量显示 3 而非 0，且卡片能进入复习队列
- 软删除一个父牌组后再触发该功能，确认创建的是新的活跃牌组而非复用垃圾桶里的

Closes #359
Closes #361