### PR TITLE
feat: 后端管线按语言参数化——TTS 语音、翻译源、分词、AI 故事提示词

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -19,6 +19,7 @@ import anthropic
 import openai
 
 import database
+import languages
 
 logger = logging.getLogger(__name__)
 
@@ -143,17 +144,19 @@ def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2
                    progress_key: str | None = None,
                    grammar_focus: str | None = None,
                    grammar_pct: int = 75,
-                   mode: str = "story") -> tuple[list[dict], str]:
+                   mode: str = "story",
+                   lang: str = "zh") -> tuple[list[dict], str]:
     """
-    Generate Mandarin sentences covering all target vocab words.
+    Generate sentences (in `lang`) covering all target vocab words.
 
     cards:         list of dicts with keys word_id, word_zh, pinyin, definition, pos
     topic:         optional theme/question/topic to guide the content
-    max_hsk:       maximum HSK level for non-target background vocabulary (1-6)
+    max_hsk:       maximum HSK level for non-target background vocabulary (1-6, zh only)
     model:         model ID to use for generation
-    grammar_focus: optional grammar pattern to encourage (e.g. "把字句")
+    grammar_focus: optional grammar pattern to encourage (e.g. "把字句", zh only)
     grammar_pct:   approximate percentage of sentences that should use the grammar (0-100)
     mode:          "story" | "qa" | "expository"
+    lang:          "zh" | "fr" — determines prompt language, level system, and matching rules
     Returns: (sentences, prompt_text)
       sentences: list of {word_ids: [int, ...], sentence_zh, sentence_en, sentence_de, sentence_fr}.
                  Multiple cards may share one sentence. Each card's word_id appears in exactly one sentence.
@@ -166,9 +169,25 @@ def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2
     word_id_set = {c["word_id"] for c in cards}
 
     def _is_sentence(word_zh: str) -> bool:
+        if lang != "zh" and word_zh.endswith('.'):
+            return True
         return word_zh.endswith(('。', '！', '？', '!', '?'))
 
+    # French articles to strip from the target word before matching it inside a
+    # generated sentence — the AI may adapt/drop the article to fit the sentence.
+    _FR_ARTICLE_PREFIXES = ("le ", "la ", "les ", "un ", "une ", "des ", "du ", "de la ", "de l'", "l'")
+
     def _word_in_sentence(word_zh: str, sentence_zh: str) -> bool:
+        if lang != "zh":
+            w = word_zh.casefold()
+            s = sentence_zh.casefold()
+            for prefix in _FR_ARTICLE_PREFIXES:
+                if w.startswith(prefix):
+                    w = w[len(prefix):]
+                    break
+            # Word-boundary match so short words don't match inside longer ones
+            # (e.g. "art" inside "partir"); tolerate a plural suffix.
+            return re.search(rf"(?<!\w){re.escape(w)}(?:s|es)?(?!\w)", s) is not None
         if '...' in word_zh or '…' in word_zh:
             chars = [c for c in word_zh if c not in '.…']
             return all(c in sentence_zh for c in chars)
@@ -191,18 +210,21 @@ def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2
     else:
         grammar_first = ""
 
-    if mode == "qa":
-        task_line = f"Answer the following question in Mandarin Chinese, one sentence at a time, to help an HSK 4-5 learner review vocabulary.\nQuestion: {topic or 'Describe something interesting.'}"
-        style_rule = "- The sentences together should form a coherent, informative answer to the question above\n- Do NOT use fictional characters or narrative story structure"
-    elif mode == "expository":
-        task_line = f"Write a short informative text in Mandarin Chinese about the following topic, to help an HSK 4-5 learner review vocabulary.\nTopic: {topic or 'an interesting subject'}"
-        style_rule = "- The sentences together should form a coherent, factual explanation of the topic above\n- Do NOT use fictional characters or narrative story structure"
-    else:
-        task_line = "Write a short Mandarin Chinese story to help an HSK 4-5 learner review vocabulary."
-        topic_clause = f"- The story should be set around this topic or theme: {topic}\n" if topic else ""
-        style_rule = f"{topic_clause}- The sentences must form a coherent narrative with the same recurring characters"
+    if lang == "zh":
+        # zh prompt kept EXACTLY as before the multi-language pipeline — no template
+        # sharing with non-zh so this path can never drift when other languages change.
+        if mode == "qa":
+            task_line = f"Answer the following question in Mandarin Chinese, one sentence at a time, to help an HSK 4-5 learner review vocabulary.\nQuestion: {topic or 'Describe something interesting.'}"
+            style_rule = "- The sentences together should form a coherent, informative answer to the question above\n- Do NOT use fictional characters or narrative story structure"
+        elif mode == "expository":
+            task_line = f"Write a short informative text in Mandarin Chinese about the following topic, to help an HSK 4-5 learner review vocabulary.\nTopic: {topic or 'an interesting subject'}"
+            style_rule = "- The sentences together should form a coherent, factual explanation of the topic above\n- Do NOT use fictional characters or narrative story structure"
+        else:
+            task_line = "Write a short Mandarin Chinese story to help an HSK 4-5 learner review vocabulary."
+            topic_clause = f"- The story should be set around this topic or theme: {topic}\n" if topic else ""
+            style_rule = f"{topic_clause}- The sentences must form a coherent narrative with the same recurring characters"
 
-    prompt = f"""{task_line}
+        prompt = f"""{task_line}
 
 {grammar_first}Target words (each must appear verbatim in at least one sentence):
 {word_list}
@@ -219,6 +241,42 @@ Rules:
 - NEVER use markdown formatting (**bold**, _italic_, etc.) anywhere in the output — write plain text only
 
 Return ONLY a numbered list of Chinese sentences, no explanation:
+1. ...
+2. ..."""
+    else:
+        cfg = languages.get_lang_config(lang)
+        lang_name = cfg["name_en"]
+        learner = cfg["learner_level"]
+
+        if mode == "qa":
+            task_line = f"Answer the following question in {lang_name}, one sentence at a time, to help a {learner} learner review vocabulary.\nQuestion: {topic or 'Describe something interesting.'}"
+            style_rule = "- The sentences together should form a coherent, informative answer to the question above\n- Do NOT use fictional characters or narrative story structure"
+        elif mode == "expository":
+            task_line = f"Write a short informative text in {lang_name} about the following topic, to help a {learner} learner review vocabulary.\nTopic: {topic or 'an interesting subject'}"
+            style_rule = "- The sentences together should form a coherent, factual explanation of the topic above\n- Do NOT use fictional characters or narrative story structure"
+        else:
+            task_line = f"Write a short {lang_name} story to help a {learner} learner review vocabulary."
+            topic_clause = f"- The story should be set around this topic or theme: {topic}\n" if topic else ""
+            style_rule = f"{topic_clause}- The sentences must form a coherent narrative with the same recurring characters"
+
+        prompt = f"""{task_line}
+
+{grammar_first}Target words (each must appear verbatim in at least one sentence):
+{word_list}
+
+Rules:
+- Each target word MUST appear verbatim in at least one sentence
+- Write the sentences in the same order as the target word list above
+- For items marked [SENTENCE]: use that exact text as the sentence, unchanged
+- Use natural {lang_name} punctuation
+- Use only simple {cfg["background_vocab"]} level vocabulary for non-target words; each sentence must contain exactly ONE target word from the list — do not use other target words from the list in that sentence
+- Keep each sentence short and simple (max {cfg["sentence_limit"]})
+{style_rule}
+- Each target word must appear in exactly the given form; you may adapt or drop its leading article (le/la/les/un/une) to fit the sentence
+- NEVER highlight, quote, or mark target words in any way — no "quotes", no 「brackets」, no （parentheses）, no bold, no underline; write them as plain text embedded naturally in the sentence
+- NEVER use markdown formatting (**bold**, _italic_, etc.) anywhere in the output — write plain text only
+
+Return ONLY a numbered list of {lang_name} sentences, no explanation:
 1. ...
 2. ..."""
 
