### PR TITLE
feat: 早晨自动预生成脚本——提前生成当日故事与 TTS 音频

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,137 @@
+# scripts/
+
+## morning_pregen.py（issue #420）
+
+新闻 / 简报模式的故事生成很慢（多次串行 AI 调用），Daniel 早上打开页面时
+不想等。这个脚本对**运行中的服务器**发请求，提前把今天所有有到期卡片的
+（牌组, 类别）的故事生成好，并预热对应的 TTS 音频缓存。
+
+只依赖 Python 标准库（`urllib.request`、`base64`、`json` 等），不需要安装
+任何依赖，本地（launchd）和服务器（cron，见 issue #417）都可以直接用同一
+份脚本。
+
+### 前提
+
+- 服务器（`bash run.sh` 或对应 systemd 服务）必须已经在运行——脚本只发
+  HTTP 请求，不会自己启动服务器。
+- 脚本读取 `GET /api/decks`，找出所有**叶子牌组**（没有子牌组的节点）里
+  到期数量（`counts.new + learning + review + learning_future`）大于 0、
+  且**未被暂停**（`all_suspended` 不为真）的（牌组, 类别）。
+  类别键名固定为 `listening`（听力）/ `reading`（阅读）/ `creating`（写作），
+  与 `routes/decks.py` 中的 `VALID_CATEGORIES` 一致。
+- 对每一项：`GET /api/story/{deck_id}/{category}`（已有今天的缓存故事则
+  秒回，否则同步生成——新闻/简报模式可能耗时数分钟，脚本设置了 15 分钟
+  超时），成功后再 `POST /api/preload-session/{deck_id}/{category}` 预热
+  TTS 音频缓存。
+- 串行执行（一次只处理一个），单项失败只记录错误、不中断整体，最后打印
+  成功/失败/跳过（已暂停）数量的汇总。
+
+### 用法
+
+```bash
+# 默认连接本机 8000 端口
+python scripts/morning_pregen.py
+
+# 指定服务器地址
+BASE_URL=http://127.0.0.1:8001 python scripts/morning_pregen.py
+
+# 如果服务器加了 HTTP Basic 认证（配合认证相关 issue）
+AUTH_USERNAME=daniel AUTH_PASSWORD=xxxx python scripts/morning_pregen.py
+```
+
+### 环境变量
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `BASE_URL` | `http://127.0.0.1:8000` | 目标服务器地址 |
+| `AUTH_USERNAME` | 无 | HTTP Basic 认证用户名（可选，需和 `AUTH_PASSWORD` 一起设置） |
+| `AUTH_PASSWORD` | 无 | HTTP Basic 认证密码（可选） |
+
+退出码：全部成功或没有待处理项时为 `0`；只要有一项失败就是 `1`（方便
+launchd/cron 的失败通知）。
+
+---
+
+### macOS：用 launchd 每天早上 06:00 自动运行
+
+launchd 是 macOS 的定时任务机制（比 cron 更适合 Mac，因为它能处理系统
+休眠/唤醒）。
+
+1. 创建 plist 文件 `~/Library/LaunchAgents/com.ankiadvanced.morning-pregen.plist`：
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ankiadvanced.morning-pregen</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/python3</string>
+        <string>/Users/daniel/Documents/AnkiAdvanced/scripts/morning_pregen.py</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>BASE_URL</key>
+        <string>http://127.0.0.1:8000</string>
+    </dict>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>6</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/daniel/Documents/AnkiAdvanced/data/morning-pregen.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/daniel/Documents/AnkiAdvanced/data/morning-pregen.err.log</string>
+</dict>
+</plist>
+```
+
+（路径按实际用户名/项目路径调整；如果生产服务器加了认证，把
+`AUTH_USERNAME`/`AUTH_PASSWORD` 也加进 `EnvironmentVariables`。）
+
+2. 加载并启动：
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.ankiadvanced.morning-pregen.plist
+```
+
+3. 常用管理命令：
+
+```bash
+# 立即手动触发一次（不用等到 06:00）
+launchctl start com.ankiadvanced.morning-pregen
+
+# 查看日志
+tail -f ~/Documents/AnkiAdvanced/data/morning-pregen.log
+
+# 卸载
+launchctl unload ~/Library/LaunchAgents/com.ankiadvanced.morning-pregen.plist
+```
+
+---
+
+### Linux 服务器：cron + systemd
+
+服务器上假设 FastAPI 服务由 systemd 管理（见 issue #417 的部署文档），
+cron 只负责在服务已经运行时定时触发预生成：
+
+```cron
+# 每天 06:00 运行早晨预生成脚本（假设服务已由 systemd 常驻运行）
+0 6 * * * cd /opt/ankiadvanced && /usr/bin/python3 scripts/morning_pregen.py >> data/morning-pregen.log 2>&1
+```
+
+用 `crontab -e` 添加以上一行。如果服务地址/端口非默认，加上环境变量：
+
+```cron
+0 6 * * * cd /opt/ankiadvanced && BASE_URL=http://127.0.0.1:8000 /usr/bin/python3 scripts/morning_pregen.py >> data/morning-pregen.log 2>&1
+```

