### PR TITLE
feat: 彻底移除 Sentences 牌组及其特殊逻辑

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -1290,7 +1290,7 @@ def get_category_all_suspended(deck_id: int, category: str) -> bool:
     conn.close()
     total = row["total"] or 0
     suspended = row["suspended_count"] or 0
-    # total==0 means no suspendable cards (e.g. Sentences deck) → treat as suspended
+    # total==0 means no suspendable cards (only sentence-type cards) → treat as suspended
     return total == suspended
 
 

--- a/database/core.py
+++ b/database/core.py
@@ -414,8 +414,8 @@ def init_db() -> None:
             conn.execute("DELETE FROM decks WHERE id = ?", (default_row["id"],))
     conn.commit()
 
-    # Ensure "Sentences" deck exists and migrate any sentence-type cards into it
-    _migrate_sentences_deck(conn, all_id, preset_id)
+    # Remove the legacy "Sentences" deck tree if it holds no cards (issue #394)
+    _drop_sentences_decks(conn)
     conn.commit()
     conn.close()
 
@@ -488,39 +488,30 @@ def _migrate_stories_category(conn: sqlite3.Connection) -> None:
         conn.commit()
 
 
-def _ensure_sentences_leaf_decks(conn: sqlite3.Connection, all_id: int,
-                                  preset_id: int) -> dict:
-    """Create (or get) the Sentences parent deck and its 3 category leaf decks."""
-    sent_id = _ensure_deck(conn, "Sentences", parent_id=all_id, preset_id=preset_id)
-    return {
-        "listening": _ensure_deck(conn, "Sentences · Listening", parent_id=sent_id,
-                                   preset_id=preset_id, category="listening"),
-        "reading":   _ensure_deck(conn, "Sentences · Reading",   parent_id=sent_id,
-                                   preset_id=preset_id, category="reading"),
-        "creating":  _ensure_deck(conn, "Sentences · Creating",  parent_id=sent_id,
-                                   preset_id=preset_id, category="creating"),
-    }
+def _drop_sentences_decks(conn: sqlite3.Connection) -> None:
+    """One-time migration: delete the legacy Sentences deck tree (issue #394).
 
-
-def _migrate_sentences_deck(conn: sqlite3.Connection, all_id: int,
-                             preset_id: int) -> None:
-    """One-time migration: move all sentence-type word cards into the Sentences deck."""
-    leaf = _ensure_sentences_leaf_decks(conn, all_id, preset_id)
-
-    # Find all cards belonging to sentence-type words that are NOT already in the Sentences deck
-    sentences_deck_ids = set(leaf.values())
-    rows = conn.execute(
-        """SELECT c.id, c.category FROM cards c
-           JOIN entries w ON w.id = c.word_id
-           WHERE w.note_type = 'sentence'
-             AND c.deck_id NOT IN ({})""".format(",".join("?" * len(sentences_deck_ids))),
-        list(sentences_deck_ids),
-    ).fetchall()
-
-    for row in rows:
-        new_deck_id = leaf[row["category"]]
-        conn.execute("UPDATE cards SET deck_id = ? WHERE id = ?",
-                     (new_deck_id, row["id"]))
+    Only deletes when the tree holds no cards, so a database that still has
+    sentence cards parked there is left untouched.
+    """
+    sent = conn.execute(
+        "SELECT id FROM decks WHERE name = 'Sentences' AND parent_id IN "
+        "(SELECT id FROM decks WHERE parent_id IS NULL) LIMIT 1"
+    ).fetchone()
+    if not sent:
+        return
+    deck_ids = [sent["id"]] + [
+        r["id"] for r in conn.execute(
+            "SELECT id FROM decks WHERE parent_id = ?", (sent["id"],)
+        ).fetchall()
+    ]
+    placeholders = ",".join("?" * len(deck_ids))
+    has_cards = conn.execute(
+        f"SELECT 1 FROM cards WHERE deck_id IN ({placeholders}) LIMIT 1", deck_ids
+    ).fetchone()
+    if has_cards:
+        return
+    conn.execute(f"DELETE FROM decks WHERE id IN ({placeholders})", deck_ids)
 
 
 def _ensure_presets(conn: sqlite3.Connection) -> None:

--- a/database/decks.py
+++ b/database/decks.py
@@ -2,7 +2,7 @@ import re
 import sqlite3
 from datetime import date
 
-from .core import anki_today, get_db, _ensure_default_preset, _ensure_sentences_leaf_decks
+from .core import anki_today, get_db, _ensure_default_preset
 
 
 # ---------------------------------------------------------------------------
@@ -48,15 +48,6 @@ def get_deck_tree() -> list[dict]:
             parent = by_id.get(d["parent_id"])
             if parent:
                 parent["children"].append(d)
