### PR TITLE
feat: 设置中新增 Enable reading 开关，默认停用 reading 类别

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -651,12 +651,45 @@ def get_parent_deck_id(deck_id: int) -> int | None:
     return row["parent_id"] if row else None
 
 
+def reading_disabled_deck_ids() -> set[int]:
+    """IDs of decks whose preset has reading_enabled = 0.
+
+    Reading cards of these decks are excluded from mixed/any-cat queues,
+    due counts and the unfinished virtual deck. The cards themselves are
+    kept untouched so re-enabling the preset flag brings them back.
+    """
+    conn = get_db()
+    rows = conn.execute(
+        """SELECT d.id FROM decks d
+           JOIN deck_presets p ON p.id = d.preset_id
+           WHERE p.reading_enabled = 0"""
+    ).fetchall()
+    conn.close()
+    return {r["id"] for r in rows}
+
+
+# SQL fragment matching cards that belong to a disabled reading category.
+_READING_DISABLED_SQL = (
+    "(category = 'reading' AND deck_id IN "
+    "(SELECT d.id FROM decks d JOIN deck_presets p ON p.id = d.preset_id "
+    "WHERE p.reading_enabled = 0))"
+)
+
+
 def _leaf_decks_with_category(root_deck_id: int) -> list[tuple[int, str]]:
-    """Return [(deck_id, category)] for all category leaves under root_deck_id."""
+    """Return [(deck_id, category)] for all category leaves under root_deck_id.
+
+    Reading leaves whose preset disables reading are omitted.
+    """
+    disabled = reading_disabled_deck_ids()
+
+    def _keep(deck_id: int, category: str) -> bool:
+        return not (category == "reading" and deck_id in disabled)
+
     all_leaf_ids = get_descendant_leaf_deck_ids(root_deck_id)
     if not all_leaf_ids:
         deck = get_deck(root_deck_id)
-        if deck and deck["category"]:
+        if deck and deck["category"] and _keep(root_deck_id, deck["category"]):
             return [(root_deck_id, deck["category"])]
         return []
     conn = get_db()
@@ -665,7 +698,7 @@ def _leaf_decks_with_category(root_deck_id: int) -> list[tuple[int, str]]:
         f"SELECT id, category FROM decks WHERE id IN ({placeholders})", all_leaf_ids
     ).fetchall()
     conn.close()
-    return [(r["id"], r["category"]) for r in rows if r["category"]]
+    return [(r["id"], r["category"]) for r in rows if r["category"] and _keep(r["id"], r["category"])]
 
 
 def get_due_cards_any_cat(root_deck_id: int) -> list[dict]:
@@ -993,6 +1026,7 @@ def _unfinished_where(scope: str) -> tuple[str, list]:
             "  OR (state = 'new' AND due <= ?)"
             ")"
             + lock_clause
+            + f" AND NOT {_READING_DISABLED_SQL}"
         )
         return clause, [today, tomorrow, today, today, *lock_params]
     clause = (
@@ -1000,6 +1034,7 @@ def _unfinished_where(scope: str) -> tuple[str, list]:
         "AND deleted_at IS NULL "
         "AND (buried_until IS NULL OR buried_until < date('now'))"
         + lock_clause
+        + f" AND NOT {_READING_DISABLED_SQL}"
     )
     return clause, [now, *lock_params]
 
@@ -1425,8 +1460,12 @@ def count_due_all_decks() -> dict:
     # neither display due cards nor contribute to parent aggregation.
     locked = get_locked_deck_ids()
 
+    # Disabled reading categories count as zero everywhere (deck badges,
+    # parent aggregation) without touching the cards themselves.
+    reading_disabled = reading_disabled_deck_ids()
+
     for key, c in counts.items():
-        if key[0] in locked:
+        if key[0] in locked or (key[1] == "reading" and key[0] in reading_disabled):
             c["new_raw"] = 0
             c["learning"] = 0
             c["review"] = 0

--- a/database/core.py
+++ b/database/core.py
@@ -295,6 +295,8 @@ def init_db() -> None:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN learning_hard_days REAL NOT NULL DEFAULT 1")
     if "learned_interval" not in preset_cols:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN learned_interval INTEGER NOT NULL DEFAULT 4")
