### PR TITLE
集成: 修复添加到明天牌组 + 锁定未来牌组 + 换新句子重示（#359 #362 #364）

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -3,7 +3,7 @@ import sqlite3
 from datetime import date, datetime, timedelta
 from .core import get_db, anki_today
 from .presets import get_preset_for_deck
-from .decks import get_deck
+from .decks import get_deck, get_locked_deck_ids
 
 logger = logging.getLogger(__name__)
 
@@ -315,6 +315,10 @@ def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = Fa
     import random
     from itertools import groupby
 
+    # Future-dated daily decks are locked until their date — no card is reviewable.
+    if deck_id in get_locked_deck_ids():
+        return []
+
     today = anki_today().isoformat()
     tomorrow = (date.fromisoformat(today) + timedelta(days=1)).isoformat()
     now = datetime.now().isoformat(timespec="seconds")
@@ -465,6 +469,8 @@ def get_next_card(deck_id: int, category: str) -> dict | None:
 
 def count_due(deck_id: int, category: str) -> dict:
     """Returns {new, learning, review} counts for deck badge display."""
+    if deck_id in get_locked_deck_ids():
+        return {"new": 0, "learning": 0, "review": 0, "learning_future": 0}
     today = anki_today().isoformat()
     now = datetime.now().isoformat(timespec="seconds")
     preset = get_preset_for_deck(deck_id, category)
@@ -838,6 +844,9 @@ def count_due_deduped(leaf_pairs: list[tuple[int, str]]) -> dict:
 
     Respects the bury_siblings setting. Falls back to a simple sum if disabled.
     """
+    # Drop locked (future-dated daily) leaves so they don't inflate parent badges.
+    locked = get_locked_deck_ids()
+    leaf_pairs = [(d, c) for d, c in leaf_pairs if d not in locked]
     if not leaf_pairs:
         return {"new": 0, "learning": 0, "review": 0}
 
@@ -906,6 +915,15 @@ def count_due_deduped(leaf_pairs: list[tuple[int, str]]) -> dict:
     return {"new": new_count, "learning": learning_count, "review": review_count}
 
 
+def _locked_exclusion() -> tuple[str, list]:
+    """SQL fragment excluding locked (future-dated daily) decks, plus its params."""
+    locked = list(get_locked_deck_ids())
+    if not locked:
+        return "", []
+    placeholders = ",".join("?" * len(locked))
+    return f" AND deck_id NOT IN ({placeholders})", locked
+
+
 def _unfinished_where(scope: str) -> tuple[str, list]:
     """Build the WHERE clause + params for the unfinished virtual deck.
 