@@ -282,10 +340,10 @@ Return ONLY a numbered list of Chinese sentences, no explanation:
             missing_ratio = len(missing_ids) / len(cards)
             last_partial = (parsed, missing_ids)
             if missing_ratio < 0.05:
-                _patch_missing(parsed, missing_ids, card_by_id)
+                _patch_missing(parsed, missing_ids, card_by_id, lang=lang)
                 _set_progress(progress_key, phase="translating",
                               msg="Translating sentences…", percent=88)
-                _fill_translations(parsed, progress_key=progress_key)
+                _fill_translations(parsed, progress_key=progress_key, lang=lang)
                 _set_progress(progress_key, phase="ai_done",
                               msg=f"✓ {len(parsed)} sentences (attempt {attempt + 1})", percent=93)
                 return parsed, prompt
@@ -299,7 +357,7 @@ Return ONLY a numbered list of Chinese sentences, no explanation:
                     len(parsed), len(cards), attempt + 1, time.time() - t_start)
         _set_progress(progress_key, phase="translating",
                       msg="Translating sentences…", percent=88)
-        _fill_translations(parsed, progress_key=progress_key)
+        _fill_translations(parsed, progress_key=progress_key, lang=lang)
         logger.info("generate_story: DONE — %.1fs total", time.time() - t_start)
         _set_progress(progress_key, phase="ai_done",
                       msg=f"✓ {len(parsed)} sentences (attempt {attempt + 1})", percent=93)
@@ -308,10 +366,10 @@ Return ONLY a numbered list of Chinese sentences, no explanation:
     if last_partial is not None:
         parsed, missing_ids = last_partial
         if len(missing_ids) / len(cards) < 0.03:
-            _patch_missing(parsed, missing_ids, card_by_id)
+            _patch_missing(parsed, missing_ids, card_by_id, lang=lang)
             _set_progress(progress_key, phase="translating",
                           msg="Translating sentences…", percent=88)
