### PR TITLE
fix: 间隔未达 learned_interval 的卡在队列与「学会了」弹窗上统一按 learning 对待

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -289,6 +289,16 @@ def resolve_bury_flags(preset: dict) -> tuple[bool, bool, bool]:
     )
 
 
+def _still_learning(card: dict, learned_interval: int) -> bool:
+    """True if a card is not yet "learned" — either in learning/relearn, or a
+    review card whose interval hasn't reached the learned_interval threshold.
+    Such cards queue with the learning group and are shown before learned cards.
+    """
+    if card["state"] in ("learning", "relearn"):
+        return True
+    return card["state"] == "review" and (card.get("interval") or 0) < learned_interval
+
+
 def _interleave_cards(base: list, inserts: list) -> list:
     """Distribute inserts evenly across the full combined length.
 
@@ -355,8 +365,11 @@ def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = Fa
     ).fetchall()
 
     all_cards = [dict(r) for r in rows]
-    learning_cards = [c for c in all_cards if c["state"] in ("learning", "relearn")]
-    review_cards   = [c for c in all_cards if c["state"] == "review"]
+    # A 'review' card whose interval hasn't reached learned_interval is still a
+    # learning card: it queues with the learning group (before learned cards).
+    threshold = preset.get("learned_interval", 4)
+    learning_cards = [c for c in all_cards if _still_learning(c, threshold)]
+    review_cards   = [c for c in all_cards if c["state"] == "review" and not _still_learning(c, threshold)]
     new_cards_raw  = [c for c in all_cards if c["state"] == "new"]
 
     # ── 1. Gather & sort new cards ────────────────────────────────────────────
@@ -719,9 +732,18 @@ def get_due_cards_any_cat(root_deck_id: int) -> list[dict]:
             cat_order.get(c["category"], 99),
         ))
     else:
+        # No story: learning-first. A review card below its deck's
+        # learned_interval is still "learning" (rank 0), before learned cards.
+        thresholds = {
+            did: (get_preset_for_deck(did) or {}).get("learned_interval", 4)
+            for did, _ in leaf_pairs
+        }
+        def _rank(c: dict) -> int:
+            if _still_learning(c, thresholds.get(c["deck_id"], 4)):
+                return 0
+            return 1 if c["state"] == "review" else 2
         all_cards.sort(key=lambda c: (
-            0 if c["state"] in ("learning", "relearn") else
-            1 if c["state"] == "review" else 2,
+            _rank(c),
             cat_order.get(c["category"], 99),
             c["due"],
         ))
@@ -788,8 +810,16 @@ def get_due_cards_multi(deck_ids: list[int], category: str, *, root_deck_id: int
     for deck_id in deck_ids:
         all_cards.extend(get_due_cards(deck_id, category, sibling_suppression=sibling_suppression))
 
-    learning_cards = [c for c in all_cards if c["state"] in ("learning", "relearn")]
-    review_cards   = [c for c in all_cards if c["state"] == "review"]
+    # Each deck may have its own learned_interval; a review card below its deck's
+    # threshold is still "learning" and queues with the learning group.
+    thresholds = {
+        did: (get_preset_for_deck(did) or {}).get("learned_interval", 4)
+        for did in deck_ids
+    }
+    def _lrn(c: dict) -> bool:
+        return _still_learning(c, thresholds.get(c["deck_id"], 4))
+    learning_cards = [c for c in all_cards if _lrn(c)]
+    review_cards   = [c for c in all_cards if c["state"] == "review" and not _lrn(c)]
     new_cards      = [c for c in all_cards if c["state"] == "new"]
 
     # Apply parent deck's combined new-card cap (Anki-style)

--- a/database/cards.py
+++ b/database/cards.py
@@ -169,7 +169,7 @@ def get_card(card_id: int) -> dict | None:
                   END AS deck_path,
                   p.id AS preset_id,
                   p.learning_steps, p.graduating_interval, p.easy_interval,
-                  p.relearning_steps, p.minimum_interval,
+                  p.relearning_steps, p.minimum_interval, p.learned_interval,
                   p.leech_threshold, p.learning_leech_threshold, p.leech_action,
                   p.desired_retention, p.maximum_interval, p.fsrs_weights, p.enable_fsrs,
                   p.learning_hard_1d, p.learning_hard_days,

--- a/routes/review.py
+++ b/routes/review.py
@@ -323,11 +323,16 @@ def submit_review(card_id: int, rating: int, user_response: str | None = None,
         )
     state_from = card_before["state"]
     state_to   = updated["state"]
+    # A card only counts as "learned" once its interval reaches learned_interval;
+    # graduating to 'review' with a shorter interval is still learning.
+    learned_threshold = updated.get("learned_interval", 4)
+    is_learned = state_to == "review" and (updated.get("interval") or 0) >= learned_threshold
     transition = {
         "from":    state_from,
         "to":      state_to,
         "changed": state_from != state_to,
         "leech":   bool(updated.get("is_leech")) and state_to == "suspended",
+        "learned": is_learned,
     }
     return {"next_card": next_card, "counts": counts, "transition": transition}
 

--- a/static/app.js
+++ b/static/app.js
@@ -345,7 +345,11 @@ const _STATE_ANIM = {
 
 // Floating Chinese state-change cue: fades + scales in, drifts up, removes itself.
 function showStateChangeAnim(transition) {
-  const info = _STATE_ANIM[transition?.to];
+  let key = transition?.to;
+  // Graduating to 'review' but below learned_interval isn't "learned" yet —
+  // show the learning cue instead of "学会了".
+  if (key === 'review' && transition?.learned === false) key = 'learning';
+  const info = _STATE_ANIM[key];
   if (!info) return;
   const el = document.createElement('div');
   el.className = 'state-anim';


### PR DESCRIPTION
## 变更内容

补齐 #383 遗漏的两处，让「间隔达到 learned_interval 才算已学会」这条规则在**所有地方**一致（此前只改了留存率统计和牌组徽章）。

- **队列顺序**（`database/cards.py`）：新增 `_still_learning()`；`get_due_cards`、`get_due_cards_multi`、`get_due_cards_any_cat`（非故事分支）把间隔 < 阈值的 review 卡归入 learning 组，排在已学会卡之前。故事分支仍按叙事顺序（有意为之）。
- **「学会了」弹窗**：
  - `get_card` 查询补上 `learned_interval` 列。
  - `routes/review.py` 的 transition 增加 `learned` 标志（毕业后间隔是否达到阈值）。
  - 前端 `showStateChangeAnim`：`transition.learned === false` 时改显示「学习中」而非「学会了」。

## 背景

复习「天赋」（relearn→review，间隔仅 2 天）时弹出了「学会了」；同时 creating 牌组徽章显示「27 learning」，但队列却在发已学会卡——因为那 27 张全是间隔<4 的 review 卡，徽章算作 learning、队列却按 review 发。根因是 #383 只改了显示层没改队列与弹窗。

## 测试方法

已用临时库验证：
- `get_due_cards`：间隔 2、1 的卡排在间隔 10 的卡之前 ✓
- 毕业 transition：间隔 ≥ 阈值 → `learned=True`；间隔 < 阈值 → `learned=False` ✓

手动复核：复习一张间隔 2 天的卡评 Good，确认不再弹「学会了」；在 creating 牌组确认未学牢的卡先发。

Closes #384

> 基于 `feat/380-daily-random-words`（#383 已合并入该分支）。