@@ -913,6 +931,7 @@ def _unfinished_where(scope: str) -> tuple[str, list]:
     scope='all': every card still due today (new + review + learning/relearn).
     """
     now = datetime.now().isoformat(timespec="seconds")
+    lock_clause, lock_params = _locked_exclusion()
     if scope == "all":
         today = anki_today().isoformat()
         tomorrow = (date.fromisoformat(today) + timedelta(days=1)).isoformat()
@@ -924,14 +943,16 @@ def _unfinished_where(scope: str) -> tuple[str, list]:
             "  OR (state = 'review' AND due <= ?)"
             "  OR (state = 'new' AND due <= ?)"
             ")"
+            + lock_clause
         )
-        return clause, [today, tomorrow, today, today]
+        return clause, [today, tomorrow, today, today, *lock_params]
     clause = (
         "state IN ('learning', 'relearn') AND due <= ? "
         "AND deleted_at IS NULL "
         "AND (buried_until IS NULL OR buried_until < date('now'))"
+        + lock_clause
     )
-    return clause, [now]
+    return clause, [now, *lock_params]
 
 
 def count_unfinished(scope: str = "unfinished") -> dict:
@@ -1351,7 +1372,16 @@ def count_due_all_decks() -> dict:
         (r["deck_id"], r["category"]): r["new_per_day"] for r in limit_rows
     }
 
+    # Future-dated daily decks are locked: force their counts to zero so they
+    # neither display due cards nor contribute to parent aggregation.
+    locked = get_locked_deck_ids()
+
     for key, c in counts.items():
+        if key[0] in locked:
+            c["new_raw"] = 0
+            c["learning"] = 0
+            c["review"] = 0
+            c["learning_future"] = 0
         limit = new_limits.get(key, 20)
         done = new_today.get(key, 0)
         c["new"] = min(c.pop("new_raw", 0), max(0, limit - done))

--- a/database/cards.py
+++ b/database/cards.py
@@ -36,25 +36,31 @@ def insert_card(word_id: int, category: str, deck_id: int,
     return row["id"]
 
 
-def promote_saved_word(word_id: int, target_deck_id: int,
+def promote_saved_word(word_id: int, target_deck_ids: dict,
                        saved_deck_id: int, due: str) -> int:
-    """Move a saved word's suspended cards out of the Saved deck into target_deck_id
-    as fresh 'new' cards due on `due`, clearing any scheduling state.
+    """Move a saved word's suspended cards out of the Saved deck into the per-category
+    leaf decks as fresh 'new' cards due on `due`, clearing any scheduling state.
+
+    target_deck_ids: {"listening": id, "reading": id, "creating": id} — each card is
+    routed to the leaf deck matching its category, so due counts and review queues
+    (keyed by deck_id, category) pick it up.
 
     Returns the number of cards promoted.
     """
     conn = get_db()
-    cur = conn.execute(
-        """UPDATE cards
-           SET deck_id=?, state='new', due=?, step_index=0, interval=0,
-               ease=2.5, repetitions=0, lapses=0, stability=NULL, difficulty=NULL,
-               last_review=NULL, learning_again_count=0, is_leech=0,
-               buried_until=NULL, pre_suspend_state=NULL
-           WHERE word_id=? AND deck_id=? AND deleted_at IS NULL""",
-        (target_deck_id, due, word_id, saved_deck_id),
-    )
+    count = 0
+    for category, target_deck_id in target_deck_ids.items():
+        cur = conn.execute(
+            """UPDATE cards
+               SET deck_id=?, state='new', due=?, step_index=0, interval=0,
+                   ease=2.5, repetitions=0, lapses=0, stability=NULL, difficulty=NULL,
+                   last_review=NULL, learning_again_count=0, is_leech=0,
+                   buried_until=NULL, pre_suspend_state=NULL
+               WHERE word_id=? AND deck_id=? AND category=? AND deleted_at IS NULL""",
+            (target_deck_id, due, word_id, saved_deck_id, category),
+        )
+        count += cur.rowcount
     conn.commit()
-    count = cur.rowcount
     conn.close()
     return count
 

--- a/database/decks.py
+++ b/database/decks.py
@@ -264,6 +264,28 @@ def get_or_create_deck_path(path: str) -> int:
     return parent_id
 
 
+def get_or_create_category_decks(parent_deck_id: int, parent_name: str) -> dict:
+    """Ensure the three per-category leaf decks exist under a date/daily parent deck,
+    and return {category: deck_id}.
+
+    The rest of the app expects cards to live in these category leaf decks
+    ('<name> · Listening/Reading/Creating', each carrying a `category`), not directly
+    in the category-less parent — due counts and review queues are keyed by
+    (deck_id, category). This is the runtime twin of importer._make_leaf_decks.
+    """
+    return {
+        "listening": get_or_create_deck(
+            f"{parent_name} · Listening", parent_id=parent_deck_id, category="listening"
+        ),
+        "reading": get_or_create_deck(
+            f"{parent_name} · Reading", parent_id=parent_deck_id, category="reading"
+        ),
+        "creating": get_or_create_deck(
+            f"{parent_name} · Creating", parent_id=parent_deck_id, category="creating"
+        ),
+    }
+
+
 def get_or_create_saved_deck() -> int:
     """The fixed 'Saved' staging deck: holds suspended compound words the user
     set aside for later (see /api/save-word). Promoting moves them to a Daily deck."""

