### PR TITLE
feat: 拆分 News briefing 与 Paste content 两个独立模式，修复文章块布局

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -489,12 +489,16 @@ ease最低值（zuì dī zhí - floor）：1.3。难词检测（jiǎncè - detec
 - `create_story()` 每次都插入新行 —— 重新生成 = 新增一行，旧故事永久保留
 - Haiku提示词要求：连贯叙事（sùshì - narrative），相同人物，每句不超过15个字，背景词汇使用HSK 1–2
 - **模式（mode）**：`story`（叙事）| `qa`（问答）| `expository`（说明文）| `kahneman`（《思考，快与慢》认知偏误风格，见 `data/kahneman_chapters.json`）
-  | `news`（新闻简报——用户在设置弹窗粘贴文章，AI 用 OpenAI `gpt-5-mini` 生成连贯中文新闻简报句子；
-  每句附带 `source_url`/`concept_zh`(标题)/`reasoning_zh`(背景说明)，复用 kahneman 模式的概念框/背景弹窗 UI；
-  文章内容存入 `stories.gen_params` 的 `articles` 字段，供 Again 单词重生成复现同一批文章。
-  **不粘贴文章时自动抓取当日新闻**：`news_fetcher.fetch_all()` 抓取 Tagesschau API + RSS 源（按天缓存），
+  | `news`（新闻简报——**纯自动抓取**当日新闻：`news_fetcher.fetch_all()` 抓取 Tagesschau API + RSS 源（按天缓存），
   然后两步 AI 调用——`ai.summarize_news_items` 挑选最重要的 8 条（平衡德国/国际/中国相关）并压缩摘要，
-  再用 `generate_news_sentences` 生成句子；抓取全部失败时报明确错误，不静默降级为普通故事模式）
+  再用 `generate_news_sentences` 生成连贯中文新闻简报句子（默认 OpenAI `gpt-5-mini`）；
+  抓取全部失败时报明确错误，不静默降级为普通故事模式）
+  | `paste`（粘贴内容摘要——用户在设置弹窗粘贴任意内容（文章/邮件/博客，issue #396），
+  句子构成该内容的连贯中文摘要；复用 news 的生成管线（`generate_news_sentences(generic=True)`），
+  必须至少粘贴一段文字，不做自动抓取回退）。
+  news/paste 两个模式共同点：每句附带 `source_url`/`concept_zh`(标题)/`reasoning_zh`(背景说明)，
+  复用 kahneman 模式的概念框/背景弹窗 UI；文章内容存入 `stories.gen_params` 的 `articles` 字段，
+  供 Again 单词重生成复现同一批内容（paste 的文章通过 regenerate 的 POST body 传输）
 
 ## 界面类别顺序（shùnxù - order）
 

--- a/ai.py
+++ b/ai.py
@@ -899,16 +899,19 @@ def generate_news_sentences(
     max_hsk: int = 2,
     progress_key: str | None = None,
     attempt_label: str = "",
+    generic: bool = False,
 ) -> list[dict]:
-    """Generate a Chinese news-briefing sentence per target word, summarizing `articles`.
+    """Generate a Chinese summary sentence per target word, summarizing `articles`.
 
-    Sentences all together form a coherent news briefing. Each sentence uses exactly
-    one target word (in HSK-limited background vocabulary otherwise) and is tagged
-    with which article it refers to, a one-line Chinese headline, and a short Chinese
-    background explanation — stored as concept_zh/reasoning_zh/source_url respectively.
+    Sentences all together form a coherent briefing/summary. Each sentence uses
+    exactly one target word (in HSK-limited background vocabulary otherwise) and is
+    tagged with which article it refers to, a one-line Chinese headline, and a short
+    Chinese background explanation — stored as concept_zh/reasoning_zh/source_url.
 
     cards:    vocab cards to cover (word_id, word_zh, pinyin, definition)