-    # Mark the Sentences deck and its children as filtered
-    for root in roots:
-        for child in root.get("children", []):
-            if child["name"] == "Sentences":
-                child["filtered"] = True
-                child["no_story"] = True
-                for leaf in child.get("children", []):
-                    leaf["filtered"] = True
-                    leaf["no_story"] = True
     return roots
 
 
@@ -212,35 +203,6 @@ def get_or_create_deck(name: str, parent_id: int | None = None,
     return deck_id
 
 
-def get_sentences_deck_ids() -> dict:
-    """Return {category: deck_id} for the three Sentences leaf decks, creating them if needed."""
-    conn = get_db()
-    all_id = conn.execute(
-        "SELECT id FROM decks WHERE name = 'All' AND parent_id IS NULL LIMIT 1"
-    ).fetchone()["id"]
-    preset_id = _ensure_default_preset(conn)
-    leaf = _ensure_sentences_leaf_decks(conn, all_id, preset_id)
-    conn.commit()
-    conn.close()
-    return leaf
-
-
-def is_sentences_deck(deck_id: int) -> bool:
-    """Return True if deck_id is the Sentences parent or one of its leaf decks."""
-    conn = get_db()
-    row = conn.execute(
-        "SELECT id FROM decks WHERE name = 'Sentences' AND parent_id IN "
-        "(SELECT id FROM decks WHERE parent_id IS NULL) LIMIT 1"
-    ).fetchone()
-    if not row:
-        conn.close()
-        return False
-    sent_id = row["id"]
-    children = {r["id"] for r in conn.execute(
-        "SELECT id FROM decks WHERE parent_id = ?", (sent_id,)
-    ).fetchall()}
-    conn.close()
-    return deck_id == sent_id or deck_id in children
 
 
 def get_all_deck_id() -> int | None:

--- a/importer.py
+++ b/importer.py
@@ -530,16 +530,6 @@ def _process_component(analysis: dict, note_word_id: int, position: int,
     database.insert_note_component(note_word_id, comp_word_id, position)
 
 
-_sentences_deck_ids_cache: dict | None = None
-
-
-def _get_sentences_deck_ids() -> dict:
-    global _sentences_deck_ids_cache
-    if _sentences_deck_ids_cache is None:
-        _sentences_deck_ids_cache = database.get_sentences_deck_ids()
-    return _sentences_deck_ids_cache
-
-
 def _import_entries(entries: list, deck_ids: dict, source: str, label: str,
                     resolutions: dict | None = None,
                     card_configs: dict | None = None,
@@ -606,26 +596,21 @@ def _import_entries(entries: list, deck_ids: dict, source: str, label: str,
         yaml_categories = entry.get("categories")   # e.g. ["creating"] or ["creating", "listening"]
         yaml_deck_hint = entry.get("deck_hint")     # e.g. "B"
 
-        # Sentences always go into the dedicated Sentences deck regardless of source
-        if note_type == "sentence":
-            target_deck_ids = _get_sentences_deck_ids()
-            logger.info("SENTENCE %s: %r → Sentences deck", label, word_zh)
+        # deck_hint from YAML takes priority over card_cfg.deck_path
+        card_deck_path = yaml_deck_hint or card_cfg.get("deck_path")
+        if card_deck_path:
+            if card_deck_path not in _deck_path_cache:
+                try:
+                    pid = database.get_or_create_deck_path(card_deck_path)
+                    parent = database.get_deck(pid)
+                    leaf_name = parent["name"] if parent else card_deck_path.split("::")[-1]
+                    _deck_path_cache[card_deck_path] = _make_leaf_decks(leaf_name, pid)
+                except Exception as e:
+                    logger.warning("deck_path %r failed (%s), using default", card_deck_path, e)
+                    _deck_path_cache[card_deck_path] = deck_ids
+            target_deck_ids = _deck_path_cache[card_deck_path]
         else:
-            # deck_hint from YAML takes priority over card_cfg.deck_path
-            card_deck_path = yaml_deck_hint or card_cfg.get("deck_path")
-            if card_deck_path:
-                if card_deck_path not in _deck_path_cache:
-                    try:
-                        pid = database.get_or_create_deck_path(card_deck_path)
-                        parent = database.get_deck(pid)
-                        leaf_name = parent["name"] if parent else card_deck_path.split("::")[-1]
-                        _deck_path_cache[card_deck_path] = _make_leaf_decks(leaf_name, pid)
-                    except Exception as e:
-                        logger.warning("deck_path %r failed (%s), using default", card_deck_path, e)
-                        _deck_path_cache[card_deck_path] = deck_ids
-                target_deck_ids = _deck_path_cache[card_deck_path]
-            else:
-                target_deck_ids = deck_ids
+            target_deck_ids = deck_ids
 
         word = _build_word_dict(entry, source=source, note_type=note_type)
         word_id = database.insert_word(word)  # INSERT OR IGNORE → always get id

--- a/routes/decks.py
+++ b/routes/decks.py
@@ -124,9 +124,6 @@ def create_deck(name: str, parent_id: int | None = None, category: str | None = 
 
 @router.delete("/api/decks/{deck_id}")
 def delete_deck(deck_id: int):
-    deck = database.get_deck(deck_id)
-    if deck and deck.get("name") in ("Sentences", "Sentences · Listening", "Sentences · Reading", "Sentences · Creating"):
-        raise HTTPException(status_code=400, detail="Filtered decks cannot be deleted")
     database.delete_deck(deck_id)
     return {"ok": True}
 

--- a/routes/story.py
+++ b/routes/story.py
@@ -357,9 +357,6 @@ def get_story(deck_id: int, category: str,
       ready, and can navigate away meanwhile. A failed background run is sticky
       (returns the error dict) so polling stops instead of restarting forever.
     """
-    if database.is_sentences_deck(deck_id):
-        return None
-
     today = database.anki_today().isoformat()
     progress_key = f"{deck_id}/{category}"
 
@@ -444,8 +441,6 @@ def regenerate_story(deck_id: int, category: str,
     """Regenerate today's story. body (optional JSON): {"articles": [{"url", "title", "text"}]}
     — pasted articles for mode="news" (too long to fit in a query string).
     Empty in news mode → today's news is auto-fetched (issue #387)."""
-    if database.is_sentences_deck(deck_id):
-        return None
     if DISABLE_AI:
         return None
     chosen_model = _validated_model(model)
@@ -615,8 +610,6 @@ def news_status():
 @router.get("/api/story/{deck_id}/{category}/count")
 def story_count(deck_id: int, category: str):
     """Return sentence count, whether a cached story exists today, and token estimate."""
-    if database.is_sentences_deck(deck_id):
-        return {"count": 0, "has_story": False, "estimated_tokens": 0}
     today = database.anki_today().isoformat()
     has_story = database.get_active_story(today, category, deck_id) is not None
     cards = _get_cards_for_story(deck_id, category)

--- a/static/app.js
+++ b/static/app.js
@@ -1171,8 +1171,7 @@ function renderDecks(decks) {
   const allDeck = virtualDecks.find(d => d.name === 'All');
   // Real decks live as children of the "All" virtual deck
   const allChildren = allDeck ? (allDeck.children || []) : decks.filter(d => !d.virtual);
-  const sentencesDeck = allChildren.find(d => d.name === 'Sentences');
-  const regularDecks = allChildren.filter(d => d.name !== 'Sentences' && d.name !== 'Default');
+  const regularDecks = allChildren.filter(d => d.name !== 'Default');
 
   let html = '';
 
@@ -1217,10 +1216,6 @@ function renderDecks(decks) {
         </div>
         <div class="cat-pills-row">${buildCategoryButtons(allDeck)}</div>
       </div>`;
-  }
-
-  if (sentencesDeck) {
-    filteredHtml += renderDeckRows([sentencesDeck], 0);
   }
 
   if (filteredHtml) {


### PR DESCRIPTION
## 变更内容
- **database/core.py**：删除 `_migrate_sentences_deck` / `_ensure_sentences_leaf_decks`（原来每次启动都会重建 Sentences 牌组），改为一次性迁移 `_drop_sentences_decks`——仅当 Sentences 牌组树里没有任何卡片时才删除，安全起见
- **database/decks.py**：移除 `get_sentences_deck_ids` / `is_sentences_deck`，以及牌组树构建时给 Sentences 打 `filtered` / `no_story` 标记的逻辑
- **importer.py**：sentence 类型词条不再强制进入专用牌组，改为按普通规则（deck_hint → deck_path → 默认牌组）导入
- **routes/decks.py**：移除阻止删除 Sentences 牌组的保护检查
- **routes/story.py**：移除三处 `is_sentences_deck` 检查（故事生成、重新生成、句子计数）
- **static/app.js**：首页 Filtered Decks 区块不再单独渲染 Sentences 牌组

`note_type = 'sentence'` 本身保留，浏览界面的 Sentences 筛选不受影响。

## 测试方法
- 已在生产数据库副本上运行 `init_db()` 验证：4 个 Sentences 牌组（id 1070–1073，全部为空）被删除，5327 张卡片完好无损
- 所有修改文件通过 `py_compile` 和 `node --check`
- 合并后重启服务器，确认首页不再显示 Sentences 牌组
- 再次重启，确认牌组不会被重建

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)