--- a/database/decks.py
+++ b/database/decks.py
@@ -192,7 +192,8 @@ def get_or_create_deck(name: str, parent_id: int | None = None,
     """Get deck id by (name, parent_id), creating it if it doesn't exist."""
     conn = get_db()
     row = conn.execute(
-        "SELECT id FROM decks WHERE name = ? AND parent_id IS ?", (name, parent_id)
+        "SELECT id FROM decks WHERE name = ? AND parent_id IS ? AND deleted_at IS NULL",
+        (name, parent_id),
     ).fetchone()
     if row:
         conn.close()

--- a/database/decks.py
+++ b/database/decks.py
@@ -1,5 +1,8 @@
+import re
 import sqlite3
-from .core import get_db, _ensure_default_preset, _ensure_sentences_leaf_decks
+from datetime import date
+
+from .core import anki_today, get_db, _ensure_default_preset, _ensure_sentences_leaf_decks
 
 
 # ---------------------------------------------------------------------------
@@ -267,6 +270,87 @@ def get_or_create_saved_deck() -> int:
     """The fixed 'Saved' staging deck: holds suspended compound words the user
     set aside for later (see /api/save-word). Promoting moves them to a Daily deck."""
     return get_or_create_deck_path("Saved")
+
+
+# ---------------------------------------------------------------------------
+# Future-dated daily deck locking
+#
+# Daily decks (the date-named children of a 'daily'/'Daily' root) are special:
+# a deck dated in the future must not be reviewable until its date arrives. We
+# detect them by parsing the date out of the deck name and comparing to today.
+# ---------------------------------------------------------------------------
+
+_ISO_DATE_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})")
+_MD_DATE_RE = re.compile(r"^(\d{1,2})[-_](\d{1,2})")
+
+
+def parse_daily_deck_date(name: str, today: date | None = None) -> date | None:
+    """Parse the date a daily deck name encodes, or None if it isn't date-like.
+
+    Handles ISO 'YYYY-MM-DD' (quick-add decks) and 'MM-DD' / 'MM_DD' (legacy daily
+    decks), each optionally followed by a suffix (e.g. '05-08_kouyu'). For the
+    year-less MM-DD form the year is inferred as the occurrence nearest to today,
+    so dates near a year boundary resolve sensibly.
+    """
+    if not name:
+        return None
+    name = name.strip()
+    m = _ISO_DATE_RE.match(name)
+    if m:
+        try:
+            return date(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+        except ValueError:
+            return None
+    m = _MD_DATE_RE.match(name)
+    if m:
+        today = today or anki_today()
+        month, day = int(m.group(1)), int(m.group(2))
+        for year in (today.year - 1, today.year, today.year + 1):
+            try:
+                candidate = date(year, month, day)
+            except ValueError:
+                continue
+            if abs((candidate - today).days) <= 183:
+                return candidate
+        return None
+    return None
+
+
+def get_locked_deck_ids() -> dict[int, str]:
+    """Return {deck_id: unlock_date_iso} for every deck locked because it is a
+    future-dated daily deck (a date-named child of a 'daily' root) or a descendant
+    of one. Locked decks contribute no due cards and cannot be reviewed until then.
+    """
+    today = anki_today()
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT id, name, parent_id FROM decks WHERE deleted_at IS NULL"
+    ).fetchall()
+    conn.close()
+
+    children: dict[int | None, list] = {}
+    for r in rows:
+        children.setdefault(r["parent_id"], []).append(r)
+    daily_root_ids = {
+        r["id"] for r in rows if (r["name"] or "").strip().lower() == "daily"
+    }
+
+    locked: dict[int, str] = {}
+    for r in rows:
+        if r["parent_id"] not in daily_root_ids:
+            continue
+        d = parse_daily_deck_date(r["name"], today)
+        if not d or d <= today:
+            continue
+        iso = d.isoformat()
+        # Lock this date deck and every descendant (its category leaf decks).
+        stack = [r["id"]]
+        while stack:
+            cur = stack.pop()
+            locked[cur] = iso
+            for kid in children.get(cur, []):
+                stack.append(kid["id"])
+    return locked
 
 
 def get_word_deck_names(word_id: int) -> list[str]:

