### PR TITLE
feat: 未来日期的日常牌组在到期前锁定，不可复习

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -3,7 +3,7 @@ import sqlite3
 from datetime import date, datetime, timedelta
 from .core import get_db, anki_today
 from .presets import get_preset_for_deck
-from .decks import get_deck
+from .decks import get_deck, get_locked_deck_ids
 
 logger = logging.getLogger(__name__)
 
@@ -315,6 +315,10 @@ def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = Fa
     import random
     from itertools import groupby
 
+    # Future-dated daily decks are locked until their date — no card is reviewable.
+    if deck_id in get_locked_deck_ids():
+        return []
+
     today = anki_today().isoformat()
     tomorrow = (date.fromisoformat(today) + timedelta(days=1)).isoformat()
     now = datetime.now().isoformat(timespec="seconds")
@@ -465,6 +469,8 @@ def get_next_card(deck_id: int, category: str) -> dict | None:
 
 def count_due(deck_id: int, category: str) -> dict:
     """Returns {new, learning, review} counts for deck badge display."""
+    if deck_id in get_locked_deck_ids():
+        return {"new": 0, "learning": 0, "review": 0, "learning_future": 0}
     today = anki_today().isoformat()
     now = datetime.now().isoformat(timespec="seconds")
     preset = get_preset_for_deck(deck_id, category)
@@ -838,6 +844,9 @@ def count_due_deduped(leaf_pairs: list[tuple[int, str]]) -> dict:
 
     Respects the bury_siblings setting. Falls back to a simple sum if disabled.
     """
+    # Drop locked (future-dated daily) leaves so they don't inflate parent badges.
+    locked = get_locked_deck_ids()
+    leaf_pairs = [(d, c) for d, c in leaf_pairs if d not in locked]
     if not leaf_pairs:
         return {"new": 0, "learning": 0, "review": 0}
 
@@ -906,6 +915,15 @@ def count_due_deduped(leaf_pairs: list[tuple[int, str]]) -> dict:
     return {"new": new_count, "learning": learning_count, "review": review_count}
 
 
+def _locked_exclusion() -> tuple[str, list]:
+    """SQL fragment excluding locked (future-dated daily) decks, plus its params."""
+    locked = list(get_locked_deck_ids())
+    if not locked:
+        return "", []
+    placeholders = ",".join("?" * len(locked))
+    return f" AND deck_id NOT IN ({placeholders})", locked
+
+
 def _unfinished_where(scope: str) -> tuple[str, list]:
     """Build the WHERE clause + params for the unfinished virtual deck.
 