-            _fill_translations(parsed, progress_key=progress_key)
+            _fill_translations(parsed, progress_key=progress_key, lang=lang)
             _set_progress(progress_key, phase="ai_done",
                           msg=f"✓ {len(parsed)} sentences (patched)", percent=93)
             return parsed, prompt
@@ -325,13 +383,16 @@ Return ONLY a numbered list of Chinese sentences, no explanation:
 
 
 def _patch_missing(sentences: list[dict], missing_word_ids: list[int],
-                   card_by_id: dict[int, dict]) -> None:
+                   card_by_id: dict[int, dict], lang: str = "zh") -> None:
     """Append fallback sentences for words the AI failed to include."""
     for wid in missing_word_ids:
         card = card_by_id.get(wid)
         if not card:
             continue
-        fallback_zh = card.get("source_sentence") or f"我学了{card['word_zh']}这个词。"
+        if lang == "zh":
+            fallback_zh = card.get("source_sentence") or f"我学了{card['word_zh']}这个词。"
+        else:
+            fallback_zh = card.get("source_sentence") or f"J'ai appris le mot {card['word_zh']}."
         sentences.append({"word_ids": [wid], "sentence_zh": fallback_zh,
                           "sentence_en": "", "sentence_de": "", "sentence_fr": ""})
 
@@ -610,10 +671,12 @@ Return ONLY valid JSON, no explanation, no markdown:
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-def _fill_translations(sentences: list[dict], progress_key: str | None = None) -> None:
+def _fill_translations(sentences: list[dict], progress_key: str | None = None,
+                       lang: str = "zh") -> None:
     """Translate sentence_zh → sentence_de in-place using Google Translate."""
     try:
         import translator as _t
+        source = languages.get_lang_config(lang)["translator_source"]
         texts = [s.get("sentence_zh", "") for s in sentences]
         total = len(texts)
 
@@ -622,7 +685,7 @@ def _fill_translations(sentences: list[dict], progress_key: str | None = None) -
                           msg=f"Translating… 0/{total}", percent=88)
 
         t0 = time.time()
-        de_results = _t.translate_batch(texts, target="de")
+        de_results = _t.translate_batch(texts, target="de", source=source)
         logger.info("translate DE done in %.1fs (%d sentences)", time.time() - t0, total)
 
         if progress_key and total > 0:
@@ -645,19 +708,20 @@ def _fill_translations(sentences: list[dict], progress_key: str | None = None) -
             s.setdefault("sentence_fr", "")
 
 
-def _fallback_sentences(cards: list[dict]) -> list[dict]:
+def _fallback_sentences(cards: list[dict], lang: str = "zh") -> list[dict]:
     """Minimal sentences used when the AI response cannot be parsed."""
+    fallback = (lambda w: f"我学了{w}这个词。") if lang == "zh" else (lambda w: f"J'ai appris le mot {w}.")
     result = [
         {
             "word_ids": [c["word_id"]],
-            "sentence_zh": f"我学了{c['word_zh']}这个词。",
+            "sentence_zh": fallback(c["word_zh"]),
             "sentence_en": "",
             "sentence_de": "",
             "sentence_fr": "",
         }
         for c in cards
     ]
-    _fill_translations(result)
+    _fill_translations(result, lang=lang)
     return result
 
 

--- a/routes/review.py
+++ b/routes/review.py
@@ -64,7 +64,7 @@ def _spawn_again_regen(card: dict) -> None:
             logger.info("again-regen  word=%s mode=%s → new sentence stored",
                         card.get("word_zh"), (gen_params or {}).get("mode", "story"))
             try:
-                tts.preload(sentence.get("sentence_zh", ""))
+                tts.preload(sentence.get("sentence_zh", ""), lang=database.get_deck_lang(card["deck_id"]))
             except Exception:
                 pass
         except Exception as e:

--- a/routes/story.py
+++ b/routes/story.py
@@ -3,6 +3,7 @@ import logging
 import math
 import os
 import random
+import re
 import threading
 
 import jieba
@@ -54,17 +55,24 @@ def _attach_part(chapter: dict) -> dict:
 jieba.setLogLevel(logging.ERROR)
 
 
-def _add_tokens(sentences: list[dict]) -> list[dict]:
+def _add_tokens(sentences: list[dict], lang: str = "zh") -> list[dict]:
     """Ensure every sentence has tokens in [[text, word_id_or_null], ...] format.
 
     New stories already have AI-provided tokens stored in the DB.
-    Old stories without tokens fall back to jieba segmentation (word_id=null for all).
+    Old stories without tokens fall back to segmentation (word_id=null for all):
+    jieba for zh, whitespace-preserving split for other languages (so the
+    frontend can rejoin tokens back into the exact original string).
     """
     for s in sentences:
         if s.get("tokens"):
             continue
         zh = s.get("sentence_zh") or ""