--- a/routes/decks.py
+++ b/routes/decks.py
@@ -78,12 +78,17 @@ def get_decks(unfinished_scope: str = "unfinished"):
     _attach_counts(flat)
     # Attach bury_mode so the frontend can render the 3-state toggle without extra calls
     presets = {p["id"]: p for p in database.list_presets()}
+    locked = database.get_locked_deck_ids()
     for deck in flat:
         pid = deck.get("preset_id")
         p = presets.get(pid, {})
         deck["bury_mode"] = deck.get("bury_quick_mode", "all")
         deck["new_review_order_override"] = deck.get("new_review_order_override")
         deck["category_order"] = p.get("category_order", "listening,reading,creating")
+        # Future-dated daily decks are locked until their date — flag for the UI.
+        if deck.get("id") in locked:
+            deck["locked"] = True
+            deck["unlock_date"] = locked[deck["id"]]
     unfinished = database.count_unfinished(unfinished_scope)
     if sum(unfinished.values()) > 0:
         tree.insert(0, {

--- a/routes/imports.py
+++ b/routes/imports.py
@@ -182,14 +182,20 @@ def quick_add_word(body: dict):
     tomorrow = (date.today() + timedelta(days=1)).isoformat()
     deck_path = f"Daily::{tomorrow}"
     deck_id = database.get_or_create_deck_path(deck_path)
+    # Cards must live in the per-category leaf decks ('<date> · Listening/Reading/Creating'),
+    # not the category-less parent — otherwise due counts and review queues never see them.
+    leaf_decks = database.get_or_create_category_decks(deck_id, tomorrow)
 
     existing = database.get_word_by_zh(word_zh)
     if existing:
         entry_id = existing["id"]
         conn = database.get_db()
+        leaf_ids = tuple(leaf_decks.values())
+        placeholders = ",".join("?" * len(leaf_ids))
         already = conn.execute(
-            "SELECT id FROM cards WHERE word_id = ? AND deck_id = ? AND deleted_at IS NULL LIMIT 1",
-            (entry_id, deck_id),
+            f"SELECT id FROM cards WHERE word_id = ? AND deck_id IN ({placeholders}) "
+            "AND deleted_at IS NULL LIMIT 1",
+            (entry_id, *leaf_ids),
         ).fetchone()
         conn.close()
         if already:
@@ -218,7 +224,7 @@ def quick_add_word(body: dict):
         status = "created"
 
     for category in ("listening", "reading", "creating"):
-        database.insert_card(entry_id, category, deck_id, state="new", due=tomorrow)
+        database.insert_card(entry_id, category, leaf_decks[category], state="new", due=tomorrow)
 
     return {"status": status, "entry_id": entry_id, "deck_path": deck_path, "deck_id": deck_id}
 
@@ -280,8 +286,9 @@ def promote_saved(word_id: int):
     tomorrow = (date.today() + timedelta(days=1)).isoformat()
     deck_path = f"Daily::{tomorrow}"
     daily_deck_id = database.get_or_create_deck_path(deck_path)
+    leaf_decks = database.get_or_create_category_decks(daily_deck_id, tomorrow)
 
-    count = database.promote_saved_word(word_id, daily_deck_id, saved_deck_id, tomorrow)
+    count = database.promote_saved_word(word_id, leaf_decks, saved_deck_id, tomorrow)
     if not count:
         raise HTTPException(status_code=404, detail="No saved cards found for this word")
 

--- a/routes/queue_manager.py
+++ b/routes/queue_manager.py
@@ -42,6 +42,9 @@ class SessionQueue:
     ) -> None:
         self.main = deque(main_ids)          # card IDs, pre-interleaved
         self.intraday = deque(intraday)      # [{id, due}, ...], sorted by due
+        # Soft requeues from the "new sentence" button: re-show a card at a
+        # timestamp WITHOUT touching its DB scheduling state. Purely in-memory.
+        self.requeued = deque()              # [{id, due}, ...], sorted by due
         self.built_date = built_date
 
 
@@ -79,13 +82,27 @@ class QueueManager:
             (e for e in q.intraday if e["due"] <= now),
             None,
         )
