### PR TITLE
fix: 去除服务器端 afplay 依赖——/api/speak 改为浏览器播放

### DIFF
--- a/routes/story.py
+++ b/routes/story.py
@@ -683,6 +683,8 @@ async def tts_file(text: str):
     return FileResponse(path, media_type="audio/mpeg")
 
 
+# 以下四个端点（speak/speak-multi/speak-status/speak-stop）通过 afplay/say 在服务器端播放音频，
+# 仅本地 macOS 使用，服务器部署不依赖此端点——前端已全部改为浏览器端播放（/api/tts-file + <audio>）。
 @router.post("/api/speak")
 def speak(text: str):
     try:

--- a/static/app.js
+++ b/static/app.js
@@ -6267,16 +6267,15 @@ function _updateListenCounters() {
   });
 }
 
-async function playSentence() {
+function playSentence() {
   const text = sentence?.sentence_zh || card?.word_zh;
   if (!text) return;
   _listenCount++;
   _updateListenCounters();
-  try {
-    await api('POST', `/api/speak?text=${encodeURIComponent(text)}`);
-  } catch (e) {
-    showError('TTS failed: ' + e.message);
-  }
+  if (_currentAudio) { _currentAudio.onended = null; _currentAudio.pause(); _currentAudio = null; }
+  const audio = new Audio(`/api/tts-file?text=${encodeURIComponent(text)}`);
+  _currentAudio = audio;
+  audio.play().catch(() => {});
 }
 
 // ── Regenerate story ─────────────────────────────────────────────────────────

--- a/tts.py
+++ b/tts.py
@@ -1,7 +1,9 @@
 """
 Text-to-speech wrapper using edge-tts + afplay (macOS).
 
-speak()            — play audio for text (instant if already cached)
+speak()/speak_sync()/speak_multi()/_play() — server-side playback via afplay/say (macOS only).
+                      Only reachable through /api/speak, /api/speak-multi, /api/speak-stop,
+                      which the frontend no longer calls (issue #418) — safe on non-macOS servers.
 preload()          — pre-generate audio in background without playing
 preload_all_async()— pre-generate a batch in parallel; awaitable
 


### PR DESCRIPTION
## 变更内容
- `static/app.js`：`playSentence()`（发音按钮点击时调用）从 `POST /api/speak` 改为浏览器端 `new Audio('/api/tts-file?text=...')` 播放，复用故事播放器已有的 `_currentAudio` 变量，播放新音频前先停掉旧的（与故事播放模式一致），`audio.play()` 失败静默处理
- `routes/story.py`：`/api/speak`、`/api/speak-multi`、`/api/speak-status`、`/api/speak-stop` 四个端点前加中文注释，标明「仅本地 macOS 使用，服务器部署不依赖此端点」
- `tts.py`：文档字符串补充说明，标明 `speak()`/`speak_sync()`/`speak_multi()`/`_play()`（内部用 `afplay`/`say`）只通过上述端点触发，前端已不再调用

## 确认结果（任务第 5 步）
逐一检查 `tts.py` 中与 `/api/tts-file`、`/api/preload`、`/api/preload-session` 相关的调用链：
- `/api/tts-file` → `tts.get_cached_path()` → `_ensure_cached()`：只用 `edge_tts.Communicate(...).save()` 生成 mp3 并返回路径，不涉及 `subprocess`/`afplay`/`say`
- `/api/preload` → `tts.preload()` → 后台线程调用 `_ensure_cached()`：同上，纯生成
- `/api/preload-session` → `tts.preload_all_async()` → 并发调用 `_ensure_cached()`：同上，纯生成

`afplay`/`say`（`subprocess.Popen`）只存在于 `_play()`，仅被 `speak()`/`speak_sync()`/`speak_multi()`/`stop()` 使用，而这些函数只被 `/api/speak`、`/api/speak-multi`、`/api/speak-stop` 调用——已确认前端全局搜索无任何调用（`grep -rn "/api/speak" static/`），故这几个端点的 afplay 依赖不影响服务器部署。

## 测试方法
- `python -m py_compile tts.py routes/story.py` 通过
- `node --check static/app.js` 通过
- 声音需 Daniel 在浏览器中实测：复习界面点击发音按钮（🔊/▶）确认能正常出声，且连续点击时新音频会打断旧音频（不会叠加播放）

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)