### PR TITLE
feat: 新闻模式自动抓取当日新闻生成简报

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,6 +392,7 @@ echo "✓ 议题创建完成"
 ├── srs.py                 # Anki风格的SM-2调度（diàodù - scheduling）算法
 ├── importer.py            # 口语YAML导入（dǎorù - import）器
 ├── ai.py                  # Anthropic API调用
+├── news_fetcher.py        # 新闻抓取（Tagesschau API + RSS；来源配置 data/news_sources.json；按天缓存 data/news_cache/）
 ├── tts.py                 # edge-tts封装（fēngzhuāng - wrapper）
 ├── translator.py          # 中→英翻译（Google Translate，需 deep-translator，可选）
 ├── yaml_fixer.py          # 修复 AI 生成的格式错误 YAML（DeepSeek 常见双引号/冒号问题）
@@ -490,7 +491,10 @@ ease最低值（zuì dī zhí - floor）：1.3。难词检测（jiǎncè - detec
 - **模式（mode）**：`story`（叙事）| `qa`（问答）| `expository`（说明文）| `kahneman`（《思考，快与慢》认知偏误风格，见 `data/kahneman_chapters.json`）
   | `news`（新闻简报——用户在设置弹窗粘贴文章，AI 用 OpenAI `gpt-5-mini` 生成连贯中文新闻简报句子；
   每句附带 `source_url`/`concept_zh`(标题)/`reasoning_zh`(背景说明)，复用 kahneman 模式的概念框/背景弹窗 UI；
-  文章内容存入 `stories.gen_params` 的 `articles` 字段，供 Again 单词重生成复现同一批文章）
+  文章内容存入 `stories.gen_params` 的 `articles` 字段，供 Again 单词重生成复现同一批文章。
+  **不粘贴文章时自动抓取当日新闻**：`news_fetcher.fetch_all()` 抓取 Tagesschau API + RSS 源（按天缓存），
+  然后两步 AI 调用——`ai.summarize_news_items` 挑选最重要的 8 条（平衡德国/国际/中国相关）并压缩摘要，
+  再用 `generate_news_sentences` 生成句子；抓取全部失败时报明确错误，不静默降级为普通故事模式）
 
 ## 界面类别顺序（shùnxù - order）
 
@@ -545,6 +549,7 @@ POST /api/preload                                    → 预加载 TTS 音频
 POST /api/preload-session/{deck_id}/{category}       → 预加载整个会话的 TTS
 GET  /api/tts-progress/{deck_id}/{category}          → TTS 预加载进度
 GET  /api/story-progress/{deck_id}/{category}        → 故事生成进度
+GET  /api/news/status                                → 当日新闻缓存状态 {cached, count}（news 自动模式）
 
 # 其他
 POST /api/import                                     → 触发YAML导入

