### PR TITLE
feat: 创建模式填空处无德语翻译时回退显示英文提示

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -5042,8 +5042,9 @@ async function renderWordBankUI() {
   const skelEl = document.getElementById('word-bank-skeleton');
   if (skelEl) {
     const escAttr = s => String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    // German hint shown faintly inside the target word's blank (first target only)
-    const deHint = (card.definition_de || '').trim();
+    // Hint shown faintly inside the target word's blank (first target only):
+    // prefer the German definition, fall back to English when no German exists.
+    const deHint = (card.definition_de || card.definition || '').trim();
     let deShown = false;
     let slotIdx = 0;
     skelEl.innerHTML = wordBankOrder.map(tok => {

--- a/static/app.js
+++ b/static/app.js
@@ -71,11 +71,11 @@ let _cachedDecks = null;       // last fetched deck tree (for toggle re-renders)
 // User overrides persist in localStorage('reviewKeymap'). Rating keys 1-4 stay fixed.
 const KEYMAP_DEFAULTS = {
   reveal:         ' ',
-  replay:         '5',
+  replay:         'a',
   pinyin:         'p',
   translation:    'u',
   worddef:        'k',
-  'new-sentence': 'a',
+  'new-sentence': '5',
   undo:           'z',
 };
 const KEYMAP_ACTIONS = [


### PR DESCRIPTION
## 变更内容
创建（creating）类别的 word bank 模式下，目标词填空处（Lücke）原本只显示德语提示 `definition_de`。当生词没有德语翻译时，填空处无任何提示。

本次改动让它在缺少德语翻译时回退（fallback）显示英文翻译 `definition`：

```js
const deHint = (card.definition_de || card.definition || '').trim();
```

这与 `app.js` 其他位置（如 3625 行）已有的 `definition_de || definition` 回退模式保持一致。

## 测试方法
- 打开一个**有**德语翻译的生词创建复习 → 填空处显示德语（行为不变）
- 打开一个**没有**德语翻译但有英文的生词 → 填空处显示英文
- 两者都无 → 显示普通空白 `＿`（行为不变）

Closes #378