### PR TITLE
feat: 法语 YAML 导入格式（lang 文件头 + 规范化适配器）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,9 +440,19 @@ echo "✓ 议题创建完成"
 
 ## 数据来源（láiyuán - source）
 
-**唯一来源：** `imports/Kouyu/*.yaml` —— 包含词性（cí xìng - part of speech）、例句（lìjù - example sentences）、词源（cí yuán - etymology）、汉字（hànzì - character）分解的丰富YAML文件。
+**唯一来源：** `imports/<Source>/*.yaml`（如 `imports/Kouyu/`、`imports/Francais/`）——文件顶部可选 `lang:` 字段（默认 `zh`），决定该文件导入到哪个语言的牌组/词条。
 
 不导入HSK CSV文件。AI在故事提示词（tíshící - prompt）中被告知"非目标词汇只使用HSK 1–2的词汇"。
+
+### 中文格式（默认，`lang: zh` 或省略）
+包含词性、例句（lìjù - example sentences）、词源（cí yuán - etymology）、汉字（hànzì - character）分解的丰富YAML文件。
+
+### 法语格式（`lang: fr`，issue #430）
+`type: word`（`word:` 字段为带冠词的词形）或 `type: sentence`（`sentence:` 字段），
+配合 `english`/`german`/`note`/`register`，`examples` 用 `fr`/`english`/`german` 三个键。
+导入时经 `importer._normalize_fr_entry` 适配为内部键结构（`word`/`sentence` → `simplified`，
+`examples[].fr` → `examples[].zh`，`examples[].german` → `examples[].de`），复用全部下游逻辑。
+汉字分解、量词、同义反义词、语法结构、`word_analyses` 组件处理**仅中文**（`lang == 'zh'`）执行。
 
 ## 数据库模式（概述）
 

--- a/importer.py
+++ b/importer.py
@@ -6,6 +6,7 @@ import re
 import yaml
 
 import database
+from languages import is_valid_lang
 from yaml_fixer import fix_yaml_content
 
 logger = logging.getLogger(__name__)
@@ -95,13 +96,6 @@ def import_kouyu_yaml(filepath: str) -> dict:
 
 def import_yaml_file(filepath: str, deck_path: list[str]) -> dict:
     """Parse one YAML file. deck_path is the folder hierarchy."""
-    parent_id = None
-    for segment in deck_path:
-        parent_id = database.get_or_create_deck(segment, parent_id=parent_id)
-
-    leaf_parent = deck_path[-1]
-    deck_ids = _make_leaf_decks(leaf_parent, parent_id)
-
     try:
         with open(filepath, "r", encoding="utf-8") as f:
             raw = f.read()
@@ -111,9 +105,21 @@ def import_yaml_file(filepath: str, deck_path: list[str]) -> dict:
         err = _format_yaml_error(e, filename=os.path.basename(filepath))
         return {"imported": 0, "skipped_duplicate": 0, "skipped_invalid": 0, "yaml_error": err}
 
+    lang = data.get("lang", "zh") if isinstance(data, dict) else "zh"
+    if not is_valid_lang(lang):
+        logger.warning("import_yaml_file %s: unknown lang %r, falling back to zh", filepath, lang)
+        lang = "zh"
+
+    parent_id = None
+    for segment in deck_path:
+        parent_id = database.get_or_create_deck(segment, parent_id=parent_id, lang=lang)
+
+    leaf_parent = deck_path[-1]
+    deck_ids = _make_leaf_decks(leaf_parent, parent_id)
+
     entries = _get_entries(data)
     source = deck_path[0].lower()
