### PR TITLE
feat: Hetzner 服务器部署准备（requirements.txt + systemd + Caddy + 部署文档）

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,249 @@
+# 部署指南 —— Hetzner VPS（Ubuntu 24.04）
+
+本文档假设你从一台全新的 Hetzner VPS（Ubuntu 24.04）开始，一步步把 AnkiAdvanced
+部署到线上，最终可以用手机浏览器通过 HTTPS 访问。任何人（或任何 AI 代理）照着做即可上线，
+不需要额外背景知识。
+
+---
+
+## 1. 服务器初始化
+
+用 root 登录服务器（`ssh root@<服务器IP>`），然后：
+
+```bash
+apt update && apt upgrade -y
+```
+
+### 创建非 root 用户
+
+不要用 root 长期运行服务。创建一个专用用户（这里叫 `anki`，你可以改名，但要和后面
+所有配置文件中的 `anki` 保持一致）：
+
+```bash
+adduser anki
+usermod -aG sudo anki
+```
+
+设置好密码后，把 SSH 公钥加入新用户（如果你已经用密钥登录 root，可以复制过去）：
+
+```bash
+rsync --archive --chown=anki:anki ~/.ssh /home/anki
+```
+
+之后用 `ssh anki@<服务器IP>` 登录，后续步骤都在 `anki` 用户下进行。
+
+### 防火墙（ufw）
+
+只开放 SSH（22）、HTTP（80）、HTTPS（443）：
+
+```bash
+sudo ufw allow 22/tcp
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw enable
+sudo ufw status
+```
+
+---
+
+## 2. 安装依赖软件
+
+### Python
+
+```bash
+sudo apt install -y python3 python3-venv python3-pip lsof git sqlite3
+```
+
+（`lsof` 供 `run.sh` 清理 8000 端口使用；`sqlite3` CLI 供备份 `.backup` 命令使用。）
+
+### Caddy（反向代理 + 自动 HTTPS）
+
+```bash
+sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | \
+    sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | \
+    sudo tee /etc/apt/sources.list.d/caddy-stable.list
+sudo apt update
+sudo apt install -y caddy
+```
+
+---
+
+## 3. 获取代码
+
+```bash
+cd /home/anki
+git clone https://github.com/daniel4828/AnkiAdvanced.git
+cd AnkiAdvanced
+```
+
+（如果仓库是私有的，用 `git clone git@github.com:daniel4828/AnkiAdvanced.git`，
+并提前在服务器上配置好部署用的 SSH key 或 GitHub Personal Access Token。）
+
+### 创建虚拟环境并安装依赖
+
+```bash
+python3 -m venv .venv
+.venv/bin/pip install --upgrade pip
+.venv/bin/pip install -r requirements.txt
+```
+
+---
+
+## 4. 配置 `.env`
+
+在项目根目录创建 `.env` 文件（**不要提交到 git**）：
+
+```bash
+nano .env
+```
+
+内容（把下面所有变量抄进去，按需填写；见 CLAUDE.md「启动与环境变量」表）：
+
+```bash
+# ===== AI 提供商密钥 =====
+ANTHROPIC_API_KEY=       # 必填。Claude API 密钥
+DEEPSEEK_API_KEY=        # 可选。DeepSeek API 密钥
+ZHIPU_API_KEY=           # 可选。ZhipuAI GLM 密钥
+QWEN_API_KEY=            # 可选。阿里云 Qwen 密钥
+OPENAI_API_KEY=          # 可选。OpenAI 密钥；新闻模式默认用它（gpt-5-mini），
+                         # 因为 DeepSeek 会审查新闻内容
+
+# ===== 数据库与运行参数 =====
+DB_PATH=data/srs.db      # 数据库路径。生产环境务必用 srs.db，不要用 dev.db
+DISABLE_AI=0             # 设为 1 可跳过 AI 故事生成（调试用，生产环境应为 0）
+LOG_LEVEL=INFO           # 日志级别，调试时可设为 DEBUG
+DEV_CLEAR_DB=            # 留空。设为任意值会在启动时清空数据库 —— 生产环境绝不要设置
+
+# ===== 访问认证（即将加入，见相关 issue）=====
+# 用于给整个站点加一层 HTTP Basic Auth，防止手机浏览器直接访问时被陌生人发现。
+# 目前 main.py 尚未读取这两个变量，加入后请提前写好，方便功能上线即可生效。
+AUTH_USERNAME=           # HTTP Basic Auth 用户名
+AUTH_PASSWORD=           # HTTP Basic Auth 密码
+```
+
+保存后确认权限收紧：
+
+```bash
+chmod 600 .env
+```
+
+### 初始化数据库并导入词汇
+
+```bash
+.venv/bin/python main.py import
+```
+
+---
+
+## 5. 配置 systemd 服务
+
+复制 service 文件并按需修改（如果用户名/路径与示例不同，需要先编辑 `deploy/ankiadvanced.service`）：
+
+```bash
+sudo cp deploy/ankiadvanced.service /etc/systemd/system/ankiadvanced.service
+sudo systemctl daemon-reload
+sudo systemctl enable ankiadvanced
+sudo systemctl start ankiadvanced
+sudo systemctl status ankiadvanced
+```
+
+查看日志：
+
+```bash
+journalctl -u ankiadvanced -f
+```
+
+---
+
+## 6. 配置 Caddy 反向代理
+
+```bash
+sudo cp deploy/Caddyfile.example /etc/caddy/Caddyfile
+sudo nano /etc/caddy/Caddyfile   # 把 your-domain.example.com 换成你自己的域名
+sudo systemctl restart caddy
+sudo systemctl enable caddy
+```
+
+确认域名的 DNS A 记录已指向服务器 IP。Caddy 会自动申请 Let's Encrypt 证书，
+首次访问 `https://your-domain.example.com` 时可能需要等待几十秒完成证书签发。
+
+---
+
+## 7. 配置自动部署（cron + deploy.sh）
+
+`deploy/deploy.sh` 会定期检查 `origin/main` 是否有新提交，有的话自动拉取、装依赖、重启服务。
+不需要 GitHub Actions/webhook，只需要服务器主动轮询。
+
+```bash
+crontab -e
+```
+
+添加一行（每 2 分钟检查一次）：
+
+```
+*/2 * * * * /home/anki/AnkiAdvanced/deploy/deploy.sh >> /home/anki/deploy.log 2>&1
+```
+
+`deploy.sh` 内部用 `flock` 防止并发运行；如果两分钟内上一次部署还没跑完，会自动跳过。
+
+要让 `deploy.sh` 里的 `sudo systemctl restart ankiadvanced` 免密码执行，
+给 `anki` 用户加一条 sudoers 规则（用 `sudo visudo -f /etc/sudoers.d/ankiadvanced`）：
+
+```
+anki ALL=(ALL) NOPASSWD: /bin/systemctl restart ankiadvanced
+```
+
+查看部署日志：
+
+```bash
+tail -f /home/anki/deploy.log
+```
+
+---
+
+## 8. 数据库备份建议
+
+数据库文件在 `data/srs.db`，建议用 cron 每 6 小时做一次快照，并保留一段时间：
+
+```bash
+mkdir -p /home/anki/AnkiAdvanced/data/backups
+crontab -e
+```
+
+添加一行：
+
+```
+0 */6 * * * sqlite3 /home/anki/AnkiAdvanced/data/srs.db ".backup '/home/anki/AnkiAdvanced/data/backups/srs_$(date +\%Y-\%m-\%d_\%H-\%M-\%S).db'"
+```
+
+（本地 Mac 上已经有类似的 `backup.sh` + launchd 方案，可以参考其保留策略——
+只保留最近 120 份快照，自动清理更早的。）
+
+**强烈建议做异地备份**：定期把服务器上的备份 `rsync` 回本地 Mac，防止服务器本身出问题导致数据全部丢失：
+
+```bash
+# 在本地 Mac 上运行（可以加进 backup.sh 或单独写一个 cron）
+rsync -avz anki@<服务器IP>:/home/anki/AnkiAdvanced/data/backups/ ~/Documents/AnkiAdvanced/data/remote_backups/
+```
+
+---
+
+## 9. 验证部署
+
+1. 浏览器访问 `https://your-domain.example.com`，确认页面加载。
+2. `curl -s https://your-domain.example.com/api/decks` 应返回 200 和牌组 JSON。
+3. 修改本地代码，`git push` 到 `main` 后，最多等 2 分钟，`tail -f /home/anki/deploy.log`
+   应能看到自动部署日志，且网站已更新（可以先在无关文件里加一行注释验证流程通不通）。
+
+---
+
+## 故障排查
+
+| 现象 | 排查方向 |
+|------|---------|
+| 服务启动失败 | `journalctl -u ankiadvanced -e`，检查 `.env` 路径/权限、`.venv` 是否存在 |
+| Caddy 无法签发证书 | 确认 80/443 端口已在 ufw 放行，且域名 DNS 已生效 |
+| deploy.sh 报 sudo 密码错误 | 检查第 7 节的 sudoers NOPASSWD 配置 |
+| 8000 端口被占用 | `run.sh` 会自动 `lsof -ti :8000 | xargs kill -9`，确认服务器已安装 `lsof` |