-    articles: [{url, title, text}, ...] — pasted news articles (url/title optional)
+    articles: [{url, title, text}, ...] — pasted texts (url/title optional)
+    generic:  False = news-briefing framing (mode="news"); True = plain content
+              summary of arbitrary pasted texts (mode="paste")
     """
     if not cards or not articles:
         return []
@@ -919,8 +922,23 @@ def generate_news_sentences(
             return all(c in sentence_zh for c in chars)
         return word_zh in sentence_zh
 
+    # generic=True swaps the news-briefing framing for a plain content summary
+    # (pasted content can be an email, blog post, book excerpt — not just news).
+    noun = "内容" if generic else "文章"
+    goal = "对这些内容的连贯中文摘要" if generic else "对这些文章的连贯新闻简报"
+    block_header = "内容（按 0 开始编号）" if generic else "新闻文章（按 0 开始编号）"
+    coherence_rule = (
+        "- 所有句子合起来必须构成一篇连贯的中文摘要，覆盖内容的关键信息" if generic
+        else "- 所有句子合起来必须像一段连贯的新闻简报，覆盖文章的关键信息")
+    headline_rule = (
+        "- headline_zh 是该段内容主题的中文一句话标题" if generic
+        else "- headline_zh 是该文章对应新闻事件的中文一句话标题")
+    background_rule = (
+        "- background_zh 是2-3句中文背景说明，帮助学习者理解这部分内容" if generic
+        else "- background_zh 是2-3句中文背景说明，帮助学习者理解这条新闻的来龙去脉")
+
     articles_block = "\n\n".join(
-        f"文章{i}（标题：{a.get('title') or '（无标题）'}）：\n{a.get('text', '').strip()}"
+        f"{noun}{i}（标题：{a.get('title') or '（无标题）'}）：\n{a.get('text', '').strip()}"
         for i, a in enumerate(articles)
     )
 
@@ -929,10 +947,10 @@ def generate_news_sentences(
             f"{i + 1}. {c['word_zh']}（{c.get('pinyin', '')}）— {c.get('definition', '')}"
             for i, c in enumerate(batch)
         )
-        return f"""任务：根据下面提供的新闻文章，写一组中文句子，合起来构成对这些文章的连贯新闻简报，
+        return f"""任务：根据下面提供的{noun}，写一组中文句子，合起来构成{goal}，
 帮助HSK 4-5学习者复习词汇。
 
-新闻文章（按 0 开始编号）：
+{block_header}：
 {articles_block}
 
 目标词汇（每句话必须恰好包含其中一个，原文出现）：
@@ -941,22 +959,23 @@ def generate_news_sentences(
 规则：
 - 每句话恰好包含一个目标词汇，词汇必须以原文形式出现
 - 每个目标词汇都必须有自己的句子，一个都不能漏
-- 所有句子合起来必须像一段连贯的新闻简报，覆盖文章的关键信息
+{coherence_rule}
 - 非目标词汇只使用HSK 1-{max_hsk}的词汇，尽量简单
 - 句子要简短（不超过15个字）
 - 所有输出（句子、标题、背景说明）只用简体中文，绝对不要出现繁体字
 - 不要使用markdown格式
-- article_idx 是该句子所总结/涉及的文章编号（上面的 0 开始编号）
-- headline_zh 是该文章对应新闻事件的中文一句话标题
-- background_zh 是2-3句中文背景说明，帮助学习者理解这条新闻的来龙去脉
+- article_idx 是该句子所总结/涉及的{noun}编号（上面的 0 开始编号）
+{headline_rule}
+{background_rule}
 
 仅返回如下JSON数组，不加任何其他文字：
 [
-  {{"sentence_zh": "句子内容", "article_idx": 0, "headline_zh": "新闻标题", "background_zh": "背景说明"}},
-  {{"sentence_zh": "句子内容", "article_idx": 0, "headline_zh": "新闻标题", "background_zh": "背景说明"}}
+  {{"sentence_zh": "句子内容", "article_idx": 0, "headline_zh": "标题", "background_zh": "背景说明"}},
+  {{"sentence_zh": "句子内容", "article_idx": 0, "headline_zh": "标题", "background_zh": "背景说明"}}
 ]"""
 
