### PR TITLE
feat: 主页设置页面 — 自定义复习快捷键（5＝重播、a＝新句子）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -65,6 +65,40 @@ let optDeckId    = null; // deck whose options modal is open
 const collapsed  = new Set(JSON.parse(localStorage.getItem('collapsedDecks') || '[]'));  // parent deck IDs that are collapsed
 let _retentionData = null;  // cached result from GET /api/retention
 let _cachedDecks = null;       // last fetched deck tree (for toggle re-renders)
+
+// — Customizable review shortcuts —
+// Each action maps to one key. Defaults below are the active bindings.
+// User overrides persist in localStorage('reviewKeymap'). Rating keys 1-4 stay fixed.
+const KEYMAP_DEFAULTS = {
+  reveal:         ' ',
+  replay:         '5',
+  pinyin:         'p',
+  translation:    'u',
+  worddef:        'k',
+  'new-sentence': 'a',
+  undo:           'z',
+};
+const KEYMAP_ACTIONS = [
+  { id: 'reveal',       label: 'Reveal answer' },
+  { id: 'replay',       label: 'Replay audio' },
+  { id: 'pinyin',       label: 'Toggle pinyin' },
+  { id: 'translation',  label: 'Toggle translation' },
+  { id: 'worddef',      label: 'Toggle word definition' },
+  { id: 'new-sentence', label: 'New sentence (regenerate)' },
+  { id: 'undo',         label: 'Undo last review' },
+];
+// Keys hardcoded elsewhere in the review view — cannot be reassigned to.
+const KEYMAP_RESERVED = ['R','1','2','3','4','e','n','q','w','f','v','c','C','D','7','L','o','g','Enter','Tab'];
+function _loadKeymap() {
+  let saved = {};
+  try { saved = JSON.parse(localStorage.getItem('reviewKeymap') || '{}'); } catch (e) {}
+  return { ...KEYMAP_DEFAULTS, ...saved };
+}
+let _keymap = _loadKeymap();
+function _key(id) { return _keymap[id]; }
+function _saveKeymap() { localStorage.setItem('reviewKeymap', JSON.stringify(_keymap)); }
+function _keyLabel(k) { return k === ' ' ? 'Space' : (k.length === 1 ? k.toUpperCase() : k); }
+
 let _timerInterval = null;
 let _timerStart = null;
 const _TIMER_CAP_MS = 40000;  // beyond this the user is likely doing something else
