### PR TITLE
feat: 复习卡片"换新句子重示"按钮（不评分、约1分钟后带新句子再现）

### DIFF
--- a/routes/queue_manager.py
+++ b/routes/queue_manager.py
@@ -42,6 +42,9 @@ class SessionQueue:
     ) -> None:
         self.main = deque(main_ids)          # card IDs, pre-interleaved
         self.intraday = deque(intraday)      # [{id, due}, ...], sorted by due
+        # Soft requeues from the "new sentence" button: re-show a card at a
+        # timestamp WITHOUT touching its DB scheduling state. Purely in-memory.
+        self.requeued = deque()              # [{id, due}, ...], sorted by due
         self.built_date = built_date
 
 
@@ -79,13 +82,27 @@ class QueueManager:
             (e for e in q.intraday if e["due"] <= now),
             None,
         )
+        # Soft-requeued card (from the "new sentence" button) due right now?
+        requeue_now = next(
+            (e for e in q.requeued if e["due"] <= now),
+            None,
+        )
 
         if due_now:
             result = due_now["id"]
             source = "intraday"
+        elif requeue_now:
+            result = requeue_now["id"]
+            source = "requeued"
         elif q.main:
             result = q.main[0]
             source = "main"
+        elif q.requeued:
+            # Nothing else to show, but a soft-requeued card is still pending.
+            # Show the soonest one now (rather than ending the session) so the
+            # requeue isn't lost when it was the last remaining card.
+            result = q.requeued[0]["id"]
+            source = "requeued_early"
         else:
             result = None
             source = "empty"
@@ -147,6 +164,9 @@ class QueueManager:
         intraday_before = [e["id"] for e in q.intraday]
         q.intraday = deque(e for e in q.intraday if e["id"] != card_id)
 
+        # A real review supersedes any pending soft requeue for this card.
+        q.requeued = deque(e for e in q.requeued if e["id"] != card_id)
+
         # Re-insert into intraday if it became a same-day learning card
         if becomes_intraday:
             entries = list(q.intraday) + [{"id": card_id, "due": new_due}]
@@ -163,6 +183,7 @@ class QueueManager:
             new_intraday = deque(e for e in q.intraday if e["id"] not in remove_set)
             buried_removed_intraday = [e["id"] for e in q.intraday if e["id"] in remove_set]
             q.intraday = new_intraday
+            q.requeued = deque(e for e in q.requeued if e["id"] not in remove_set)
 
         logger.debug(
             "[QueueMgr] after_review key=%s card=#%d → state=%s due=%s\n"
@@ -184,6 +205,31 @@ class QueueManager:
             intraday_before,
             [e["id"] for e in q.intraday],
         )
+
+    def soft_requeue(self, key: tuple, card_id: int, due: str) -> bool:
+        """Re-show a card at `due` WITHOUT changing its DB scheduling state.
+
+        Backs the "new sentence" button: the card is pulled from its current
+        position and parked in the in-memory `requeued` deque (sorted by due), so
+        it reappears around `due` while the user reviews other cards meanwhile.
+        Returns False if there is no live queue for this key (nothing to do).
+        """
+        if key not in self._queues:
+            logger.debug("[QueueMgr] soft_requeue key=%s — queue not found, skipping", key)
+            return False
+        q = self._queues[key]
+        # Pull the card out of wherever it currently sits.
+        q.main = deque(cid for cid in q.main if cid != card_id)
+        q.intraday = deque(e for e in q.intraday if e["id"] != card_id)
+        q.requeued = deque(e for e in q.requeued if e["id"] != card_id)
+        # Park it in requeued, kept sorted by due so requeued[0] is the soonest.
+        entries = list(q.requeued) + [{"id": card_id, "due": due}]
+        q.requeued = deque(sorted(entries, key=lambda e: e["due"]))
+        logger.debug(
+            "[QueueMgr] soft_requeue key=%s card=#%d due=%s → requeued=%s",
+            key, card_id, due, [(e["id"], e["due"]) for e in q.requeued],
+        )
+        return True
 
     def invalidate(self, key: tuple | None = None) -> None:
         """Discard one queue (or all queues) so the next access rebuilds."""

--- a/routes/review.py
+++ b/routes/review.py
@@ -1,6 +1,6 @@
 import logging
 import threading
-from datetime import datetime
+from datetime import datetime, timedelta
 from fastapi import APIRouter, HTTPException
 
 import database
@@ -20,11 +20,13 @@ _undo_stack: list[dict] = []
 # ---------------------------------------------------------------------------
 
 def _attach_again_sentence(card: dict | None) -> dict | None:
