### PR TITLE
feat: 可选的 HTTP Basic Auth（通过环境变量启用）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -604,6 +604,8 @@ bash run.dev.sh      # 开发启动（DB_PATH=data/dev.db，DISABLE_AI=1）
 | `DISABLE_AI` | `0` | 设为 `1` 跳过 AI 故事生成 |
 | `LOG_LEVEL` | `INFO` | 日志级别（`DEBUG` 可输出详细日志） |
 | `DEV_CLEAR_DB` | `` | 设为任意值则启动时清空数据库 |
+| `AUTH_USERNAME` | 可选 | 两者都设置时启用 HTTP Basic Auth（保护所有路径），单用户登录名 |
+| `AUTH_PASSWORD` | 可选 | 两者都设置时启用 HTTP Basic Auth（保护所有路径），单用户密码 |
 
 ## 里程碑（lǐchéngbēi - milestones）
 

--- a/main.py
+++ b/main.py
@@ -151,11 +151,14 @@ def main():
 # ---------------------------------------------------------------------------
 
 try:
+    import base64
+    import binascii
+    import secrets
     import time
     from contextlib import asynccontextmanager
     from fastapi import FastAPI, Request
     from fastapi.staticfiles import StaticFiles
-    from fastapi.responses import FileResponse
+    from fastapi.responses import FileResponse, JSONResponse
     import uvicorn
 
     from routes import decks, review, story, browse, imports
@@ -179,6 +182,42 @@ try:
     app = FastAPI(title="AnkiAdvanced", lifespan=lifespan)
 
     ui_logger = logging.getLogger("ui")
+
+    # Optional single-user HTTP Basic Auth — enabled only when both
+    # AUTH_USERNAME and AUTH_PASSWORD are set (issue #419). If either is
+    # missing, this middleware is a no-op — local dev behavior unchanged.
+    _AUTH_USERNAME = os.environ.get("AUTH_USERNAME", "")
+    _AUTH_PASSWORD = os.environ.get("AUTH_PASSWORD", "")
+    _AUTH_ENABLED = bool(_AUTH_USERNAME and _AUTH_PASSWORD)
+
+    def _unauthorized() -> JSONResponse:
+        return JSONResponse(
+            status_code=401,
+            content={"detail": "Unauthorized"},
+            headers={"WWW-Authenticate": 'Basic realm="AnkiAdvanced"'},
+        )
+
+    @app.middleware("http")
+    async def basic_auth(request: Request, call_next):
+        if not _AUTH_ENABLED:
+            return await call_next(request)
+
+        header = request.headers.get("authorization", "")
+        if not header.startswith("Basic "):
+            return _unauthorized()
+
+        try:
+            decoded = base64.b64decode(header[6:]).decode("utf-8")
+            username, _, password = decoded.partition(":")
+        except (ValueError, UnicodeDecodeError, binascii.Error):
+            return _unauthorized()
+
+        user_ok = secrets.compare_digest(username.encode("utf-8"), _AUTH_USERNAME.encode("utf-8"))
+        pass_ok = secrets.compare_digest(password.encode("utf-8"), _AUTH_PASSWORD.encode("utf-8"))
+        if not (user_ok and pass_ok):
+            return _unauthorized()
+
+        return await call_next(request)
 
     @app.middleware("http")
     async def log_requests(request: Request, call_next):


### PR DESCRIPTION
## 变更内容
- 在 `main.py` 的 FastAPI 应用中新增一个 `http` 中间件 `basic_auth`（与已有的 `log_requests` 中间件相邻）
- 仅当环境变量 `AUTH_USERNAME` 和 `AUTH_PASSWORD` 均已设置时启用校验；否则中间件直接放行，本地开发无感
- 解析 `Authorization: Basic` 头，使用 `secrets.compare_digest` 分别比较用户名和密码（两次比较都执行，避免短路造成的时序差异）
- 校验失败返回 `401` + `WWW-Authenticate: Basic realm="AnkiAdvanced"` 头，浏览器会自动弹出登录框
- 保护所有路径，无豁免（包括 `/static` 和 `/api/tts-file`）
- `CLAUDE.md` 环境变量表新增 `AUTH_USERNAME` / `AUTH_PASSWORD` 两行说明

## 测试方法
使用临时数据库（`DB_PATH` 指向 scratchpad 临时文件）+ `DISABLE_AI=1` + 高位随机端口启动服务器，未占用 8000 端口和生产数据库。用 `curl` 离线验证三种情况：

**1. 不设 AUTH_USERNAME/AUTH_PASSWORD（行为不变）**
```
GET /api/decks         → 200
GET /static/index.html → 200
```

**2. 设置了变量，无凭证**
```
$ curl -s -i http://127.0.0.1:58422/api/decks
HTTP/1.1 401 Unauthorized
www-authenticate: Basic realm="AnkiAdvanced"
content-type: application/json

{"detail":"Unauthorized"}
```

**3. 设置了变量，正确凭证**
```
$ curl -u danieltest:s3cr3t http://127.0.0.1:58422/api/decks         → 200
$ curl -u danieltest:s3cr3t http://127.0.0.1:58422/static/index.html → 200
$ curl -u danieltest:wrong  http://127.0.0.1:58422/api/decks         → 401
```

`python -m py_compile main.py` 通过。测试完成后已杀掉进程并删除临时数据库文件。

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)