-    _set_progress(progress_key, phase="request", msg=f"生成新闻简报句子…{attempt_label}", percent=20)
+    _set_progress(progress_key, phase="request",
+                  msg=f"{'生成内容摘要句子' if generic else '生成新闻简报句子'}…{attempt_label}", percent=20)
 
     sentences: list[dict] = []
     remaining = list(cards)
@@ -967,7 +986,8 @@ def generate_news_sentences(
         prompt = _build_prompt(remaining)
         # 8192: gpt-5 series shares this budget with internal reasoning tokens,
         # so leave generous headroom above the ~2-3k tokens of actual output.
-        raw = _call_api(model, [{"role": "user", "content": prompt}], 8192, purpose="news")
+        raw = _call_api(model, [{"role": "user", "content": prompt}], 8192,
+                        purpose="paste" if generic else "news")
 
         json_start = raw.find("[")
         json_end = raw.rfind("]") + 1

--- a/routes/story.py
+++ b/routes/story.py
@@ -185,15 +185,18 @@ def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
             parsed_chapter_ids = [int(x) for x in chapter_ids.split(",") if x.strip()] if chapter_ids else []
             sentences, prompt_text = _generate_kahneman_story_sentences(
                 cards, parsed_chapter_ids, model=model, progress_key=progress_key)
-        elif mode == "news":
-            if not articles:
-                # No pasted articles → auto-fetch today's news and let the AI
+        elif mode in ("news", "paste"):
+            if mode == "news" and not articles:
+                # News mode always auto-fetches today's news and lets the AI
                 # condense it into briefing source articles (issue #387).
                 # Rebinding `articles` here also persists the fetched articles
                 # in gen_params below, so Again-regeneration reuses them.
+                # Paste mode never auto-fetches: no pasted content is an error
+                # (raised inside _generate_news_story_sentences).
                 articles = _auto_news_articles(model=model, progress_key=progress_key)
             sentences, prompt_text = _generate_news_story_sentences(
-                cards, articles, model=model, progress_key=progress_key)
+                cards, articles, model=model, progress_key=progress_key,
+                generic=(mode == "paste"))
         else:
             sentences, prompt_text = _generate_story_sentences(
                 cards, topic=topic, max_hsk=max_hsk, model=model,
@@ -318,10 +321,11 @@ def generate_sentence_for_word(card: dict, gen_params: dict | None) -> dict | No
                 sentences = ai.generate_kahneman_sentences([card], chapter, model=model)
             else:  # book data missing → fall back to a plain sentence
                 sentences, _ = ai.generate_story([card], model=model)
-        elif mode == "news":
+        elif mode in ("news", "paste"):
             articles = gp.get("articles") or []
             if articles:
-                sentences = ai.generate_news_sentences([card], articles, model=model)
+                sentences = ai.generate_news_sentences(
+                    [card], articles, model=model, generic=(mode == "paste"))
             else:  # no articles context saved → fall back to a plain sentence
                 sentences, _ = ai.generate_story([card], model=model)
         else:
@@ -439,8 +443,9 @@ def regenerate_story(deck_id: int, category: str,
                      chapter_ids: str | None = None,
                      body: dict | None = None):
     """Regenerate today's story. body (optional JSON): {"articles": [{"url", "title", "text"}]}
-    — pasted articles for mode="news" (too long to fit in a query string).
-    Empty in news mode → today's news is auto-fetched (issue #387)."""
+    — pasted texts for mode="paste" (too long to fit in a query string).
+    mode="news" ignores pasted articles and auto-fetches today's news (issue #387);
+    mode="paste" with no articles is an error (issue #396)."""
     if DISABLE_AI:
         return None
     chosen_model = _validated_model(model)
@@ -562,12 +567,17 @@ def _generate_kahneman_story_sentences(
 
 def _generate_news_story_sentences(
     cards: list, articles: list[dict], model: str, progress_key: str | None,
+    generic: bool = False,
 ) -> tuple[list, str]:
     """Split cards into batches of ai.MAX_NEWS_BATCH, call AI once per batch, merge
     results. All batches share the same `articles` context so the sentences form
-    one coherent briefing."""
+    one coherent briefing/summary. generic=True → paste mode (plain content
+    summary instead of news-briefing framing)."""
     if not articles:
         raise RuntimeError(
+            "Paste mode requires at least one pasted text. "
+            "Please add content via the setup modal."
+            if generic else
             "News mode requires at least one pasted article. "
             "Please add articles via the setup modal.")
 
@@ -575,11 +585,12 @@ def _generate_news_story_sentences(
     chunks = [cards[i:i + chunk_size] for i in range(0, len(cards), chunk_size)]
 
     all_sentences: list[dict] = []
-    prompt_summary = f"news mode — {len(articles)} articles"
+    prompt_summary = f"{'paste' if generic else 'news'} mode — {len(articles)} articles"
     for idx, chunk in enumerate(chunks):
         label = f" ({idx + 1}/{len(chunks)})"
         chunk_sentences = ai.generate_news_sentences(
-            chunk, articles, model=model, progress_key=progress_key, attempt_label=label
+            chunk, articles, model=model, progress_key=progress_key,
+            attempt_label=label, generic=generic
         )
         all_sentences.extend(chunk_sentences)
 

--- a/static/app.js
+++ b/static/app.js
@@ -3156,13 +3156,13 @@ async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mo
   }
 }
 
-// News mode with pasted articles goes through the regenerate POST body (articles
-// are too large for a GET query string). Without articles fall back to the normal
-// GET/poll flow: it returns today's cached briefing if one exists (e.g. resuming
-// a session), and otherwise auto-fetches today's news server-side (issue #387).
+// Paste mode with pasted texts goes through the regenerate POST body (texts are
+// too large for a GET query string). Everything else falls back to the normal
+// GET/poll flow: it returns today's cached story if one exists (e.g. resuming
+// a session); news mode auto-fetches today's news server-side (issue #387).
 async function _fetchStoryOrNewsRegen(storyDeckId, storyCategory, topic, maxHsk, model,
                                       grammarFocus, grammarPct, mode, chapterIds, articles, bgUrl) {
-  if (mode === 'news' && articles && articles.length) {
+  if (mode === 'paste' && articles && articles.length) {
     const url = `/api/story/${storyDeckId}/${storyCategory}/regenerate`
       + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds);
     return api('POST', url, { articles });
@@ -3244,7 +3244,7 @@ async function _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPc
     if (!noStory) {
       // Load a single unified story covering all categories (1 AI call instead of 3)
       try {
-        story = (mode === 'news' && articles && articles.length)
+        story = (mode === 'paste' && articles && articles.length)
           ? await api('POST', `/api/story/${rootDeckId}/unified/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds), { articles })
           : await api('GET', `/api/story/${rootDeckId}/unified` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds));
       } catch (e) {
@@ -3350,7 +3350,7 @@ async function _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, gram
     const firstDeckId = todayData.card.deck_id;
     // Load the first card's deck story (generate only when story mode = "new")
     try {
-      if (!noGen && mode === 'news' && articles && articles.length) {
+      if (!noGen && mode === 'paste' && articles && articles.length) {
         story = await api('POST', `/api/story/${firstDeckId}/unified/regenerate`
           + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds), { articles });
       } else {
@@ -3846,7 +3846,7 @@ function revealAnswer() {
     const renderConcept = (ch) => {
       _conceptEl.innerHTML =
           (ch?.part_zh ? `<span class="concept-part-label">${ch.part_zh}</span>` : '')
-        + `<span class="concept-chapter-title">${isNewsConcept ? '📰 ' : ''}${sentence.concept_zh}</span>`;
+        + `<span class="concept-chapter-title">${isNewsConcept ? (_currentStoryMode === 'paste' ? '📋 ' : '📰 ') : ''}${sentence.concept_zh}</span>`;
       if (chNum) {
         _conceptEl.classList.add('concept-clickable');
         _conceptEl.onclick = () => openKahnemanExamples(chNum, sentence.concept_zh);
@@ -5534,7 +5534,9 @@ function updateSetupMode() {
   const btn = document.getElementById('setup-generate-btn');
   const kahnemanSection = document.getElementById('setup-kahneman-section');
   const newsSection = document.getElementById('setup-news-section');
+  const pasteSection = document.getElementById('setup-paste-section');
   newsSection.style.display = 'none';
+  pasteSection.style.display = 'none';
   if (mode === 'qa') {
     topicLabel.childNodes[0].textContent = 'Question ';
     topicInput.placeholder = 'e.g. How was life in ancient China?';
@@ -5557,8 +5559,13 @@ function updateSetupMode() {
     kahnemanSection.style.display = 'none';
     newsSection.style.display = 'block';
     btn.textContent = 'Generate news briefing';
-    if (!document.getElementById('setup-news-articles').children.length) addNewsArticleBlock();
     _loadNewsStatus();
+  } else if (mode === 'paste') {
+    topicLabel.style.display = 'none';
+    kahnemanSection.style.display = 'none';
+    pasteSection.style.display = 'block';
+    btn.textContent = 'Generate summary';
+    if (!document.getElementById('setup-paste-blocks').children.length) addPasteBlock();
   } else {
     topicLabel.childNodes[0].textContent = 'Topic ';
     topicInput.placeholder = 'e.g. a day at a coffee shop';
@@ -5568,8 +5575,8 @@ function updateSetupMode() {
   }
 }
 
-// ── News mode: repeatable pasted-article blocks ─────────────────────────────
-let _newsArticleSeq = 0;
+// ── Paste mode: repeatable pasted-content blocks ────────────────────────────
+let _pasteBlockSeq = 0;
 
 // Show in the setup modal whether today's news is already fetched (auto mode
 // reuses the per-day cache, so a second generation today re-fetches nothing).
@@ -5583,29 +5590,29 @@ async function _loadNewsStatus() {
   } catch (_) {}
 }
 
-function addNewsArticleBlock() {
-  const container = document.getElementById('setup-news-articles');
-  const id = `news-article-${_newsArticleSeq++}`;
+function addPasteBlock() {
+  const container = document.getElementById('setup-paste-blocks');
+  const id = `paste-block-${_pasteBlockSeq++}`;
   const block = document.createElement('div');
-  block.className = 'news-article-block';
+  block.className = 'paste-block';
   block.id = id;
   block.style.cssText = 'border:1px solid var(--border,#ddd);border-radius:6px;padding:8px;margin-bottom:8px';
   block.innerHTML = `
     <div style="display:flex;gap:8px;margin-bottom:6px;align-items:center">
-      <input class="edit-input news-article-title" type="text" placeholder="Title (optional)" style="flex:1;min-width:0;box-sizing:border-box">
-      <input class="edit-input news-article-url" type="url" placeholder="URL (optional)" style="flex:1;min-width:0;box-sizing:border-box">
+      <input class="edit-input paste-block-title" type="text" placeholder="Title (optional)" style="flex:1;min-width:0;box-sizing:border-box">
+      <input class="edit-input paste-block-url" type="url" placeholder="URL (optional)" style="flex:1;min-width:0;box-sizing:border-box">
       <button class="edit-cancel-btn" style="padding:4px 10px;font-size:12px;flex-shrink:0" onclick="document.getElementById('${id}').remove()">✕</button>
     </div>
-    <textarea class="edit-input news-article-text" rows="5" placeholder="Paste content here…" style="display:block;width:100%;box-sizing:border-box;resize:vertical"></textarea>`;
+    <textarea class="edit-input paste-block-text" rows="5" placeholder="Paste content here…" style="display:block;width:100%;box-sizing:border-box;resize:vertical"></textarea>`;
   container.appendChild(block);
 }
 
-function _collectNewsArticles() {
-  return Array.from(document.querySelectorAll('#setup-news-articles .news-article-block'))
+function _collectPastedContents() {
+  return Array.from(document.querySelectorAll('#setup-paste-blocks .paste-block'))
     .map(block => ({
-      title: block.querySelector('.news-article-title').value.trim(),
-      url: block.querySelector('.news-article-url').value.trim(),
-      text: block.querySelector('.news-article-text').value.trim(),
+      title: block.querySelector('.paste-block-title').value.trim(),
+      url: block.querySelector('.paste-block-url').value.trim(),
+      text: block.querySelector('.paste-block-text').value.trim(),
     }))
     .filter(a => a.text);
 }
@@ -5674,11 +5681,16 @@ function closeKahnemanExamples() {
 let _currentReasoning = '';
 let _currentSourceUrl = '';
 let _currentReasoningIsNews = false;
+// Mode of the last story generation started from the setup modal ('' when the
+// session was resumed without it) — only used to pick the background-popup title.
+let _currentStoryMode = '';
 
 function openReasoning() {
   if (!_currentReasoning) return;
   document.getElementById('reasoning-modal-title').textContent =
-    _currentReasoningIsNews ? '📰 新闻背景' : '💡 为什么这句体现本章偏误?';
+    _currentReasoningIsNews
+      ? (_currentStoryMode === 'paste' ? '📋 内容背景' : '📰 新闻背景')
+      : '💡 为什么这句体现本章偏误?';
   document.getElementById('reasoning-body').textContent = _currentReasoning;
   const linkEl = document.getElementById('reasoning-source-link');
   if (_currentSourceUrl) {
@@ -5791,10 +5803,14 @@ function confirmStorySetup() {
   const grammarPct  = parseInt(document.getElementById('setup-grammar-pct').value, 10) || 75;
   const mode        = document.getElementById('setup-mode').value;
   const chapterIds  = mode === 'kahneman' ? _getSelectedChapterIds() : null;
-  const articles    = mode === 'news' ? _collectNewsArticles() : null;
-  // News mode without pasted articles is valid: regeneration auto-fetches
-  // today's news server-side; the start-review paths load today's cached
-  // briefing via GET (or auto-generate one) — see issue #387.
+  const articles    = mode === 'paste' ? _collectPastedContents() : null;
+  // News mode never sends articles: today's news is auto-fetched server-side
+  // (issue #387). Paste mode requires at least one non-empty text (issue #396).
+  if (mode === 'paste' && !articles.length) {
+    showError('Paste mode needs at least one text — paste some content first.');
+    return;
+  }
+  _currentStoryMode = mode;
   _closeSetupModal();
   if (_setupIsDeckListRegen) {
     _doRegenStoryForDeckList(_deckListRegenId, topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, articles);

--- a/static/app.js
+++ b/static/app.js
@@ -5591,12 +5591,12 @@ function addNewsArticleBlock() {
   block.id = id;
   block.style.cssText = 'border:1px solid var(--border,#ddd);border-radius:6px;padding:8px;margin-bottom:8px';
   block.innerHTML = `
-    <div style="display:flex;gap:8px;margin-bottom:6px">
-      <input class="edit-input news-article-title" type="text" placeholder="Title (optional)" style="flex:1">
-      <input class="edit-input news-article-url" type="url" placeholder="URL (optional)" style="flex:1">
-      <button class="edit-cancel-btn" style="padding:4px 10px;font-size:12px" onclick="document.getElementById('${id}').remove()">✕</button>
+    <div style="display:flex;gap:8px;margin-bottom:6px;align-items:center">
+      <input class="edit-input news-article-title" type="text" placeholder="Title (optional)" style="flex:1;min-width:0;box-sizing:border-box">
+      <input class="edit-input news-article-url" type="url" placeholder="URL (optional)" style="flex:1;min-width:0;box-sizing:border-box">
+      <button class="edit-cancel-btn" style="padding:4px 10px;font-size:12px;flex-shrink:0" onclick="document.getElementById('${id}').remove()">✕</button>
     </div>
-    <textarea class="edit-input news-article-text" rows="5" placeholder="Paste article text here…"></textarea>`;
+    <textarea class="edit-input news-article-text" rows="5" placeholder="Paste content here…" style="display:block;width:100%;box-sizing:border-box;resize:vertical"></textarea>`;
   container.appendChild(block);
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -669,7 +669,8 @@
         <option value="qa">❓ Q&amp;A — answer a question</option>
         <option value="expository">📚 Expository — informative text</option>
         <option value="kahneman">🧠 Kahneman — cognitive bias style</option>
-        <option value="news">📰 News briefing — paste articles</option>
+        <option value="news">📰 News briefing — today's news, auto-fetched</option>
+        <option value="paste">📋 Paste content — summarize anything</option>
       </select>
     </label>
     <!-- Kahneman chapter selector (shown only in kahneman mode) -->
@@ -681,15 +682,21 @@
       <div id="setup-kahneman-chapters" style="max-height:220px;overflow-y:auto;border:1px solid var(--border,#ddd);border-radius:6px;padding:4px 0"></div>
       <div id="setup-kahneman-loading" style="display:none;padding:12px;text-align:center;color:var(--muted,#888);font-size:13px">Loading chapters…</div>
     </div>
-    <!-- News articles input (shown only in news mode) -->
+    <!-- News auto-fetch info (shown only in news mode) -->
     <div id="setup-news-section" style="display:none">
-      <label class="edit-label" style="margin:0">Articles <span style="font-weight:400;text-transform:none">(optional)</span></label>
       <div style="font-size:12px;color:var(--muted,#888);margin:2px 0 6px">
-        Paste articles below — or leave empty to auto-fetch today's news (Tagesschau + BBC World).
+        Today's news is fetched automatically (Tagesschau + BBC World) and condensed into a briefing.
         <span id="setup-news-status" style="display:block"></span>
       </div>
-      <div id="setup-news-articles"></div>
-      <button class="edit-cancel-btn" style="padding:4px 10px;font-size:12px;margin-top:6px" onclick="addNewsArticleBlock()">+ Add article</button>
+    </div>
+    <!-- Pasted content input (shown only in paste mode) -->
+    <div id="setup-paste-section" style="display:none">
+      <label class="edit-label" style="margin:0">Content</label>
+      <div style="font-size:12px;color:var(--muted,#888);margin:2px 0 6px">
+        Paste anything — articles, e-mails, blog posts. The sentences will form a Chinese summary of it.
+      </div>
+      <div id="setup-paste-blocks"></div>
+      <button class="edit-cancel-btn" style="padding:4px 10px;font-size:12px;margin-top:6px" onclick="addPasteBlock()">+ Add text</button>
     </div>
     <label class="edit-label" id="setup-topic-label">Topic <span style="font-weight:400;text-transform:none">(optional)</span>
       <input class="edit-input" id="setup-topic" type="text" placeholder="e.g. a day at a coffee shop" onkeydown="if(event.key==='Enter')confirmStorySetup()">


### PR DESCRIPTION
## 变更内容

### 1. 布局修复（第一个提交，独立可用）
- 文章块的两个输入框加 `min-width:0`，不再把「×」按钮挤出弹窗
- textarea 改为全宽（`width:100%; box-sizing:border-box`），可垂直调整大小

### 2. 拆分为两个独立模式
- **📰 News briefing**（mode=news）：纯自动抓取当日新闻（Tagesschau + BBC World），设置弹窗里不再有粘贴框，只显示说明和当日缓存状态
- **📋 Paste content**（mode=paste，新增）：粘贴任意内容（文章、邮件、博客等），生成的句子构成该内容的连贯中文摘要；每句一个目标词、背景弹窗（📋 内容背景）和原文链接照旧
- paste 复用 news 的生成管线：`generate_news_sentences(generic=True)` 把提示词从"新闻简报"框架换成通用"内容摘要"框架
- paste 模式必须至少粘贴一段文字：前端校验报错，后端也拒绝（不做自动抓取回退）
- "Again" 单词重生成在两个模式下都从 `gen_params.articles` 取回上下文

## 测试方法
- `python -m py_compile ai.py routes/story.py`、`node --check static/app.js` 通过
- 真实端到端测试（gpt-5-mini + 临时数据库）：粘贴一篇德语短文 + 2 个目标词 → 正确生成中文摘要句子（"汉堡开了一座图书馆"、"孩子和学生入场免费"），headline/background/source_url 全部正确
- 浏览器验证：弹窗中选 Paste content → 文章块布局正常（× 在弹窗内、textarea 全宽）；News briefing 无粘贴框；paste 模式留空点生成 → 前端报错

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)