@@ -913,6 +931,7 @@ def _unfinished_where(scope: str) -> tuple[str, list]:
     scope='all': every card still due today (new + review + learning/relearn).
     """
     now = datetime.now().isoformat(timespec="seconds")
+    lock_clause, lock_params = _locked_exclusion()
     if scope == "all":
         today = anki_today().isoformat()
         tomorrow = (date.fromisoformat(today) + timedelta(days=1)).isoformat()
@@ -924,14 +943,16 @@ def _unfinished_where(scope: str) -> tuple[str, list]:
             "  OR (state = 'review' AND due <= ?)"
             "  OR (state = 'new' AND due <= ?)"
             ")"
+            + lock_clause
         )
-        return clause, [today, tomorrow, today, today]
+        return clause, [today, tomorrow, today, today, *lock_params]
     clause = (
         "state IN ('learning', 'relearn') AND due <= ? "
         "AND deleted_at IS NULL "
         "AND (buried_until IS NULL OR buried_until < date('now'))"
+        + lock_clause
     )
-    return clause, [now]
+    return clause, [now, *lock_params]
 
 
 def count_unfinished(scope: str = "unfinished") -> dict:
@@ -1351,7 +1372,16 @@ def count_due_all_decks() -> dict:
         (r["deck_id"], r["category"]): r["new_per_day"] for r in limit_rows
     }
 
+    # Future-dated daily decks are locked: force their counts to zero so they
+    # neither display due cards nor contribute to parent aggregation.
+    locked = get_locked_deck_ids()
+
     for key, c in counts.items():
+        if key[0] in locked:
+            c["new_raw"] = 0
+            c["learning"] = 0
+            c["review"] = 0
+            c["learning_future"] = 0
         limit = new_limits.get(key, 20)
         done = new_today.get(key, 0)
         c["new"] = min(c.pop("new_raw", 0), max(0, limit - done))

--- a/database/decks.py
+++ b/database/decks.py
@@ -1,5 +1,8 @@
+import re
 import sqlite3
-from .core import get_db, _ensure_default_preset, _ensure_sentences_leaf_decks
+from datetime import date
+
+from .core import anki_today, get_db, _ensure_default_preset, _ensure_sentences_leaf_decks
 
 
 # ---------------------------------------------------------------------------
@@ -267,6 +270,87 @@ def get_or_create_saved_deck() -> int:
     """The fixed 'Saved' staging deck: holds suspended compound words the user
     set aside for later (see /api/save-word). Promoting moves them to a Daily deck."""
     return get_or_create_deck_path("Saved")
+
+
+# ---------------------------------------------------------------------------
+# Future-dated daily deck locking
+#
+# Daily decks (the date-named children of a 'daily'/'Daily' root) are special:
+# a deck dated in the future must not be reviewable until its date arrives. We
+# detect them by parsing the date out of the deck name and comparing to today.
+# ---------------------------------------------------------------------------
+
+_ISO_DATE_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})")
+_MD_DATE_RE = re.compile(r"^(\d{1,2})[-_](\d{1,2})")
+
+
+def parse_daily_deck_date(name: str, today: date | None = None) -> date | None:
+    """Parse the date a daily deck name encodes, or None if it isn't date-like.
+
+    Handles ISO 'YYYY-MM-DD' (quick-add decks) and 'MM-DD' / 'MM_DD' (legacy daily
+    decks), each optionally followed by a suffix (e.g. '05-08_kouyu'). For the
+    year-less MM-DD form the year is inferred as the occurrence nearest to today,
+    so dates near a year boundary resolve sensibly.
+    """
+    if not name:
+        return None
+    name = name.strip()
+    m = _ISO_DATE_RE.match(name)
+    if m:
+        try:
+            return date(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+        except ValueError:
+            return None
+    m = _MD_DATE_RE.match(name)
+    if m:
+        today = today or anki_today()
+        month, day = int(m.group(1)), int(m.group(2))
+        for year in (today.year - 1, today.year, today.year + 1):
+            try:
+                candidate = date(year, month, day)
+            except ValueError:
+                continue
+            if abs((candidate - today).days) <= 183:
+                return candidate
+        return None
+    return None
+
+
+def get_locked_deck_ids() -> dict[int, str]:
+    """Return {deck_id: unlock_date_iso} for every deck locked because it is a
+    future-dated daily deck (a date-named child of a 'daily' root) or a descendant
+    of one. Locked decks contribute no due cards and cannot be reviewed until then.
+    """
+    today = anki_today()
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT id, name, parent_id FROM decks WHERE deleted_at IS NULL"
+    ).fetchall()
+    conn.close()
+
+    children: dict[int | None, list] = {}
+    for r in rows:
+        children.setdefault(r["parent_id"], []).append(r)
+    daily_root_ids = {
+        r["id"] for r in rows if (r["name"] or "").strip().lower() == "daily"
+    }
+
+    locked: dict[int, str] = {}
+    for r in rows:
+        if r["parent_id"] not in daily_root_ids:
+            continue
+        d = parse_daily_deck_date(r["name"], today)
+        if not d or d <= today:
+            continue
+        iso = d.isoformat()
+        # Lock this date deck and every descendant (its category leaf decks).
+        stack = [r["id"]]
+        while stack:
+            cur = stack.pop()
+            locked[cur] = iso
+            for kid in children.get(cur, []):
+                stack.append(kid["id"])
+    return locked
 
 
 def get_word_deck_names(word_id: int) -> list[str]:

--- a/routes/decks.py
+++ b/routes/decks.py
@@ -78,12 +78,17 @@ def get_decks(unfinished_scope: str = "unfinished"):
     _attach_counts(flat)
     # Attach bury_mode so the frontend can render the 3-state toggle without extra calls
     presets = {p["id"]: p for p in database.list_presets()}
+    locked = database.get_locked_deck_ids()
     for deck in flat:
         pid = deck.get("preset_id")
         p = presets.get(pid, {})
         deck["bury_mode"] = deck.get("bury_quick_mode", "all")
         deck["new_review_order_override"] = deck.get("new_review_order_override")
         deck["category_order"] = p.get("category_order", "listening,reading,creating")
+        # Future-dated daily decks are locked until their date — flag for the UI.
+        if deck.get("id") in locked:
+            deck["locked"] = True
+            deck["unlock_date"] = locked[deck["id"]]
     unfinished = database.count_unfinished(unfinished_scope)
     if sum(unfinished.values()) > 0:
         tree.insert(0, {

--- a/static/app.js
+++ b/static/app.js
@@ -1233,6 +1233,22 @@ function renderDeckRows(decks, depth, sortMode) {
     const c = deck.counts || { new: 0, learning: 0, review: 0 };
     const deckCounts = `<span class="deck-counts">${_mixNewBtn(deck.id, deck.new_review_order_override)}<span class="n-new">${c.new}</span><span class="n-lrn">${c.learning}</span><span class="n-rev">${c.review}</span></span>`;
 
+    // Future-dated daily decks are locked until their date: greyed, not reviewable.
+    if (deck.locked) {
+      const lockRow = `
+        <div class="tree-row tree-parent deck-locked" style="padding-left:${16 + indent}px">
+          <span class="tree-toggle"></span>
+          <span class="tree-name-wrap">
+            <span class="tree-name">${deck.name}</span>
+            <span class="deck-lock-badge" title="Locked until ${deck.unlock_date}">🔒 unlocks ${deck.unlock_date}</span>
+          </span>
+        </div>`;
+      const lockedChildRows = hasStructChildren && !isCollapsed
+        ? renderDeckRows(structChildren, depth + 1, mode)
+        : '';
+      return lockRow + lockedChildRows;
+    }
+
     const buryMode   = deck.bury_mode || 'all';
     const buryIcon   = buryMode === 'all' ? '⛓' : buryMode === 'none' ? '⊘' : '≡';
     const buryClass  = `bury-btn bury-${buryMode}`;

--- a/static/style.css
+++ b/static/style.css
@@ -1781,6 +1781,16 @@ main.browse-open {
 .tree-cat-icon { font-size: 15px; flex-shrink: 0; }
 .tree-name-wrap { flex: 1; display: flex; align-items: center; gap: 4px; min-width: 0; }
 .tree-name  { font-size: 15px; font-weight: 600; }
+
+/* Future-dated daily decks: locked until their date, not reviewable. */
+.deck-locked .tree-name { color: #9ca3af; font-weight: 600; cursor: default; }
+.deck-locked { opacity: 0.7; }
+.deck-lock-badge {
+  font-size: 12px;
+  font-weight: 600;
+  color: #9ca3af;
+  white-space: nowrap;
+}
 .tree-counts { font-size: 13px; font-weight: 700; white-space: nowrap; }
 .tree-card {
   background: var(--card);


### PR DESCRIPTION
## 变更内容
日常牌组（`daily` 树下以日期命名的牌组）现在是"特殊牌组"：名字解析出的日期若在未来，则该牌组及其类别子牌组被锁定，到期前完全不可复习。

### 后端
- 新增 `database.parse_daily_deck_date(name)`：解析 ISO（`YYYY-MM-DD`）与 `MM-DD`/`MM_DD`（含年份推断）日期
- 新增 `database.get_locked_deck_ids()`：返回 {deck_id: 解锁日期}（未来日期牌组 + 其后代）
- `get_due_cards` 对锁定牌组返回空列表 —— 一处覆盖单牌组/混合/全部复习
- `count_due`、`count_due_all_decks`、`count_due_deduped`、`count_unfinished` 系列对锁定牌组计数为 0、排除出队列
- `/api/decks` 为锁定牌组附带 `locked` 与 `unlock_date`

### 前端
- 锁定牌组在列表中灰显、不可点击复习，显示 🔒 与解锁日期

## 测试方法
- 创建一个未来日期的日常牌组（卡片 due 设为今天，模拟导入泄漏）：确认它在列表中灰显并标注解锁日期、到期数量为 0，且单/混合/全部/unfinished 复习都取不到它的卡片
- 对照今天/过去日期的牌组：确认不受影响、正常复习
- 已用临时数据库验证：锁定牌组 get_due_cards=0、count_due=0、父级去重计数=0、unfinished 排除；对照牌组正常

Closes #362