-        s["tokens"] = [[tok, None] for tok in jieba.lcut(zh)] if zh else []
+        if not zh:
+            s["tokens"] = []
+        elif lang == "zh":
+            s["tokens"] = [[tok, None] for tok in jieba.lcut(zh)]
+        else:
+            s["tokens"] = [[tok, None] for tok in re.findall(r"\s+|\S+", zh)]
     return sentences
 
 logger = logging.getLogger(__name__)
@@ -120,12 +128,12 @@ CHUNK_SIZE = 70
 
 
 def _generate_story_sentences(cards: list, *, topic, max_hsk, model, progress_key,
-                               grammar_focus, grammar_pct, mode) -> tuple[list, str]:
+                               grammar_focus, grammar_pct, mode, lang: str = "zh") -> tuple[list, str]:
     """Generate story sentences, splitting into chunks of CHUNK_SIZE when cards > CHUNK_SIZE."""
     if len(cards) <= CHUNK_SIZE:
         return ai.generate_story(cards, topic=topic, max_hsk=max_hsk, model=model,
                                  progress_key=progress_key, grammar_focus=grammar_focus,
-                                 grammar_pct=grammar_pct, mode=mode)
+                                 grammar_pct=grammar_pct, mode=mode, lang=lang)
 
     chunks = [cards[i:i + CHUNK_SIZE] for i in range(0, len(cards), CHUNK_SIZE)]
     logger.info("story  CHUNKED %d cards → %d chunks of ≤%d", len(cards), len(chunks), CHUNK_SIZE)
@@ -138,7 +146,7 @@ def _generate_story_sentences(cards: list, *, topic, max_hsk, model, progress_ke
         chunk_sentences, chunk_prompt = ai.generate_story(
             chunk, topic=topic, max_hsk=max_hsk, model=model,
             progress_key=None,  # suppress per-chunk progress spam
-            grammar_focus=grammar_focus, grammar_pct=grammar_pct, mode=mode,
+            grammar_focus=grammar_focus, grammar_pct=grammar_pct, mode=mode, lang=lang,
         )
         all_sentences.extend(chunk_sentences)
         if idx == 0:
@@ -178,9 +186,12 @@ def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
     """
     if not cards:
         return None
+    lang = database.get_deck_lang(deck_id)
     ai.fix_definition_commas(cards)
     ai._story_progress[progress_key] = {"phase": "starting", "msg": "Starting…", "percent": 5}
     try:
+        if lang != "zh" and mode in ("kahneman", "news", "paste", "briefing"):
+            raise ValueError(f"mode '{mode}' is only available for Chinese decks")
         if mode == "kahneman":
             parsed_chapter_ids = [int(x) for x in chapter_ids.split(",") if x.strip()] if chapter_ids else []
             sentences, prompt_text = _generate_kahneman_story_sentences(
@@ -205,13 +216,13 @@ def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
             sentences, prompt_text = _generate_story_sentences(
                 cards, topic=topic, max_hsk=max_hsk, model=model,
                 progress_key=progress_key, grammar_focus=grammar_focus,
-                grammar_pct=grammar_pct, mode=mode)
+                grammar_pct=grammar_pct, mode=mode, lang=lang)
         for i, s in enumerate(sentences):
             s["position"] = i
         gen_params = _gen_params_dict(
             topic=topic, max_hsk=max_hsk, model=model,
             grammar_focus=grammar_focus, grammar_pct=grammar_pct,
-            mode=mode, chapter_ids=chapter_ids, articles=articles)
+            mode=mode, chapter_ids=chapter_ids, articles=articles, lang=lang)
         database.create_story(today, category, deck_id, sentences, prompt_text, topic, gen_params)
         story = database.get_active_story(today, category, deck_id)
     except Exception as e:
@@ -223,7 +234,7 @@ def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
             "has_history": database.has_story_history(deck_id, category),
         }
     if story:
-        story["sentences"] = _add_tokens(database.get_story_sentences(story["id"]))
+        story["sentences"] = _add_tokens(database.get_story_sentences(story["id"]), lang=lang)
         logger.info("story  SAVED   deck=%d cat=%s sentences=%d",
                     deck_id, category, len(story["sentences"]))
         _log_story(story)
@@ -263,7 +274,7 @@ def _start_background_generation(deck_id: int, category: str, today: str, cards:
 
 
 def _gen_params_dict(*, topic, max_hsk, model, grammar_focus, grammar_pct,
-                     mode, chapter_ids, articles=None) -> dict:
+                     mode, chapter_ids, articles=None, lang="zh") -> dict:
     """Bundle the story generation settings persisted on each story row, so the
     Again regeneration can reproduce the same style (see generate_sentence_for_word).
 
@@ -279,6 +290,7 @@ def _gen_params_dict(*, topic, max_hsk, model, grammar_focus, grammar_pct,
         "grammar_pct": grammar_pct,
         "chapter_ids": chapter_ids,
         "articles": articles,
+        "lang": lang,
     }
 
 
@@ -318,13 +330,14 @@ def generate_sentence_for_word(card: dict, gen_params: dict | None) -> dict | No
     gp = gen_params or {}
     mode = gp.get("mode") or "story"
     model = _validated_model(gp.get("model"))
+    lang = gp.get("lang") or database.get_deck_lang(card["deck_id"])
     try:
         if mode == "kahneman":
             chapter = _pick_kahneman_chapter(gp.get("chapter_ids"))
             if chapter is not None:
                 sentences = ai.generate_kahneman_sentences([card], chapter, model=model)
             else:  # book data missing → fall back to a plain sentence
-                sentences, _ = ai.generate_story([card], model=model)
+                sentences, _ = ai.generate_story([card], model=model, lang=lang)
         elif mode in ("news", "paste", "briefing"):
             # Briefing Again-regen reuses the single-sentence news path: one word
             # gets one fresh sentence from the same articles (no context chain).
@@ -333,18 +346,18 @@ def generate_sentence_for_word(card: dict, gen_params: dict | None) -> dict | No
                 sentences = ai.generate_news_sentences(
                     [card], articles, model=model, generic=(mode == "paste"))
             else:  # no articles context saved → fall back to a plain sentence
-                sentences, _ = ai.generate_story([card], model=model)
+                sentences, _ = ai.generate_story([card], model=model, lang=lang)
         else:
             sentences, _ = ai.generate_story(
                 [card], topic=gp.get("topic"), max_hsk=gp.get("max_hsk", 2),
                 model=model, grammar_focus=gp.get("grammar_focus"),
-                grammar_pct=gp.get("grammar_pct", 75), mode=mode)
+                grammar_pct=gp.get("grammar_pct", 75), mode=mode, lang=lang)
     except Exception as e:
         logger.warning("again-regen  generation error for word=%s: %s", card.get("word_zh"), e)
         return None
     if not sentences:
         return None