-    return _import_entries(entries, deck_ids, source, label=os.path.basename(filepath))
+    return _import_entries(entries, deck_ids, source, label=os.path.basename(filepath), lang=lang)
 
 
 def import_yaml_content(content: str, parent_deck_id: int,
@@ -133,6 +139,13 @@ def import_yaml_content(content: str, parent_deck_id: int,
         return {"imported": 0, "skipped_duplicate": 0, "skipped_invalid": 0,
                 "yaml_error": _format_yaml_error(e)}
 
+    lang = data.get("lang") if isinstance(data, dict) else None
+    if lang and not is_valid_lang(lang):
+        logger.warning("import_yaml_content: unknown lang %r, falling back to zh", lang)
+        lang = "zh"
+    if not lang:
+        lang = database.get_deck_lang(parent_deck_id)
+
     parent = database.get_deck(parent_deck_id)
     leaf_parent = parent["name"] if parent else "Upload"
     default_deck_ids = _make_leaf_decks(leaf_parent, parent_deck_id)
@@ -142,7 +155,8 @@ def import_yaml_content(content: str, parent_deck_id: int,
     return _import_entries(entries, default_deck_ids, source, label="<upload>",
                            resolutions=resolutions or {},
                            card_configs=card_configs or {},
-                           custom_fields=custom_fields or {})
+                           custom_fields=custom_fields or {},
+                           lang=lang)
 
 
 def preview_yaml_content(content: str) -> dict:
@@ -165,6 +179,10 @@ def preview_yaml_content(content: str) -> dict:
             "error_detail": _format_yaml_error(e),
         }
 
+    preview_lang = data.get("lang") if isinstance(data, dict) else None
+    if preview_lang and not is_valid_lang(preview_lang):
+        preview_lang = "zh"
+
     entries = _get_entries(data)
     result_entries = []
     conflicts = []
@@ -172,6 +190,9 @@ def preview_yaml_content(content: str) -> dict:
     summary = {"ok": 0, "duplicate": 0, "invalid": 0, "unknown_type": 0}
 
     for entry in entries:
+        if preview_lang and preview_lang != "zh":
+            entry = _normalize_fr_entry(entry)
+
         yaml_type = entry.get("type", "")
         note_type = NOTE_TYPE_MAP.get(yaml_type)
 
@@ -210,10 +231,11 @@ def preview_yaml_content(content: str) -> dict:
             })
             continue
 
-        stripped = _strip_ellipsis(word_zh)
-        if stripped != word_zh:
-            logger.warning("STRIP preview: ellipsis stripped from %r → %r", word_zh, stripped)
-            word_zh = stripped
+        if not preview_lang or preview_lang == "zh":
+            stripped = _strip_ellipsis(word_zh)
+            if stripped != word_zh:
+                logger.warning("STRIP preview: ellipsis stripped from %r → %r", word_zh, stripped)
+                word_zh = stripped
 
         english = entry.get("english", "")
         hsk = str(entry.get("hsk", "") or "")
@@ -309,14 +331,45 @@ def _strip_ellipsis(word_zh: str) -> str:
     return word_zh.strip('.')
 
 
-def _build_word_dict(entry: dict, source: str, note_type: str = "vocabulary") -> dict:
+def _normalize_fr_entry(entry: dict) -> dict:
+    """Reshape a French-format YAML entry into the internal (Chinese-era) key
+    layout so all downstream processing (_build_word_dict, examples, etc.)
+    stays untouched. Non-French language modules (characters, measure words,
+    word_analyses) are simply absent from the French format for now.
+    """
+    normalized = dict(entry)
+    normalized["simplified"] = (
+        entry.get("word") or entry.get("sentence")
+        or entry.get("expression") or entry.get("simplified") or ""
+    )
+    normalized["examples"] = [
+        {
+            "zh":     ex.get("fr", ""),
+            "english": ex.get("english"),
+            "de":     ex.get("german") or ex.get("de"),
+            "pinyin": None,
+        }
+        for ex in (entry.get("examples") or [])
+    ]
+    # French format doesn't define these Chinese-only fields yet
+    for key in ("hsk", "traditional", "pinyin", "word_analyses",
+                "characters", "measure_words", "similar_sentences"):
+        normalized.pop(key, None)
+    return normalized
+
+
+def _build_word_dict(entry: dict, source: str, note_type: str = "vocabulary",
+                     lang: str = "zh") -> dict:
     register = entry.get("register")
     if register not in _VALID_REGISTERS:
         if register is not None:
             logger.warning("_build_word_dict: invalid register %r — set to None", register)
         register = None