-    """If this learning/relearn card has a freshly regenerated sentence (from a
-    previous Again today), attach it as card["again_sentence"] so the frontend
-    shows the new sentence instead of the old story one."""
-    if (card and card.get("state") in ("learning", "relearn")
-            and card.get("note_type") != "sentence" and card.get("word_id")):
+    """If a fresh sentence was regenerated for this word today (from a previous
+    Again, or the "new sentence" requeue button), attach it as
+    card["again_sentence"] so the frontend shows it instead of the old story one.
+
+    Not gated on card state: the requeue button leaves scheduling untouched, so
+    the card can be in any state when it reappears with its new sentence."""
+    if (card and card.get("note_type") != "sentence" and card.get("word_id")):
         today = database.anki_today().isoformat()
         again = database.get_again_sentence_for_word(card["word_id"], today)
         if again:
@@ -329,6 +331,62 @@ def submit_review(card_id: int, rating: int, user_response: str | None = None,
     }
     return {"next_card": next_card, "counts": counts, "transition": transition}
 
+
+@router.post("/api/review/requeue")
+def requeue_card(card_id: int, root_deck_id: int | None = None,
+                 parent_deck_id: int | None = None, unfinished_mode: bool = False,
+                 unfinished_scope: str = "unfinished", delay_seconds: int = 60):
+    """"New sentence" button: re-show this card ~delay_seconds later WITHOUT any
+    scheduling change, and regenerate its sentence in the background.
+
+    Unlike a rating this touches no SRS state (ease/interval/state/lapses/today's
+    review count are all untouched). It mirrors /api/review's queue context so the
+    card lands back in the same session queue. Returns {next_card, counts} so the
+    frontend advances exactly as it does after a rating."""
+    card = database.get_card(card_id)
+    if not card:
+        raise HTTPException(status_code=404, detail="Card not found")
+    deck_id = card["deck_id"]
+    cat = card["category"]
+
+    # Background: regenerate one fresh sentence for this word (reuses Again infra).
+    _spawn_again_regen(card)
+
+    due = (datetime.now() + timedelta(seconds=delay_seconds)).isoformat(timespec="seconds")
+
+    if unfinished_mode:
+        # The unfinished virtual deck isn't backed by an in-memory queue, so there
+        # is nothing to soft-requeue into; just advance (regen still happens).
+        next_card = database.get_next_unfinished_card(unfinished_scope)
+        if next_card:
+            next_card["intervals"] = srs.preview_intervals(next_card)
+            next_card["fsrs"] = srs.explain_card(next_card)
+            _attach_again_sentence(next_card)
+        counts = database.count_unfinished(unfinished_scope)
+    elif root_deck_id:
+        key, build_fn = _key_and_build(root_deck_id=root_deck_id)
+        _queue_mgr.soft_requeue(key, card_id, due)
+        next_card = _next_card_from_queue(key, build_fn)
+        counts = database.count_due_any_cat(root_deck_id)
+        counts["by_cat"] = database.count_due_by_category(root_deck_id)
+    elif parent_deck_id:
+        ids = leaf_ids(parent_deck_id, cat)
+        key, build_fn = _key_and_build(ids=ids, category=cat, parent_for_multi=parent_deck_id)
+        _queue_mgr.soft_requeue(key, card_id, due)
+        next_card = _next_card_from_queue(key, build_fn)
+        counts = database.count_due_multi(ids, cat, root_deck_id=parent_deck_id)
+        counts["by_cat"] = database.count_due_by_category(parent_deck_id)
+    else:
+        key, build_fn = _key_and_build(deck_id=deck_id, category=cat)
+        _queue_mgr.soft_requeue(key, card_id, due)
+        next_card = _next_card_from_queue(key, build_fn)
+        counts = database.count_due(deck_id, cat)
+        parent_id = database.get_parent_deck_id(deck_id)
+        counts["by_cat"] = database.count_due_by_category(parent_id or deck_id)
+
+    logger.info("requeue  card=#%d word=%s cat=%s → re-show at %s (no scheduling change)",
+                card_id, card.get("word_zh"), cat, due)
+    return {"next_card": next_card, "counts": counts}
 
 
 @router.post("/api/review/undo")

--- a/static/app.js
+++ b/static/app.js
@@ -5027,6 +5027,33 @@ async function rate(rating) {
   }
 }
 
