### PR TITLE
fix: 词块目标填空格固定宽度，填写后不再重排且居中

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1732,6 +1732,20 @@ main.browse-open {
   font-weight: 700;
   letter-spacing: -2px;
 }
+/* Target word's blank: fixed geometry so the hint (before) and the typed word
+   (after) occupy the same box width — the rest of the sentence never reflows.
+   Width uses rem (not em) so it stays constant despite the font-size change
+   between the small hint and the large filled word. data-de is kept on the
+   span after filling (only the wb-de-hint class is removed), so this selector
+   covers both states. */
+.wb-skel-blank[data-de] {
+  display: inline-block;
+  width: 13rem;
+  white-space: normal;
+  line-height: 1.2;
+  text-align: center;
+  vertical-align: middle;
+}
 /* Faint German translation shown inside the target word's blank as a hint */
 .wb-skel-blank.wb-de-hint {
   color: #c2c2c2;
@@ -1739,10 +1753,6 @@ main.browse-open {
   font-size: 14px;
   font-style: italic;
   letter-spacing: 0;
-  white-space: normal;
-  max-width: 13em;
-  line-height: 1.2;
-  text-align: center;
 }
 .word-bank-tokens {
   display: flex;


### PR DESCRIPTION
## 变更内容
- 给带德语提示的目标填空格（`.wb-skel-blank[data-de]`）设固定宽度（`13rem`）、`display:inline-block`、`text-align:center`
- 用 `rem` 而非 `em`，使宽度不受「小号提示 → 大号目标词」字号变化影响，填写前后盒子同宽
- 利用填写后仍保留的 `data-de` 属性，用属性选择器同时覆盖提示态与填入态，无需改动 JS

## 效果
- 填写答案后，句子其余字保持原位，不再重排
- 目标词所在空格保留一个较大空隙（按需求可接受）
- 填入的目标词在空格内居中显示

## 测试方法
- 进入一个目标词带德语提示的词块填空复习卡
- 输入目标词，确认句子其余字位置不变、目标词在空格内居中

Closes #370