+    simplified = entry.get("simplified", "").strip()
+    word_zh = _strip_ellipsis(simplified) if lang == "zh" else simplified
     return {
-        "word_zh":         _strip_ellipsis(entry.get("simplified", "").strip()),
+        "word_zh":         word_zh,
+        "lang":            lang,
         "pinyin":          entry.get("pinyin"),
         "definition":      entry.get("english"),
         "definition_de":   entry.get("german"),
@@ -533,7 +586,8 @@ def _process_component(analysis: dict, note_word_id: int, position: int,
 def _import_entries(entries: list, deck_ids: dict, source: str, label: str,
                     resolutions: dict | None = None,
                     card_configs: dict | None = None,
-                    custom_fields: dict | None = None) -> dict:
+                    custom_fields: dict | None = None,
+                    lang: str = "zh") -> dict:
     if resolutions is None:
         resolutions = {}
     if card_configs is None:
@@ -549,6 +603,9 @@ def _import_entries(entries: list, deck_ids: dict, source: str, label: str,
 
     for entry in entries:
       try:
+        if lang != "zh":
+            entry = _normalize_fr_entry(entry)
+
         yaml_type = entry.get("type", "")
         note_type = NOTE_TYPE_MAP.get(yaml_type)
 
@@ -569,10 +626,11 @@ def _import_entries(entries: list, deck_ids: dict, source: str, label: str,
             skipped_invalid += 1
             continue
 
-        stripped = _strip_ellipsis(word_zh)
-        if stripped != word_zh:
-            logger.warning("STRIP %s: ellipsis stripped from %r → %r", label, word_zh, stripped)
-            word_zh = stripped
+        if lang == "zh":
+            stripped = _strip_ellipsis(word_zh)
+            if stripped != word_zh:
+                logger.warning("STRIP %s: ellipsis stripped from %r → %r", label, word_zh, stripped)
+                word_zh = stripped
 
         warning = _validate_entry(word_zh, note_type)
         if warning:
@@ -612,7 +670,7 @@ def _import_entries(entries: list, deck_ids: dict, source: str, label: str,
         else:
             target_deck_ids = deck_ids
 
-        word = _build_word_dict(entry, source=source, note_type=note_type)
+        word = _build_word_dict(entry, source=source, note_type=note_type, lang=lang)
         word_id = database.insert_word(word)  # INSERT OR IGNORE → always get id
 
         if database.word_has_cards(word_id):
@@ -647,12 +705,13 @@ def _import_entries(entries: list, deck_ids: dict, source: str, label: str,
             else:
                 skipped_duplicate += 1
                 skipped_entries.append({"word": word_zh, "reason": "already in deck"})
-            # Always process word_analyses (all types) so components stay linked
-            for pos, analysis in enumerate(entry.get("word_analyses") or []):
-                if analysis.get("char_only"):
-                    _process_char_only_component(analysis, word_id, pos, source)
-                elif analysis.get("type") in NOTE_TYPE_MAP:
-                    _process_component(analysis, word_id, pos, source, resolutions, custom_fields)
+            # Always process word_analyses (all types) so components stay linked (Chinese-only)
+            if lang == "zh":
+                for pos, analysis in enumerate(entry.get("word_analyses") or []):
+                    if analysis.get("char_only"):
+                        _process_char_only_component(analysis, word_id, pos, source)
+                    elif analysis.get("type") in NOTE_TYPE_MAP:
+                        _process_component(analysis, word_id, pos, source, resolutions, custom_fields)
             continue
 
         # Examples
@@ -683,27 +742,31 @@ def _import_entries(entries: list, deck_ids: dict, source: str, label: str,
                     example_type="similar",
                 )
 
-        # Legacy: top-level `characters:` on vocabulary entries.
-        # New format uses `word_analyses:` for all entry types (handled below).
-        if note_type == "vocabulary":
-            _process_characters(entry, word_id)
+        # The following processors handle Chinese-only YAML fields (characters,
+        # measure words, synonyms/antonyms, grammar structures, word_analyses
+        # components) — French format doesn't define them yet.
+        if lang == "zh":
+            # Legacy: top-level `characters:` on vocabulary entries.
+            # New format uses `word_analyses:` for all entry types (handled below).
+            if note_type == "vocabulary":
+                _process_characters(entry, word_id)
 
-        # Measure words (量词)
-        _process_measure_words(entry, word_id)
+            # Measure words (量词)
+            _process_measure_words(entry, word_id)
 
-        # Synonyms / antonyms
-        _process_word_relations(entry, word_id)
+            # Synonyms / antonyms
+            _process_word_relations(entry, word_id)
 
-        # Grammar structures (sentence entries)
-        if note_type == "sentence":
-            _process_grammar_structures(entry, word_id)
+            # Grammar structures (sentence entries)
+            if note_type == "sentence":
+                _process_grammar_structures(entry, word_id)
 
-        # Component word_analyses (sentences / chengyu / expressions)
-        for pos, analysis in enumerate(entry.get("word_analyses") or []):
-            if analysis.get("char_only"):
-                _process_char_only_component(analysis, word_id, pos, source)
-            elif analysis.get("type") in NOTE_TYPE_MAP:
-                _process_component(analysis, word_id, pos, source, resolutions)
+            # Component word_analyses (sentences / chengyu / expressions)
+            for pos, analysis in enumerate(entry.get("word_analyses") or []):
+                if analysis.get("char_only"):
+                    _process_char_only_component(analysis, word_id, pos, source)
+                elif analysis.get("type") in NOTE_TYPE_MAP:
+                    _process_component(analysis, word_id, pos, source, resolutions)
 
         # categories field from YAML overrides card_cfg.suspended (frontend has final say)
         if yaml_categories and not card_cfg.get("suspended"):

--- a/tests/fixtures/francais_test.yaml
+++ b/tests/fixtures/francais_test.yaml
@@ -1,0 +1,43 @@
+lang: fr
+entries:
+  - type: word
+    date: "07/06"
+    word: le boulanger
+    english: baker
+    german: der Bäcker
+    register: neutral
+    note: |
+      Männliches Substantiv. Für die weibliche Form siehe "la boulangère".
+      Wird oft mit dem bestimmten Artikel "le" benutzt, wenn man über den
+      Beruf im Allgemeinen spricht.
+    examples:
+      - fr: Le boulanger ouvre à sept heures.
+        english: The baker opens at seven o'clock.
+        german: Der Bäcker öffnet um sieben Uhr.
+      - fr: Mon oncle est boulanger depuis vingt ans.
+        english: My uncle has been a baker for twenty years.
+        german: Mein Onkel ist seit zwanzig Jahren Bäcker.
+
+  - type: word
+    date: "07/06"
+    word: la confiture
+    english: jam
+    german: die Marmelade
+    register: neutral
+    note: |
+      Weibliches Substantiv. Wird meist im Singular benutzt, auch wenn man
+      von mehreren Sorten spricht ("les confitures" ist aber ebenfalls korrekt).
+    examples:
+      - fr: J'aime la confiture de fraises.
+        english: I like strawberry jam.
+        german: Ich mag Erdbeermarmelade.
+
+  - type: sentence
+    date: "07/06"
+    sentence: Je n'en reviens pas.
+    english: I can't get over it.
+    german: Ich fasse es nicht.
+    note: |
+      Umgangssprachlicher Ausdruck des Erstaunens. "En revenir" bedeutet
+      wörtlich "davon zurückkommen" — im übertragenen Sinn "sich erholen/
+      fassen können".

--- a/tests/test_importer_fr.py
+++ b/tests/test_importer_fr.py
@@ -1,0 +1,145 @@
+"""
+Integration tests for the French YAML import format (issue #430).
+
+Each test gets its own isolated temp DB. Note: unlike tests/test_importer.py's
+`tmp_db` fixture (which monkeypatches the `database` package attribute —
+a no-op, since database.get_db() actually reads the module-level DB_PATH
+bound inside database/core.py's own namespace), this file monkeypatches
+`database.core.DB_PATH` directly so each test truly gets a fresh file.
+"""
+import os
+import sys
+import uuid
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import database
+import database.core as db_core
+import importer
+
+FIXTURE_PATH = os.path.join(os.path.dirname(__file__), "fixtures", "francais_test.yaml")
+
+SCRATCHPAD = ("/private/tmp/claude-501/-Users-daniel-Documents-AnkiAdvanced/"
+              "30a5ad06-70ac-41c2-bff5-48df913a3af3/scratchpad")
+
+
+@pytest.fixture
+def tmp_db(monkeypatch):
+    """Point database.core.DB_PATH at a fresh scratchpad file and init the schema."""
+    os.makedirs(SCRATCHPAD, exist_ok=True)
+    db_file = os.path.join(SCRATCHPAD, f"test_importer_fr_{uuid.uuid4().hex}.db")
+    monkeypatch.setattr(db_core, "DB_PATH", db_file)
+    database.init_db()
+    yield db_file
+    if os.path.exists(db_file):
+        os.remove(db_file)
+
+
+class TestFrenchImport:
+    def test_import_produces_three_entries_with_fr_lang(self, tmp_db):
+        result = importer.import_yaml_file(FIXTURE_PATH, ["Francais"])
+        assert result["imported"] == 3, result
+
+        for word_zh in ("le boulanger", "la confiture", "Je n'en reviens pas."):
+            entry = database.get_word_by_zh(word_zh)
+            assert entry is not None, f"missing entry: {word_zh!r}"
+            assert entry["lang"] == "fr"
+
+    def test_decks_are_created_with_fr_lang(self, tmp_db):
+        importer.import_yaml_file(FIXTURE_PATH, ["Francais"])
+
+        conn = database.get_db()
+        rows = conn.execute("SELECT name, lang FROM decks WHERE deleted_at IS NULL").fetchall()
+        conn.close()
+        by_name = {r["name"]: r["lang"] for r in rows}
+
+        assert by_name.get("Francais") == "fr"
+        assert by_name.get("Francais · Listening") == "fr"
+        assert by_name.get("Francais · Reading") == "fr"
+        assert by_name.get("Francais · Creating") == "fr"
+
+    def test_three_cards_per_entry(self, tmp_db):
+        importer.import_yaml_file(FIXTURE_PATH, ["Francais"])
+
+        entry = database.get_word_by_zh("le boulanger")
+        cards = database.get_all_cards_for_browse({})
+        my_cards = [c for c in cards if c["word_id"] == entry["id"]]
+        assert len(my_cards) == 3
+        categories = {c["category"] for c in my_cards}
+        assert categories == {"listening", "reading", "creating"}
+        # Reading is suspended by default, listening/creating are not
+        reading_card = next(c for c in my_cards if c["category"] == "reading")
+        assert reading_card["state"] == "suspended"
+
+    def test_examples_hold_french_and_german_text(self, tmp_db):
+        importer.import_yaml_file(FIXTURE_PATH, ["Francais"])
+
+        entry = database.get_word_by_zh("le boulanger")
+        examples = database.get_word_examples(entry["id"])
+        assert len(examples) == 2
+        assert examples[0]["example_zh"] == "Le boulanger ouvre à sept heures."
+        assert examples[0]["example_de"] == "Der Bäcker öffnet um sieben Uhr."
+        assert examples[0]["example_en"] == "The baker opens at seven o'clock."
+
+    def test_sentence_keeps_trailing_period(self, tmp_db):
+        importer.import_yaml_file(FIXTURE_PATH, ["Francais"])
+
+        entry = database.get_word_by_zh("Je n'en reviens pas.")
+        assert entry is not None
+        assert entry["word_zh"] == "Je n'en reviens pas."
+        assert entry["note_type"] == "sentence"
+
+    def test_reimport_is_idempotent(self, tmp_db):
+        first = importer.import_yaml_file(FIXTURE_PATH, ["Francais"])
+        assert first["imported"] == 3
+
+        second = importer.import_yaml_file(FIXTURE_PATH, ["Francais"])
+        assert second["imported"] == 0
+        assert second["skipped_duplicate"] == 3
+
+
+class TestChineseImportUnchanged:
+    """Importing a YAML file with no `lang:` header must still behave as zh."""
+
+    def test_no_lang_header_defaults_to_zh_everywhere(self, tmp_db, tmp_path):
+        entries = [
+            {
+                "type": "vocabulary",
+                "simplified": "你好",
+                "traditional": "你好",
+                "pinyin": "nǐ hǎo",
+                "english": "hello",
+                "hsk": "1",
+            },
+            {
+                "type": "sentence",
+                "simplified": "你好吗……",
+                "english": "how are you",
+            },
+        ]
+        import yaml
+        kouyu_dir = tmp_path / "Kouyu"
+        kouyu_dir.mkdir(parents=True, exist_ok=True)
+        yaml_path = kouyu_dir / "1_1.yaml"
+        yaml_path.write_text(yaml.dump({"entries": entries}, allow_unicode=True))
+
+        result = importer.import_yaml_file(str(yaml_path), ["Kouyu"])
+        assert result["imported"] == 2, result
+
+        entry = database.get_word_by_zh("你好")
+        assert entry is not None
+        assert entry["lang"] == "zh"
+
+        # Chinese ellipsis-stripping behavior must be unchanged: "你好吗……" → "你好吗"
+        stripped_entry = database.get_word_by_zh("你好吗")
+        assert stripped_entry is not None
+        assert stripped_entry["lang"] == "zh"
+
+        conn = database.get_db()
+        rows = conn.execute("SELECT name, lang FROM decks WHERE deleted_at IS NULL").fetchall()
+        conn.close()
+        by_name = {r["name"]: r["lang"] for r in rows}
+        assert by_name.get("Kouyu") == "zh"
+        assert by_name.get("Kouyu · Listening") == "zh"


### PR DESCRIPTION
## 变更内容
由 Sonnet 子代理在隔离 worktree 中实现，Fable 审查验收：

- YAML 文件顶部可选 `lang:` 字段（默认 zh，未知语言回退 zh 并告警）；决定牌组与词条的语言
- `_normalize_fr_entry` 适配器：`word`/`sentence` → `simplified`、`examples[].fr` → `.zh`、`examples[].german` → `.de`——下游导入逻辑全部复用，零重复代码
- 汉字分解/量词/同义反义/语法结构/word_analyses 处理加 `lang == 'zh'` 守卫（法语格式不含这些字段）
- 法语词条不做 `_strip_ellipsis`（法语句子保留句尾句号）
- 上传预览（preview_yaml_content）同样支持 lang 头
- `tests/fixtures/francais_test.yaml`（2 词 + 1 句，B1 法语 + 德语注释）+ `tests/test_importer_fr.py`（7 个测试）
- CLAUDE.md 数据来源章节补充法语格式说明
- 样例特意**不放** imports/（那是未跟踪的用户数据目录，放进仓库会在服务器上被自动导入）

## 测试方法
- `tests/test_importer_fr.py` 7/7 通过（entries.lang='fr'、牌组树继承 fr、三类卡片、例句 fr/de 落库、句尾句号保留、重复导入幂等、无 lang 头的中文导入 lang='zh'）
- `tests/test_importer.py` 改动前后失败数一致（15，均为既有失败——其 tmp_db fixture 的 monkeypatch 绑定就有问题，与本 PR 无关），无回归

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)