+        # Soft-requeued card (from the "new sentence" button) due right now?
+        requeue_now = next(
+            (e for e in q.requeued if e["due"] <= now),
+            None,
+        )
 
         if due_now:
             result = due_now["id"]
             source = "intraday"
+        elif requeue_now:
+            result = requeue_now["id"]
+            source = "requeued"
         elif q.main:
             result = q.main[0]
             source = "main"
+        elif q.requeued:
+            # Nothing else to show, but a soft-requeued card is still pending.
+            # Show the soonest one now (rather than ending the session) so the
+            # requeue isn't lost when it was the last remaining card.
+            result = q.requeued[0]["id"]
+            source = "requeued_early"
         else:
             result = None
             source = "empty"
@@ -147,6 +164,9 @@ class QueueManager:
         intraday_before = [e["id"] for e in q.intraday]
         q.intraday = deque(e for e in q.intraday if e["id"] != card_id)
 
+        # A real review supersedes any pending soft requeue for this card.
+        q.requeued = deque(e for e in q.requeued if e["id"] != card_id)
+
         # Re-insert into intraday if it became a same-day learning card
         if becomes_intraday:
             entries = list(q.intraday) + [{"id": card_id, "due": new_due}]
@@ -163,6 +183,7 @@ class QueueManager:
             new_intraday = deque(e for e in q.intraday if e["id"] not in remove_set)
             buried_removed_intraday = [e["id"] for e in q.intraday if e["id"] in remove_set]
             q.intraday = new_intraday
+            q.requeued = deque(e for e in q.requeued if e["id"] not in remove_set)
 
         logger.debug(
             "[QueueMgr] after_review key=%s card=#%d → state=%s due=%s\n"
@@ -184,6 +205,31 @@ class QueueManager:
             intraday_before,
             [e["id"] for e in q.intraday],
         )
+
+    def soft_requeue(self, key: tuple, card_id: int, due: str) -> bool:
+        """Re-show a card at `due` WITHOUT changing its DB scheduling state.
+
+        Backs the "new sentence" button: the card is pulled from its current
+        position and parked in the in-memory `requeued` deque (sorted by due), so
+        it reappears around `due` while the user reviews other cards meanwhile.
+        Returns False if there is no live queue for this key (nothing to do).
+        """
+        if key not in self._queues:
+            logger.debug("[QueueMgr] soft_requeue key=%s — queue not found, skipping", key)
+            return False
+        q = self._queues[key]
+        # Pull the card out of wherever it currently sits.
+        q.main = deque(cid for cid in q.main if cid != card_id)
+        q.intraday = deque(e for e in q.intraday if e["id"] != card_id)
+        q.requeued = deque(e for e in q.requeued if e["id"] != card_id)
+        # Park it in requeued, kept sorted by due so requeued[0] is the soonest.
+        entries = list(q.requeued) + [{"id": card_id, "due": due}]
+        q.requeued = deque(sorted(entries, key=lambda e: e["due"]))
+        logger.debug(
+            "[QueueMgr] soft_requeue key=%s card=#%d due=%s → requeued=%s",
+            key, card_id, due, [(e["id"], e["due"]) for e in q.requeued],
+        )
+        return True
 
     def invalidate(self, key: tuple | None = None) -> None:
         """Discard one queue (or all queues) so the next access rebuilds."""