--- a/deploy/Caddyfile.example
+++ b/deploy/Caddyfile.example
@@ -1,0 +1,11 @@
+# Caddyfile 示例 —— 复制为 /etc/caddy/Caddyfile 并替换域名
+# Caddy 会自动申请并续期 Let's Encrypt 证书，无需额外配置。
+
+your-domain.example.com {
+	reverse_proxy 127.0.0.1:8000
+
+	# 可选：Caddy 访问日志
+	log {
+		output file /var/log/caddy/ankiadvanced.log
+	}
+}

--- a/deploy/ankiadvanced.service
+++ b/deploy/ankiadvanced.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=AnkiAdvanced 中文间隔重复系统
+After=network.target
+
+[Service]
+Type=simple
+# 替换为你在服务器上创建的非 root 用户（见 DEPLOY.md 第 2 步）
+User=anki
+Group=anki
+# 替换为项目在服务器上的实际路径
+WorkingDirectory=/home/anki/AnkiAdvanced
+EnvironmentFile=/home/anki/AnkiAdvanced/.env
+ExecStart=/home/anki/AnkiAdvanced/.venv/bin/python main.py
+Restart=always
+RestartSec=3
+
+# 基本安全加固（可按需调整）
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# 自动部署脚本 —— 无需 GitHub secrets/webhook，靠 cron 轮询实现“推送即上线”。
+#
+# 用法：配合 cron 每 2 分钟运行一次，例如在服务器上执行 `crontab -e` 后添加：
+#   */2 * * * * /home/anki/AnkiAdvanced/deploy/deploy.sh >> /home/anki/deploy.log 2>&1
+#
+# 行为：
+#   1. git fetch 获取 origin/main 最新提交
+#   2. 若本地 HEAD 已经等于 origin/main，什么都不做（幂等）
+#   3. 否则：git pull → 用 .venv 安装依赖 → 重启 systemd 服务
+#
+# 用 flock 防止上一次部署还没跑完时 cron 又并发触发一次。
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOCK_FILE="/tmp/ankiadvanced-deploy.lock"
+
+exec 200>"$LOCK_FILE"
+if ! flock -n 200; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] 上一次部署仍在进行中，跳过本次运行。"
+    exit 0
+fi
+
+cd "$REPO_DIR"
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] 检查更新..."
+git fetch origin main --quiet
+
+LOCAL_REV="$(git rev-parse HEAD)"
+REMOTE_REV="$(git rev-parse origin/main)"
+
+if [ "$LOCAL_REV" = "$REMOTE_REV" ]; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] 已是最新（$LOCAL_REV），无需部署。"
+    exit 0
+fi
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] 发现新提交：$LOCAL_REV -> $REMOTE_REV"
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] 拉取最新代码..."
+git pull --ff-only origin main
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] 安装/更新依赖..."
+.venv/bin/pip install -q -r requirements.txt
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] 重启服务..."
+sudo systemctl restart ankiadvanced
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] 部署完成，当前版本：$(git rev-parse HEAD)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+# AnkiAdvanced 运行依赖
+# 版本号采用 “>=当前次版本,<下一主版本” 的宽松固定方式，
+# 既能接收补丁/次版本更新，又能避免破坏性大版本升级。
+
+fastapi>=0.135,<1.0
+uvicorn>=0.41,<1.0
+anthropic>=0.84,<1.0
+openai>=2.29,<3.0
+edge-tts>=7.2,<8.0
+PyYAML>=6.0,<7.0
+python-multipart>=0.0.22,<0.1
+deep-translator>=1.11,<2.0
+jieba>=0.42,<1.0
+pypinyin>=0.55,<1.0