@@ -720,7 +754,7 @@ function _triggerClapAnimation() {
 
 function showView(name) {
   if (name === 'done' && _sessionReviewedCount > 0) _triggerClapAnimation();
-  ['loading', 'decks', 'review', 'done', 'browse', 'word-detail', 'hanzi-detail', 'stats'].forEach(v => {
+  ['loading', 'decks', 'review', 'done', 'browse', 'word-detail', 'hanzi-detail', 'stats', 'settings'].forEach(v => {
     document.getElementById(`view-${v}`).style.display = 'none';
   });
   document.getElementById(`view-${name}`).style.display =
@@ -735,7 +769,8 @@ function showView(name) {
     name === 'browse'       ? 'Browse' :
     name === 'word-detail'  ? 'Word Detail' :
     name === 'hanzi-detail' ? 'Hanzi Detail' :
-    name === 'stats'        ? 'Stats' : 'AnkiAdvanced';
+    name === 'stats'        ? 'Stats' :
+    name === 'settings'     ? 'Settings' : 'AnkiAdvanced';
   if (name === 'decks') quickMode = false;
   const headerRegenBtn = document.getElementById('header-regen-btn');
   if (headerRegenBtn) headerRegenBtn.style.display = (name === 'review' && !unfinishedMode && !quickMode) ? '' : 'none';
@@ -1118,6 +1153,7 @@ function renderDecks(decks) {
     <div class="nav-row">
       <button class="nav-btn" onclick="openBrowse()" title="Shortcut: B">Browse Cards</button>
       <button class="nav-btn" onclick="openStats()">Stats</button>
+      <button class="nav-btn" onclick="openSettings()" title="Customize shortcuts">⚙ Settings</button>
       <button class="nav-btn" onclick="openCostModal()">API Costs</button>
       <button class="nav-btn" onclick="openImportModal()" title="Shortcut: Command+I">Import</button>
       <button class="nav-btn" onclick="openQuickAddCard()" title="Shortcut: A">Add Card</button>
@@ -2375,6 +2411,69 @@ async function openStats() {
     showView('decks');
   }
 }
+
+// ── Settings (customize review shortcuts) ────────────────────────────────────
+let _capturingAction = null;
+let _settingsMsg = '';
+function openSettings() {
+  _capturingAction = null; _settingsMsg = '';
+  showView('settings');
+  renderSettings();
+}
+function renderSettings() {
+  const rows = KEYMAP_ACTIONS.map(a => {
+    const capturing = _capturingAction === a.id;
+    const keyTxt = capturing ? 'Press a key…' : _keyLabel(_keymap[a.id]);
+    const isDefault = _keymap[a.id] === KEYMAP_DEFAULTS[a.id];
+    return `<div class="keymap-row">
+      <span class="keymap-label">${a.label}</span>
+      <button class="keymap-key${capturing ? ' capturing' : ''}" onclick="startKeyCapture('${a.id}')">${keyTxt}</button>
+      <button class="keymap-reset" onclick="resetKeymapAction('${a.id}')" ${isDefault ? 'disabled' : ''} title="Reset to default">↺</button>
+    </div>`;
+  }).join('');
+  const msg = _settingsMsg ? `<div class="keymap-msg">${_settingsMsg}</div>` : '';
+  document.getElementById('view-settings-content').innerHTML = `
+    <div class="keymap-panel">
+      <h2 class="keymap-heading">Review shortcuts</h2>
+      <p class="keymap-hint">Click a key, then press the new key. Rating keys 1–4 are fixed.</p>
+      ${msg}
+      ${rows}
+      <button class="keymap-reset-all" onclick="resetKeymapAll()">Reset all to defaults</button>
+    </div>`;
+}
+function startKeyCapture(id) {
+  _capturingAction = id; _settingsMsg = ''; renderSettings();
+}
+function resetKeymapAction(id) {
+  _keymap[id] = KEYMAP_DEFAULTS[id]; _saveKeymap();
+  _capturingAction = null; _settingsMsg = ''; renderSettings();
+}
+function resetKeymapAll() {
+  _keymap = { ...KEYMAP_DEFAULTS }; _saveKeymap();
+  _capturingAction = null; _settingsMsg = ''; renderSettings();
+}
+// Capture-phase listener: grabs the next keypress while rebinding,
+// before the global review handler can act on it.
+function _settingsKeydown(e) {
+  if (!_capturingAction) return;
+  e.preventDefault(); e.stopPropagation();
+  const id = _capturingAction;
+  if (e.key === 'Escape') { _capturingAction = null; _settingsMsg = ''; renderSettings(); return; }
+  if (e.shiftKey || e.ctrlKey || e.metaKey || e.altKey) {
+    _settingsMsg = 'Press a single key without modifiers.'; renderSettings(); return;
+  }
+  const key = e.key;
+  if (KEYMAP_RESERVED.includes(key)) {
+    _settingsMsg = `"${_keyLabel(key)}" is reserved and can't be reassigned.`; renderSettings(); return;
+  }
+  const clash = KEYMAP_ACTIONS.find(a => a.id !== id && _keymap[a.id] === key);
+  if (clash) {
+    _settingsMsg = `"${_keyLabel(key)}" is already used by "${clash.label}".`; renderSettings(); return;
+  }
+  _keymap[id] = key; _saveKeymap();
+  _capturingAction = null; _settingsMsg = ''; renderSettings();
+}
+document.addEventListener('keydown', _settingsKeydown, true);
 
 async function openCostModal() {
   try {
@@ -7306,7 +7405,11 @@ document.addEventListener('keydown', async e => {
       return;
     }
 
-    if (!e.metaKey && !e.ctrlKey && !e.altKey) {
+    // In the review view, let configured shortcut keys fall through to the
+    // review handler below instead of firing global nav (Back/Browse/Add Card).
+    const _reviewActive = document.getElementById('view-review')?.style.display !== 'none';
+    const _mappedInReview = _reviewActive && Object.values(_keymap).includes(e.key);
+    if (!e.metaKey && !e.ctrlKey && !e.altKey && !_mappedInReview) {
       if (code === 'KeyD') {
         e.preventDefault();
         goBack();
@@ -7348,27 +7451,27 @@ document.addEventListener('keydown', async e => {
     const backVisible = document.getElementById('side-back')?.style.display === 'flex';
     if (e.key === 'R') {
       e.preventDefault(); location.reload();
-    } else if (e.key === 'a') {
+    } else if (e.key === _key('replay')) {
       e.preventDefault(); playSentence();
-    } else if (e.key === 'p') {
+    } else if (e.key === _key('pinyin')) {
       e.preventDefault(); togglePinyin();
-    } else if (e.key === 'u') {
+    } else if (e.key === _key('translation')) {
       e.preventDefault(); toggleTranslation();
-    } else if (e.key === 'k') {
+    } else if (e.key === _key('worddef')) {
       e.preventDefault(); toggleWordDef();
-    } else if (e.key === ' ') {
+    } else if (e.key === _key('reveal')) {
       e.preventDefault(); if (!backVisible) revealAnswer();
     } else if (['1','2','3','4'].includes(e.key) && backVisible) {
       e.preventDefault();
       const btns = document.querySelectorAll('.r-btn');
       if (btns.length && !btns[0].disabled) rate(Number(e.key));
-    } else if (e.key === '5' && !backVisible) {
+    } else if (e.key === _key('new-sentence') && !backVisible) {
       // New sentence: regenerate a fresh sentence and requeue this card (front only)
       const nsBtn = document.getElementById('new-sentence-btn');
       if (nsBtn && nsBtn.offsetParent !== null && !nsBtn.disabled) {
         e.preventDefault(); requeueNewSentence();
       }
-    } else if (e.key === 'z') {
+    } else if (e.key === _key('undo')) {
       const undoBtn = document.getElementById('undo-btn');
       if (undoBtn && !undoBtn.disabled) { e.preventDefault(); undoReview(); }
     } else if (backVisible && e.key === 'e') {

--- a/static/app.js
+++ b/static/app.js
@@ -97,7 +97,7 @@ function _loadKeymap() {
 let _keymap = _loadKeymap();
 function _key(id) { return _keymap[id]; }
 function _saveKeymap() { localStorage.setItem('reviewKeymap', JSON.stringify(_keymap)); }
-function _keyLabel(k) { return k === ' ' ? 'Space' : (k.length === 1 ? k.toUpperCase() : k); }
+function _keyLabel(k) { return k == null ? 'None' : (k === ' ' ? 'Space' : (k.length === 1 ? k.toUpperCase() : k)); }
 
 let _timerInterval = null;
 let _timerStart = null;
@@ -2425,9 +2425,11 @@ function renderSettings() {
     const capturing = _capturingAction === a.id;
     const keyTxt = capturing ? 'Press a key…' : _keyLabel(_keymap[a.id]);
     const isDefault = _keymap[a.id] === KEYMAP_DEFAULTS[a.id];
+    const isUnbound = _keymap[a.id] == null;
     return `<div class="keymap-row">
       <span class="keymap-label">${a.label}</span>
-      <button class="keymap-key${capturing ? ' capturing' : ''}" onclick="startKeyCapture('${a.id}')">${keyTxt}</button>
+      <button class="keymap-key${capturing ? ' capturing' : ''}${isUnbound ? ' unbound' : ''}" onclick="startKeyCapture('${a.id}')">${keyTxt}</button>
+      <button class="keymap-clear" onclick="clearKeymapAction('${a.id}')" ${isUnbound ? 'disabled' : ''} title="Remove shortcut">✕</button>
       <button class="keymap-reset" onclick="resetKeymapAction('${a.id}')" ${isDefault ? 'disabled' : ''} title="Reset to default">↺</button>
     </div>`;
   }).join('');
@@ -2435,7 +2437,7 @@ function renderSettings() {
   document.getElementById('view-settings-content').innerHTML = `
     <div class="keymap-panel">
       <h2 class="keymap-heading">Review shortcuts</h2>
-      <p class="keymap-hint">Click a key, then press the new key. Rating keys 1–4 are fixed.</p>
+      <p class="keymap-hint">Click a key, then press the new key. Press Backspace or ✕ to remove a shortcut. Rating keys 1–4 are fixed.</p>
       ${msg}
       ${rows}
       <button class="keymap-reset-all" onclick="resetKeymapAll()">Reset all to defaults</button>
@@ -2446,6 +2448,10 @@ function startKeyCapture(id) {
 }
 function resetKeymapAction(id) {
   _keymap[id] = KEYMAP_DEFAULTS[id]; _saveKeymap();
+  _capturingAction = null; _settingsMsg = ''; renderSettings();
+}
+function clearKeymapAction(id) {
+  _keymap[id] = null; _saveKeymap();
   _capturingAction = null; _settingsMsg = ''; renderSettings();
 }
 function resetKeymapAll() {
@@ -2459,6 +2465,10 @@ function _settingsKeydown(e) {
   e.preventDefault(); e.stopPropagation();
   const id = _capturingAction;
   if (e.key === 'Escape') { _capturingAction = null; _settingsMsg = ''; renderSettings(); return; }
+  if (e.key === 'Backspace' || e.key === 'Delete') {
+    _keymap[id] = null; _saveKeymap();
+    _capturingAction = null; _settingsMsg = ''; renderSettings(); return;
+  }
   if (e.shiftKey || e.ctrlKey || e.metaKey || e.altKey) {
     _settingsMsg = 'Press a single key without modifiers.'; renderSettings(); return;
   }

--- a/static/index.html
+++ b/static/index.html
@@ -423,6 +423,11 @@
     <div class="section-title">Card States</div>
     <div class="state-row" id="state-row"></div>
   </div>
+
+  <!-- Settings -->
+  <div id="view-settings">
+    <div id="view-settings-content"></div>
+  </div>
 </main>
 
 <!-- Options modal -->

--- a/static/style.css
+++ b/static/style.css
@@ -2838,6 +2838,24 @@ main.browse-open {
 /* ── Stats view ──────────────────────────────────────── */
 #view-stats { display: none; }
 
+/* — Settings view (customize shortcuts) — */
+#view-settings { display: none; }
+#view-settings-content { max-width: 640px; margin: 0 auto; padding: 16px; }
+.keymap-panel { display: flex; flex-direction: column; gap: 8px; }
+.keymap-heading { font-size: 18px; margin: 0; }
+.keymap-hint { color: var(--text-dim, #888); font-size: 13px; margin: 0 0 8px; }
+.keymap-msg { color: var(--danger, #e06c5a); font-size: 13px; padding: 6px 0; }
+.keymap-row { display: flex; align-items: center; gap: 12px; padding: 8px 0; border-bottom: 1px solid rgba(128,128,128,0.15); }
+.keymap-label { flex: 1; }
+.keymap-key { min-width: 96px; padding: 6px 12px; border: 1px solid var(--border, #ccc); border-radius: 6px; background: rgba(128,128,128,0.08); font-family: monospace; cursor: pointer; text-align: center; color: inherit; }
+.keymap-key:hover { border-color: var(--primary); color: var(--primary); }
+.keymap-key.capturing { border-color: var(--primary); color: var(--primary); font-style: italic; }
+.keymap-reset { border: none; background: none; cursor: pointer; font-size: 16px; opacity: 0.7; color: inherit; }
+.keymap-reset:hover:not(:disabled) { opacity: 1; }
+.keymap-reset:disabled { opacity: 0.25; cursor: default; }
+.keymap-reset-all { margin-top: 16px; align-self: flex-start; padding: 8px 14px; border: 1px solid var(--border, #ccc); border-radius: 6px; background: none; color: inherit; cursor: pointer; }
+.keymap-reset-all:hover { border-color: var(--primary); color: var(--primary); }
+
 .stat-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);

--- a/static/style.css
+++ b/static/style.css
@@ -2850,6 +2850,10 @@ main.browse-open {
 .keymap-key { min-width: 96px; padding: 6px 12px; border: 1px solid var(--border, #ccc); border-radius: 6px; background: rgba(128,128,128,0.08); font-family: monospace; cursor: pointer; text-align: center; color: inherit; }
 .keymap-key:hover { border-color: var(--primary); color: var(--primary); }
 .keymap-key.capturing { border-color: var(--primary); color: var(--primary); font-style: italic; }
+.keymap-key.unbound { color: var(--text-dim, #888); font-style: italic; }
+.keymap-clear { border: none; background: none; cursor: pointer; font-size: 15px; opacity: 0.7; color: inherit; }
+.keymap-clear:hover:not(:disabled) { opacity: 1; color: var(--danger, #e06c5a); }
+.keymap-clear:disabled { opacity: 0.25; cursor: default; }
 .keymap-reset { border: none; background: none; cursor: pointer; font-size: 16px; opacity: 0.7; color: inherit; }
 .keymap-reset:hover:not(:disabled) { opacity: 1; }
 .keymap-reset:disabled { opacity: 0.25; cursor: default; }


### PR DESCRIPTION
## 变更内容
- 主页导航栏新增 **⚙ Settings** 入口 → 独立全页视图 `view-settings`（复用全局 ← 返回按钮）
- 复习视图 7 个核心快捷键改为查 `localStorage('reviewKeymap')` 映射表（`_key`）：
  Reveal / Replay audio / Toggle pinyin / Toggle translation / Toggle word definition / New sentence / Undo
- **默认键调整：`5`＝重播音频，`a`＝新句子**（评分键 1–4 固定）
- **修复**：全局单键 A/D/B（Add Card/Back/Browse）原本在复习视图会遮蔽绑定到 a/b/d 的复习动作；现加 `_mappedInReview` 守卫，复习中命中映射键即放行到复习处理块
- 设置页支持重绑、冲突校验（撞保留键或其他动作则拒绝）、单项/全部恢复默认

## 测试方法
- 主页点 ⚙ Settings 进入设置页
- 重绑某快捷键，回复习确认新键生效、旧键失效
- 复习中按 `5` 重播音频、按 `a` 生成新句子
- 尝试绑定保留键（如 1/R）或已占用键，确认被拒绝并提示
- 单项/全部恢复默认后键位还原；刷新页面配置仍在

Closes #376