+// ── "New sentence" — re-show this card soon with a freshly generated sentence ──
+// Not a rating: scheduling (ease/interval/state/today's count) is untouched. The
+// card is soft-requeued ~1 min out while a new sentence regenerates in the
+// background, so the user reviews other cards meanwhile.
+async function requeueNewSentence() {
+  document.querySelectorAll('.r-btn').forEach(b => b.disabled = true);
+  try {
+    let url = `/api/review/requeue?card_id=${card.id}`;
+    if (unfinishedMode) url += `&unfinished_mode=true&unfinished_scope=${_unfinishedScope}`;
+    else if (rootDeckId) url += `&root_deck_id=${rootDeckId}`;
+    else if (deckId) url += `&parent_deck_id=${deckId}`;
+    const result = await api('POST', url);
+    if (!result.next_card) {
+      rootDeckId = null;
+      unfinishedMode = false;
+      showView('done');
+      return;
+    }
+    if (unfinishedMode || rootDeckId) category = result.next_card.category;
+    loadCard(result.next_card, result.counts);
+    document.querySelectorAll('.r-btn').forEach(b => b.disabled = false);
+  } catch (e) {
+    showError('Could not requeue: ' + e.message);
+    document.querySelectorAll('.r-btn').forEach(b => b.disabled = false);
+  }
+}
+
 // ── Undo last rating ─────────────────────────────────────────────────────────
 async function undoReview() {
   try {

--- a/static/index.html
+++ b/static/index.html
@@ -214,6 +214,8 @@
               <button class="r-btn r-hard"  onclick="rate(2)">Hard<small id="int-2"></small></button>
               <button class="r-btn r-good"  onclick="rate(3)">Good<small id="int-3"></small></button>
               <button class="r-btn r-easy"  onclick="rate(4)">Easy<small id="int-4"></small></button>
+              <button class="r-btn r-newsentence" id="new-sentence-btn" onclick="requeueNewSentence()"
+                      title="New sentence — show this card again in ~1 min with a freshly generated sentence (not a rating, no scheduling change)">🔄</button>
             </div>
             <!-- Free-text note carried over to the next time this card is seen -->
             <div class="next-note-row" id="next-note-row">

--- a/static/style.css
+++ b/static/style.css
@@ -640,7 +640,7 @@ main.browse-open {
 /* Rating buttons */
 .rating-row {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(4, 1fr) auto;
   gap: 8px;
 }
 
@@ -736,6 +736,12 @@ main.browse-open {
 .r-hard  { background: var(--hard); }
 .r-good  { background: var(--good); }
 .r-easy  { background: var(--easy); }
+/* "New sentence" requeue — neutral, compact, sits to the right of the ratings. */
+.r-newsentence {
+  background: #64748b;
+  font-size: 16px;
+  padding: 11px 12px 9px;
+}
 
 /* ── Vocab detail (below ratings on back side) ───────── */
 .vocab-detail {


### PR DESCRIPTION
## 变更内容
复习时新增一个非评分按钮 🔄（在 Again/Hard/Good/Easy 旁）：点一下后这张卡约 1 分钟后带**新生成的句子**再次出现，这一分钟里继续复习别的卡片，后台同时重新生成句子。**完全不影响调度**——不降 ease、不算遗忘、不改 state/interval、不计入今日复习数。

### 后端
- `routes/queue_manager.py`：SessionQueue 新增 `requeued` 软重排队列与 `soft_requeue()`，按时间戳重排卡片且不读写数据库调度状态；主队列耗尽时优先显示重排卡，避免会话提前结束、丢失重排
- `routes/review.py`：新增 `POST /api/review/requeue`，沿用 `/api/review` 的队列上下文（单/多/混合），后台触发单句重生成（复用 Again 机制），约 60 秒后再现，返回 {next_card, counts}；放宽 `_attach_again_sentence` 使任意状态的重排卡也能附上新句子

### 前端
- 评分键旁加 🔄 图标按钮，调用重排接口并加载下一张卡；复用现有 `again_sentence` 显示逻辑

## 复用
直接复用了为 Again 做的单句重生成基础设施（`generate_sentence_for_word`、`store_again_sentence`、`get_again_sentence_for_word`）。

## 测试方法
- 复习中点 🔄：确认卡片约 1 分钟后再现、句子已更新，且 ease/interval/state/今日复习数均未变化
- 这一分钟内能正常复习其他卡片
- 当前是最后一张卡时，确认会话不会提前结束
- 已用独立单元测试验证队列重排逻辑（重排后先复习其他卡、最后一张提前显示、到点再现、复习完结束）

Closes #364