### PR DESCRIPTION
## 变更内容
- `requirements.txt`：补全生产环境实际使用的依赖（通过检查所有 `.py` 文件的 import 确认），版本号采用宽松固定（`>=次版本,<下一主版本`）。除议题中列出的库外，额外发现 `jieba`（routes/story.py 分词）和 `pypinyin`（routes/browse.py 拼音）也是运行时必需依赖，一并加入。`pdfplumber` 只被一次性脚本 `extract_kahneman.py` 使用，非服务运行时依赖，未加入。
- `deploy/ankiadvanced.service`：systemd 单元文件，`User=anki` 占位、`WorkingDirectory`、`EnvironmentFile=.env`、`ExecStart=.venv/bin/python main.py`、`Restart=always`、`RestartSec=3`，附带基本安全加固（`NoNewPrivileges`、`PrivateTmp`）。
- `deploy/Caddyfile.example`：反向代理到 `127.0.0.1:8000`，域名用占位符，Caddy 自动签发 HTTPS 证书。
- `deploy/deploy.sh`：cron 轮询式自动部署（无需 GitHub webhook/secrets）。`git fetch` 后比较本地 `HEAD` 与 `origin/main`，无变化则跳过；有新提交则 `pull --ff-only` + `pip install -r requirements.txt` + `systemctl restart`。用 `flock` 防止并发部署，全程 `echo` 带时间戳的进度日志，脚本顶部注释说明配合 cron `*/2 * * * *` 使用。
- `run.sh`：检查后确认 Linux 兼容（`lsof`/`xargs` 在 Ubuntu 均可用，只需 `apt install lsof`），**未做修改**。
- `DEPLOY.md`：从全新 Ubuntu 24.04 服务器到上线的完整教程——创建非 root 用户、ufw 防火墙（仅开 22/80/443）、安装 Python/Caddy、`git clone`、创建 venv、`.env` 配置（抄录 CLAUDE.md 环境变量表全部变量并附中文说明，同时预留 `AUTH_USERNAME`/`AUTH_PASSWORD` 两个即将加入的认证变量）、systemd 启用、Caddy 配置、cron 自动部署配置（含 sudoers NOPASSWD 免密重启说明）、数据库备份建议（cron 每 6 小时快照 + 建议 rsync 回本地 Mac 做异地备份）、部署验证步骤、故障排查表。

## 测试方法
- `bash -n` 检查所有 `.sh` 文件（`run.sh`、`run.dev.sh`、`backup.sh`、`deploy/deploy.sh`）均语法正确
- 人工检查 systemd 单元文件字段完整性（`[Unit]`/`[Service]`/`[Install]` 三段齐全）
- 未改动任何现有 Python 运行逻辑，`git diff` 仅新增文件

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)