-    _add_tokens(sentences)
+    _add_tokens(sentences, lang=lang)
     return sentences[0]
 
 
@@ -369,11 +382,12 @@ def get_story(deck_id: int, category: str,
     """
     today = database.anki_today().isoformat()
     progress_key = f"{deck_id}/{category}"
+    lang = database.get_deck_lang(deck_id)
 
     # Always return today's cached story — custom params only apply when generating a new one
     story = database.get_active_story(today, category, deck_id)
     if story:
-        story["sentences"] = _add_tokens(database.get_story_sentences(story["id"]))
+        story["sentences"] = _add_tokens(database.get_story_sentences(story["id"]), lang=lang)
         logger.info("story  CACHED  deck=%d cat=%s sentences=%d story_id=%d",
                     deck_id, category, len(story["sentences"]), story["id"])
         _log_story(story)
@@ -477,7 +491,8 @@ def get_history_story(deck_id: int, category: str):
     """Return the most recent story for this deck+category, regardless of date."""
     story = database.get_latest_story(deck_id, category)
     if story:
-        story["sentences"] = _add_tokens(database.get_story_sentences(story["id"]))
+        story["sentences"] = _add_tokens(database.get_story_sentences(story["id"]),
+                                         lang=database.get_deck_lang(deck_id))
     return story
 
 
@@ -491,7 +506,10 @@ def sentence_for_word(word_id: int):
     sentence = database.get_latest_sentence_for_word(word_id)
     if sentence is None:
         return {"sentence": None}
-    _add_tokens([sentence])
+    # No deck_id in this endpoint's path — read lang directly off the entry row.
+    word = database.get_word(word_id)
+    lang = (word or {}).get("lang") or "zh"
+    _add_tokens([sentence], lang=lang)
     return {"sentence": sentence}
 
 
@@ -677,18 +695,18 @@ def story_count(deck_id: int, category: str):
 
 
 @router.get("/api/tts-file")
-async def tts_file(text: str):
+async def tts_file(text: str, lang: str = "zh"):
     """Return the cached mp3 for text (generating it if needed). Used by the browser Audio API."""
-    path = await tts.get_cached_path(text)
+    path = await tts.get_cached_path(text, lang=lang)
     return FileResponse(path, media_type="audio/mpeg")
 
 
 # 以下四个端点（speak/speak-multi/speak-status/speak-stop）通过 afplay/say 在服务器端播放音频，
 # 仅本地 macOS 使用，服务器部署不依赖此端点——前端已全部改为浏览器端播放（/api/tts-file + <audio>）。
 @router.post("/api/speak")
-def speak(text: str):
+def speak(text: str, lang: str = "zh"):
     try:
-        tts.speak_sync(text)
+        tts.speak_sync(text, lang=lang)
     except Exception:
         pass
     return {"ok": True}
@@ -697,7 +715,8 @@ def speak(text: str):
 @router.post("/api/speak-multi")
 def speak_multi(body: dict):
     try:
-        tts.speak_multi(body.get("texts", []), start_idx=body.get("start_idx", 0))
+        tts.speak_multi(body.get("texts", []), start_idx=body.get("start_idx", 0),
+                        lang=body.get("lang", "zh"))
     except Exception:
         pass
     return {"ok": True}
@@ -715,9 +734,10 @@ def speak_stop():
 
 
 @router.post("/api/preload")
-def preload(text: str):
+def preload(text: str, body: dict | None = None):
+    lang = (body or {}).get("lang", "zh")
     try:
-        tts.preload(text)
+        tts.preload(text, lang=lang)
     except Exception:
         pass
     return {"ok": True}
@@ -726,24 +746,25 @@ def preload(text: str):
 @router.post("/api/preload-session/{deck_id}/{category}")
 async def preload_session(deck_id: int, category: str, quick: bool = False):
     progress_key = f"{deck_id}/{category}"
+    lang = database.get_deck_lang(deck_id)
     if quick:
         ids = leaf_ids(deck_id, category) or [deck_id]
         cards = database.get_due_cards_multi(ids, category) if len(ids) > 1 else database.get_due_cards(ids[0], category)
         texts = [c["word_zh"] for c in cards if c.get("word_zh")]
         logger.info("tts  quick preloading %d word audio files", len(texts))
         try:
-            await tts.preload_all_async(texts, progress_key=progress_key)
+            await tts.preload_all_async(texts, progress_key=progress_key, lang=lang)
         except Exception as e:
             logger.warning("tts  quick preload error: %s", e)
     else:
         today = database.anki_today().isoformat()
         story = database.get_active_story(today, category, deck_id)
         if story:
-            sentences = _add_tokens(database.get_story_sentences(story["id"]))
+            sentences = _add_tokens(database.get_story_sentences(story["id"]), lang=lang)
             texts = [s["sentence_zh"] for s in sentences if s.get("sentence_zh")]
             logger.info("tts  preloading %d sentences", len(texts))
             try:
-                await tts.preload_all_async(texts, progress_key=progress_key)
+                await tts.preload_all_async(texts, progress_key=progress_key, lang=lang)
                 logger.info("tts  preload done")
             except Exception as e:
                 logger.warning("tts  preload error: %s", e)

--- a/translator.py
+++ b/translator.py
@@ -1,5 +1,8 @@
 """
-Chinese → target language translation using Google Translate (via deep_translator).
+Source language → target language translation using Google Translate (via deep_translator).
+
+The source language is configurable (defaults to Chinese, "zh-CN") so this module
+can also translate other learner languages (e.g. French) into German.
 
 Requires internet access (VPN recommended in China).
 Install: pip install deep-translator
@@ -8,39 +11,40 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-_translators: dict[str, object] = {}
+_translators: dict[tuple[str, str], object] = {}
 
 
-def _load(target: str) -> object | None:
-    if target in _translators:
-        return _translators[target]
+def _load(source: str, target: str) -> object | None:
+    key = (source, target)
+    if key in _translators:
+        return _translators[key]
     try:
         from deep_translator import GoogleTranslator
-        t = GoogleTranslator(source="zh-CN", target=target)
-        _translators[target] = t
-        logger.info("translator: GoogleTranslator loaded (target=%s)", target)
+        t = GoogleTranslator(source=source, target=target)
+        _translators[key] = t
+        logger.info("translator: GoogleTranslator loaded (source=%s, target=%s)", source, target)
         return t
     except Exception as e:
-        logger.error("translator: failed to load (target=%s) — %s", target, e)
-        _translators[target] = None
+        logger.error("translator: failed to load (source=%s, target=%s) — %s", source, target, e)
+        _translators[key] = None
         return None
 
 
-def translate_zh(text: str, target: str = "en") -> str:
-    """Translate a Chinese string to the target language. Returns original on failure."""
-    t = _load(target)
+def translate_zh(text: str, target: str = "en", source: str = "zh-CN") -> str:
+    """Translate a string from `source` to the target language. Returns original on failure."""
+    t = _load(source, target)
     if t is None or not text.strip():
         return text
     try:
         return t.translate(text) or text
     except Exception as e:
-        logger.warning("translator: error (target=%s) — %s", target, e)
+        logger.warning("translator: error (source=%s, target=%s) — %s", source, target, e)
         return text
 
 
-def translate_batch(texts: list[str], target: str = "en") -> list[str]:
-    """Translate a list of Chinese strings in a single HTTP request."""
-    t = _load(target)
+def translate_batch(texts: list[str], target: str = "en", source: str = "zh-CN") -> list[str]:
+    """Translate a list of strings from `source` in a single HTTP request."""
+    t = _load(source, target)
     if t is None:
         return texts
     if not texts:
@@ -55,9 +59,9 @@ def translate_batch(texts: list[str], target: str = "en") -> list[str]:
             return [p.strip() or orig for p, orig in zip(parts, texts)]
         logger.warning("translator: split count mismatch (%d vs %d), falling back", len(parts), len(texts))
     except Exception as e:
-        logger.warning("translator: batch error (target=%s) — %s", target, e)
+        logger.warning("translator: batch error (source=%s, target=%s) — %s", source, target, e)
 
-    return [translate_zh(text, target) for text in texts]
+    return [translate_zh(text, target, source) for text in texts]
 
 
 # Legacy aliases kept for any callers that used the old API

--- a/tts.py
+++ b/tts.py
@@ -24,6 +24,8 @@ import threading
 
 import edge_tts
 
+import languages
+
 # Bypass system proxy (e.g. Shadowrocket in China) for edge-tts WebSocket connections.
 # The VPN tunnel routes traffic at the network level, so direct connections work fine.
 os.environ.setdefault("NO_PROXY", "*")
@@ -41,14 +43,19 @@ _hot: set[str] = set()
 _preload_progress: dict[str, dict] = {}
 
 
-def _cache_path(text: str) -> str:
-    key = hashlib.sha256(text.encode()).hexdigest()
+def _cache_path(text: str, voice: str = VOICE) -> str:
+    # Keep the existing key formula for the zh default voice so the pre-existing
+    # cache stays valid; other voices get a voice-prefixed key to avoid collisions.
+    if voice == VOICE:
+        key = hashlib.sha256(text.encode()).hexdigest()
+    else:
+        key = hashlib.sha256(f"{voice}|{text}".encode()).hexdigest()
     return os.path.join(TTS_CACHE_DIR, f"{key}.mp3")
 
 
-async def _ensure_cached(text: str) -> str:
+async def _ensure_cached(text: str, voice: str = VOICE) -> str:
     """Return path to mp3 for text, generating via edge-tts if not on disk."""
-    path = _cache_path(text)
+    path = _cache_path(text, voice)
     if path in _hot or os.path.exists(path):
         _hot.add(path)
         return path
@@ -56,7 +63,7 @@ async def _ensure_cached(text: str) -> str:
     os.makedirs(TTS_CACHE_DIR, exist_ok=True)
     tmp = path + ".tmp"
     logger.debug("tts  generating %r → %s", text[:30], os.path.basename(path))
-    communicate = edge_tts.Communicate(text, VOICE)
+    communicate = edge_tts.Communicate(text, voice)
     try:
         await communicate.save(tmp)
         if not os.path.exists(tmp):
@@ -77,15 +84,17 @@ _TTS_CONCURRENCY = 12   # max parallel edge-tts connections
 _TTS_TIMEOUT = 20.0     # seconds per sentence before giving up
 
 
-async def preload_all_async(texts: list[str], progress_key: str | None = None) -> None:
+async def preload_all_async(texts: list[str], progress_key: str | None = None,
+                            lang: str = "zh") -> None:
     """Pre-generate audio for all texts with bounded concurrency. Awaitable — blocks until done.
 
     If progress_key is given, updates _preload_progress[progress_key] as each
     sentence finishes so callers can poll for live progress.
     """
+    voice = languages.get_lang_config(lang)["tts_voice"]
     total = len(texts)
-    missing = [t for t in texts if _cache_path(t) not in _hot
-               and not os.path.exists(_cache_path(t))]
+    missing = [t for t in texts if _cache_path(t, voice) not in _hot
+               and not os.path.exists(_cache_path(t, voice))]
     already_cached = total - len(missing)
 
     if progress_key is not None:
@@ -106,7 +115,7 @@ async def preload_all_async(texts: list[str], progress_key: str | None = None) -
         nonlocal done_count
         async with sem:
             try:
-                result = await asyncio.wait_for(_ensure_cached(text), timeout=_TTS_TIMEOUT)
+                result = await asyncio.wait_for(_ensure_cached(text, voice), timeout=_TTS_TIMEOUT)
             except asyncio.TimeoutError:
                 logger.warning("tts  timeout after %.0fs for: %r", _TTS_TIMEOUT, text[:40])
                 if progress_key is not None:
@@ -133,9 +142,10 @@ async def preload_all_async(texts: list[str], progress_key: str | None = None) -
         _preload_progress[progress_key]["done"] = total
 
 
-def preload(text: str) -> None:
+def preload(text: str, lang: str = "zh") -> None:
     """Fire-and-forget single-item preload (background thread)."""
-    threading.Thread(target=lambda: asyncio.run(_ensure_cached(text)),
+    voice = languages.get_lang_config(lang)["tts_voice"]
+    threading.Thread(target=lambda: asyncio.run(_ensure_cached(text, voice)),
                      daemon=True).start()
 
 
@@ -147,9 +157,10 @@ _current_play_idx: int = -1
 _is_multi_playing: bool = False
 
 
-async def get_cached_path(text: str) -> str:
+async def get_cached_path(text: str, lang: str = "zh") -> str:
     """Return local mp3 path for text, generating via edge-tts if not cached."""
-    return await _ensure_cached(text)
+    voice = languages.get_lang_config(lang)["tts_voice"]
+    return await _ensure_cached(text, voice)
 
 
 def get_status() -> dict:
@@ -157,18 +168,18 @@ def get_status() -> dict:
     return {"idx": _current_play_idx, "playing": _is_multi_playing}
 
 
-def speak(text: str) -> None:
+def speak(text: str, lang: str = "zh") -> None:
     """Play audio, killing any ongoing playback first (fire-and-forget)."""
-    threading.Thread(target=lambda: asyncio.run(_play(text)),
+    threading.Thread(target=lambda: asyncio.run(_play(text, lang)),
                      daemon=True).start()
 
 
-def speak_sync(text: str) -> None:
+def speak_sync(text: str, lang: str = "zh") -> None:
     """Play audio and block until playback is complete."""
-    asyncio.run(_play(text))
+    asyncio.run(_play(text, lang))
 
 
-def speak_multi(texts: list[str], start_idx: int = 0) -> None:
+def speak_multi(texts: list[str], start_idx: int = 0, lang: str = "zh") -> None:
     """Play texts[start_idx:] sequentially with minimal gap.
 
     Sets _stop_requested before acquiring _multi_lock so any in-progress
@@ -178,20 +189,20 @@ def speak_multi(texts: list[str], start_idx: int = 0) -> None:
     _stop_requested = True   # interrupt any current playback fast
     with _multi_lock:
         _stop_requested = False  # safe to start now — old loop has exited
-        asyncio.run(_play_multi(texts, start_idx))
+        asyncio.run(_play_multi(texts, start_idx, lang))
 
 
-async def _play_multi(texts: list[str], start_idx: int = 0) -> None:
+async def _play_multi(texts: list[str], start_idx: int = 0, lang: str = "zh") -> None:
     """Pre-cache all sentences in parallel, then play from start_idx."""
     global _stop_requested, _current_play_idx, _is_multi_playing
-    await preload_all_async(texts)
+    await preload_all_async(texts, lang=lang)
     _is_multi_playing = True
     try:
         for i, text in enumerate(texts[start_idx:], start=start_idx):
             if _stop_requested:
                 break
             _current_play_idx = i
-            await _play(text)
+            await _play(text, lang)
     finally:
         _is_multi_playing = False
         _current_play_idx = -1
@@ -210,14 +221,15 @@ def stop() -> None:
 SAY_VOICE = "Tingting"  # macOS built-in zh_CN fallback
 
 
-async def _play(text: str) -> None:
+async def _play(text: str, lang: str = "zh") -> None:
     global _current_playback
+    cfg = languages.get_lang_config(lang)
     try:
-        path = await asyncio.wait_for(_ensure_cached(text), timeout=5.0)
+        path = await asyncio.wait_for(_ensure_cached(text, cfg["tts_voice"]), timeout=5.0)
         cmd = ["afplay", path]
     except Exception:
         logger.warning("tts  edge-tts failed, falling back to macOS say")
-        cmd = ["say", "-v", SAY_VOICE, text]
+        cmd = ["say", "-v", cfg["say_voice"], text]
 
     with _playback_lock:
         if _current_playback and _current_playback.poll() is None:


### PR DESCRIPTION
## 变更内容
由 Sonnet 子代理按详细规格实现，Fable 审查并加固（法语目标词匹配加词边界）：

- **tts.py**：全部公开函数接受 `lang`，按 languages.py 注册表选语音（fr → `fr-FR-DeniseNeural`）。**zh 缓存键保持 `sha256(text)` 不变**——现有音频缓存全部有效；其他语言用 `sha256(voice|text)`
- **translator.py**：翻译源语言可配置（fr → de 直译），缓存按 (source, target)
- **ai.py**：`generate_story(lang=...)`——zh 提示词在独立分支中逐字保留（已验证与改动前 byte 级一致）；法语提示词用 CEFR B1 / A1-A2 背景词汇 / 12 词句长上限；法语词匹配 = casefold + 冠词剥离 + **词边界**（防止 "art" 误匹配 "partir"）+ 容忍复数；法语兜底句 "J'ai appris le mot …"
- **routes/story.py**：分词按语言（zh=jieba，其他=`\s+|\S+` 保留空格切分，tokens 无损拼回原句）；非中文牌组请求 kahneman/news/paste/briefing 时报结构化错误；`gen_params` 持久化 lang（Again 单句重生成沿用同语言）；`/api/tts-file`、`/api/preload`、`/api/preload-session` 等全部支持 lang
- **routes/review.py**：Again 重生成的 TTS 预加载按牌组语言

## 测试方法
离线验证（scratchpad 数据库副本，未碰 8000 端口/生产库）：
- zh 缓存键公式不变；fr 键带语音前缀
- fr 分词往返无损（`''.join(tokens) == 原句`）；zh 仍走 jieba
- 用假 API 响应验证：法语故事两个目标词（含 `l'art` 缩合冠词）全部正确匹配；"partir" 不再误匹配 "art"；漏词走法语兜底句
- zh 提示词标记（Mandarin Chinese/HSK 4-5/HSK 1-2/中文标点行）全部原样
- TestClient 服务器启动 + /api/decks 200

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)