### PR TITLE
feat: News flow 加载画面显示详细进度（生词计数、步骤、新闻标题、真实进度条）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -1059,6 +1059,7 @@ def generate_briefing_sentences(
     max_hsk: int = 2,
     progress_key: str | None = None,
     attempt_label: str = "",
+    progress_extra: dict | None = None,
 ) -> list[dict]:
     """News flow mode (issue #399): one flowing Chinese news summary instead of
     one forced sentence per word.
@@ -1071,9 +1072,29 @@ def generate_briefing_sentences(
     attached to it — Chinese into reasoning_zh (background popup), German
     (Google Translate, no extra AI cost) into context_de (shown on the card).
     Target-word order = order of appearance in the summary.
+
+    progress_extra: extra fields merged into every progress update (issue #407) —
+    the chunker passes words_done/words_total/articles so the loading screen can
+    show real overall progress; words_done is advanced here as words get covered.
     """
     if not cards or not articles:
         return []
+
+    extra = dict(progress_extra or {})
+    base_done = extra.get("words_done", 0)
+    words_total = extra.get("words_total")
+
+    def _progress(msg: str) -> None:
+        if not progress_key:
+            return
+        fields = dict(extra)
+        if words_total:
+            done = base_done + (len(cards) - len(remaining))
+            fields["words_done"] = done
+            fields["percent"] = 15 + int(70 * done / max(words_total, 1))
+        else:
+            fields.setdefault("percent", 20)
+        _set_progress(progress_key, phase="request", msg=msg, **fields)
 
     def _word_in_sentence(word_zh: str, sentence_zh: str) -> bool:
         if '...' in word_zh or '…' in word_zh:
