### PR TITLE
docs: 核心规则 R3 更新——CI 通过后由 Claude 自行合并

### DIFF
--- a/.claude/rules.txt
+++ b/.claude/rules.txt
@@ -7,5 +7,5 @@ LANGUAGE (every message, no exceptions):
 
 GIT:
 - R1: Never push directly to `main`. All work via PR.
-- R3: Never merge PRs. Daniel merges on GitHub. Claude does everything else.
+- R3: Claude merges PRs himself after CI passes (authorized by Daniel 2026-07-05). Never merge with failing CI.
 - COMMIT: Commit after every complete, atomic change (a bug fix, a feature unit, a refactor). Not after every single line — not after all work is done. If the code still runs and the change is meaningful, commit it.


### PR DESCRIPTION
## 变更内容
每条消息注入的核心规则（.claude/rules.txt）中 R3 与 CLAUDE.md 矛盾：CLAUDE.md 写「Claude 自行合并」，rules.txt 写「绝不合并」。Daniel 今天明确确认由 Claude 自行合并，本 PR 让 rules.txt 与 CLAUDE.md 一致。

## 测试方法
纯文本改动，CI 照常通过即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)