### PR TITLE
feat: 主页添加「每日十个随机词」弹窗按钮

### DIFF
--- a/database/browse.py
+++ b/database/browse.py
@@ -354,12 +354,13 @@ def insert_review(card_id: int, rating: int,
                   user_response: str | None = None,
                   ai_score: int | None = None,
                   duration_ms: int | None = None,
-                  state: str | None = None) -> int:
+                  state: str | None = None,
+                  last_interval: int | None = None) -> int:
     conn = get_db()
     cur = conn.execute(
-        """INSERT INTO review_log (card_id, rating, user_response, ai_score, duration_ms, state)
-           VALUES (?, ?, ?, ?, ?, ?)""",
-        (card_id, rating, user_response, ai_score, duration_ms, state),
+        """INSERT INTO review_log (card_id, rating, user_response, ai_score, duration_ms, state, last_interval)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        (card_id, rating, user_response, ai_score, duration_ms, state, last_interval),
     )
     conn.commit()
     log_id = cur.lastrowid

--- a/database/cards.py
+++ b/database/cards.py
@@ -289,6 +289,16 @@ def resolve_bury_flags(preset: dict) -> tuple[bool, bool, bool]:
     )
 
 
+def _still_learning(card: dict, learned_interval: int) -> bool:
+    """True if a card is not yet "learned" — either in learning/relearn, or a
+    review card whose interval hasn't reached the learned_interval threshold.
+    Such cards queue with the learning group and are shown before learned cards.
+    """
+    if card["state"] in ("learning", "relearn"):
+        return True
+    return card["state"] == "review" and (card.get("interval") or 0) < learned_interval
+
+
 def _interleave_cards(base: list, inserts: list) -> list:
     """Distribute inserts evenly across the full combined length.
 
@@ -355,8 +365,11 @@ def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = Fa
     ).fetchall()
 
     all_cards = [dict(r) for r in rows]
-    learning_cards = [c for c in all_cards if c["state"] in ("learning", "relearn")]
-    review_cards   = [c for c in all_cards if c["state"] == "review"]
+    # A 'review' card whose interval hasn't reached learned_interval is still a
+    # learning card: it queues with the learning group (before learned cards).
+    threshold = preset.get("learned_interval", 4)
+    learning_cards = [c for c in all_cards if _still_learning(c, threshold)]
+    review_cards   = [c for c in all_cards if c["state"] == "review" and not _still_learning(c, threshold)]
     new_cards_raw  = [c for c in all_cards if c["state"] == "new"]
 
     # ── 1. Gather & sort new cards ────────────────────────────────────────────
@@ -719,9 +732,18 @@ def get_due_cards_any_cat(root_deck_id: int) -> list[dict]:
             cat_order.get(c["category"], 99),
         ))
     else:
+        # No story: learning-first. A review card below its deck's
+        # learned_interval is still "learning" (rank 0), before learned cards.
+        thresholds = {
+            did: (get_preset_for_deck(did) or {}).get("learned_interval", 4)
+            for did, _ in leaf_pairs
+        }
+        def _rank(c: dict) -> int:
+            if _still_learning(c, thresholds.get(c["deck_id"], 4)):
+                return 0
+            return 1 if c["state"] == "review" else 2
         all_cards.sort(key=lambda c: (
-            0 if c["state"] in ("learning", "relearn") else
-            1 if c["state"] == "review" else 2,
+            _rank(c),
             cat_order.get(c["category"], 99),
             c["due"],
         ))
