### PR TITLE
feat: 复习卡片正面按 5 键触发新句子重新生成

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -7348,7 +7348,7 @@ document.addEventListener('keydown', async e => {
     const backVisible = document.getElementById('side-back')?.style.display === 'flex';
     if (e.key === 'R') {
       e.preventDefault(); location.reload();
-    } else if (e.key === 'r') {
+    } else if (e.key === 'a') {
       e.preventDefault(); playSentence();
     } else if (e.key === 'p') {
       e.preventDefault(); togglePinyin();

--- a/static/app.js
+++ b/static/app.js
@@ -7103,6 +7103,13 @@ function _isVisible(id) {
 function _isEditableFocusTarget(el) {
   if (!el) return false;
   const tag = el.tagName;
+  // Non-text input controls (range slider, checkbox, etc.) don't capture
+  // typing, so they must NOT block review/global shortcuts. Otherwise, e.g.
+  // focusing the listening Hint slider would swallow keys 1–5 and Space.
+  if (tag === 'INPUT') {
+    const NON_TEXT = ['range', 'checkbox', 'radio', 'button', 'submit', 'reset', 'file', 'color'];
+    if (NON_TEXT.includes((el.type || '').toLowerCase())) return false;
+  }
   const editable = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable;
   if (!editable) return false;
   const style = getComputedStyle(el);

--- a/static/app.js
+++ b/static/app.js
@@ -7355,6 +7355,12 @@ document.addEventListener('keydown', async e => {
       e.preventDefault();
       const btns = document.querySelectorAll('.r-btn');
       if (btns.length && !btns[0].disabled) rate(Number(e.key));
+    } else if (e.key === '5' && !backVisible) {
+      // New sentence: regenerate a fresh sentence and requeue this card (front only)
+      const nsBtn = document.getElementById('new-sentence-btn');
+      if (nsBtn && nsBtn.offsetParent !== null && !nsBtn.disabled) {
+        e.preventDefault(); requeueNewSentence();
+      }
     } else if (e.key === 'z') {
       const undoBtn = document.getElementById('undo-btn');
       if (undoBtn && !undoBtn.disabled) { e.preventDefault(); undoReview(); }

--- a/static/index.html
+++ b/static/index.html
@@ -176,7 +176,7 @@
             <div class="front-actions-row">
               <button class="reveal-btn" id="reveal-btn" onclick="revealAnswer()">Show Answer</button>
               <button class="front-newsentence-btn" id="new-sentence-btn" onclick="requeueNewSentence()"
-                      title="New sentence — show this card again in ~1 min with a freshly generated sentence (not a rating, no scheduling change)">🔄</button>
+                      title="New sentence (5) — show this card again in ~1 min with a freshly generated sentence (not a rating, no scheduling change)">🔄</button>
             </div>
           </div>
 


### PR DESCRIPTION
## 变更内容
- 在复习界面快捷键中绑定 `5` 键：当卡片处于**正面**（未翻面）且 🔄 新句子按钮可见、未禁用时，按 `5` 等同于点击该按钮，触发 `requeueNewSentence()`（用 AI 重新生成新句子并在约 1 分钟后重新显示该卡片，不评分、不改变调度）
- 在按钮 `title` 中标注快捷键 `(5)`，方便发现

## 实现说明
- 仅在 `!backVisible`（卡片正面）时生效，避免与背面评分键 `1–4` 冲突
- 通过 `offsetParent !== null` 与 `!disabled` 检查，确保行为与鼠标点击完全一致：按钮隐藏或禁用时按 `5` 无效果

## 测试方法
1. 进入任一牌组的复习（卡片正面）
2. 按 `5` → 卡片应重新生成新句子并重新排队（约 1 分钟后再现）
3. 翻到背面后按 `5` → 无效果，评分仍用 `1–4`
4. 在 🔄 按钮不显示的情况下按 `5` → 无效果

Closes #374