### PR TITLE
fix: 复习界面顶部状态标记与计数分类不一致

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -1044,18 +1044,30 @@ def count_unfinished(scope: str = "unfinished") -> dict:
     clause, params = _unfinished_where(scope)
     conn = get_db()
     rows = conn.execute(
-        f"SELECT state, COUNT(*) AS n FROM cards WHERE {clause} GROUP BY state",
+        f"SELECT deck_id, state, interval FROM cards WHERE {clause}",
         params,
     ).fetchall()
     conn.close()
+    # A 'review' card whose interval hasn't reached its deck's learned_interval
+    # is still "learning" — same classification as count_due().
+    thresholds: dict[int, int] = {}
     counts = {"new": 0, "learning": 0, "review": 0}
     for r in rows:
+        if r["state"] == "new":
+            counts["new"] += 1
+            continue
         if r["state"] in ("learning", "relearn"):
-            counts["learning"] += r["n"]
-        elif r["state"] == "review":
-            counts["review"] += r["n"]
-        elif r["state"] == "new":
-            counts["new"] += r["n"]
+            counts["learning"] += 1
+            continue
+        if r["state"] != "review":
+            continue
+        did = r["deck_id"]
+        if did not in thresholds:
+            thresholds[did] = (get_preset_for_deck(did) or {}).get("learned_interval", 4)
+        if (r["interval"] or 0) < thresholds[did]:
+            counts["learning"] += 1
+        else:
+            counts["review"] += 1
     return counts
 
 

--- a/static/app.js
+++ b/static/app.js
@@ -3413,10 +3413,12 @@ function loadCard(c, counts) {
   document.getElementById('cnt-lrn').textContent = counts.learning;
   document.getElementById('cnt-rev').textContent = counts.review;
 
-  // Highlight the active state item
+  // Highlight the active state item — same classification as the backend
+  // counts: a review card below learned_interval is still "learning"
   const stateToItemId = { new: 'cnt-item-new', learning: 'cnt-item-lrn', review: 'cnt-item-rev', relearn: 'cnt-item-lrn' };
   ['cnt-item-new', 'cnt-item-lrn', 'cnt-item-rev'].forEach(id => document.getElementById(id)?.classList.remove('cnt-item-active'));
-  const activeStateId = stateToItemId[c?.state];
+  const youngReview = c?.state === 'review' && (c.interval || 0) < (c.learned_interval ?? 4);
+  const activeStateId = youngReview ? 'cnt-item-lrn' : stateToItemId[c?.state];
   if (activeStateId) document.getElementById(activeStateId)?.classList.add('cnt-item-active');
 
   // Per-category breakdown (mixed/all mode only)


### PR DESCRIPTION
## 变更内容
- `static/app.js` `loadCard()`：高亮当前状态列时采用与后端计数相同的分类——`state === 'review'` 且 `interval < learned_interval` 的年轻卡高亮 **learning** 列，而不是 review 列
- `database/cards.py` `count_unfinished()`：这是唯一没有做年轻卡重分类的计数函数，同步改为按各牌组的 `learned_interval` 把年轻 review 卡计入 learning

## 原因
`count_due()` 把间隔未达 `learned_interval`（默认4天）的 review 卡计入 learning 数量，但前端高亮只看原始 `state`。复习年轻卡时 learning 数字在减少，标记却点在 review 列上。

## 测试方法
- 语法检查：`node --check static/app.js`、`ast.parse` 均通过
- 离线测试：用数据库副本调用 `count_unfinished()` / `count_unfinished('all')`，年轻卡正确归入 learning
- 手动验证：复习一张 interval < 4d 的 review 卡，标记应指向 learning 列且数字递减

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)