### PR TITLE
feat: 新增"已学会间隔阈值"——间隔达到阈值才算已学会（默认 4 天）

### DIFF
--- a/database/browse.py
+++ b/database/browse.py
@@ -354,12 +354,13 @@ def insert_review(card_id: int, rating: int,
                   user_response: str | None = None,
                   ai_score: int | None = None,
                   duration_ms: int | None = None,
-                  state: str | None = None) -> int:
+                  state: str | None = None,
+                  last_interval: int | None = None) -> int:
     conn = get_db()
     cur = conn.execute(
-        """INSERT INTO review_log (card_id, rating, user_response, ai_score, duration_ms, state)
-           VALUES (?, ?, ?, ?, ?, ?)""",
-        (card_id, rating, user_response, ai_score, duration_ms, state),
+        """INSERT INTO review_log (card_id, rating, user_response, ai_score, duration_ms, state, last_interval)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        (card_id, rating, user_response, ai_score, duration_ms, state, last_interval),
     )
     conn.commit()
     log_id = cur.lastrowid

--- a/database/cards.py
+++ b/database/cards.py
@@ -487,7 +487,7 @@ def count_due(deck_id: int, category: str) -> dict:
     new_remaining = max(0, new_limit - new_done_today)
 
     rows = conn.execute(
-        """SELECT c.word_id, c.state, c.due FROM cards c
+        """SELECT c.word_id, c.state, c.due, c.interval FROM cards c
            WHERE c.deck_id = ? AND c.category = ?
              AND c.state != 'suspended'
              AND c.deleted_at IS NULL
@@ -500,8 +500,15 @@ def count_due(deck_id: int, category: str) -> dict:
         (deck_id, category, today, now, today, today),
     ).fetchall()
 
-    learning = sum(1 for r in rows if r["state"] in ("learning", "relearn"))
-    review   = sum(1 for r in rows if r["state"] == "review")
+    # A 'review' card whose interval hasn't reached learned_interval is still
+    # "learning" for badge purposes (not yet learned/mature).
+    threshold = preset.get("learned_interval", 4)
+    def _is_learning(r) -> bool:
+        return (r["state"] in ("learning", "relearn")
+                or (r["state"] == "review" and (r["interval"] or 0) < threshold))
+
+    learning = sum(1 for r in rows if _is_learning(r))
+    review   = sum(1 for r in rows if r["state"] == "review" and not _is_learning(r))
     new_avail = sum(1 for r in rows if r["state"] == "new")
 
     learning_future = conn.execute(
@@ -876,11 +883,12 @@ def count_due_deduped(leaf_pairs: list[tuple[int, str]]) -> dict:
 
     for deck_id, category in leaf_pairs:
         pr = get_preset_for_deck(deck_id)
+        threshold = pr.get("learned_interval", 4)
         new_done = _count_new_introduced_today(conn, deck_id, category, today)
         new_remaining_map[(deck_id, category)] = max(0, pr["new_per_day"] - new_done)
 
         rows = conn.execute(
-            """SELECT c.word_id, c.state FROM cards c
+            """SELECT c.word_id, c.state, c.interval FROM cards c
                WHERE c.deck_id = ? AND c.category = ?
                  AND c.state != 'suspended'
                  AND c.deleted_at IS NULL
@@ -896,8 +904,13 @@ def count_due_deduped(leaf_pairs: list[tuple[int, str]]) -> dict:
         for r in rows:
             sr = 0 if r["state"] in ("learning", "relearn") else 1 if r["state"] == "review" else 2
             cr = cat_rank_map[category]
+            # A young 'review' card (interval below learned_interval) is tallied
+            # as learning; dedup priority still uses the raw state rank so which
+            # category a word is attributed to is unchanged.
+            is_lrn = (r["state"] in ("learning", "relearn")
+                      or (r["state"] == "review" and (r["interval"] or 0) < threshold))
             if r["word_id"] not in best or (sr, cr) < best[r["word_id"]][:2]:
-                best[r["word_id"]] = (sr, cr, r["state"], deck_id, category)
+                best[r["word_id"]] = (sr, cr, r["state"], deck_id, category, is_lrn)
 
     conn.close()
 
@@ -905,14 +918,14 @@ def count_due_deduped(leaf_pairs: list[tuple[int, str]]) -> dict:
     review_count = 0
     new_by_deck: dict[tuple, int] = {}
 
-    for sr, cr, state, deck_id, category in best.values():
-        if sr == 0:
-            learning_count += 1
-        elif sr == 1:
-            review_count += 1
-        else:
+    for sr, cr, state, deck_id, category, is_lrn in best.values():
+        if state == "new":
             key = (deck_id, category)
             new_by_deck[key] = new_by_deck.get(key, 0) + 1
+        elif is_lrn:
+            learning_count += 1
+        else:
+            review_count += 1
 
     new_count = sum(
         min(count, new_remaining_map.get(key, 0))

--- a/database/core.py
+++ b/database/core.py
@@ -236,6 +236,8 @@ def init_db() -> None:
         conn.execute("ALTER TABLE review_log ADD COLUMN duration_ms INTEGER")
     if "state" not in rl_cols:
         conn.execute("ALTER TABLE review_log ADD COLUMN state TEXT")
+    if "last_interval" not in rl_cols:
+        conn.execute("ALTER TABLE review_log ADD COLUMN last_interval INTEGER")
 
     preset_cols = {r["name"] for r in conn.execute("PRAGMA table_info(deck_presets)").fetchall()}
     if "new_gather_order" not in preset_cols:
@@ -289,6 +291,8 @@ def init_db() -> None:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN learning_hard_1d INTEGER NOT NULL DEFAULT 1")
     if "learning_hard_days" not in preset_cols:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN learning_hard_days REAL NOT NULL DEFAULT 1")
+    if "learned_interval" not in preset_cols:
+        conn.execute("ALTER TABLE deck_presets ADD COLUMN learned_interval INTEGER NOT NULL DEFAULT 4")
 
     conn.execute("""CREATE TABLE IF NOT EXISTS preset_category_overrides (
         id                  INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/database/presets.py
+++ b/database/presets.py
@@ -16,6 +16,7 @@ def default_preset() -> dict:
         "easy_interval": 4,
         "relearning_steps": "10",
         "minimum_interval": 1,
+        "learned_interval": 4,
         "insertion_order": "sequential",
         "bury_siblings": 1,
         "randomize_story_order": 0,
@@ -207,12 +208,13 @@ def insert_preset(preset: dict) -> int:
     preset.setdefault("enable_fsrs", 1)
     preset.setdefault("learning_hard_1d", 1)
     preset.setdefault("learning_hard_days", 1)
+    preset.setdefault("learned_interval", 4)
     conn = get_db()
     cur = conn.execute(
         """INSERT INTO deck_presets
            (name, new_per_day, reviews_per_day,
             learning_steps, graduating_interval, easy_interval,
-            relearning_steps, minimum_interval, insertion_order,
+            relearning_steps, minimum_interval, learned_interval, insertion_order,
             bury_siblings, randomize_story_order, leech_threshold, learning_leech_threshold, leech_action,
             desired_retention, maximum_interval, fsrs_weights, enable_fsrs, learning_hard_1d, learning_hard_days,
             new_gather_order, new_sort_order, new_review_order,
@@ -221,7 +223,7 @@ def insert_preset(preset: dict) -> int:
             bury_quick_mode, category_order, sibling_separation, sibling_factor)
            VALUES (:name, :new_per_day, :reviews_per_day,
                    :learning_steps, :graduating_interval, :easy_interval,
-                   :relearning_steps, :minimum_interval, :insertion_order,
+                   :relearning_steps, :minimum_interval, :learned_interval, :insertion_order,
                    :bury_siblings, :randomize_story_order, :leech_threshold, :learning_leech_threshold, :leech_action,
                    :desired_retention, :maximum_interval, :fsrs_weights, :enable_fsrs, :learning_hard_1d, :learning_hard_days,
                    :new_gather_order, :new_sort_order, :new_review_order,
@@ -240,7 +242,7 @@ def update_preset(preset_id: int, fields: dict) -> None:
     allowed = {
         "name", "new_per_day", "reviews_per_day",
         "learning_steps", "graduating_interval", "easy_interval",
-        "relearning_steps", "minimum_interval", "insertion_order",
+        "relearning_steps", "minimum_interval", "learned_interval", "insertion_order",
         "bury_siblings", "randomize_story_order", "leech_threshold", "learning_leech_threshold", "leech_action",
         "desired_retention", "maximum_interval", "fsrs_weights", "enable_fsrs", "learning_hard_1d", "learning_hard_days",
         "new_gather_order", "new_sort_order", "new_review_order",

--- a/database/stats.py
+++ b/database/stats.py
@@ -138,8 +138,11 @@ def get_retention_bulk(days: int = 30) -> dict:
     Rating > 1 (Hard/Good/Easy) counts as correct; rating == 1 (Again) counts as wrong.
 
     Only counts reviews of *learned* cards — those answered in the 'review' phase
-    (state='review'). Learning/relearning/new-card steps are excluded, matching
-    Anki's "true retention". Legacy rows with no recorded state are excluded too.
+    (state='review') whose interval had reached the deck's learned_interval
+    threshold (default 4 days). Learning/relearning/new-card steps and young
+    review cards (interval below the threshold) are excluded, matching an
+    Anki-style "mature retention". Legacy rows with no recorded state are excluded;
+    legacy 'review' rows with no recorded interval keep counting (not retroactive).
     """
     conn = get_db()
     since = (anki_today() - _dt.timedelta(days=days)).isoformat()
@@ -151,8 +154,10 @@ def get_retention_bulk(days: int = 30) -> dict:
            FROM review_log rl
            JOIN cards c ON c.id = rl.card_id
            JOIN decks d ON d.id = c.deck_id
+           JOIN deck_presets p ON p.id = d.preset_id
            WHERE date(datetime(rl.reviewed_at, 'localtime')) >= ?
              AND rl.state = 'review'
+             AND (rl.last_interval IS NULL OR rl.last_interval >= p.learned_interval)
            GROUP BY c.deck_id""",
         [since],
     ).fetchall()
@@ -204,9 +209,12 @@ def get_calendar_stats(days: int = 365, deck_id: int | None = None) -> dict:
     day_expr = "date(datetime(rl.reviewed_at, 'localtime', '-4 hours'))"
     rows = conn.execute(
         f"""SELECT {day_expr} AS d, c.category AS cat, rl.rating AS rating,
-                   rl.state AS state, rl.duration_ms AS dur, rl.card_id AS card_id
+                   rl.state AS state, rl.duration_ms AS dur, rl.card_id AS card_id,
+                   rl.last_interval AS last_ivl, p.learned_interval AS learned_int
             FROM review_log rl
             JOIN cards c ON c.id = rl.card_id
+            JOIN decks d ON d.id = c.deck_id
+            JOIN deck_presets p ON p.id = d.preset_id
             WHERE {day_expr} >= ? {deck_filter}""",
         params,
     ).fetchall()
@@ -246,12 +254,17 @@ def get_calendar_stats(days: int = 365, deck_id: int | None = None) -> dict:
                 bucket["duration_ms"] += r["dur"]
                 bucket["timed_count"] += 1
 
-        # Phase split (learning/relearn/new = "learning"; review = "review")
+        # Phase split (learning/relearn/new = "learning"; review = "review").
+        # A 'review'-state card whose interval hadn't yet reached the deck's
+        # learned_interval threshold counts as "learning" (not yet learned).
+        # Legacy 'review' rows with no recorded interval keep counting as review.
         phase = None
         if r["state"] in ("new", "learning", "relearn"):
             phase = "learning"
         elif r["state"] == "review":
-            phase = "review"
+            li = r["last_ivl"]
+            thr = r["learned_int"]
+            phase = "learning" if (li is not None and li < thr) else "review"
         if phase:
             for bucket in (day, c):
                 bucket[phase]["total"]   += 1

--- a/schema.sql
+++ b/schema.sql
@@ -26,6 +26,12 @@ CREATE TABLE IF NOT EXISTS deck_presets (
     -- Review scheduling
     minimum_interval        INTEGER NOT NULL DEFAULT 1,
 
+    -- learned_interval: minimum interval (in days) a card must reach before it
+    -- counts as "learned/mature". Reviews of cards below this interval (plus all
+    -- relearn cards) are treated as "still learning" in retention stats and deck
+    -- badge counts. Does NOT change the SRS state machine or queue order.
+    learned_interval        INTEGER NOT NULL DEFAULT 4,
+
     -- ── FSRS scheduling ──────────────────────────────────────────────────────
     -- desired_retention: target recall probability that sets every interval
     -- maximum_interval: hard cap on any computed interval (days)
@@ -307,7 +313,9 @@ CREATE TABLE IF NOT EXISTS review_log (
     user_response   TEXT,       -- what the user typed (creating category)
     ai_score        INTEGER,    -- future: AI evaluation score
     duration_ms     INTEGER,    -- time spent on this review in milliseconds (NULL for legacy rows)
-    state           TEXT        -- card state at review time (new/learning/review/relearn) — NULL for legacy rows
+    state           TEXT,       -- card state at review time (new/learning/review/relearn) — NULL for legacy rows
+    last_interval   INTEGER     -- the interval (days) the card had when shown, i.e. the interval being tested
+                                -- (used to tell "learned/mature" reviews apart) — NULL for legacy rows
 );
 
 -- ---------------------------------------------------------------------------

--- a/srs.py
+++ b/srs.py
@@ -359,6 +359,7 @@ def apply_review(card_id: int, rating: int,
     if not card:
         raise ValueError(f"Card {card_id} not found")
     state_before = card["state"]
+    interval_before = card.get("interval") or 0
 
     preset = {
         "learning_steps":      card["learning_steps"],
@@ -402,6 +403,7 @@ def apply_review(card_id: int, rating: int,
     log_id = database.insert_review(
         card_id, rating, user_response=user_response,
         duration_ms=duration_ms, state=state_before,
+        last_interval=interval_before,
     )
     return database.get_card(card_id), log_id
 

--- a/static/app.js
+++ b/static/app.js
@@ -2652,6 +2652,8 @@ const INFO_TEXT = {
     'The interval (in days) a card gets the first time it leaves learning with Good. Only used by SM-2 — under FSRS the first interval is computed from the card\'s initial stability instead.'],
   easy_interval: ['Easy interval (SM-2 only)',
     'The interval (in days) a learning card jumps to when rated Easy. Only used by SM-2 — under FSRS this is computed from stability.'],
+  learned_interval: ['Learned interval',
+    'The interval (in days) a card must reach before it counts as "learned/mature". Reviews of cards below this interval — plus all relearning cards — are treated as "still learning" in the retention stats and the deck badge counts. This does not change scheduling or queue order, only how cards are labelled and counted. Default 4.'],
   desired_retention: ['Desired retention (FSRS only)',
     'The probability you want of still recalling a card when it comes due, e.g. 90%. Higher retention = shorter intervals and more reviews; lower = longer intervals, fewer reviews but more lapses. This is the main FSRS knob.'],
   maximum_interval: ['Maximum interval (FSRS only)',
@@ -2700,6 +2702,7 @@ function loadPresetFields(preset) {
   document.getElementById('opt-learn-steps').value     = preset.learning_steps;
   document.getElementById('opt-grad-int').value        = preset.graduating_interval;
   document.getElementById('opt-easy-int').value        = preset.easy_interval;
+  document.getElementById('opt-learned-int').value     = preset.learned_interval ?? 4;
   document.getElementById('opt-relearn-steps').value   = preset.relearning_steps;
   document.getElementById('opt-leech').value           = preset.leech_threshold;
   document.getElementById('opt-learning-leech').value  = preset.learning_leech_threshold;
@@ -2867,6 +2870,7 @@ async function saveOptions() {
     learning_steps:      document.getElementById('opt-learn-steps').value.trim(),
     graduating_interval: parseInt(document.getElementById('opt-grad-int').value),
     easy_interval:       parseInt(document.getElementById('opt-easy-int').value),
+    learned_interval:    parseInt(document.getElementById('opt-learned-int').value),
     relearning_steps:    document.getElementById('opt-relearn-steps').value.trim(),
     leech_threshold:     parseInt(document.getElementById('opt-leech').value),
     learning_leech_threshold: parseInt(document.getElementById('opt-learning-leech').value),

--- a/static/app.js
+++ b/static/app.js
@@ -2924,6 +2924,14 @@ async function setDefaultPreset() {
   }
 }
 
+// Jump straight into the "All" deck's review for a given category.
+// Used by the home-view keyboard shortcuts (L → listening, C → creating).
+function _startAllDeckCategory(cat) {
+  const allDeck = (_cachedDecks || []).find(d => d.virtual && d.name === 'All');
+  if (!allDeck) return;
+  startReview(allDeck.id, cat, 'All', !!allDeck.no_story);
+}
+
 // ── Start review session ────────────────────────────────────────────────────
 async function startReview(id, cat, name, noStory = false, quick = false) {
   quickMode = quick;
@@ -7443,6 +7451,20 @@ document.addEventListener('keydown', async e => {
         e.preventDefault();
         openQuickAddCard();
         return;
+      }
+      // On the home (decks) view: L → All deck Listening, C → All deck Creating.
+      const _decksActive = document.getElementById('view-decks')?.style.display !== 'none';
+      if (_decksActive) {
+        if (code === 'KeyL') {
+          e.preventDefault();
+          _startAllDeckCategory('listening');
+          return;
+        }
+        if (code === 'KeyC') {
+          e.preventDefault();
+          _startAllDeckCategory('creating');
+          return;
+        }
       }
     }
   }

--- a/static/index.html
+++ b/static/index.html
@@ -457,6 +457,7 @@
       <div class="opt-row"><span class="opt-label">Steps (minutes, space-separated) <span class="info-i" data-info="learning_steps">i</span></span><input class="opt-input wide" id="opt-learn-steps"  type="text"></div>
       <div class="opt-row sched-sm2"><span class="opt-label">Graduating interval (days) <span class="info-i" data-info="graduating_interval">i</span></span>       <input class="opt-input" id="opt-grad-int"     type="number" min="1"></div>
       <div class="opt-row sched-sm2"><span class="opt-label">Easy interval (days) <span class="info-i" data-info="easy_interval">i</span></span>              <input class="opt-input" id="opt-easy-int"     type="number" min="1"></div>
+      <div class="opt-row"><span class="opt-label">Learned interval (days) <span class="info-i" data-info="learned_interval">i</span><br><span style="font-weight:400;font-size:11px;color:var(--muted)">interval a card must reach to count as learned</span></span><input class="opt-input" id="opt-learned-int" type="number" min="1" step="1"></div>
     </div>
 
     <div class="opt-group">


### PR DESCRIPTION
## 变更内容

新增按牌组可配置的 **`learned_interval`（默认 4 天）**：卡片间隔达到该值才算"已学会/成熟"。低于阈值的复习卡片、以及所有 relearn 卡片，都归入"learning（学习中）"。这解决了 Daniel 的问题——3 天间隔的卡片经常还会被评为 Again，不该算作已学会。

范围（已与 Daniel 确认）：**统计 + 徽章显示**，不改动 SRS 状态机与队列顺序。

- **schema + 迁移**：`deck_presets` 加 `learned_interval`（默认 4）；`review_log` 加 `last_interval`（复习时卡片的间隔，旧数据 NULL）。
- **写入日志**：`srs.apply_review` 把复习前的 `interval` 写入 `last_interval`。
- **留存率**（`database/stats.py`）：`get_retention_bulk` 与 `get_calendar_stats` 只把 `state='review'` 且 `last_interval ≥ 阈值` 的复习计为已学会；`last_interval` 为 NULL 的旧数据保持原行为（不追溯）。
- **牌组徽章**（`database/cards.py`）：`count_due`、`count_due_deduped` 把间隔 < 阈值的 review 卡片计入 learning 数字。
- **预设读写**（`database/presets.py`）：加入 `learned_interval`。
- **前端**（`static/`）：牌组选项弹窗新增"Learned interval"输入框与说明。

## 测试方法

已用临时数据库做功能验证（阈值=4，一张间隔 2 的卡 + 一张间隔 10 的卡）：
- `count_due` → learning=1, review=1 ✓
- `get_retention_bulk` → total=1（仅间隔 10 的复习计入）✓
- `get_calendar_stats` phase 拆分 → learning=1, review=1 ✓
- `count_due_deduped` → learning=1, review=1 ✓

手动复核建议：在牌组选项里改阈值，确认留存率徽章与 learning/review 数字随之变化。

## 说明

- 本分支基于 `feat/380-daily-random-words`（"留存率=复习阶段"的基础在那里）。请先合并 feat/380，GitHub 会自动把本 PR 的 base 重定向到 main。
- 历史 `review_log` 无 `last_interval`，因此阈值规则只对今后的复习生效，不追溯旧数据。

Closes #382