--- a/routes/review.py
+++ b/routes/review.py
@@ -1,6 +1,6 @@
 import logging
 import threading
-from datetime import datetime
+from datetime import datetime, timedelta
 from fastapi import APIRouter, HTTPException
 
 import database
@@ -20,11 +20,13 @@ _undo_stack: list[dict] = []
 # ---------------------------------------------------------------------------
 
 def _attach_again_sentence(card: dict | None) -> dict | None:
-    """If this learning/relearn card has a freshly regenerated sentence (from a
-    previous Again today), attach it as card["again_sentence"] so the frontend
-    shows the new sentence instead of the old story one."""
-    if (card and card.get("state") in ("learning", "relearn")
-            and card.get("note_type") != "sentence" and card.get("word_id")):
+    """If a fresh sentence was regenerated for this word today (from a previous
+    Again, or the "new sentence" requeue button), attach it as
+    card["again_sentence"] so the frontend shows it instead of the old story one.
+
+    Not gated on card state: the requeue button leaves scheduling untouched, so
+    the card can be in any state when it reappears with its new sentence."""
+    if (card and card.get("note_type") != "sentence" and card.get("word_id")):
         today = database.anki_today().isoformat()
         again = database.get_again_sentence_for_word(card["word_id"], today)
         if again:
@@ -329,6 +331,62 @@ def submit_review(card_id: int, rating: int, user_response: str | None = None,
     }
     return {"next_card": next_card, "counts": counts, "transition": transition}
 
+
+@router.post("/api/review/requeue")
+def requeue_card(card_id: int, root_deck_id: int | None = None,
+                 parent_deck_id: int | None = None, unfinished_mode: bool = False,
+                 unfinished_scope: str = "unfinished", delay_seconds: int = 60):
+    """"New sentence" button: re-show this card ~delay_seconds later WITHOUT any
+    scheduling change, and regenerate its sentence in the background.
+
+    Unlike a rating this touches no SRS state (ease/interval/state/lapses/today's
+    review count are all untouched). It mirrors /api/review's queue context so the
+    card lands back in the same session queue. Returns {next_card, counts} so the
+    frontend advances exactly as it does after a rating."""
+    card = database.get_card(card_id)
+    if not card:
+        raise HTTPException(status_code=404, detail="Card not found")
+    deck_id = card["deck_id"]
+    cat = card["category"]
+
+    # Background: regenerate one fresh sentence for this word (reuses Again infra).
+    _spawn_again_regen(card)
+
+    due = (datetime.now() + timedelta(seconds=delay_seconds)).isoformat(timespec="seconds")
+
+    if unfinished_mode:
+        # The unfinished virtual deck isn't backed by an in-memory queue, so there
+        # is nothing to soft-requeue into; just advance (regen still happens).
+        next_card = database.get_next_unfinished_card(unfinished_scope)
+        if next_card:
+            next_card["intervals"] = srs.preview_intervals(next_card)
+            next_card["fsrs"] = srs.explain_card(next_card)
+            _attach_again_sentence(next_card)
+        counts = database.count_unfinished(unfinished_scope)
+    elif root_deck_id:
+        key, build_fn = _key_and_build(root_deck_id=root_deck_id)
+        _queue_mgr.soft_requeue(key, card_id, due)
+        next_card = _next_card_from_queue(key, build_fn)
+        counts = database.count_due_any_cat(root_deck_id)
+        counts["by_cat"] = database.count_due_by_category(root_deck_id)
+    elif parent_deck_id:
+        ids = leaf_ids(parent_deck_id, cat)
+        key, build_fn = _key_and_build(ids=ids, category=cat, parent_for_multi=parent_deck_id)
+        _queue_mgr.soft_requeue(key, card_id, due)
+        next_card = _next_card_from_queue(key, build_fn)
+        counts = database.count_due_multi(ids, cat, root_deck_id=parent_deck_id)
+        counts["by_cat"] = database.count_due_by_category(parent_deck_id)
+    else:
+        key, build_fn = _key_and_build(deck_id=deck_id, category=cat)
+        _queue_mgr.soft_requeue(key, card_id, due)
+        next_card = _next_card_from_queue(key, build_fn)
+        counts = database.count_due(deck_id, cat)
+        parent_id = database.get_parent_deck_id(deck_id)
+        counts["by_cat"] = database.count_due_by_category(parent_id or deck_id)
+
+    logger.info("requeue  card=#%d word=%s cat=%s → re-show at %s (no scheduling change)",
+                card_id, card.get("word_zh"), cat, due)
+    return {"next_card": next_card, "counts": counts}
 
 
 @router.post("/api/review/undo")

