### PR TITLE
feat: 牌组列表故事重新生成改为后台进行（提示横幅 + 完成可点击）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -5984,50 +5984,44 @@ async function regenerateStoryFromList(deckId) {
   document.getElementById('setup-topic').focus();
 }
 
+// Regenerate a deck's story in the BACKGROUND: instead of a blocking full-screen
+// loader, show a small persistent banner and let the user keep reviewing. When
+// the new story is ready the banner turns into a clickable "open for review".
 async function _doRegenStoryForDeckList(deckId, topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', chapterIds = null) {
-  setLoading('Regenerating story…', true);
-  setLoadingStep(10, null, 'Sending request to AI…');
-  _startFakeProgress(10, 55, 45000);
-  _startStoryProgressPoll(deckId, 'unified');
+  const deck = flatten(_cachedDecks || []).find(d => d.id === deckId);
+  const deckName = deck ? deck.name : 'deck';
+  const noStory = !!(deck && deck.no_story);
+
+  const banner = document.getElementById('bg-story-banner');
+  if (banner) {
+    banner.classList.add('bg-banner-progress');
+    banner.textContent = `⏳ Regenerating story for ${deckName} in the background — keep reviewing…`;
+    banner.onclick = null;
+    banner.style.display = 'block';
+  }
+
   try {
-    let storyData;
-    try {
-      storyData = await api('POST', `/api/story/${deckId}/unified/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds));
-    } catch (e) {
-      _stopFakeProgress(); _stopStoryProgressPoll();
-      _showLoadingError('AI request failed', e.message);
-      await new Promise(r => setTimeout(r, 2500));
-      showError('Regenerate failed: ' + e.message);
-      showView('decks');
-      return;
-    }
-    _stopFakeProgress(); _stopStoryProgressPoll();
-
-    // Preload audio before starting review
-    const sentenceCount = storyData?.sentences?.length ?? 0;
-    setLoadingStep(70, 'Story ready!',
-      sentenceCount > 0 ? `Generating audio — 0 / ${sentenceCount} sentences…` : 'Loading audio…');
-    await _preloadWithProgress(deckId, 'unified', (done, total) => {
-      const pct = 70 + Math.round((done / total) * 28);
-      setLoadingStep(pct, null, `Generating audio — ${done} / ${total} sentences…`);
-    });
-
-    _showLoadingSuccess('Story regenerated!');
-    await new Promise(r => setTimeout(r, 500));
-
-    // Auto-open the deck for review (story is already in DB, will load fast)
-    const deck = flatten(_cachedDecks || []).find(d => d.id === deckId);
-    if (deck) {
-      await startReviewMixed(deckId, deck.name, !!deck.no_story);
-    } else {
-      showView('decks');
+    await api('POST', `/api/story/${deckId}/unified/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds));
+    // Warm the audio cache in the background so review starts fast; don't block
+    // the "ready" banner on it.
+    _preloadWithProgress(deckId, 'unified', () => {}).catch(() => {});
+    if (banner) {
+      banner.classList.remove('bg-banner-progress');
+      banner.textContent = `📖 Story ready — ${deckName} · click to review`;
+      banner.style.display = 'block';
+      banner.onclick = () => {
+        banner.style.display = 'none';
+        banner.onclick = null;
+        startReviewMixed(deckId, deckName, noStory);
+      };
     }
   } catch (e) {
-    _stopFakeProgress(); _stopStoryProgressPoll();
-    _showLoadingError('Regenerate failed', e.message);
-    await new Promise(r => setTimeout(r, 2500));
+    if (banner) {
+      banner.classList.remove('bg-banner-progress');
+      banner.onclick = null;
+      banner.style.display = 'none';
+    }
     showError('Regenerate failed: ' + e.message);
-    showView('decks');
   }
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -5044,11 +5044,13 @@ async function rate(rating) {
 }
 
 // ── "New sentence" — re-show this card soon with a freshly generated sentence ──
-// Not a rating: scheduling (ease/interval/state/today's count) is untouched. The
-// card is soft-requeued ~1 min out while a new sentence regenerates in the
-// background, so the user reviews other cards meanwhile.
+// Lives on the FRONT of the card: when the sentence reads badly, swap it before
+// even flipping. Not a rating: scheduling (ease/interval/state/today's count) is
+// untouched. The card is soft-requeued ~1 min out while a new sentence
+// regenerates in the background, so the user reviews other cards meanwhile.
 async function requeueNewSentence() {
-  document.querySelectorAll('.r-btn').forEach(b => b.disabled = true);
+  const btn = document.getElementById('new-sentence-btn');
+  if (btn) btn.disabled = true;
   try {
     let url = `/api/review/requeue?card_id=${card.id}`;
     if (unfinishedMode) url += `&unfinished_mode=true&unfinished_scope=${_unfinishedScope}`;
@@ -5063,10 +5065,10 @@ async function requeueNewSentence() {
     }
     if (unfinishedMode || rootDeckId) category = result.next_card.category;
     loadCard(result.next_card, result.counts);
-    document.querySelectorAll('.r-btn').forEach(b => b.disabled = false);
+    if (btn) btn.disabled = false;
   } catch (e) {
     showError('Could not requeue: ' + e.message);
-    document.querySelectorAll('.r-btn').forEach(b => b.disabled = false);
+    if (btn) btn.disabled = false;
   }
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -163,7 +163,11 @@
                      oninput="updateWordBankPreview(this.value)"
                      onkeydown="if(event.key==='Enter')revealAnswer()">
             </div>
-            <button class="reveal-btn" id="reveal-btn" onclick="revealAnswer()">Show Answer</button>
+            <div class="front-actions-row">
+              <button class="reveal-btn" id="reveal-btn" onclick="revealAnswer()">Show Answer</button>
+              <button class="front-newsentence-btn" id="new-sentence-btn" onclick="requeueNewSentence()"
+                      title="New sentence — show this card again in ~1 min with a freshly generated sentence (not a rating, no scheduling change)">🔄</button>
+            </div>
           </div>
 
           <!-- Back: sentence → ratings → word summary (no collapsible sections) -->
@@ -214,8 +218,6 @@
               <button class="r-btn r-hard"  onclick="rate(2)">Hard<small id="int-2"></small></button>
               <button class="r-btn r-good"  onclick="rate(3)">Good<small id="int-3"></small></button>
               <button class="r-btn r-easy"  onclick="rate(4)">Easy<small id="int-4"></small></button>
-              <button class="r-btn r-newsentence" id="new-sentence-btn" onclick="requeueNewSentence()"
-                      title="New sentence — show this card again in ~1 min with a freshly generated sentence (not a rating, no scheduling change)">🔄</button>
             </div>
             <!-- Free-text note carried over to the next time this card is seen -->
             <div class="next-note-row" id="next-note-row">

--- a/static/style.css
+++ b/static/style.css
@@ -577,6 +577,23 @@ main.browse-open {
 }
 .reveal-btn:hover { border-color: var(--primary); color: var(--primary); }
 
+/* Front-of-card "new sentence" button sits beside Show Answer. */
+.front-actions-row { display: flex; gap: 8px; align-items: stretch; }
+.front-actions-row .reveal-btn { flex: 1; width: auto; }
+.front-newsentence-btn {
+  flex: 0 0 auto;
+  padding: 12px 14px;
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  background: none;
+  font-size: 16px;
+  cursor: pointer;
+  color: var(--text);
+  transition: border-color 0.15s, color 0.15s;
+}
+.front-newsentence-btn:hover { border-color: var(--primary); color: var(--primary); }
+.front-newsentence-btn:disabled { opacity: 0.4; cursor: default; }
+
 /* Regenerate button (inline in counts row) */
 .regen-btn {
   background: none;
@@ -648,7 +665,7 @@ main.browse-open {
 /* Rating buttons */
 .rating-row {
   display: grid;
-  grid-template-columns: repeat(4, 1fr) auto;
+  grid-template-columns: repeat(4, 1fr);
   gap: 8px;
 }
 
@@ -744,12 +761,6 @@ main.browse-open {
 .r-hard  { background: var(--hard); }
 .r-good  { background: var(--good); }
 .r-easy  { background: var(--easy); }
-/* "New sentence" requeue — neutral, compact, sits to the right of the ratings. */
-.r-newsentence {
-  background: #64748b;
-  font-size: 16px;
-  padding: 11px 12px 9px;
-}
 
 /* ── Vocab detail (below ratings on back side) ───────── */
 .vocab-detail {

--- a/static/style.css
+++ b/static/style.css
@@ -172,6 +172,14 @@ main.browse-open {
   display: none;
 }
 #bg-story-banner:hover { background: #d1fae5; }
+/* In-progress state: neutral amber, not yet clickable. */
+#bg-story-banner.bg-banner-progress {
+  background: #fffbeb;
+  color: #92400e;
+  border-color: #fde68a;
+  cursor: default;
+}
+#bg-story-banner.bg-banner-progress:hover { background: #fffbeb; }
 
 /* ── Deck list ───────────────────────────────────────── */
 #view-decks { display: none; }


### PR DESCRIPTION
本分支包含两项前端改动。

## 1. 牌组列表故事重新生成改为后台进行（Closes #367）
点 ↺ 确认设置后不再全屏加载等待，改为后台生成：立刻显示常驻横幅 `⏳ Regenerating…`，用户可继续复习；完成后横幅变为可点击的 `📖 Story ready · click to review`，点击进入混合复习。复用现有 `#bg-story-banner` 机制，新增进行中横幅中性配色。

## 2. "换新句子" 🔄 按钮移到卡片正面（Closes #369）
原先该按钮在评分键（Again/Hard/Good/Easy）旁，即卡片背面；现移至**正面**"Show Answer"旁——读到不好的句子时无需先翻面即可更换。评分网格恢复 4 列；`requeueNewSentence` 改为禁用正面按钮自身。

## 测试方法
- ↺ 重新生成：确认后立刻见横幅、能继续操作；完成后横幅可点击进入复习；失败有提示不卡界面
- 换新句子按钮：仅在卡片正面显示，点击后卡片约 1 分钟后带新句子再现、调度状态不变

Closes #367
Closes #369