@@ -1118,14 +1139,16 @@ def generate_briefing_sentences(
   {{"sentence_zh": "含目标词的句子", "target_word": "词汇", "article_idx": 0}}
 ]"""
 
-    _set_progress(progress_key, phase="request", msg=f"生成新闻总结…{attempt_label}", percent=20)
-
     sentences: list[dict] = []
     remaining = list(cards)
+
+    _progress(f"生成新闻总结…{attempt_label}")
 
     for attempt in range(3):
         if not remaining:
             break
+        if attempt > 0:
+            _progress(f"补漏 {len(remaining)} 个词（第{attempt + 1}轮）…{attempt_label}")
         prompt = _build_prompt(remaining)
         # 8192: gpt-5 series shares this budget with internal reasoning tokens,
         # and context sentences add output on top of the card sentences.
@@ -1179,6 +1202,7 @@ def generate_briefing_sentences(
                 "tokens": [],
             })
 
+        _progress(f"生成新闻总结…{attempt_label}")
         if remaining:
             logger.warning(
                 "briefing attempt %d: missing words (will re-request): %s",

--- a/routes/story.py
+++ b/routes/story.py
@@ -618,14 +618,26 @@ def _generate_briefing_story_sentences(
     chunk_size = ai.MAX_NEWS_BATCH
     chunks = [cards[i:i + chunk_size] for i in range(0, len(cards), chunk_size)]
 
+    # Detailed loading-screen progress (issue #407): overall word counter and the
+    # news headlines being covered, carried through every progress update.
+    titles = [a.get("title") or a.get("url") or "" for a in articles]
+    titles = [t for t in titles if t][:10]
+
     all_sentences: list[dict] = []
     prompt_summary = f"briefing mode — {len(articles)} articles"
+    words_done = 0
     for idx, chunk in enumerate(chunks):
         label = f" ({idx + 1}/{len(chunks)})"
         chunk_sentences = ai.generate_briefing_sentences(
-            chunk, articles, model=model, progress_key=progress_key, attempt_label=label
+            chunk, articles, model=model, progress_key=progress_key, attempt_label=label,
+            progress_extra={
+                "words_done": words_done,
+                "words_total": len(cards),
+                "articles": titles,
+            },
         )
         all_sentences.extend(chunk_sentences)
+        words_done += len(chunk)
 
     return all_sentences, prompt_summary
 

--- a/static/app.js
+++ b/static/app.js
@@ -799,6 +799,8 @@ function setLoading(msg, useProgress = false) {
     wrap.style.display = 'none';
   }
   if (sub) { sub.textContent = ''; sub.className = ''; }
+  const arts = document.getElementById('loading-articles');
+  if (arts) { arts.innerHTML = ''; arts.style.display = 'none'; }
   if (spinner) spinner.style.visibility = '';
   showView('loading');
 }
@@ -853,8 +855,33 @@ function _startStoryProgressPoll(deckId, cat) {
         _startFakeProgress(5, 50, 30000);
         if (subEl) { subEl.textContent = p.msg; subEl.className = 'warn'; }
       } else if (p.msg) {
-        if (subEl) { subEl.textContent = p.msg; subEl.className = ''; }
+        // News flow (issue #407): append the overall word counter and drive the
+        // bar with the backend's real percent (never move it backwards).
+        let txt = p.msg;
+        if (p.words_total) txt += ` · 生词 ${p.words_done ?? 0}/${p.words_total}`;
+        if (subEl) { subEl.textContent = txt; subEl.className = ''; }
         if (bar && p.phase !== 'ai_done') bar.className = '';
+        if (bar && p.words_total && typeof p.percent === 'number') {
+          const cur = parseFloat(bar.style.width) || 0;
+          if (p.percent > cur) bar.style.width = p.percent + '%';
+        }
+      }
+      // Headlines currently being summarized (news flow) — plain textContent
+      // per line, the titles come from external news sources.
+      const artEl = document.getElementById('loading-articles');
+      if (artEl) {
+        const titles = Array.isArray(p.articles) ? p.articles : [];
+        const key = titles.join('');
+        if (artEl.dataset.key !== key) {
+          artEl.dataset.key = key;
+          artEl.innerHTML = '';
+          for (const t of titles) {
+            const line = document.createElement('div');
+            line.textContent = `📰 ${t}`;
+            artEl.appendChild(line);
+          }
+        }
+        artEl.style.display = titles.length ? 'block' : 'none';
       }
     } catch (_) {}
   }, 400);

--- a/static/index.html
+++ b/static/index.html
@@ -68,6 +68,8 @@
       <div id="loading-progress-bar"></div>
     </div>
     <div id="loading-sub"></div>
+    <!-- News flow: headlines currently being summarized (filled by the progress poll) -->
+    <div id="loading-articles" style="display:none"></div>
     <button id="loading-bg-btn" style="display:none" onclick="_continueStoryInBackground()">
       Continue in background ⏎
     </button>

--- a/static/style.css
+++ b/static/style.css
@@ -141,6 +141,16 @@ main.browse-open {
 #loading-sub { font-size: 12px; color: var(--muted); margin-top: 8px; min-height: 18px; }
 #loading-sub.error { color: #b91c1c; font-size: 13px; }
 #loading-sub.warn  { color: #d97706; font-size: 13px; }
+/* News flow: headlines being summarized, listed under the progress line */
+#loading-articles {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 10px auto 0;
+  max-width: 520px;
+  text-align: left;
+  line-height: 1.7;
+  opacity: 0.85;
+}
 .spinner.hidden { display: none; }
 
 /* "Continue in background" button on the story-generation loading screen */


### PR DESCRIPTION
## 变更内容

News flow 生成时间长，原加载画面只有"生成新闻总结… (9/20)"。现在：

**后端**（进度字典新增字段，/api/story-progress 原样透传）：
- `_generate_briefing_story_sentences` 逐批传入 `progress_extra`：整体 `words_done`/`words_total`、正在处理的新闻标题列表（最多 10 条）
- `generate_briefing_sentences` 每轮尝试后更新已覆盖词数并按词数计算真实 percent（15–85%）；补漏重试时显示"补漏 N 个词（第X轮）"

**前端**：
- 副标题追加"· 生词 X/Y"
- 副标题下方新增 #loading-articles 区域：📰 逐行列出正在总结的新闻标题（textContent 防注入，标题变化才重渲染）
- 有 words_total 的更新用后端真实 percent 驱动进度条（只前进不后退）；翻译阶段的 percent 不影响进度条
- setLoading 重置时清空标题区

## 测试方法
- 离线测试（模拟 _call_api）：words_done 10→12、percent 50→57、articles 全程携带，断言通过
- `node --check`、`py_compile` 通过
- 浏览器验证：生成 News flow 时看到"生成新闻总结… (2/20) · 生词 12/199"+ 新闻标题列表 + 平滑前进的进度条

Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)