+    if "reading_enabled" not in preset_cols:
+        conn.execute("ALTER TABLE deck_presets ADD COLUMN reading_enabled INTEGER NOT NULL DEFAULT 0")
 
     conn.execute("""CREATE TABLE IF NOT EXISTS preset_category_overrides (
         id                  INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/database/presets.py
+++ b/database/presets.py
@@ -41,6 +41,7 @@ def default_preset() -> dict:
         "category_order": "listening,reading,creating",
         "sibling_separation": 3,
         "sibling_factor": 0.2,
+        "reading_enabled": 0,
     }
 
 
@@ -209,6 +210,7 @@ def insert_preset(preset: dict) -> int:
     preset.setdefault("learning_hard_1d", 1)
     preset.setdefault("learning_hard_days", 1)
     preset.setdefault("learned_interval", 4)
+    preset.setdefault("reading_enabled", 0)
     conn = get_db()
     cur = conn.execute(
         """INSERT INTO deck_presets
@@ -220,7 +222,8 @@ def insert_preset(preset: dict) -> int:
             new_gather_order, new_sort_order, new_review_order,
             interday_learning_review_order, review_sort_order,
             bury_new_siblings, bury_review_siblings, bury_interday_siblings,
-            bury_quick_mode, category_order, sibling_separation, sibling_factor)
+            bury_quick_mode, category_order, sibling_separation, sibling_factor,
+            reading_enabled)
            VALUES (:name, :new_per_day, :reviews_per_day,
                    :learning_steps, :graduating_interval, :easy_interval,
                    :relearning_steps, :minimum_interval, :learned_interval, :insertion_order,
@@ -229,7 +232,8 @@ def insert_preset(preset: dict) -> int:
                    :new_gather_order, :new_sort_order, :new_review_order,
                    :interday_learning_review_order, :review_sort_order,
                    :bury_new_siblings, :bury_review_siblings, :bury_interday_siblings,
-                   :bury_quick_mode, :category_order, :sibling_separation, :sibling_factor)""",
+                   :bury_quick_mode, :category_order, :sibling_separation, :sibling_factor,
+                   :reading_enabled)""",
         preset,
     )
     conn.commit()
@@ -249,7 +253,7 @@ def update_preset(preset_id: int, fields: dict) -> None:
         "interday_learning_review_order", "review_sort_order",
         "bury_new_siblings", "bury_review_siblings", "bury_interday_siblings",
         "bury_quick_mode", "category_order", "new_review_order_override",
-        "sibling_separation", "sibling_factor",
+        "sibling_separation", "sibling_factor", "reading_enabled",
     }
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:

--- a/routes/decks.py
+++ b/routes/decks.py
@@ -22,12 +22,17 @@ def _flatten(tree: list) -> list:
 
 
 def _leaf_pairs(deck: dict) -> list[tuple[int, str]]:
-    """All (id, category) tuples for leaf descendants that have a category."""
+    """All (id, category) tuples for leaf descendants that have a category.
+
+    Reading leaves are skipped when their preset disables reading, so parent
+    badges and all-suspended flags ignore the hidden category.
+    """
     result = []
     for child in deck.get("children", []):
         if not child.get("children"):
-            if child.get("category"):
-                result.append((child["id"], child["category"]))
+            cat = child.get("category")
+            if cat and not (cat == "reading" and not child.get("reading_enabled")):
+                result.append((child["id"], cat))
         else:
             result.extend(_leaf_pairs(child))
     return result
@@ -75,8 +80,8 @@ def _attach_counts(flat_decks: list) -> None:
 def get_decks(unfinished_scope: str = "unfinished"):
     tree = database.get_deck_tree()
     flat = _flatten(tree)
-    _attach_counts(flat)
-    # Attach bury_mode so the frontend can render the 3-state toggle without extra calls
+    # Attach preset-derived fields first — _attach_counts needs reading_enabled
+    # to skip disabled reading leaves in parent aggregation
     presets = {p["id"]: p for p in database.list_presets()}
     locked = database.get_locked_deck_ids()
     for deck in flat:
@@ -85,6 +90,9 @@ def get_decks(unfinished_scope: str = "unfinished"):
         deck["bury_mode"] = deck.get("bury_quick_mode", "all")
         deck["new_review_order_override"] = deck.get("new_review_order_override")
         deck["category_order"] = p.get("category_order", "listening,reading,creating")
+        deck["reading_enabled"] = 1 if p.get("reading_enabled") else 0
+    _attach_counts(flat)
+    for deck in flat:
         # Future-dated daily decks are locked until their date — flag for the UI.
         if deck.get("id") in locked:
             deck["locked"] = True