--- a/ai.py
+++ b/ai.py
@@ -1032,6 +1032,65 @@ def generate_news_sentences(
     return sentences
 
 
+def summarize_news_items(items: list[dict], model: str = "gpt-5-mini",
+                         max_items: int = 8, progress_key: str | None = None) -> list[dict]:
+    """News auto mode, step 1 of 2: pick the most important of today's fetched
+    news items and condense each into a short summary. The result feeds
+    generate_news_sentences exactly like pasted articles do.
+
+    items: news_fetcher.fetch_all() output [{url, title, text, source_name}]
+    Returns [{url, title, text}] — text is the AI's condensed summary.
+
+    Falls back to the first max_items raw items when the AI reply is unusable —
+    that is still real news content, only the selection/condensing is skipped
+    (a network failure upstream raises news_fetcher.NewsFetchError instead).
+    """
+    if not items:
+        return []
+
+    _set_progress(progress_key, phase="request", msg="Selecting today's top news…", percent=12)
+    listing = "\n\n".join(
+        f"[{i}] ({it.get('source_name', '')}) {it.get('title', '')}\n{(it.get('text') or '')[:400]}"
+        for i, it in enumerate(items)
+    )
+    prompt = f"""Below are today's news items fetched from German and international sources.
+
+{listing}
+
+Task: choose the {max_items} most important items for a daily world-news briefing.
+Balance the selection: German domestic news, international news, and China-related news (when available).
+Skip near-duplicates covering the same event.
+
+Return ONLY a JSON array, no other text:
+[
+  {{"idx": 0, "summary": "3-5 sentence factual English summary of the item"}}
+]
+idx is the item number in square brackets above."""
+
+    try:
+        raw = _call_api(model, [{"role": "user", "content": prompt}], 8192, purpose="news-select")
+        start, end = raw.find("["), raw.rfind("]") + 1
+        picked = json.loads(raw[start:end]) if start != -1 and end != 0 else []
+        articles = []
+        for p in picked:
+            idx = p.get("idx")
+            summary = (p.get("summary") or "").strip()
+            if isinstance(idx, int) and 0 <= idx < len(items) and summary:
+                it = items[idx]
+                articles.append({"url": it.get("url", ""), "title": it.get("title", ""),
+                                 "text": summary})
+        if articles:
+            logger.info("[%s] summarize_news_items: %d/%d items selected",
+                        model, len(articles), len(items))
+            return articles[:max_items]
+        logger.warning("summarize_news_items: empty/unusable selection, falling back to raw items")
+    except Exception as e:
+        logger.warning("summarize_news_items failed (%s), falling back to raw items", e)
+    return [{"url": it.get("url", ""), "title": it.get("title", ""),
+             "text": (it.get("text") or "")[:600]}
+            for it in items[:max_items]]
+
+
 def estimate_story_tokens(num_cards: int) -> int:
     """Rough token estimate for generating a story with num_cards words.
 

--- a/news_fetcher.py
+++ b/news_fetcher.py
@@ -1,0 +1,160 @@
+"""Fetch daily news from configured sources (Tagesschau API + RSS feeds).
+
+Zero external dependencies: urllib, json, xml.etree, html, re only.
+
+Sources are configured in data/news_sources.json (created with defaults on
+first use). Results are cached per Anki day in data/news_cache/YYYY-MM-DD.json
+so repeated story generations on the same day do not re-fetch.
+
+Unified item shape: {"url": str, "title": str, "text": str, "source_name": str}
+"""
+from __future__ import annotations
+
+import html
+import json
+import logging
+import re
+import urllib.request
+from datetime import date
+from pathlib import Path
+from xml.etree import ElementTree
+
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+SOURCES_PATH = DATA_DIR / "news_sources.json"
+CACHE_DIR = DATA_DIR / "news_cache"
+
+# NOTE: the Tagesschau URL must NOT have a trailing slash — with a slash the
+# API 301-redirects and some clients end up with an empty body.
+DEFAULT_SOURCES = [
+    {"name": "Tagesschau", "type": "tagesschau",
+     "url": "https://www.tagesschau.de/api2u/homepage", "enabled": True},
+    {"name": "BBC World", "type": "rss",
+     "url": "http://feeds.bbci.co.uk/news/world/rss.xml", "enabled": True},
+]
+
+MAX_ITEMS_PER_SOURCE = 12
+MAX_TEXT_CHARS = 600
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+
+
+class NewsFetchError(Exception):
+    """Raised when no news could be fetched from any enabled source."""
+
+
+def _clean(raw: str | None) -> str:
+    if not raw:
+        return ""
+    text = html.unescape(_TAG_RE.sub(" ", raw))
+    return _WS_RE.sub(" ", text).strip()
+
+
+def _http_get(url: str, timeout: int = 20) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": "AnkiAdvanced/1.0"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read()
+
+
+def _fetch_tagesschau(source: dict) -> list[dict]:
+    data = json.loads(_http_get(source["url"]))
+    items = []
+    for n in data.get("news", []):
+        if n.get("type") != "story":
+            continue  # skip videos / weather etc.
+        title = _clean(n.get("title"))
+        topline = _clean(n.get("topline"))
+        if topline:
+            title = f"{topline}: {title}"
+        paragraphs = [_clean(c.get("value"))
+                      for c in (n.get("content") or []) if c.get("type") == "text"]
+        text = " ".join(p for p in [_clean(n.get("firstSentence")), *paragraphs] if p)
+        items.append({
+            "url": n.get("detailsweb") or n.get("shareURL") or "",
+            "title": title,
+            "text": text[:MAX_TEXT_CHARS],
+            "source_name": source["name"],
+        })
+        if len(items) >= MAX_ITEMS_PER_SOURCE:
+            break
+    return items
+
+
+def _fetch_rss(source: dict) -> list[dict]:
+    root = ElementTree.fromstring(_http_get(source["url"]))
+    items = []
+    for it in root.findall(".//item")[:MAX_ITEMS_PER_SOURCE]:
+        def _t(tag: str) -> str:
+            el = it.find(tag)
+            return _clean(el.text if el is not None else "")
+        items.append({
+            "url": _t("link"),
+            "title": _t("title"),
+            "text": _t("description")[:MAX_TEXT_CHARS],
+            "source_name": source["name"],
+        })
+    return items
+
+
+_FETCHERS = {"tagesschau": _fetch_tagesschau, "rss": _fetch_rss}
+
+
+def load_sources() -> list[dict]:
+    """Read the source list, writing the default config on first use."""
+    if not SOURCES_PATH.exists():
+        SOURCES_PATH.parent.mkdir(parents=True, exist_ok=True)
+        SOURCES_PATH.write_text(
+            json.dumps(DEFAULT_SOURCES, ensure_ascii=False, indent=2),
+            encoding="utf-8")
+        logger.info("news_fetcher: wrote default sources to %s", SOURCES_PATH)
+    return json.loads(SOURCES_PATH.read_text(encoding="utf-8"))
+
+
+def fetch_all(force: bool = False, today: str | None = None) -> list[dict]:
+    """Return today's news items from all enabled sources (per-day cache).
+
+    Raises NewsFetchError if every enabled source fails — callers must surface
+    the error instead of silently falling back to another story mode.
+    """
+    today = today or date.today().isoformat()
+    cache_file = CACHE_DIR / f"{today}.json"
+    if not force and cache_file.exists():
+        return json.loads(cache_file.read_text(encoding="utf-8"))
+
+    items: list[dict] = []
+    errors: list[str] = []
+    for source in load_sources():
+        if not source.get("enabled", True):
+            continue
+        fetcher = _FETCHERS.get(source.get("type"))
+        if fetcher is None:
+            errors.append(f"{source.get('name')}: unknown type {source.get('type')!r}")
+            continue
+        try:
+            fetched = fetcher(source)
+            items.extend(fetched)
+            logger.info("news_fetcher: %s -> %d items", source["name"], len(fetched))
+        except Exception as exc:  # network / parse errors per source
+            logger.warning("news_fetcher: %s failed: %s", source["name"], exc)
+            errors.append(f"{source.get('name')}: {exc}")
+
+    if not items:
+        raise NewsFetchError("No news could be fetched: " + "; ".join(errors))
+
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(json.dumps(items, ensure_ascii=False, indent=2),
+                          encoding="utf-8")
+    return items
+
+
+def cached_today_count(today: str | None = None) -> int | None:
+    """Number of items in today's cache, or None if nothing was fetched yet."""
+    today = today or date.today().isoformat()
+    cache_file = CACHE_DIR / f"{today}.json"
+    if not cache_file.exists():
+        return None
+    try:
+        return len(json.loads(cache_file.read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError):
+        return None

--- a/routes/story.py
+++ b/routes/story.py
@@ -8,6 +8,7 @@ import threading
 import jieba
 import database
 import ai
+import news_fetcher
 import tts
 from fastapi import APIRouter
 from fastapi.responses import FileResponse
@@ -185,8 +186,14 @@ def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
             sentences, prompt_text = _generate_kahneman_story_sentences(
                 cards, parsed_chapter_ids, model=model, progress_key=progress_key)
         elif mode == "news":
+            if not articles:
+                # No pasted articles → auto-fetch today's news and let the AI
+                # condense it into briefing source articles (issue #387).
+                # Rebinding `articles` here also persists the fetched articles
+                # in gen_params below, so Again-regeneration reuses them.
+                articles = _auto_news_articles(model=model, progress_key=progress_key)
             sentences, prompt_text = _generate_news_story_sentences(
-                cards, articles or [], model=model, progress_key=progress_key)
+                cards, articles, model=model, progress_key=progress_key)
         else:
             sentences, prompt_text = _generate_story_sentences(
                 cards, topic=topic, max_hsk=max_hsk, model=model,
@@ -379,18 +386,9 @@ def get_story(deck_id: int, category: str,
 
     chosen_model = _validated_model(model)
 
-    # News mode needs pasted articles, which only arrive via the regenerate POST
-    # body (too long for a GET query string). No cached story with articles in
-    # gen_params exists at this point, so there is nothing to generate from —
-    # tell the user to use the setup modal instead of silently falling back.
-    if mode == "news":
-        logger.info("story  NEWS-NO-ARTICLES deck=%d cat=%s — no cached story with articles", deck_id, category)
-        return {
-            "error": True,
-            "reason": "News mode requires pasted articles. Please open the story setup and paste at least one article, then regenerate.",
-            "model": chosen_model,
-            "has_history": database.has_story_history(deck_id, category),
-        }
+    # News mode without pasted articles auto-fetches today's news inside
+    # _generate_and_store (issue #387), so it flows through the normal
+    # (possibly backgrounded) generation below like every other mode.
 
     # ── Background mode: don't block — start a thread and report progress ──────
     if background:
@@ -444,7 +442,8 @@ def regenerate_story(deck_id: int, category: str,
                      chapter_ids: str | None = None,
                      body: dict | None = None):
     """Regenerate today's story. body (optional JSON): {"articles": [{"url", "title", "text"}]}
-    — required for mode="news" (too long to fit in a query string)."""
+    — pasted articles for mode="news" (too long to fit in a query string).
+    Empty in news mode → today's news is auto-fetched (issue #387)."""
     if database.is_sentences_deck(deck_id):
         return None
     if DISABLE_AI:
@@ -453,13 +452,6 @@ def regenerate_story(deck_id: int, category: str,
     today = database.anki_today().isoformat()
     progress_key = f"{deck_id}/{category}"
     articles = (body or {}).get("articles") or []
-    if mode == "news" and not articles:
-        return {
-            "error": True,
-            "reason": "News mode requires at least one pasted article. Please add articles via the setup modal.",
-            "model": chosen_model,
-            "has_history": database.has_story_history(deck_id, category),
-        }
     cards = _get_cards_for_story(deck_id, category)
     logger.info("regen  deck=%d cat=%s due_cards=%d topic=%r max_hsk=%d model=%s mode=%s articles=%d",
                 deck_id, category, len(cards), topic, max_hsk, chosen_model, mode, len(articles))
@@ -597,6 +589,27 @@ def _generate_news_story_sentences(
         all_sentences.extend(chunk_sentences)
 
     return all_sentences, prompt_summary
+
+
+def _auto_news_articles(model: str, progress_key: str | None) -> list[dict]:
+    """News auto mode: fetch today's news (sources per data/news_sources.json,
+    cached per day) and have the AI pick + condense the most important items
+    into briefing source articles ({url, title, text} — the pasted-articles shape).
+
+    news_fetcher.NewsFetchError propagates when every source fails, so the
+    caller reports a clear error instead of silently using another mode."""
+    ai._set_progress(progress_key, phase="request", msg="Fetching today's news…", percent=8)
+    items = news_fetcher.fetch_all()
+    logger.info("news auto: fetched %d items from sources", len(items))
+    return ai.summarize_news_items(items, model=model, progress_key=progress_key)
+
+
+@router.get("/api/news/status")
+def news_status():
+    """Whether today's news has already been fetched (news auto mode) and how
+    many items the per-day cache holds — shown in the story-setup news panel."""
+    count = news_fetcher.cached_today_count()
+    return {"cached": count is not None, "count": count or 0}
 
 
 @router.get("/api/story/{deck_id}/{category}/count")

--- a/static/app.js
+++ b/static/app.js
@@ -3157,9 +3157,9 @@ async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mo
 }
 
 // News mode with pasted articles goes through the regenerate POST body (articles
-// are too large for a GET query string). Without articles (e.g. resuming a session
-// whose briefing was already generated today) fall back to the normal GET/poll
-// flow, which returns the cached story — POSTing would either re-generate or fail.
+// are too large for a GET query string). Without articles fall back to the normal
+// GET/poll flow: it returns today's cached briefing if one exists (e.g. resuming
+// a session), and otherwise auto-fetches today's news server-side (issue #387).
 async function _fetchStoryOrNewsRegen(storyDeckId, storyCategory, topic, maxHsk, model,
                                       grammarFocus, grammarPct, mode, chapterIds, articles, bgUrl) {
   if (mode === 'news' && articles && articles.length) {
@@ -5555,6 +5555,7 @@ function updateSetupMode() {
     newsSection.style.display = 'block';
     btn.textContent = 'Generate news briefing';
     if (!document.getElementById('setup-news-articles').children.length) addNewsArticleBlock();
+    _loadNewsStatus();
   } else {
     topicLabel.childNodes[0].textContent = 'Topic ';
     topicInput.placeholder = 'e.g. a day at a coffee shop';
@@ -5566,6 +5567,18 @@ function updateSetupMode() {
 
 // ── News mode: repeatable pasted-article blocks ─────────────────────────────
 let _newsArticleSeq = 0;
+
+// Show in the setup modal whether today's news is already fetched (auto mode
+// reuses the per-day cache, so a second generation today re-fetches nothing).
+async function _loadNewsStatus() {
+  const el = document.getElementById('setup-news-status');
+  if (!el) return;
+  el.textContent = '';
+  try {
+    const s = await api('GET', '/api/news/status');
+    if (s.cached) el.textContent = `✓ Today's news already fetched: ${s.count} items (cached)`;
+  } catch (_) {}
+}
 
 function addNewsArticleBlock() {
   const container = document.getElementById('setup-news-articles');
@@ -5776,12 +5789,9 @@ function confirmStorySetup() {
   const mode        = document.getElementById('setup-mode').value;
   const chapterIds  = mode === 'kahneman' ? _getSelectedChapterIds() : null;
   const articles    = mode === 'news' ? _collectNewsArticles() : null;
-  // Explicit regeneration needs fresh articles; the start-review paths may run
-  // without them — they then load today's cached news briefing via GET instead.
-  if (mode === 'news' && (!articles || !articles.length) && (_setupIsRegen || _setupIsDeckListRegen)) {
-    showError('News mode requires at least one pasted article.');
-    return;
-  }
+  // News mode without pasted articles is valid: regeneration auto-fetches
+  // today's news server-side; the start-review paths load today's cached
+  // briefing via GET (or auto-generate one) — see issue #387.
   _closeSetupModal();
   if (_setupIsDeckListRegen) {
     _doRegenStoryForDeckList(_deckListRegenId, topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, articles);

--- a/static/index.html
+++ b/static/index.html
@@ -675,7 +675,11 @@
     </div>
     <!-- News articles input (shown only in news mode) -->
     <div id="setup-news-section" style="display:none">
-      <label class="edit-label" style="margin:0">Articles <span style="font-weight:400;text-transform:none">(paste 1 or more)</span></label>
+      <label class="edit-label" style="margin:0">Articles <span style="font-weight:400;text-transform:none">(optional)</span></label>
+      <div style="font-size:12px;color:var(--muted,#888);margin:2px 0 6px">
+        Paste articles below — or leave empty to auto-fetch today's news (Tagesschau + BBC World).
+        <span id="setup-news-status" style="display:block"></span>
+      </div>
       <div id="setup-news-articles"></div>
       <button class="edit-cancel-btn" style="padding:4px 10px;font-size:12px;margin-top:6px" onclick="addNewsArticleBlock()">+ Add article</button>
     </div>


### PR DESCRIPTION
## 变更内容

（接替 #389——原 PR 因 #388 分支删除被 GitHub 自动关闭；本分支已变基到最新 main，内容完全相同）

news 模式**不粘贴文章**时，服务器自动抓取当日新闻生成世界新闻简报：

- **news_fetcher.py（新文件，零新依赖）**：Tagesschau 官方免费 API + RSS（默认 BBC World），全部标准库实现；来源配置 `data/news_sources.json`（首次使用写入默认值）；按天缓存 `data/news_cache/YYYY-MM-DD.json`；全部来源失败时抛 `NewsFetchError`，明确报错、不静默降级
- **两步 AI 管线**：`ai.summarize_news_items` 先挑选最重要的 8 条（平衡德国国内/国际/中国相关，跳过重复事件）并压缩摘要；再复用 #386 的 `generate_news_sentences` 生成句子，每句带 `source_url` 原文链接。抓取的文章随 `gen_params` 持久化，Again 单词重生成复用同一批新闻
- **routes/story.py**：GET 故事接口移除 news 早期报错分支——news 与其他模式一样走（可后台的）正常生成流程；regenerate 空文章 = 自动抓取；新增 `GET /api/news/status`
- **前端**：news 面板文章输入改为可选，提示「留空则自动抓取今日新闻」，显示当日已抓取条目数

## 测试方法

- `python3 -m py_compile` 全部改动 .py + `import main` + `node --check static/app.js` ✅
- 现场抓取：Tagesschau 10 条 + BBC World 12 条，二次调用命中当天缓存 ✅
- 临时库 + 8765 端口（未碰 8000/dev.db）：`/api/decks` 200、`/api/news/status` 返回 `{cached:true, count:22}`、空文章 news regenerate 正常接受 ✅
- **真实端到端（OPENAI_API_KEY + gpt-5-mini）**：22 条真实新闻 → AI 挑选 5 条 → 生成句子全部含目标词、带中文标题/背景/原文链接 ✅

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)