### PR TITLE
fix: 停用 reading 后复习卡不再显示 R 圆圈

### DIFF
--- a/database/browse.py
+++ b/database/browse.py
@@ -83,10 +83,12 @@ def get_cards_for_word(word_id: int) -> list[dict]:
     """Return all cards for a word with full deck path (parent › child)."""
     conn = get_db()
     rows = conn.execute(
-        """SELECT c.*, d.name as deck_name, p.name as parent_deck_name
+        """SELECT c.*, d.name as deck_name, p.name as parent_deck_name,
+                  pr.reading_enabled as reading_enabled
            FROM cards c
            JOIN decks d ON d.id = c.deck_id
            LEFT JOIN decks p ON p.id = d.parent_id
+           JOIN deck_presets pr ON pr.id = d.preset_id
            WHERE c.word_id = ? AND c.deleted_at IS NULL ORDER BY c.category""",
         (word_id,),
     ).fetchall()

--- a/static/app.js
+++ b/static/app.js
@@ -4060,6 +4060,8 @@ function renderReviewCatRow() {
   const html = CATS.map(cat => {
     const c = cards.find(c => c.category === cat && !c.deleted_at);
     if (!c) return '';
+    // Reading disabled via preset → no R circle (the card is kept but hidden)
+    if (cat === 'reading' && !c.reading_enabled) return '';
     const isCurrent = cat === card?.category;
     const isSusp = c.state === 'suspended';
     const cls = ['rcat-btn', isSusp ? 'rcat-susp' : 'rcat-active', isCurrent ? 'rcat-current' : ''].join(' ').trim();
@@ -4073,7 +4075,9 @@ function renderReviewCatRow() {
 function _toggleSuspendCat(category) {
   const cards = wordDetails?.cards || [];
   const c = cards.find(c => c.category === category && !c.deleted_at);
-  if (c) toggleReviewCat(c.id);
+  if (!c) return;
+  if (category === 'reading' && !c.reading_enabled) return; // hidden circle → shortcut inert
+  toggleReviewCat(c.id);
 }
 
 async function toggleReviewCat(cardId) {


### PR DESCRIPTION
## 变更内容

PR #392 的补充修复。复习卡片上的类别暂停圆圈行（`renderReviewCatRow()`）之前仍显示 R 圆圈，因为它基于词的同胞卡渲染，而 reading 卡按设计保留在数据库里。

- `database/browse.py`：`get_cards_for_word` JOIN `deck_presets`，给每张卡附带 `reading_enabled`
- `static/app.js`：`renderReviewCatRow()` 在预设停用 reading 时不渲染 R 圆圈
- `static/app.js`：`f` 快捷键（切换 reading 暂停）在停用时不再作用于隐藏的卡

浏览页和词语详情弹窗仍显示 reading 卡——那是数据管理视图，保留是有意的。

## 测试方法

- 脚本化验证：`get_cards_for_word` 每张卡带 `reading_enabled`，切换预设后值正确变化；`node --check` 通过
- 手动验证：重启服务器后进入复习，卡片上应只有 L / C 两个圆圈；按 `f` 无反应；在 Deck Options 勾选 Enable reading 保存后 R 圆圈恢复

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)