@@ -788,8 +810,16 @@ def get_due_cards_multi(deck_ids: list[int], category: str, *, root_deck_id: int
     for deck_id in deck_ids:
         all_cards.extend(get_due_cards(deck_id, category, sibling_suppression=sibling_suppression))
 
-    learning_cards = [c for c in all_cards if c["state"] in ("learning", "relearn")]
-    review_cards   = [c for c in all_cards if c["state"] == "review"]
+    # Each deck may have its own learned_interval; a review card below its deck's
+    # threshold is still "learning" and queues with the learning group.
+    thresholds = {
+        did: (get_preset_for_deck(did) or {}).get("learned_interval", 4)
+        for did in deck_ids
+    }
+    def _lrn(c: dict) -> bool:
+        return _still_learning(c, thresholds.get(c["deck_id"], 4))
+    learning_cards = [c for c in all_cards if _lrn(c)]
+    review_cards   = [c for c in all_cards if c["state"] == "review" and not _lrn(c)]
     new_cards      = [c for c in all_cards if c["state"] == "new"]
 
     # Apply parent deck's combined new-card cap (Anki-style)

--- a/database/cards.py
+++ b/database/cards.py
@@ -487,7 +487,7 @@ def count_due(deck_id: int, category: str) -> dict:
     new_remaining = max(0, new_limit - new_done_today)
 
     rows = conn.execute(
-        """SELECT c.word_id, c.state, c.due FROM cards c
+        """SELECT c.word_id, c.state, c.due, c.interval FROM cards c
            WHERE c.deck_id = ? AND c.category = ?
              AND c.state != 'suspended'
              AND c.deleted_at IS NULL
@@ -500,8 +500,15 @@ def count_due(deck_id: int, category: str) -> dict:
         (deck_id, category, today, now, today, today),
     ).fetchall()
 
-    learning = sum(1 for r in rows if r["state"] in ("learning", "relearn"))
-    review   = sum(1 for r in rows if r["state"] == "review")
+    # A 'review' card whose interval hasn't reached learned_interval is still
+    # "learning" for badge purposes (not yet learned/mature).
+    threshold = preset.get("learned_interval", 4)
+    def _is_learning(r) -> bool:
+        return (r["state"] in ("learning", "relearn")
+                or (r["state"] == "review" and (r["interval"] or 0) < threshold))
+
+    learning = sum(1 for r in rows if _is_learning(r))
+    review   = sum(1 for r in rows if r["state"] == "review" and not _is_learning(r))
     new_avail = sum(1 for r in rows if r["state"] == "new")
 
     learning_future = conn.execute(
@@ -876,11 +883,12 @@ def count_due_deduped(leaf_pairs: list[tuple[int, str]]) -> dict:
 
     for deck_id, category in leaf_pairs:
         pr = get_preset_for_deck(deck_id)
+        threshold = pr.get("learned_interval", 4)
         new_done = _count_new_introduced_today(conn, deck_id, category, today)
         new_remaining_map[(deck_id, category)] = max(0, pr["new_per_day"] - new_done)
 
         rows = conn.execute(
-            """SELECT c.word_id, c.state FROM cards c
+            """SELECT c.word_id, c.state, c.interval FROM cards c
                WHERE c.deck_id = ? AND c.category = ?
                  AND c.state != 'suspended'
                  AND c.deleted_at IS NULL
@@ -896,8 +904,13 @@ def count_due_deduped(leaf_pairs: list[tuple[int, str]]) -> dict:
         for r in rows:
             sr = 0 if r["state"] in ("learning", "relearn") else 1 if r["state"] == "review" else 2
             cr = cat_rank_map[category]
+            # A young 'review' card (interval below learned_interval) is tallied
+            # as learning; dedup priority still uses the raw state rank so which
+            # category a word is attributed to is unchanged.
+            is_lrn = (r["state"] in ("learning", "relearn")
+                      or (r["state"] == "review" and (r["interval"] or 0) < threshold))
             if r["word_id"] not in best or (sr, cr) < best[r["word_id"]][:2]:
-                best[r["word_id"]] = (sr, cr, r["state"], deck_id, category)
+                best[r["word_id"]] = (sr, cr, r["state"], deck_id, category, is_lrn)
 
     conn.close()
 
@@ -905,14 +918,14 @@ def count_due_deduped(leaf_pairs: list[tuple[int, str]]) -> dict:
     review_count = 0
     new_by_deck: dict[tuple, int] = {}
 
-    for sr, cr, state, deck_id, category in best.values():
-        if sr == 0:
-            learning_count += 1
-        elif sr == 1:
-            review_count += 1
-        else:
+    for sr, cr, state, deck_id, category, is_lrn in best.values():
+        if state == "new":
             key = (deck_id, category)
             new_by_deck[key] = new_by_deck.get(key, 0) + 1
+        elif is_lrn:
+            learning_count += 1
+        else:
+            review_count += 1
 
     new_count = sum(
         min(count, new_remaining_map.get(key, 0))

--- a/database/cards.py
+++ b/database/cards.py
@@ -169,7 +169,7 @@ def get_card(card_id: int) -> dict | None:
                   END AS deck_path,
                   p.id AS preset_id,
                   p.learning_steps, p.graduating_interval, p.easy_interval,
-                  p.relearning_steps, p.minimum_interval,
+                  p.relearning_steps, p.minimum_interval, p.learned_interval,
                   p.leech_threshold, p.learning_leech_threshold, p.leech_action,
                   p.desired_retention, p.maximum_interval, p.fsrs_weights, p.enable_fsrs,
                   p.learning_hard_1d, p.learning_hard_days,

--- a/database/core.py
+++ b/database/core.py
@@ -236,6 +236,8 @@ def init_db() -> None:
         conn.execute("ALTER TABLE review_log ADD COLUMN duration_ms INTEGER")
     if "state" not in rl_cols:
         conn.execute("ALTER TABLE review_log ADD COLUMN state TEXT")
+    if "last_interval" not in rl_cols:
+        conn.execute("ALTER TABLE review_log ADD COLUMN last_interval INTEGER")
 
     preset_cols = {r["name"] for r in conn.execute("PRAGMA table_info(deck_presets)").fetchall()}
     if "new_gather_order" not in preset_cols:
@@ -289,6 +291,8 @@ def init_db() -> None:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN learning_hard_1d INTEGER NOT NULL DEFAULT 1")
     if "learning_hard_days" not in preset_cols:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN learning_hard_days REAL NOT NULL DEFAULT 1")
+    if "learned_interval" not in preset_cols:
+        conn.execute("ALTER TABLE deck_presets ADD COLUMN learned_interval INTEGER NOT NULL DEFAULT 4")
 
     conn.execute("""CREATE TABLE IF NOT EXISTS preset_category_overrides (
         id                  INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/database/entries.py
+++ b/database/entries.py
@@ -515,3 +515,22 @@ def get_random_word(exclude_word: str = "") -> str | None:
     ).fetchone()
     conn.close()
     return row["word_zh"] if row else None
+
+
+def get_random_words(n: int = 10) -> list[dict]:
+    """Return n random lexical entries for the 'daily random words' popup.
+
+    Includes vocabulary / chengyu / expression (things you can actually use);
+    excludes full sentences and grammar points. No SRS involvement.
+    """
+    conn = get_db()
+    rows = conn.execute(
+        """SELECT word_zh, pinyin, definition, definition_zh
+           FROM entries
+           WHERE note_type IN ('vocabulary', 'chengyu', 'expression')
+             AND word_zh IS NOT NULL AND word_zh != ''
+           ORDER BY RANDOM() LIMIT ?""",
+        (n,),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]

--- a/database/presets.py
+++ b/database/presets.py
@@ -16,6 +16,7 @@ def default_preset() -> dict:
         "easy_interval": 4,
         "relearning_steps": "10",
         "minimum_interval": 1,
+        "learned_interval": 4,
         "insertion_order": "sequential",
         "bury_siblings": 1,
         "randomize_story_order": 0,
@@ -207,12 +208,13 @@ def insert_preset(preset: dict) -> int:
     preset.setdefault("enable_fsrs", 1)
     preset.setdefault("learning_hard_1d", 1)
     preset.setdefault("learning_hard_days", 1)
+    preset.setdefault("learned_interval", 4)
     conn = get_db()
     cur = conn.execute(
         """INSERT INTO deck_presets
            (name, new_per_day, reviews_per_day,
             learning_steps, graduating_interval, easy_interval,
-            relearning_steps, minimum_interval, insertion_order,
+            relearning_steps, minimum_interval, learned_interval, insertion_order,
             bury_siblings, randomize_story_order, leech_threshold, learning_leech_threshold, leech_action,
             desired_retention, maximum_interval, fsrs_weights, enable_fsrs, learning_hard_1d, learning_hard_days,
             new_gather_order, new_sort_order, new_review_order,
@@ -221,7 +223,7 @@ def insert_preset(preset: dict) -> int:
             bury_quick_mode, category_order, sibling_separation, sibling_factor)
            VALUES (:name, :new_per_day, :reviews_per_day,
                    :learning_steps, :graduating_interval, :easy_interval,
-                   :relearning_steps, :minimum_interval, :insertion_order,
+                   :relearning_steps, :minimum_interval, :learned_interval, :insertion_order,
                    :bury_siblings, :randomize_story_order, :leech_threshold, :learning_leech_threshold, :leech_action,
                    :desired_retention, :maximum_interval, :fsrs_weights, :enable_fsrs, :learning_hard_1d, :learning_hard_days,
                    :new_gather_order, :new_sort_order, :new_review_order,
@@ -240,7 +242,7 @@ def update_preset(preset_id: int, fields: dict) -> None:
     allowed = {
         "name", "new_per_day", "reviews_per_day",
         "learning_steps", "graduating_interval", "easy_interval",
-        "relearning_steps", "minimum_interval", "insertion_order",
+        "relearning_steps", "minimum_interval", "learned_interval", "insertion_order",
         "bury_siblings", "randomize_story_order", "leech_threshold", "learning_leech_threshold", "leech_action",
         "desired_retention", "maximum_interval", "fsrs_weights", "enable_fsrs", "learning_hard_1d", "learning_hard_days",
         "new_gather_order", "new_sort_order", "new_review_order",

--- a/database/stats.py
+++ b/database/stats.py
@@ -138,8 +138,11 @@ def get_retention_bulk(days: int = 30) -> dict:
     Rating > 1 (Hard/Good/Easy) counts as correct; rating == 1 (Again) counts as wrong.
 
     Only counts reviews of *learned* cards — those answered in the 'review' phase
-    (state='review'). Learning/relearning/new-card steps are excluded, matching
-    Anki's "true retention". Legacy rows with no recorded state are excluded too.
+    (state='review') whose interval had reached the deck's learned_interval
+    threshold (default 4 days). Learning/relearning/new-card steps and young
+    review cards (interval below the threshold) are excluded, matching an
+    Anki-style "mature retention". Legacy rows with no recorded state are excluded;
+    legacy 'review' rows with no recorded interval keep counting (not retroactive).
     """
     conn = get_db()
     since = (anki_today() - _dt.timedelta(days=days)).isoformat()
@@ -151,8 +154,10 @@ def get_retention_bulk(days: int = 30) -> dict:
            FROM review_log rl
            JOIN cards c ON c.id = rl.card_id
            JOIN decks d ON d.id = c.deck_id
+           JOIN deck_presets p ON p.id = d.preset_id
            WHERE date(datetime(rl.reviewed_at, 'localtime')) >= ?
              AND rl.state = 'review'
+             AND (rl.last_interval IS NULL OR rl.last_interval >= p.learned_interval)
            GROUP BY c.deck_id""",
         [since],
     ).fetchall()
@@ -204,9 +209,12 @@ def get_calendar_stats(days: int = 365, deck_id: int | None = None) -> dict:
     day_expr = "date(datetime(rl.reviewed_at, 'localtime', '-4 hours'))"
     rows = conn.execute(
         f"""SELECT {day_expr} AS d, c.category AS cat, rl.rating AS rating,
-                   rl.state AS state, rl.duration_ms AS dur, rl.card_id AS card_id
+                   rl.state AS state, rl.duration_ms AS dur, rl.card_id AS card_id,
+                   rl.last_interval AS last_ivl, p.learned_interval AS learned_int
             FROM review_log rl
             JOIN cards c ON c.id = rl.card_id
+            JOIN decks d ON d.id = c.deck_id
+            JOIN deck_presets p ON p.id = d.preset_id
             WHERE {day_expr} >= ? {deck_filter}""",
         params,
     ).fetchall()
@@ -246,12 +254,17 @@ def get_calendar_stats(days: int = 365, deck_id: int | None = None) -> dict:
                 bucket["duration_ms"] += r["dur"]
                 bucket["timed_count"] += 1
 
-        # Phase split (learning/relearn/new = "learning"; review = "review")
+        # Phase split (learning/relearn/new = "learning"; review = "review").
+        # A 'review'-state card whose interval hadn't yet reached the deck's
+        # learned_interval threshold counts as "learning" (not yet learned).
+        # Legacy 'review' rows with no recorded interval keep counting as review.
         phase = None
         if r["state"] in ("new", "learning", "relearn"):
             phase = "learning"
         elif r["state"] == "review":
-            phase = "review"
+            li = r["last_ivl"]
+            thr = r["learned_int"]
+            phase = "learning" if (li is not None and li < thr) else "review"
         if phase:
             for bucket in (day, c):
                 bucket[phase]["total"]   += 1

--- a/database/stats.py
+++ b/database/stats.py
@@ -136,6 +136,10 @@ def get_retention_bulk(days: int = 30) -> dict:
           "days":    int
         }
     Rating > 1 (Hard/Good/Easy) counts as correct; rating == 1 (Again) counts as wrong.
+
+    Only counts reviews of *learned* cards — those answered in the 'review' phase
+    (state='review'). Learning/relearning/new-card steps are excluded, matching
+    Anki's "true retention". Legacy rows with no recorded state are excluded too.
     """
     conn = get_db()
     since = (anki_today() - _dt.timedelta(days=days)).isoformat()
@@ -148,6 +152,7 @@ def get_retention_bulk(days: int = 30) -> dict:
            JOIN cards c ON c.id = rl.card_id
            JOIN decks d ON d.id = c.deck_id
            WHERE date(datetime(rl.reviewed_at, 'localtime')) >= ?
+             AND rl.state = 'review'
            GROUP BY c.deck_id""",
         [since],
     ).fetchall()

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -308,6 +308,13 @@ def random_word(exclude: str = ""):
     return {"word": word}
 
 
+@router.get("/api/random-words")
+def random_words(n: int = 10):
+    """Random lexical entries for the daily 'random words' popup (no SRS)."""
+    n = max(1, min(n, 50))
+    return {"words": database.get_random_words(n)}
+
+
 @router.get("/api/hanzi")
 def get_all_hanzi():
     return database.get_all_characters()

--- a/routes/review.py
+++ b/routes/review.py
@@ -323,11 +323,16 @@ def submit_review(card_id: int, rating: int, user_response: str | None = None,
         )
     state_from = card_before["state"]
     state_to   = updated["state"]
+    # A card only counts as "learned" once its interval reaches learned_interval;
+    # graduating to 'review' with a shorter interval is still learning.
+    learned_threshold = updated.get("learned_interval", 4)
+    is_learned = state_to == "review" and (updated.get("interval") or 0) >= learned_threshold
     transition = {
         "from":    state_from,
         "to":      state_to,
         "changed": state_from != state_to,
         "leech":   bool(updated.get("is_leech")) and state_to == "suspended",
+        "learned": is_learned,
     }
     return {"next_card": next_card, "counts": counts, "transition": transition}
 

--- a/schema.sql
+++ b/schema.sql
@@ -26,6 +26,12 @@ CREATE TABLE IF NOT EXISTS deck_presets (
     -- Review scheduling
     minimum_interval        INTEGER NOT NULL DEFAULT 1,
 
+    -- learned_interval: minimum interval (in days) a card must reach before it
+    -- counts as "learned/mature". Reviews of cards below this interval (plus all
+    -- relearn cards) are treated as "still learning" in retention stats and deck
+    -- badge counts. Does NOT change the SRS state machine or queue order.
+    learned_interval        INTEGER NOT NULL DEFAULT 4,
+
     -- ── FSRS scheduling ──────────────────────────────────────────────────────
     -- desired_retention: target recall probability that sets every interval
     -- maximum_interval: hard cap on any computed interval (days)
@@ -307,7 +313,9 @@ CREATE TABLE IF NOT EXISTS review_log (
     user_response   TEXT,       -- what the user typed (creating category)
     ai_score        INTEGER,    -- future: AI evaluation score
     duration_ms     INTEGER,    -- time spent on this review in milliseconds (NULL for legacy rows)
-    state           TEXT        -- card state at review time (new/learning/review/relearn) — NULL for legacy rows
+    state           TEXT,       -- card state at review time (new/learning/review/relearn) — NULL for legacy rows
+    last_interval   INTEGER     -- the interval (days) the card had when shown, i.e. the interval being tested
+                                -- (used to tell "learned/mature" reviews apart) — NULL for legacy rows
 );
 
 -- ---------------------------------------------------------------------------

--- a/srs.py
+++ b/srs.py
@@ -359,6 +359,7 @@ def apply_review(card_id: int, rating: int,
     if not card:
         raise ValueError(f"Card {card_id} not found")
     state_before = card["state"]
+    interval_before = card.get("interval") or 0
 
     preset = {
         "learning_steps":      card["learning_steps"],
@@ -402,6 +403,7 @@ def apply_review(card_id: int, rating: int,
     log_id = database.insert_review(
         card_id, rating, user_response=user_response,
         duration_ms=duration_ms, state=state_before,
+        last_interval=interval_before,
     )
     return database.get_card(card_id), log_id
 

--- a/static/app.js
+++ b/static/app.js
@@ -2652,6 +2652,8 @@ const INFO_TEXT = {
     'The interval (in days) a card gets the first time it leaves learning with Good. Only used by SM-2 — under FSRS the first interval is computed from the card\'s initial stability instead.'],
   easy_interval: ['Easy interval (SM-2 only)',
     'The interval (in days) a learning card jumps to when rated Easy. Only used by SM-2 — under FSRS this is computed from stability.'],
+  learned_interval: ['Learned interval',
+    'The interval (in days) a card must reach before it counts as "learned/mature". Reviews of cards below this interval — plus all relearning cards — are treated as "still learning" in the retention stats and the deck badge counts. This does not change scheduling or queue order, only how cards are labelled and counted. Default 4.'],
   desired_retention: ['Desired retention (FSRS only)',
     'The probability you want of still recalling a card when it comes due, e.g. 90%. Higher retention = shorter intervals and more reviews; lower = longer intervals, fewer reviews but more lapses. This is the main FSRS knob.'],
   maximum_interval: ['Maximum interval (FSRS only)',
@@ -2700,6 +2702,7 @@ function loadPresetFields(preset) {
   document.getElementById('opt-learn-steps').value     = preset.learning_steps;
   document.getElementById('opt-grad-int').value        = preset.graduating_interval;
   document.getElementById('opt-easy-int').value        = preset.easy_interval;
+  document.getElementById('opt-learned-int').value     = preset.learned_interval ?? 4;
   document.getElementById('opt-relearn-steps').value   = preset.relearning_steps;
   document.getElementById('opt-leech').value           = preset.leech_threshold;
   document.getElementById('opt-learning-leech').value  = preset.learning_leech_threshold;
@@ -2867,6 +2870,7 @@ async function saveOptions() {
     learning_steps:      document.getElementById('opt-learn-steps').value.trim(),
     graduating_interval: parseInt(document.getElementById('opt-grad-int').value),
     easy_interval:       parseInt(document.getElementById('opt-easy-int').value),
+    learned_interval:    parseInt(document.getElementById('opt-learned-int').value),
     relearning_steps:    document.getElementById('opt-relearn-steps').value.trim(),
     leech_threshold:     parseInt(document.getElementById('opt-leech').value),
     learning_leech_threshold: parseInt(document.getElementById('opt-learning-leech').value),

--- a/static/app.js
+++ b/static/app.js
@@ -8063,7 +8063,10 @@ function _hcalDayValue(date) {
   const d = _hcalData.by_date[date];
   if (!d) return { value: null, has: false };
   if (_hcalMetric === 'retention') {
-    return { value: d.total > 0 ? d.correct / d.total : null, has: d.total > 0 };
+    // "Learned cards only" — count reviews in the review phase (state='review'),
+    // matching the daily badge / Anki true retention. Learning steps excluded.
+    const rv = d.review;
+    return { value: rv.total > 0 ? rv.correct / rv.total : null, has: rv.total > 0 };
   }
   if (_hcalMetric === 'cards') {
     return { value: d.cards || 0, has: (d.cards || 0) > 0 };
@@ -8268,14 +8271,14 @@ function _hcalTipHtml(date) {
   const d = _hcalData.by_date[date];
   if (!d || d.total === 0) return `<div class="hcal-tip-date">${nice}</div><div class="hcal-tip-empty">no reviews</div>`;
 
-  const head = `<div class="hcal-tip-big">${d.cards} cards · ${_hcalFmtRR(d.correct, d.total)} retention</div>`;
+  const head = `<div class="hcal-tip-big">${d.cards} cards · ${_hcalFmtRR(d.review.correct, d.review.total)} retention</div>`;
   const time = d.timed_count > 0
     ? `<div class="hcal-tip-sub">${_hcalFmtTime(d.duration_ms)} total · ${_hcalFmtTime(d.duration_ms / d.timed_count)}/card</div>`
     : '';
   const rows = _HCAL_CATS.filter(c => d.by_cat[c.key]).map(c => {
     const cd = d.by_cat[c.key];
-    const ph = `L ${_hcalFmtRR(cd.learning.correct, cd.learning.total)} · R ${_hcalFmtRR(cd.review.correct, cd.review.total)}`;
-    return `<div class="hcal-tip-row"><b>${c.zh}</b> ${cd.cards}c · ${_hcalFmtRR(cd.correct, cd.total)} <span class="hcal-tip-dim">(${ph})</span></div>`;
+    const ph = `learning ${_hcalFmtRR(cd.learning.correct, cd.learning.total)}`;
+    return `<div class="hcal-tip-row"><b>${c.zh}</b> ${cd.cards}c · ${_hcalFmtRR(cd.review.correct, cd.review.total)} <span class="hcal-tip-dim">(${ph})</span></div>`;
   }).join('');
   return `<div class="hcal-tip-date">${nice}</div>${head}${time}<div class="hcal-tip-rows">${rows}</div>`;
 }
@@ -8306,15 +8309,14 @@ function _hcalRenderDetail() {
 
   const catRows = _HCAL_CATS.map(c => {
     const cd = d.by_cat[c.key];
-    if (!cd) return `<tr><td>${c.zh} ${c.en}</td><td>0</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>`;
+    if (!cd) return `<tr><td>${c.zh} ${c.en}</td><td>0</td><td>—</td><td>—</td><td>—</td></tr>`;
     const avg = cd.timed_count > 0 ? _hcalFmtTime(cd.duration_ms / cd.timed_count) : '—';
     const tot = cd.timed_count > 0 ? _hcalFmtTime(cd.duration_ms) : '—';
     return `<tr>
       <td>${c.zh} ${c.en}</td>
       <td>${cd.cards}</td>
-      <td>${_hcalFmtRR(cd.correct, cd.total)}</td>
-      <td>${_hcalFmtRR(cd.learning.correct, cd.learning.total)}</td>
       <td>${_hcalFmtRR(cd.review.correct, cd.review.total)}</td>
+      <td>${_hcalFmtRR(cd.learning.correct, cd.learning.total)}</td>
       <td>${avg} <span class="hcal-tip-dim">/ ${tot}</span></td>
     </tr>`;
   }).join('');
@@ -8324,12 +8326,11 @@ function _hcalRenderDetail() {
   return `
     <div class="hcal-detail-head">${nice}</div>
     <table class="hcal-tbl">
-      <tr><th>Category</th><th>Cards</th><th>Retention</th><th>Learn</th><th>Review</th><th>Avg / Total</th></tr>
+      <tr><th>Category</th><th>Cards</th><th>Retention</th><th>Learn</th><th>Avg / Total</th></tr>
       ${catRows}
       <tr class="hcal-tbl-total">
-        <td>All</td><td>${d.cards}</td><td>${_hcalFmtRR(d.correct, d.total)}</td>
+        <td>All</td><td>${d.cards}</td><td>${_hcalFmtRR(d.review.correct, d.review.total)}</td>
         <td>${_hcalFmtRR(d.learning.correct, d.learning.total)}</td>
-        <td>${_hcalFmtRR(d.review.correct, d.review.total)}</td>
         <td>${totAvg} <span class="hcal-tip-dim">/ ${totTot}</span></td>
       </tr>
     </table>`;

--- a/static/app.js
+++ b/static/app.js
@@ -6217,6 +6217,14 @@ function goBack() {
   loadDecks();
 }
 
+// ── Daily random words popup ─────────────────────────────────────────────────
+// Opens a small separate browser window showing 10 random words to use today.
+// Reusing the window name means a second click reloads it → a fresh set of words.
+function openRandomWords() {
+  window.open('/static/random-words.html', 'randomwords',
+              'width=460,height=680,menubar=no,toolbar=no,location=no');
+}
+
 // ── Import modal ─────────────────────────────────────────────────────────────
 
 let importResolutions = {};    // {word_zh: "keep"|"update"|"custom"}

--- a/static/app.js
+++ b/static/app.js
@@ -2924,6 +2924,14 @@ async function setDefaultPreset() {
   }
 }
 
+// Jump straight into the "All" deck's review for a given category.
+// Used by the home-view keyboard shortcuts (L → listening, C → creating).
+function _startAllDeckCategory(cat) {
+  const allDeck = (_cachedDecks || []).find(d => d.virtual && d.name === 'All');
+  if (!allDeck) return;
+  startReview(allDeck.id, cat, 'All', !!allDeck.no_story);
+}
+
 // ── Start review session ────────────────────────────────────────────────────
 async function startReview(id, cat, name, noStory = false, quick = false) {
   quickMode = quick;
@@ -7443,6 +7451,20 @@ document.addEventListener('keydown', async e => {
         e.preventDefault();
         openQuickAddCard();
         return;
+      }
+      // On the home (decks) view: L → All deck Listening, C → All deck Creating.
+      const _decksActive = document.getElementById('view-decks')?.style.display !== 'none';
+      if (_decksActive) {
+        if (code === 'KeyL') {
+          e.preventDefault();
+          _startAllDeckCategory('listening');
+          return;
+        }
+        if (code === 'KeyC') {
+          e.preventDefault();
+          _startAllDeckCategory('creating');
+          return;
+        }
       }
     }
   }

--- a/static/app.js
+++ b/static/app.js
@@ -7290,51 +7290,51 @@ function _fsrsParam(k, v, title) {
 function renderFsrsInspector() {
   const body = document.getElementById('fsrs-insp-body');
   if (!body) return;
-  if (!card) { body.innerHTML = '<div class="fsrs-note">没有正在复习的卡片。</div>'; return; }
+  if (!card) { body.innerHTML = '<div class="fsrs-note">No card is being reviewed.</div>'; return; }
   const f = card.fsrs;
-  if (!f) { body.innerHTML = '<div class="fsrs-note">这张卡没有 FSRS 数据。</div>'; return; }
+  if (!f) { body.innerHTML = '<div class="fsrs-note">This card has no FSRS data.</div>'; return; }
 
   const word = card.word_zh ? `「${card.word_zh}」` : '';
   const S = f.stability, D = f.difficulty, R = f.retrievability;
   let html = '';
 
-  if (!f.enabled) html += `<div class="fsrs-note">⚠️ 该牌组未启用 FSRS（仍用旧版 SM-2）。</div>`;
+  if (!f.enabled) html += `<div class="fsrs-note">⚠️ FSRS is not enabled for this deck (still using legacy SM-2).</div>`;
 
-  html += `<div class="fsrs-section-label">当前参数 ${word} · ${f.state}</div>`;
+  html += `<div class="fsrs-section-label">Current parameters ${word} · ${f.state}</div>`;
   html += '<div class="fsrs-params">';
-  html += _fsrsParam('Stability 稳定性', S != null ? S.toFixed(2) + ' d' : '—', '记忆能撑多少天（衰减到 90%）');
-  html += _fsrsParam('Difficulty 难度', D != null ? D.toFixed(2) + ' /10' : '—', '1–10，越高越难；每次向中值回归');
-  html += _fsrsParam('Elapsed 已过', f.elapsed_days + ' d', '距上次复习的天数');
-  html += _fsrsParam('Desired R 目标', Math.round(f.desired_retention * 100) + '%', '目标记忆率，决定所有间隔');
+  html += _fsrsParam('Stability', S != null ? S.toFixed(2) + ' d' : '—', 'How many days memory lasts (decays to 90%)');
+  html += _fsrsParam('Difficulty', D != null ? D.toFixed(2) + ' /10' : '—', '1–10, higher is harder; reverts toward the mean each time');
+  html += _fsrsParam('Elapsed', f.elapsed_days + ' d', 'Days since the last review');
+  html += _fsrsParam('Desired R', Math.round(f.desired_retention * 100) + '%', 'Target recall rate; determines all intervals');
   if (R != null) {
-    html += `<div class="fsrs-param full"><span class="k">Retrievability 当前可提取性</span><span class="v">${(R * 100).toFixed(1)}%</span></div>`;
+    html += `<div class="fsrs-param full"><span class="k">Retrievability</span><span class="v">${(R * 100).toFixed(1)}%</span></div>`;
     html += `<div class="fsrs-param full" style="background:transparent;padding:0"><div class="fsrs-bar"><i style="width:${Math.round(R * 100)}%"></i></div></div>`;
   }
   html += '</div>';
 
   if (f.ratings && Object.keys(f.ratings).length) {
-    html += `<div class="fsrs-section-label">点每个评分会发生什么</div>`;
-    html += '<table class="fsrs-table"><thead><tr><th>评分</th><th>新 S</th><th>新 D</th><th>下次间隔</th></tr></thead><tbody>';
+    html += `<div class="fsrs-section-label">What each rating does</div>`;
+    html += '<table class="fsrs-table"><thead><tr><th>Rating</th><th>New S</th><th>New D</th><th>Next interval</th></tr></thead><tbody>';
     [1, 2, 3, 4].forEach(r => {
       const e = f.ratings[String(r)];
       if (!e) return;
-      const note = r === 1 ? ' <span style="color:var(--muted);font-weight:400">(先进重学)</span>' : '';
+      const note = r === 1 ? ' <span style="color:var(--muted);font-weight:400">(enters relearning first)</span>' : '';
       html += `<tr class="r-row-${r}"><td class="rate-cell">${_RATING_NAMES[r]}</td><td>${e.stability}</td><td>${e.difficulty}</td><td class="ivl">${_fsrsFmtIvl(e.interval)}${note}</td></tr>`;
     });
     html += '</tbody></table>';
   } else {
-    html += `<div class="fsrs-note">这张卡还在学习/重学阶段，按钮间隔由分钟级步骤决定，尚未进入 FSRS 记忆模型。</div>`;
+    html += `<div class="fsrs-note">This card is still in the learning/relearning phase; button intervals are set by minute-level steps and it has not yet entered the FSRS memory model.</div>`;
   }
 
-  html += `<div class="fsrs-section-label">参数如何代入公式</div>`;
+  html += `<div class="fsrs-section-label">How the parameters plug into the formulas</div>`;
   html += `<div class="fsrs-formula">
-    <b>1. 可提取性</b> R = (1 + 19/81 · t/S)<sup>−0.5</sup>，t=${f.elapsed_days}，S=${S != null ? S.toFixed(1) : '—'} → R=${R != null ? (R * 100).toFixed(1) + '%' : '—'}<br>
-    <b>2. 答对 →</b> 稳定性增长，<code>等得越久(R越低)、难度越低，奖励越大</code>；Hard 打折、Easy 加成。<br>
-    <b>3. 答错(Again) →</b> 稳定性温和下降（不砍半），难度上升。<br>
-    <b>4. 下次间隔</b> = 让 R 衰减到目标 ${Math.round(f.desired_retention * 100)}% 所需天数 ≈ 新的 S。<br>
-    <b>5. 难度</b> 每次都向中值回归 → 不会永久卡死（无 ease 地狱）。
+    <b>1. Retrievability</b> R = (1 + 19/81 · t/S)<sup>−0.5</sup>, t=${f.elapsed_days}, S=${S != null ? S.toFixed(1) : '—'} → R=${R != null ? (R * 100).toFixed(1) + '%' : '—'}<br>
+    <b>2. Correct →</b> stability grows, <code>the longer you wait (lower R) and the lower the difficulty, the bigger the boost</code>; Hard is discounted, Easy gets a bonus.<br>
+    <b>3. Wrong (Again) →</b> stability drops gently (not halved), difficulty rises.<br>
+    <b>4. Next interval</b> = the number of days for R to decay to the target ${Math.round(f.desired_retention * 100)}% ≈ the new S.<br>
+    <b>5. Difficulty</b> reverts toward the mean every time → never gets permanently stuck (no ease hell).
   </div>`;
-  html += `<div class="fsrs-note">间隔已强制 Again < Hard ≤ Good < Easy 单调。按 Shift+S 或 Esc 关闭。</div>`;
+  html += `<div class="fsrs-note">Intervals are forced monotonic: Again < Hard ≤ Good < Easy. Press Shift+S or Esc to close.</div>`;
 
   body.innerHTML = html;
 }

--- a/static/app.js
+++ b/static/app.js
@@ -345,7 +345,11 @@ const _STATE_ANIM = {
 
 // Floating Chinese state-change cue: fades + scales in, drifts up, removes itself.
 function showStateChangeAnim(transition) {
-  const info = _STATE_ANIM[transition?.to];
+  let key = transition?.to;
+  // Graduating to 'review' but below learned_interval isn't "learned" yet —
+  // show the learning cue instead of "学会了".
+  if (key === 'review' && transition?.learned === false) key = 'learning';
+  const info = _STATE_ANIM[key];
   if (!info) return;
   const el = document.createElement('div');
   el.className = 'state-anim';

--- a/static/index.html
+++ b/static/index.html
@@ -457,6 +457,7 @@
       <div class="opt-row"><span class="opt-label">Steps (minutes, space-separated) <span class="info-i" data-info="learning_steps">i</span></span><input class="opt-input wide" id="opt-learn-steps"  type="text"></div>
       <div class="opt-row sched-sm2"><span class="opt-label">Graduating interval (days) <span class="info-i" data-info="graduating_interval">i</span></span>       <input class="opt-input" id="opt-grad-int"     type="number" min="1"></div>
       <div class="opt-row sched-sm2"><span class="opt-label">Easy interval (days) <span class="info-i" data-info="easy_interval">i</span></span>              <input class="opt-input" id="opt-easy-int"     type="number" min="1"></div>
+      <div class="opt-row"><span class="opt-label">Learned interval (days) <span class="info-i" data-info="learned_interval">i</span><br><span style="font-weight:400;font-size:11px;color:var(--muted)">interval a card must reach to count as learned</span></span><input class="opt-input" id="opt-learned-int" type="number" min="1" step="1"></div>
     </div>
 
     <div class="opt-group">

--- a/static/index.html
+++ b/static/index.html
@@ -237,7 +237,7 @@
             </div>
             <!-- FSRS scheduler inspector trigger (Shift+S) -->
             <div class="fsrs-inspect-row">
-              <button class="fsrs-inspect-btn" onclick="toggleFsrsInspector()" title="复习调度详情 / FSRS scheduler (Shift+S)">🔬 Scheduler</button>
+              <button class="fsrs-inspect-btn" onclick="toggleFsrsInspector()" title="FSRS scheduler details (Shift+S)">🔬 Scheduler</button>
             </div>
             <!-- Word summary: character, pinyin, pos, definition -->
             <div class="vocab-detail">
@@ -1073,7 +1073,7 @@
   <div id="fsrs-inspector">
     <div class="fsrs-insp-header">
       <span class="fsrs-insp-title">🔬 FSRS Scheduler</span>
-      <button class="fsrs-insp-close" onclick="closeFsrsInspector()" title="关闭 (Shift+S / Esc)">✕</button>
+      <button class="fsrs-insp-close" onclick="closeFsrsInspector()" title="Close (Shift+S / Esc)">✕</button>
     </div>
     <div id="fsrs-insp-body"></div>
   </div>

--- a/static/index.html
+++ b/static/index.html
@@ -50,6 +50,7 @@
     <button class="undo-btn" id="session-graph-btn" onclick="openSessionSummary()" title="Graph of cards reviewed this session">📈 Session</button>
   </div>
   <div class="header-right">
+    <button id="random-words-btn" onclick="openRandomWords()" title="10 random words for today">🎲</button>
     <button id="header-regen-btn" onclick="regenerateStory()" title="Regenerate story" style="display:none">↺</button>
   </div>
 </header>

--- a/static/random-words.html
+++ b/static/random-words.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>今日随机词</title>
+<style>
+  :root {
+    --bg:      #f1f5f9;
+    --card:    #ffffff;
+    --border:  #e2e8f0;
+    --text:    #1e293b;
+    --muted:   #64748b;
+    --primary: #2563eb;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: -apple-system, "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+  }
+  header {
+    position: sticky;
+    top: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    background: var(--card);
+    border-bottom: 1px solid var(--border);
+  }
+  header h1 { font-size: 16px; font-weight: 700; margin: 0; }
+  #refresh-btn {
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    color: #fff;
+    background: var(--primary);
+    border: none;
+    padding: 7px 14px;
+    border-radius: 8px;
+  }
+  #refresh-btn:hover  { background: #1d4ed8; }
+  #refresh-btn:active { transform: translateY(1px); }
+  #list { padding: 12px 16px 24px; }
+  .word-card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 14px 16px;
+    margin-bottom: 10px;
+  }
+  .word-top { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+  .word-zh  { font-size: 26px; font-weight: 700; line-height: 1.1; }
+  .word-py  { font-size: 15px; color: var(--primary); }
+  .word-zhdef { margin-top: 6px; font-size: 15px; }
+  .word-endef { margin-top: 2px; font-size: 13px; color: var(--muted); }
+  #status { padding: 24px 16px; text-align: center; color: var(--muted); }
+</style>
+</head>
+<body>
+  <header>
+    <h1>🎲 今日随机词</h1>
+    <button id="refresh-btn" onclick="load()">换一批</button>
+  </header>
+  <div id="status">加载中…</div>
+  <div id="list"></div>
+
+<script>
+  const listEl = document.getElementById('list');
+  const statusEl = document.getElementById('status');
+
+  function esc(s) {
+    return (s == null ? '' : String(s))
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  async function load() {
+    statusEl.style.display = 'block';
+    statusEl.textContent = '加载中…';
+    listEl.innerHTML = '';
+    try {
+      const res = await fetch('/api/random-words?n=10');
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      const data = await res.json();
+      const words = data.words || [];
+      if (!words.length) {
+        statusEl.textContent = '词库里还没有词。';
+        return;
+      }
+      statusEl.style.display = 'none';
+      listEl.innerHTML = words.map(w => `
+        <div class="word-card">
+          <div class="word-top">
+            <span class="word-zh">${esc(w.word_zh)}</span>
+            <span class="word-py">${esc(w.pinyin)}</span>
+          </div>
+          ${w.definition_zh ? `<div class="word-zhdef">${esc(w.definition_zh)}</div>` : ''}
+          ${w.definition ? `<div class="word-endef">${esc(w.definition)}</div>` : ''}
+        </div>
+      `).join('');
+    } catch (e) {
+      statusEl.style.display = 'block';
+      statusEl.textContent = '加载失败：' + e.message;
+    }
+  }
+
+  load();
+</script>
+</body>
+</html>

--- a/static/style.css
+++ b/static/style.css
@@ -76,6 +76,17 @@ header h1 { font-size: 18px; font-weight: 700; }
   margin-left: 4px;
 }
 #header-regen-btn:hover { background: var(--border); color: #6366f1; }
+#random-words-btn {
+  background: none;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 6px;
+  line-height: 1;
+  margin-left: 4px;
+}
+#random-words-btn:hover { background: var(--border); }
 
 /* ── Layout ──────────────────────────────────────────── */
 main {


### PR DESCRIPTION
## 变更内容

### 1. 每日十个随机词弹窗（Closes #380）
- `database/entries.py`：新增 `get_random_words(n=10)`，从所有词汇类词条（vocabulary / chengyu / expression）随机抽取，返回汉字、拼音、中文与英文意思。排除整句 sentence 和语法点 grammar。不涉及 SRS。
- `routes/browse.py`：新增 `GET /api/random-words?n=10`（n 限制在 1–50）。
- `static/index.html` + `style.css`：顶栏 header-right 添加 🎲 按钮。
- `static/app.js`：新增 `openRandomWords()`，用 `window.open` 打开弹窗；复用同一窗口名，再次点击即刷新为新词。
- 新建 `static/random-words.html`：自包含弹窗页，抓取接口并渲染，含「换一批」按钮。

### 2. 留存率仅统计已学过的卡片
把留存率（retention rate）改为**只统计复习阶段（state='review'）的作答**，即已毕业/已学过的卡片，排除学习、重学、新卡阶段的作答。对应 Anki 的"真实留存率"。旧的 NULL 状态记录也一并排除。

- `database/stats.py`：`get_retention_bulk` 加 `AND rl.state = 'review'` 过滤——影响复习时的每日留存率徽章和牌组徽章。
- `static/app.js`：首页日历热力图的 retention 指标（热力图颜色、悬浮提示、详情表）改为读取后端已提供的 `.review` 子对象；详情表移除与之重复的 "Review" 列，保留 "Learn" 列作为学习阶段的对照。

**效果**：近 30 天留存率从全阶段的 84% 变为仅复习阶段的 88%（学习阶段的 Again 不再拉低数字）。

## 测试方法
- 🎲 按钮：主页点 🎲 → 弹窗显示十个词（汉字/拼音/中英文意思）；点「换一批」或再次点 🎲 → 新的一批。
- 留存率：复习时查看顶栏留存率徽章、首页牌组徽章、首页日历热力图的 Retention 指标——数字应只反映已毕业卡片。

Closes #380