### PR TITLE
feat: 多语言基础——decks/entries 增加 lang 列 + languages.py 语言注册表

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,6 +381,7 @@ echo "✓ 议题创建完成"
 ```
 ├── CLAUDE.md              # 本文件
 ├── main.py                # CLI入口 + FastAPI应用
+├── languages.py           # 语言注册表（每种语言的 TTS 语音/翻译源/分词方式/AI 提示词参数/功能开关）
 ├── database/              # 所有数据库访问（其他文件不写原始SQL）
 │   ├── __init__.py        # 重新导出所有函数（import database 仍然有效）
 │   ├── core.py            # 连接管理、迁移
@@ -426,6 +427,16 @@ echo "✓ 议题创建完成"
 └── imports/
     └── Kouyu/             # YAML词汇文件（唯一导入来源）
 ```
+
+## 多语言支持（duō yǔyán - multi-language）
+
+系统支持在同一个软件、同一个数据库里学习多种语言（2026-07-06 起，议题 #428–#431）。当前语言：中文（zh，默认）+ 法语（fr，CEFR B1，释义以德语为主）。
+
+- **`languages.py` 是语言注册表**：每种语言定义 TTS 语音、翻译源、分词方式（jieba/空格）、AI 提示词参数（学习者水平、背景词汇上限、句长限制）、功能开关（拼音/汉字/量词仅中文）。加新语言 = 在注册表加一个条目
+- **`decks.lang` / `entries.lang`**（TEXT，默认 `'zh'`）：牌组和词条的目标语言；子牌组在创建时继承父牌组的 lang
+- **字段重新解释**：`word_zh` 对所有语言存"目标语言词形"（_zh 后缀是历史遗留）；法语词条的 pinyin/hsk_level/characters 留空
+- **已知限制**：`UNIQUE(word_zh)` 是全局约束而非按语言——只要各语言文字系统不同（中文 vs 法语）就不冲突；将来加第二种拉丁字母语言时需改为 `UNIQUE(word_zh, lang)`（需要重建表）
+- **中文专属功能**：汉字分解、量词、拼音、news/kahneman/paste/briefing 故事模式——法语牌组不提供
 
 ## 数据来源（láiyuán - source）
 

--- a/database/core.py
+++ b/database/core.py
@@ -119,6 +119,8 @@ def init_db() -> None:
         conn.execute("ALTER TABLE entries ADD COLUMN definition_fr TEXT")
     if "source_sentence" not in cols:
         conn.execute("ALTER TABLE entries ADD COLUMN source_sentence TEXT")
+    if "lang" not in cols:
+        conn.execute("ALTER TABLE entries ADD COLUMN lang TEXT NOT NULL DEFAULT 'zh'")
     if "grammar_notes" not in cols:
         conn.execute("ALTER TABLE entries ADD COLUMN grammar_notes TEXT")
 
@@ -208,6 +210,8 @@ def init_db() -> None:
         conn.execute("ALTER TABLE decks ADD COLUMN new_review_order_override TEXT")
     if "bury_quick_mode" not in deck_cols:
         conn.execute("ALTER TABLE decks ADD COLUMN bury_quick_mode TEXT NOT NULL DEFAULT 'all'")
+    if "lang" not in deck_cols:
+        conn.execute("ALTER TABLE decks ADD COLUMN lang TEXT NOT NULL DEFAULT 'zh'")
     card_cols = {r["name"] for r in conn.execute("PRAGMA table_info(cards)").fetchall()}
     if "deleted_at" not in card_cols:
         conn.execute("ALTER TABLE cards ADD COLUMN deleted_at TEXT")

--- a/database/decks.py
+++ b/database/decks.py
@@ -9,12 +9,23 @@ from .core import anki_today, get_db, _ensure_default_preset
 # Decks
 # ---------------------------------------------------------------------------
 
+def _resolve_deck_lang(conn, parent_id: int | None, lang: str | None) -> str:
+    """Deck language: explicit value wins, else inherit from parent, else 'zh'."""
+    if lang:
+        return lang
+    if parent_id is not None:
+        row = conn.execute("SELECT lang FROM decks WHERE id = ?", (parent_id,)).fetchone()
+        if row and row["lang"]:
+            return row["lang"]
+    return "zh"
+
+
 def insert_deck(name: str, parent_id: int | None, preset_id: int,
-                category: str | None = None) -> int:
+                category: str | None = None, lang: str | None = None) -> int:
     conn = get_db()
     cur = conn.execute(
-        "INSERT INTO decks (name, parent_id, preset_id, category) VALUES (?, ?, ?, ?)",
-        (name, parent_id, preset_id, category),
+        "INSERT INTO decks (name, parent_id, preset_id, category, lang) VALUES (?, ?, ?, ?, ?)",
+        (name, parent_id, preset_id, category, _resolve_deck_lang(conn, parent_id, lang)),
     )
     conn.commit()
     deck_id = cur.lastrowid