--- a/scripts/morning_pregen.py
+++ b/scripts/morning_pregen.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""早晨自动预生成脚本（issue #420）。
+
+对一台运行中的服务器发请求，提前生成"今天"所有有到期卡片的叶子牌组
+（牌组+类别）的故事，并预热对应的 TTS 音频缓存，这样 Daniel 早上打开
+页面时，故事和语音都已经就绪（新闻/简报模式尤其慢，多次串行 AI 调用）。
+
+只使用 Python 标准库（urllib.request 等），本地用 launchd、服务器用
+cron 都可以直接运行，见 scripts/README.md。
+
+用法：
+    BASE_URL=http://127.0.0.1:8000 python scripts/morning_pregen.py
+
+环境变量：
+    BASE_URL       服务器地址，默认 http://127.0.0.1:8000
+    AUTH_USERNAME  可选，HTTP Basic 认证用户名（配合认证议题）
+    AUTH_PASSWORD  可选，HTTP Basic 认证密码
+"""
+
+import base64
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+BASE_URL = os.environ.get("BASE_URL", "http://127.0.0.1:8000").rstrip("/")
+AUTH_USERNAME = os.environ.get("AUTH_USERNAME")
+AUTH_PASSWORD = os.environ.get("AUTH_PASSWORD")
+
+# /api/story/{deck_id}/{category} 在没有缓存故事时会同步生成——新闻/简报模式
+# 可能涉及多次串行 AI 调用，耗时可达数分钟，因此设置较长的超时。
+STORY_TIMEOUT_SECONDS = 15 * 60
+# 牌组列表、预热 TTS 等轻量请求的超时。
+SHORT_TIMEOUT_SECONDS = 60
+
+# 叶子牌组分类键名（阅读=reading，听力=listening，写作=creating）——
+# 与 routes/decks.py 的 VALID_CATEGORIES / _leaf_pairs 保持一致。
+CATEGORIES = ("listening", "reading", "creating")
+
+
+def _log(msg: str) -> None:
+    ts = time.strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[{ts}] {msg}", flush=True)
+
+
+def _auth_header() -> dict:
+    if AUTH_USERNAME is not None and AUTH_PASSWORD is not None:
+        token = base64.b64encode(f"{AUTH_USERNAME}:{AUTH_PASSWORD}".encode()).decode()
+        return {"Authorization": f"Basic {token}"}
+    return {}
+
+
+def _request(method: str, path: str, timeout: int, body: dict | None = None):
+    """Send an HTTP request to BASE_URL + path, return parsed JSON (or None)."""
+    url = f"{BASE_URL}{path}"
+    data = None
+    headers = _auth_header()
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read()
+        if not raw:
+            return None
+        return json.loads(raw)
+
+
+def _flatten(tree: list) -> list:
+    result = []
+    for node in tree:
+        result.append(node)
+        result.extend(_flatten(node.get("children") or []))
+    return result
+
+
+def _due_count(deck: dict) -> int:
+    counts = deck.get("counts") or {}
+    return sum(counts.get(k, 0) for k in ("new", "learning", "review", "learning_future"))
+
+
+def find_due_leaf_pairs() -> tuple[list[tuple[int, str, str]], int]:
+    """Return ([(deck_id, category, deck_name), ...], n_skipped_suspended) for
+    leaf decks with due cards in a non-suspended category. Reads GET /api/decks
+    (see routes/decks.py:_leaf_pairs / _attach_counts for the tree shape)."""
+    tree = _request("GET", "/api/decks", SHORT_TIMEOUT_SECONDS)
+    if not tree:
+        return [], 0
+    pairs = []
+    n_skipped = 0
+    for deck in _flatten(tree):
+        if deck.get("children"):
+            continue  # only leaf decks carry a category
+        category = deck.get("category")
+        if category not in CATEGORIES:
+            continue
+        if deck.get("all_suspended"):
+            _log(f"跳过 已暂停  牌组={deck.get('name')!r} 类别={category}")
+            n_skipped += 1
+            continue
+        if _due_count(deck) <= 0:
+            continue
+        pairs.append((deck["id"], category, deck.get("name", f"deck#{deck['id']}")))
+    return pairs, n_skipped
+
+
+def pregen_one(deck_id: int, category: str, name: str) -> tuple[bool, str]:
+    """Generate (or reuse cached) story for one (deck, category), then preload
+    TTS. Returns (success, message)."""
+    label = f"牌组={name!r} 类别={category}"
+    try:
+        story = _request("GET", f"/api/story/{deck_id}/{category}", STORY_TIMEOUT_SECONDS)
+    except urllib.error.URLError as e:
+        return False, f"{label} 故事生成请求失败: {e}"
+    except Exception as e:
+        return False, f"{label} 故事生成异常: {e}"
+
+    if isinstance(story, dict) and story.get("error"):
+        return False, f"{label} 故事生成返回错误: {story.get('reason')}"
+    if not story:
+        return False, f"{label} 没有返回故事（可能没有到期卡片或 AI 已禁用）"
+
+    n_sentences = len(story.get("sentences") or [])
+    _log(f"  {label} 故事就绪（{n_sentences} 句），开始预热语音…")
+
+    try:
+        _request("POST", f"/api/preload-session/{deck_id}/{category}", STORY_TIMEOUT_SECONDS)
+    except Exception as e:
+        # 故事已经生成成功——语音预热失败不算整体失败，但要记录。
+        return True, f"{label} 故事已生成，但语音预热失败: {e}"
+
+    return True, f"{label} 完成（{n_sentences} 句 + 语音预热）"
+
+
+def main() -> int:
+    _log(f"早晨预生成开始  BASE_URL={BASE_URL}")
+
+    try:
+        pairs, n_skipped = find_due_leaf_pairs()
+    except urllib.error.URLError as e:
+        _log(f"无法连接服务器 {BASE_URL}: {e}")
+        return 1
+    except Exception as e:
+        _log(f"读取牌组列表失败: {e}")
+        return 1
+
+    if not pairs:
+        _log(f"没有找到任何有到期卡片的（牌组, 类别）（跳过已暂停 {n_skipped} 个），无需生成，退出。")
+        return 0
+
+    _log(f"共 {len(pairs)} 个（牌组, 类别）待处理:")
+    for deck_id, category, name in pairs:
+        _log(f"  - {name!r} / {category} (deck_id={deck_id})")
+
+    n_ok = 0
+    n_fail = 0
+    failures: list[str] = []
+
+    for deck_id, category, name in pairs:
+        _log(f"处理中 牌组={name!r} 类别={category} (deck_id={deck_id})…")
+        ok, msg = pregen_one(deck_id, category, name)
+        if ok:
+            n_ok += 1
+            _log(f"  ✓ {msg}")
+        else:
+            n_fail += 1
+            failures.append(msg)
+            _log(f"  ✗ {msg}")
+
+    _log("---- 汇总 ----")
+    _log(f"成功: {n_ok}  失败: {n_fail}  跳过(已暂停): {n_skipped}  总计处理: {len(pairs)}")
+    if failures:
+        _log("失败详情:")
+        for f in failures:
+            _log(f"  - {f}")
+
+    return 0 if n_fail == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 变更内容
- 新增 `scripts/morning_pregen.py`：只用标准库（`urllib.request`、`base64`、`json` 等），对一台**运行中的服务器**发请求：
  - `GET /api/decks` 找出所有有到期卡片、且未被暂停的叶子牌组（无子牌组的节点）+ 类别组合（类别键名 `listening`/`reading`/`creating`，读取 `routes/decks.py` 的 `VALID_CATEGORIES`/`_leaf_pairs`/`_attach_counts` 确认）
  - 逐个（串行）调用 `GET /api/story/{deck_id}/{category}` 触发生成（已有今天缓存的故事会秒回；新闻/简报模式无缓存时可能耗时数分钟，超时设为 15 分钟）
  - 生成成功后调用 `POST /api/preload-session/{deck_id}/{category}` 预热 TTS 音频缓存
  - 支持 `BASE_URL`（默认 `http://127.0.0.1:8000`）、`AUTH_USERNAME`/`AUTH_PASSWORD`（HTTP Basic，配合认证相关议题）
  - 单项失败打印错误继续下一项，不中断整体；结尾打印成功/失败/跳过（已暂停）汇总；有失败时退出码为 1
- 新增 `scripts/README.md`：脚本说明、环境变量表、macOS launchd plist 完整示例（每天 06:00，说明放 `~/Library/LaunchAgents` 及 `launchctl load`/`start`/`unload` 命令）、Linux cron 行示例（配合 systemd 常驻服务，见 issue #417）

未改动 `DEPLOY.md`（另一议题正在写，避免冲突）。

## 侦察确认的事实（避免猜测）
- 叶子牌组：`children` 为空数组的节点；`category` 字段即分类键，固定为 `listening`/`reading`/`creating`
- 到期数量字段：`counts = {new, learning, review, learning_future}`
- 暂停标记：叶子节点上的 `all_suspended`（bool），来自 `routes/decks.py:_attach_counts`
- `GET /api/story/{deck_id}/{category}`（不带 `background=true`）：无缓存故事时**同步阻塞生成**并返回故事字典；无到期卡片或 `DISABLE_AI=1` 时返回 `None`；生成异常时返回 `{"error": true, "reason": ...}`
- `POST /api/preload-session/{deck_id}/{category}`（不带 `quick=true`）：读取当天已生成的故事，逐句预热 TTS 音频

## 测试方法
本地用临时端口 + `DB_PATH` 指向临时数据库文件（未占用 8000/`data/dev.db`/`data/srs.db`）验证：

1. **空库**：`DISABLE_AI=1` 启动开发服务器，运行脚本 → 立即打印"没有找到任何有到期卡片的（牌组, 类别）"，退出码 0
2. **有到期卡片**：手动插入一个牌组 + 一个新卡片（`listening` 分类），运行脚本 → 正确发现该 (牌组, 类别)，调用 `/api/story`；因 `DISABLE_AI=1` 返回 `None`，脚本打印失败详情、退出码 1（符合"AI 已禁用/无到期卡片"的预期分支）
3. **暂停跳过**：对该分类调用 `toggle-suspension` 后重新运行脚本 → 打印"跳过 已暂停"，跳过计数 = 1，退出码 0

实际运行输出摘录：
```
[2026-07-05 23:07:40] 早晨预生成开始  BASE_URL=http://127.0.0.1:8765
[2026-07-05 23:07:40] 共 1 个（牌组, 类别）待处理:
[2026-07-05 23:07:40]   - 'TestDeck' / listening (deck_id=2)
[2026-07-05 23:07:40] 处理中 牌组='TestDeck' 类别=listening (deck_id=2)…
[2026-07-05 23:07:40]   ✗ 牌组='TestDeck' 类别=listening 没有返回故事（可能没有到期卡片或 AI 已禁用）
[2026-07-05 23:07:40] ---- 汇总 ----
[2026-07-05 23:07:40] 成功: 0  失败: 1  跳过(已暂停): 0  总计处理: 1
```
```
[2026-07-05 23:07:51] 早晨预生成开始  BASE_URL=http://127.0.0.1:8765
[2026-07-05 23:07:51] 跳过 已暂停  牌组='TestDeck' 类别=listening
[2026-07-05 23:07:51] 没有找到任何有到期卡片的（牌组, 类别）（跳过已暂停 1 个），无需生成，退出。
```

测试完毕已杀掉临时服务器进程，删除临时数据库文件。另外 `python -m py_compile scripts/morning_pregen.py` 通过。

Closes #420