--- a/schema.sql
+++ b/schema.sql
@@ -113,6 +113,11 @@ CREATE TABLE IF NOT EXISTS deck_presets (
     -- Order of L/R/C category pills shown in the deck list
     category_order          TEXT NOT NULL DEFAULT 'listening,reading,creating',
 
+    -- When 0, the reading category is fully disabled for decks using this
+    -- preset: no R pill, no due counts, excluded from mixed/unfinished queues.
+    -- Cards are kept and come back untouched when re-enabled.
+    reading_enabled         INTEGER NOT NULL DEFAULT 0,
+
     -- Minimum days between sibling card reviews (R/T/C of the same word)
     sibling_separation      INTEGER NOT NULL DEFAULT 3,
 

--- a/static/app.js
+++ b/static/app.js
@@ -1120,8 +1120,10 @@ function buildCategoryButtons(deck) {
   const DEFAULT_ORDER = ['listening', 'reading', 'creating'];
   const orderStr = deck.category_order || 'listening,reading,creating';
   const ordered = orderStr.split(',').map(s => s.trim()).filter(s => DEFAULT_ORDER.includes(s));
-  // Ensure all 3 categories present (in case of corrupt/partial value)
-  const CATS = [...ordered, ...DEFAULT_ORDER.filter(c => !ordered.includes(c))];
+  // Ensure all 3 categories present (in case of corrupt/partial value),
+  // then drop reading entirely when the deck's preset disables it
+  const CATS = [...ordered, ...DEFAULT_ORDER.filter(c => !ordered.includes(c))]
+    .filter(c => c !== 'reading' || deck.reading_enabled);
   const LABELS = { listening: 'L', reading: 'R', creating: 'C' };
   const catLeaves = getCategoryLeaves(deck);
   const safeName  = deck.name.replace(/'/g, "\\'");
@@ -2725,6 +2727,7 @@ function loadPresetFields(preset) {
   document.getElementById('opt-hard-days').value       = preset.learning_hard_days == null ? 1 : preset.learning_hard_days;
   document.getElementById('opt-desired-retention').value = Math.round((preset.desired_retention ?? 0.9) * 100);
   document.getElementById('opt-max-int').value         = preset.maximum_interval ?? 36500;
+  document.getElementById('opt-reading-enabled').checked = !!preset.reading_enabled;
   applySchedulerVisibility();
 
   // Category order
@@ -2894,6 +2897,7 @@ async function saveOptions() {
     desired_retention:      Math.min(0.99, Math.max(0.70, (parseInt(document.getElementById('opt-desired-retention').value) || 90) / 100)),
     maximum_interval:       Math.max(1, parseInt(document.getElementById('opt-max-int').value) || 36500),
     category_order: _getCategoryOrderUI(),
+    reading_enabled:        document.getElementById('opt-reading-enabled').checked ? 1 : 0,
   };
   try {
     const [savedPreset] = await Promise.all([
@@ -3403,6 +3407,9 @@ function loadCard(c, counts) {
       document.getElementById(`cnt-${prefix}-lrn`).textContent = cc.learning;
       document.getElementById(`cnt-${prefix}-rev`).textContent = cc.review;
     }
+    // Reading disabled via preset → its key is absent from by_cat → hide the 读 item
+    const readingItem = document.getElementById('cnt-cat-reading');
+    if (readingItem) readingItem.style.display = counts.by_cat.reading ? '' : 'none';
     // Highlight the active category item
     ['cnt-cat-reading', 'cnt-cat-listening', 'cnt-cat-creating'].forEach(id => document.getElementById(id)?.classList.remove('cnt-cat-item-active'));
     const activeCat = c?.category;

--- a/static/index.html
+++ b/static/index.html
@@ -486,6 +486,14 @@
     </div>
 
     <div class="opt-group">
+      <div class="opt-group-label">Categories</div>
+      <div class="opt-row">
+        <span class="opt-label">Enable reading<br><span style="font-weight:400;font-size:11px;color:var(--muted)">off = no R pill, reading cards excluded from queues &amp; counts (cards are kept)</span></span>
+        <input type="checkbox" id="opt-reading-enabled" style="width:18px;height:18px;cursor:pointer">
+      </div>
+    </div>
+
+    <div class="opt-group">
       <div class="opt-group-label">Category Overrides <span style="font-weight:400;font-size:11px;color:var(--muted)">— leave blank to use preset default</span></div>
       <div id="cat-overrides-container">
         <!-- Listening -->


### PR DESCRIPTION
## 变更内容

- `deck_presets` 新增 `reading_enabled` 列（默认 **0 = 停用**），含 `schema.sql` 与 `core.py` 迁移
- `database/presets.py`：`default_preset` / `insert_preset` / `update_preset` 支持该字段
- `database/cards.py`：
  - 新增 `reading_disabled_deck_ids()` 辅助函数
  - `_leaf_decks_with_category` 过滤已停用的 reading 叶子（覆盖混合复习、any-cat 队列、by_cat 统计）
  - `count_due_all_decks` 把停用 reading 的计数归零（牌组徽章、父级聚合）
  - `_unfinished_where` 排除停用 reading 的卡片（未完成虚拟牌组）
- `routes/decks.py`：deck 树节点附带 `reading_enabled`，父级聚合与 all-suspended 标志跳过停用的 reading 叶子
- 前端：
  - Deck Options 新增 "Categories → Enable reading" 复选框（加载/保存）
  - `buildCategoryButtons` 在停用时不渲染 R 药丸
  - 混合复习头部在 by_cat 缺少 reading 时隐藏「读」计数

**卡片数据完全保留**——重新勾选开关并保存后，reading 卡原样恢复。直接访问 `/api/today/{deck}/reading` 的行为不变。

## 测试方法

已用临时数据库验证（脚本化测试全部通过）：
1. 迁移后 `reading_enabled` 列存在，默认值 0
2. 停用时：`count_due_by_category` 无 reading 键、any-cat 队列无 reading 卡、`/api/decks` 父级计数只含 L+C
3. 启用并保存后：以上全部恢复，父级计数含全部三个类别
4. `node --check app.js` 语法通过

手动验证建议：
- 打开任意牌组的 ⚙ 选项，确认出现 "Enable reading"（默认未勾选）
- 主页牌组列表应不再显示 R 药丸，父级到期徽章不含 reading
- 勾选保存后 R 药丸和计数恢复

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)