@@ -27,6 +38,14 @@ def get_deck(deck_id: int) -> dict | None:
     row = conn.execute("SELECT * FROM decks WHERE id = ?", (deck_id,)).fetchone()
     conn.close()
     return dict(row) if row else None
+
+
+def get_deck_lang(deck_id: int) -> str:
+    """Language of a deck; falls back to 'zh' for missing decks/legacy rows."""
+    conn = get_db()
+    row = conn.execute("SELECT lang FROM decks WHERE id = ?", (deck_id,)).fetchone()
+    conn.close()
+    return row["lang"] if row and row["lang"] else "zh"
 
 
 def get_all_decks() -> list[dict]:
@@ -182,7 +201,7 @@ def purge_old_trash(days: int = 30) -> int:
 
 
 def get_or_create_deck(name: str, parent_id: int | None = None,
-                       category: str | None = None) -> int:
+                       category: str | None = None, lang: str | None = None) -> int:
     """Get deck id by (name, parent_id), creating it if it doesn't exist."""
     conn = get_db()
     row = conn.execute(
@@ -194,8 +213,8 @@ def get_or_create_deck(name: str, parent_id: int | None = None,
         return row["id"]
     preset_id = _ensure_default_preset(conn)
     cur = conn.execute(
-        "INSERT INTO decks (name, parent_id, preset_id, category) VALUES (?, ?, ?, ?)",
-        (name, parent_id, preset_id, category),
+        "INSERT INTO decks (name, parent_id, preset_id, category, lang) VALUES (?, ?, ?, ?, ?)",
+        (name, parent_id, preset_id, category, _resolve_deck_lang(conn, parent_id, lang)),
     )
     conn.commit()
     deck_id = cur.lastrowid

--- a/database/entries.py
+++ b/database/entries.py
@@ -12,14 +12,15 @@ def insert_word(word: dict) -> int:
     conn = get_db()
     conn.execute(
         """INSERT OR IGNORE INTO entries
-           (word_zh, pinyin, definition, pos, hsk_level,
+           (word_zh, lang, pinyin, definition, pos, hsk_level,
             traditional, definition_zh, source, note_type,
             notes, date_yaml, source_sentence, grammar_notes, register, definition_de, definition_fr)
-           VALUES (:word_zh, :pinyin, :definition, :pos, :hsk_level,
+           VALUES (:word_zh, :lang, :pinyin, :definition, :pos, :hsk_level,
                    :traditional, :definition_zh, :source, :note_type,
                    :notes, :date_yaml, :source_sentence, :grammar_notes, :register, :definition_de, :definition_fr)""",
         {
             **word,
+            "lang":            word.get("lang") or "zh",
             "pinyin":          word.get("pinyin"),
             "definition":      word.get("definition"),
             "pos":             word.get("pos"),

--- a/languages.py
+++ b/languages.py
@@ -1,0 +1,78 @@
+"""
+Language registry — the single source of truth for per-language behavior.
+
+Every language the app supports gets one entry here. Adding a new language
+means adding one dict entry (plus an importer YAML format if it needs one) —
+no other module should hard-code language-specific values.
+
+Consumers (wired up across PRs #428–#431):
+  - tts.py             → tts_voice / say_voice
+  - translator.py      → translator_source
+  - routes/story.py    → tokenizer (jieba vs. whitespace)
+  - ai.py              → prompt fragments (language_name, learner_level,
+                          background_vocab, sentence_limit)
+  - static/app.js      → features (which UI elements to show per deck)
+"""
+
+DEFAULT_LANG = "zh"
+
+LANGUAGES = {
+    "zh": {
+        "code": "zh",
+        "name_en": "Mandarin Chinese",     # language name used inside AI prompts
+        "name_native": "中文",
+        # ── TTS ──
+        "tts_voice": "zh-CN-XiaoxiaoNeural",   # edge-tts voice
+        "say_voice": "Tingting",               # macOS `say` fallback voice
+        # ── Translation (deep-translator source code) ──
+        "translator_source": "zh-CN",
+        # ── Story tokenization for click-to-lookup: 'jieba' | 'whitespace' ──
+        "tokenizer": "jieba",
+        # ── AI prompt fragments ──
+        "level_system": "HSK",
+        "learner_level": "HSK 4-5",            # the learner's level
+        "background_vocab": "HSK 1-2",         # default level cap for non-target words
+        "sentence_limit": "15 Chinese characters",
+        # ── Language-specific features (drive schema usage + frontend UI) ──
+        "features": {
+            "pinyin": True,
+            "characters": True,        # per-character breakdown (汉字)
+            "measure_words": True,     # 量词
+            "traditional": True,
+            # news/kahneman/paste/briefing story modes are zh-only for now
+            "extended_story_modes": True,
+        },
+    },
+    "fr": {
+        "code": "fr",
+        "name_en": "French",
+        "name_native": "français",
+        "tts_voice": "fr-FR-DeniseNeural",
+        "say_voice": "Thomas",
+        "translator_source": "fr",
+        "tokenizer": "whitespace",
+        "level_system": "CEFR",
+        "learner_level": "CEFR B1",            # Daniel's French level (2026-07-06)
+        "background_vocab": "CEFR A1-A2",
+        "sentence_limit": "12 words",
+        "features": {
+            "pinyin": False,
+            "characters": False,
+            "measure_words": False,
+            "traditional": False,
+            "extended_story_modes": False,
+        },
+    },
+}
+
+
+def get_lang_config(lang: str | None) -> dict:
+    """Return the config for `lang`, falling back to the default language.
+
+    Unknown/legacy values fall back to zh so old rows can never crash the app.
+    """
+    return LANGUAGES.get(lang or DEFAULT_LANG, LANGUAGES[DEFAULT_LANG])
+
+
+def is_valid_lang(lang: str | None) -> bool:
+    return lang in LANGUAGES

--- a/routes/decks.py
+++ b/routes/decks.py
@@ -1,6 +1,7 @@
 import logging
 
 import database
+import languages
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from .utils import queue_mgr
@@ -110,7 +111,10 @@ def get_decks(unfinished_scope: str = "unfinished"):
 
 
 @router.post("/api/decks")
-def create_deck(name: str, parent_id: int | None = None, category: str | None = None):
+def create_deck(name: str, parent_id: int | None = None, category: str | None = None,
+                lang: str | None = None):
+    if lang is not None and not languages.is_valid_lang(lang):
+        raise HTTPException(400, f"unknown lang: {lang!r}")
     # Support Anki-style 'Parent::Child' hierarchy in name
     if "::" in name:
         deck_id = database.get_or_create_deck_path(name)
@@ -118,7 +122,8 @@ def create_deck(name: str, parent_id: int | None = None, category: str | None = 
     if parent_id is None:
         parent_id = database.get_all_deck_id()
     preset_id = database.get_preset_for_deck(parent_id)["id"]
-    deck_id = database.insert_deck(name, parent_id, preset_id, category)
+    # lang=None inherits the parent deck's language (database._resolve_deck_lang)
+    deck_id = database.insert_deck(name, parent_id, preset_id, category, lang=lang)
     return database.get_deck(deck_id)
 
 

--- a/schema.sql
+++ b/schema.sql
@@ -1,4 +1,4 @@
--- Chinese SRS Database Schema
+-- SRS Database Schema (multi-language; Chinese-specific tables are unused for other languages)
 
 PRAGMA foreign_keys = ON;
 
@@ -136,6 +136,9 @@ CREATE TABLE IF NOT EXISTS decks (
     preset_id   INTEGER NOT NULL REFERENCES deck_presets(id),
     -- NULL for parent decks; set for category leaf decks
     category    TEXT CHECK(category IN ('listening', 'reading', 'creating')),
+    -- target language of this deck's content (see languages.py registry);
+    -- child decks inherit the parent's lang at creation time
+    lang        TEXT NOT NULL DEFAULT 'zh',
     -- soft delete: set when moved to trash, hard-deleted after 30 days
     deleted_at  TEXT,
     UNIQUE(name, parent_id)
@@ -146,7 +149,12 @@ CREATE TABLE IF NOT EXISTS decks (
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS entries (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    -- word_zh holds the target-language headword for ALL languages (the _zh
+    -- suffix is historical). Known limitation: UNIQUE(word_zh) is global, not
+    -- per-lang — fine while languages use different scripts (zh vs fr).
     word_zh         TEXT NOT NULL UNIQUE,
+    -- target language of this entry (see languages.py registry)
+    lang            TEXT NOT NULL DEFAULT 'zh',
     pinyin          TEXT,
     definition      TEXT,           -- English definition
     pos             TEXT,           -- part of speech


### PR DESCRIPTION
## 变更内容
- 新建 `languages.py` 语言注册表（zh + fr）：TTS 语音、翻译源、分词方式、AI 提示词参数（法语 CEFR B1、释义德语为主——Daniel 2026-07-06 确认）、功能开关
- 迁移：`decks.lang` / `entries.lang`（TEXT NOT NULL DEFAULT 'zh'，纯追加式 ALTER TABLE）
- 子牌组创建时继承父牌组语言；`POST /api/decks` 接受可选 `lang`（未知语言 400）；`GET /api/decks` 树自动返回 lang
- `insert_word` 贯通 `entries.lang`
- CLAUDE.md 新增"多语言支持"章节（架构决定 + UNIQUE(word_zh) 已知限制）

## 测试方法
在**生产数据库副本**上验证（scratchpad，非 8000 端口/dev.db）：
- 迁移后 2935 个现有词条全部 lang='zh'，行为不变
- fr 父牌组 → 子牌组/叶子牌组全部继承 fr；默认创建仍为 zh
- TestClient：POST /api/decks lang=fr → 200 且返回 lang；lang=es → 400；GET /api/decks 树带 lang
- pytest 套件：main 上 38 个既有失败（与本 PR 无关，测试早已脱节），本分支 37 个，无新增失败

## 部署说明
合并即自动上线（deploy.sh）——迁移为追加式，服务器数据库无风险。

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)