--- a/static/app.js
+++ b/static/app.js
@@ -5027,6 +5027,33 @@ async function rate(rating) {
   }
 }
 
+// ── "New sentence" — re-show this card soon with a freshly generated sentence ──
+// Not a rating: scheduling (ease/interval/state/today's count) is untouched. The
+// card is soft-requeued ~1 min out while a new sentence regenerates in the
+// background, so the user reviews other cards meanwhile.
+async function requeueNewSentence() {
+  document.querySelectorAll('.r-btn').forEach(b => b.disabled = true);
+  try {
+    let url = `/api/review/requeue?card_id=${card.id}`;
+    if (unfinishedMode) url += `&unfinished_mode=true&unfinished_scope=${_unfinishedScope}`;
+    else if (rootDeckId) url += `&root_deck_id=${rootDeckId}`;
+    else if (deckId) url += `&parent_deck_id=${deckId}`;
+    const result = await api('POST', url);
+    if (!result.next_card) {
+      rootDeckId = null;
+      unfinishedMode = false;
+      showView('done');
+      return;
+    }
+    if (unfinishedMode || rootDeckId) category = result.next_card.category;
+    loadCard(result.next_card, result.counts);
+    document.querySelectorAll('.r-btn').forEach(b => b.disabled = false);
+  } catch (e) {
+    showError('Could not requeue: ' + e.message);
+    document.querySelectorAll('.r-btn').forEach(b => b.disabled = false);
+  }
+}
+
 // ── Undo last rating ─────────────────────────────────────────────────────────
 async function undoReview() {
   try {

--- a/static/app.js
+++ b/static/app.js
@@ -1233,6 +1233,22 @@ function renderDeckRows(decks, depth, sortMode) {
     const c = deck.counts || { new: 0, learning: 0, review: 0 };
     const deckCounts = `<span class="deck-counts">${_mixNewBtn(deck.id, deck.new_review_order_override)}<span class="n-new">${c.new}</span><span class="n-lrn">${c.learning}</span><span class="n-rev">${c.review}</span></span>`;
 
+    // Future-dated daily decks are locked until their date: greyed, not reviewable.
+    if (deck.locked) {
+      const lockRow = `
+        <div class="tree-row tree-parent deck-locked" style="padding-left:${16 + indent}px">
+          <span class="tree-toggle"></span>
+          <span class="tree-name-wrap">
+            <span class="tree-name">${deck.name}</span>
+            <span class="deck-lock-badge" title="Locked until ${deck.unlock_date}">🔒 unlocks ${deck.unlock_date}</span>
+          </span>
+        </div>`;
+      const lockedChildRows = hasStructChildren && !isCollapsed
+        ? renderDeckRows(structChildren, depth + 1, mode)
+        : '';
+      return lockRow + lockedChildRows;
+    }
+
     const buryMode   = deck.bury_mode || 'all';
     const buryIcon   = buryMode === 'all' ? '⛓' : buryMode === 'none' ? '⊘' : '≡';
     const buryClass  = `bury-btn bury-${buryMode}`;

--- a/static/index.html
+++ b/static/index.html
@@ -214,6 +214,8 @@
               <button class="r-btn r-hard"  onclick="rate(2)">Hard<small id="int-2"></small></button>
               <button class="r-btn r-good"  onclick="rate(3)">Good<small id="int-3"></small></button>
               <button class="r-btn r-easy"  onclick="rate(4)">Easy<small id="int-4"></small></button>
+              <button class="r-btn r-newsentence" id="new-sentence-btn" onclick="requeueNewSentence()"
+                      title="New sentence — show this card again in ~1 min with a freshly generated sentence (not a rating, no scheduling change)">🔄</button>
             </div>
             <!-- Free-text note carried over to the next time this card is seen -->
             <div class="next-note-row" id="next-note-row">

--- a/static/style.css
+++ b/static/style.css
@@ -640,7 +640,7 @@ main.browse-open {
 /* Rating buttons */
 .rating-row {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(4, 1fr) auto;
   gap: 8px;
 }
 
@@ -736,6 +736,12 @@ main.browse-open {
 .r-hard  { background: var(--hard); }
 .r-good  { background: var(--good); }
 .r-easy  { background: var(--easy); }
+/* "New sentence" requeue — neutral, compact, sits to the right of the ratings. */
+.r-newsentence {
+  background: #64748b;
+  font-size: 16px;
+  padding: 11px 12px 9px;
+}
 
 /* ── Vocab detail (below ratings on back side) ───────── */
 .vocab-detail {

--- a/static/style.css
+++ b/static/style.css
@@ -1781,6 +1781,16 @@ main.browse-open {
 .tree-cat-icon { font-size: 15px; flex-shrink: 0; }
 .tree-name-wrap { flex: 1; display: flex; align-items: center; gap: 4px; min-width: 0; }
 .tree-name  { font-size: 15px; font-weight: 600; }
+
+/* Future-dated daily decks: locked until their date, not reviewable. */
+.deck-locked .tree-name { color: #9ca3af; font-weight: 600; cursor: default; }
+.deck-locked { opacity: 0.7; }
+.deck-lock-badge {
+  font-size: 12px;
+  font-weight: 600;
+  color: #9ca3af;
+  white-space: nowrap;
+}
 .tree-counts { font-size: 13px; font-weight: 700; white-space: nowrap; }
 .tree-card {
   background: var(--card);


### PR DESCRIPTION
把三个分支合并到一起，方便一次性审核合并。包含 PR #360、#363、#365 的全部改动。

## 包含的三组改动

### 1. 修复"添加到明天的牌组"功能（Closes #359）
- `get_or_create_deck` 查找时排除已软删除牌组，避免新牌组挂到垃圾桶里的同名父牌组下变成孤儿
- 新增 `get_or_create_category_decks`：quick-add / promote 改为把卡片放进`日期 · Listening/Reading/Creating`三个类别子牌组，修复数量显示 0、无法复习

### 2. 锁定未来日期的日常牌组（Closes #362）
- `parse_daily_deck_date` + `get_locked_deck_ids`：解析日常牌组名里的日期（ISO 与 MM-DD）
- 未来日期牌组在所有复习/计数路径返回空、计数为 0；`/api/decks` 附带 `locked`/`unlock_date`
- 前端灰显锁定牌组并显示解锁日期

### 3. "换新句子重示"按钮（Closes #364）
- `QueueManager.soft_requeue`：按时间戳软重排卡片，不改数据库调度状态
- `POST /api/review/requeue`：不评分、约 1 分钟后带新句子再现，后台复用 Again 的单句重生成
- 前端评分键旁加 🔄 按钮

## 验证
- 全部模块导入正常、语法检查通过
- 三个功能的关键函数/端点均已确认共存（合并无逻辑冲突）
- 各功能在独立分支上已分别用临时数据库 / 单元测试验证过

## 合并方式
合并此 PR 即等于一次性合入 #359/#362/#364 三组改动。原三个独立 PR（#360/#363/#365）可在此合并后关闭。

Closes #359
Closes #362
Closes #364