### PR TITLE
feat: 首页把 Filtered Decks 区块移到图表上方

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1174,8 +1174,6 @@ function renderDecks(decks) {
   const sentencesDeck = allChildren.find(d => d.name === 'Sentences');
   const regularDecks = allChildren.filter(d => d.name !== 'Sentences' && d.name !== 'Default');
 
-  let html = '';
-
   // ── Filtered Decks section ────────────────────────────────────────────────
   let filteredHtml = '';
 
@@ -1223,21 +1221,24 @@ function renderDecks(decks) {
     filteredHtml += renderDeckRows([sentencesDeck], 0);
   }
 
+  let filteredSection = '';
   if (filteredHtml) {
-    html += `<div class="section-label">Filtered Decks</div><div class="tree-card filtered-tree-card">${filteredHtml}</div>`;
+    filteredSection = `<div class="section-label">Filtered Decks</div><div class="tree-card filtered-tree-card">${filteredHtml}</div>`;
   }
 
   // ── Regular Decks section ─────────────────────────────────────────────────
   const deckSortMode = localStorage.getItem('deckSortMode') || 'name';
   const sortLabel = deckSortMode === 'due' ? 'Sort: Due ↓' : deckSortMode === 'name-desc' ? 'Sort: Z→A' : 'Sort: A→Z';
   const regularHtml = renderDeckRows(regularDecks, 0, deckSortMode);
+  let regularSection = '';
   if (regularHtml.trim()) {
-    html += `<div class="section-label section-label-row">Decks<button class="deck-sort-btn" onclick="toggleDeckSort()">${sortLabel}</button></div><div class="tree-card">${regularHtml}</div>`;
+    regularSection = `<div class="section-label section-label-row">Decks<button class="deck-sort-btn" onclick="toggleDeckSort()">${sortLabel}</button></div><div class="tree-card">${regularHtml}</div>`;
   }
 
   document.getElementById('view-decks').innerHTML =
-    navRow + '<div id="home-calendar" class="hcal-card"></div>' +
-    '<div id="home-evolution" class="hcal-card"></div>' + html;
+    navRow + filteredSection +
+    '<div id="home-calendar" class="hcal-card"></div>' +
+    '<div id="home-evolution" class="hcal-card"></div>' + regularSection;
   if (typeof initHomeCalendar === 'function') initHomeCalendar();
   if (typeof initHomeEvolution === 'function') initHomeEvolution();
 }


### PR DESCRIPTION
## 变更内容
- `renderDecks()` 中把首页拼装顺序从「导航栏 → 日历图 → 演变图 → Filtered Decks → Decks」改为「导航栏 → **Filtered Decks** → 日历图 → 演变图 → Decks」
- 把原来累加进 `html` 的两个区块拆成 `filteredSection` 和 `regularSection` 两个变量，分别插入到图表前后

## 测试方法
- 打开首页，确认 Unfinished Cards / All 所在的 Filtered Decks 区块显示在两个图表上方
- 确认常规 Decks 区块仍在图表下方
- 确认日历热力图和演变图仍正常加载（initHomeCalendar / initHomeEvolution 依赖的 DOM id 未改动）

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)