### PR TITLE
feat: news/briefing/paste 模式自动默认 gpt-5-mini

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -5553,6 +5553,7 @@ function updateSetupMode() {
   const pasteSection = document.getElementById('setup-paste-section');
   newsSection.style.display = 'none';
   pasteSection.style.display = 'none';
+  _autoSwitchModelForMode(mode);
   if (mode === 'qa') {
     topicLabel.childNodes[0].textContent = 'Question ';
     topicInput.placeholder = 'e.g. How was life in ancient China?';
@@ -5588,6 +5589,29 @@ function updateSetupMode() {
     btn.textContent = 'Generate story';
     topicLabel.style.display = '';
     kahnemanSection.style.display = 'none';
+  }
+}
+
+// ── News-family modes default to gpt-5-mini ─────────────────────────────────
+// news/briefing/paste are designed for OpenAI (DeepSeek censors news content).
+// Switching to one of them auto-selects gpt-5-mini and remembers the previous
+// model; switching back restores it. A manual model change while in a news
+// mode is respected (we only restore what we auto-switched away from).
+let _modelBeforeNewsMode = null;
+
+function _autoSwitchModelForMode(mode) {
+  const modelSel = document.getElementById('setup-model');
+  if (!modelSel) return;
+  const isNewsFamily = mode === 'news' || mode === 'briefing' || mode === 'paste';
+  if (isNewsFamily) {
+    if (modelSel.value !== 'gpt-5-mini') {
+      _modelBeforeNewsMode = modelSel.value;
+      modelSel.value = 'gpt-5-mini';
+    }
+  } else if (_modelBeforeNewsMode !== null) {
+    // Only restore if the user kept our auto-choice; a manual change sticks.
+    if (modelSel.value === 'gpt-5-mini') modelSel.value = _modelBeforeNewsMode;
+    _modelBeforeNewsMode = null;
   }
 }
 


### PR DESCRIPTION
## 变更内容

- Story setup 弹窗里切换到 news / News flow / paste 模式时，模型下拉自动切换为 **GPT-5 Mini**（这三个模式为 OpenAI 设计，DeepSeek 会审查新闻内容）
- 切回 story/qa/expository/kahneman 时恢复之前记住的模型
- 在新闻类模式下手动改成别的模型时尊重手动选择（只恢复我们自动切换过的值）

## 测试方法
- 打开 Story setup（默认 DeepSeek）→ 选 News flow → 模型自动变为 GPT-5 Mini
- 切回 Story → 模型恢复 DeepSeek
- 选 News flow 后手动改成 Claude Haiku → 切回 Story 再切回 News flow → 保持用户选择逻辑一致

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)