### PR TITLE
feat: 前端多语言适配——法语牌组界面与牌组创建语言选择

### DIFF
--- a/database/decks.py
+++ b/database/decks.py
@@ -234,17 +234,19 @@ def get_all_deck_id() -> int | None:
     return row["id"] if row else None
 
 
-def get_or_create_deck_path(path: str) -> int:
+def get_or_create_deck_path(path: str, lang: str | None = None) -> int:
     """Parse an Anki-style 'Parent::Child::Leaf' path and ensure all decks exist.
 
     Returns the id of the deepest (leaf) deck. Roots are placed under 'All'.
+    `lang`, if given, is applied to every newly-created segment (existing decks
+    keep their own lang); `None` keeps the normal parent-inheritance behavior.
     """
     segments = [s.strip() for s in path.split("::") if s.strip()]
     if not segments:
         raise ValueError(f"Empty deck path: {path!r}")
     parent_id = get_all_deck_id()
     for segment in segments:
-        parent_id = get_or_create_deck(segment, parent_id=parent_id)
+        parent_id = get_or_create_deck(segment, parent_id=parent_id, lang=lang)
     return parent_id
 
 

--- a/routes/decks.py
+++ b/routes/decks.py
@@ -117,7 +117,7 @@ def create_deck(name: str, parent_id: int | None = None, category: str | None = 
         raise HTTPException(400, f"unknown lang: {lang!r}")
     # Support Anki-style 'Parent::Child' hierarchy in name
     if "::" in name:
-        deck_id = database.get_or_create_deck_path(name)
+        deck_id = database.get_or_create_deck_path(name, lang=lang)
         return database.get_deck(deck_id)
     if parent_id is None:
         parent_id = database.get_all_deck_id()

--- a/static/app.js
+++ b/static/app.js
@@ -1329,6 +1329,7 @@ function renderDeckRows(decks, depth, sortMode) {
         <span class="tree-toggle" onclick="toggleDeck(${deck.id})">${toggleIcon}</span>
         <span class="tree-name-wrap">
           <span class="tree-name" onclick="startReviewMixed(${deck.id},'${safeName}',${!!deck.no_story})" style="cursor:pointer">${deck.name}</span>
+          ${deck.lang === 'fr' ? `<span class="deck-lang-chip" title="French deck">FR</span>` : ''}
           ${!deck.no_story ? `<button class="deck-regen-btn" onclick="event.stopPropagation();regenerateStoryFromList(${deck.id})" title="Regenerate story">↺</button>` : ''}
         </span>
         ${deckCounts}
@@ -1499,8 +1500,15 @@ async function renameDeck(id, currentName) {
 async function createDeck() {
   const path = await showPrompt('New deck path (use :: to nest, e.g. Daily::03-19)');
   if (!path || !path.trim()) return;
+  let lang = await showPrompt('Language: zh (Chinese) or fr (French)', 'zh');
+  if (lang === null) return; // user cancelled
+  lang = lang.trim().toLowerCase() || 'zh';
+  if (lang !== 'zh' && lang !== 'fr') {
+    showError(`Unknown language "${lang}" — expected zh or fr`);
+    return;
+  }
   try {
-    await api('POST', `/api/decks?name=${encodeURIComponent(path.trim())}`);
+    await api('POST', `/api/decks?name=${encodeURIComponent(path.trim())}&lang=${encodeURIComponent(lang)}`);
     loadDecks();
   } catch (e) {
     showError('Create deck failed: ' + e.message);

--- a/static/app.js
+++ b/static/app.js
@@ -5610,7 +5610,8 @@ function _applySetupLangRestrictions() {
   const lang = _deckLangById[deckId] || 'zh';
   const modeSelect = document.getElementById('setup-mode');
   const zhOnlyOptions = modeSelect.querySelectorAll('option.setup-mode-zh-only');
-  zhOnlyOptions.forEach(opt => { opt.hidden = lang !== 'zh'; });
+  // hidden alone is ignored by iOS Safari for <option> — disabled greys it out there
+  zhOnlyOptions.forEach(opt => { opt.hidden = lang !== 'zh'; opt.disabled = lang !== 'zh'; });
   if (lang !== 'zh' && zhOnlyOptions && [...zhOnlyOptions].some(o => o.value === modeSelect.value)) {
     modeSelect.value = 'story';
   }

--- a/static/app.js
+++ b/static/app.js
@@ -5031,7 +5031,13 @@ async function _buildWordBank() {
   if (targetCount < expectedCount) order.push({ type: 'target', word: targetParts ? targetParts[targetCount] : target });
 
   const MAX_TILES = parseInt(document.getElementById('word-bank-slider')?.value ?? _wordBankTileDefault(), 10);
-  const isWord = tok => /[一-鿿㐀-䶿]/.test(tok.char);
+  // Chinese: a "word" tile is any CJK character. French (space-separated tokens):
+  // a tile is any non-whitespace token — whitespace-only tokens (preserved as
+  // separate tokens by the tokenizer) must stay pre-placed, never become an
+  // empty chip.
+  const isWord = tok => currentCardLang() === 'zh'
+    ? /[一-鿿㐀-䶿]/.test(tok.char)
+    : tok.char.trim().length > 0;
   const allChars = order.filter(it => it.type === 'char');
   allChars.forEach(c => { if (!isWord(c)) c.type = 'pre'; });
   const wordTokens = allChars.filter(c => c.type === 'char');
@@ -5992,7 +5998,7 @@ function updateStoryHighlight(idx) {
 }
 
 function _storyAudioUrl(idx) {
-  return `/api/tts-file?text=${encodeURIComponent(story.sentences[idx].sentence_zh)}`;
+  return `/api/tts-file?text=${encodeURIComponent(story.sentences[idx].sentence_zh)}&lang=${currentCardLang()}`;
 }
 
 function _playStoryAtIdx(idx) {
@@ -6304,7 +6310,7 @@ function playSentence() {
   _listenCount++;
   _updateListenCounters();
   if (_currentAudio) { _currentAudio.onended = null; _currentAudio.pause(); _currentAudio = null; }
-  const audio = new Audio(`/api/tts-file?text=${encodeURIComponent(text)}`);
+  const audio = new Audio(`/api/tts-file?text=${encodeURIComponent(text)}&lang=${currentCardLang()}`);
   _currentAudio = audio;
   audio.play().catch(() => {});
 }

--- a/static/app.js
+++ b/static/app.js
@@ -5595,11 +5595,27 @@ function openStorySetup(sentenceCount, { isMixed = false, isUnfinished = false, 
   document.getElementById('setup-hsk-slider').value = 3;
   document.getElementById('setup-mode').value = 'story';
   updateHskLabel();
+  _applySetupLangRestrictions();
   updateSetupMode();
   document.getElementById('setup-modal-overlay').style.display = 'block';
   document.getElementById('setup-modal').style.display        = 'flex';
   document.getElementById('setup-topic').focus();
   return new Promise(resolve => { _setupResolve = resolve; });
+}
+
+// Story setup modal: kahneman/news/briefing/paste and grammar-focus are
+// Chinese-only server features (backend rejects those modes, and grammar
+// patterns like 把字句 don't apply to French) — hide them for non-zh decks.
+function _applySetupLangRestrictions() {
+  const lang = _deckLangById[deckId] || 'zh';
+  const modeSelect = document.getElementById('setup-mode');
+  const zhOnlyOptions = modeSelect.querySelectorAll('option.setup-mode-zh-only');
+  zhOnlyOptions.forEach(opt => { opt.hidden = lang !== 'zh'; });
+  if (lang !== 'zh' && zhOnlyOptions && [...zhOnlyOptions].some(o => o.value === modeSelect.value)) {
+    modeSelect.value = 'story';
+  }
+  const grammarLabel = document.getElementById('setup-grammar-label');
+  if (grammarLabel) grammarLabel.style.display = lang === 'zh' ? '' : 'none';
 }
 
 function togglePriceTable(e) {

--- a/static/app.js
+++ b/static/app.js
@@ -65,6 +65,18 @@ let optDeckId    = null; // deck whose options modal is open
 const collapsed  = new Set(JSON.parse(localStorage.getItem('collapsedDecks') || '[]'));  // parent deck IDs that are collapsed
 let _retentionData = null;  // cached result from GET /api/retention
 let _cachedDecks = null;       // last fetched deck tree (for toggle re-renders)
+let _deckLangById = {};        // deckId → 'zh'|'fr', rebuilt whenever decks load (flatten(decks))
+
+// Resolve the language of the card currently being reviewed. Prefers the
+// card's own deck_id (set per-card in unfinished/mixed mode); falls back to
+// the review view's current deckId. Defaults to 'zh' when unknown (e.g. decks
+// not loaded yet), which keeps the existing Chinese-only affordances working.
+function currentCardLang() {
+  const id = (typeof card !== 'undefined' && card?.deck_id) ? card.deck_id
+    : (typeof deckId !== 'undefined' ? deckId : null);
+  if (id == null) return 'zh';
+  return _deckLangById[id] || 'zh';
+}
 
 // — Customizable review shortcuts —
 // Each action maps to one key. Defaults below are the active bindings.
@@ -961,6 +973,10 @@ async function loadDecks() {
     ]);
     _cachedDecks = decks;
     _retentionData = retention;
+    _deckLangById = {};
+    for (const d of flatten(decks)) {
+      if (d.id != null) _deckLangById[d.id] = d.lang || 'zh';
+    }
     renderDecks(decks);
     showView('decks');
   } catch (e) {
@@ -3560,12 +3576,17 @@ function loadCard(c, counts) {
     deckPath.style.display = 'none';
   }
 
-  // HSK badge — always visible; "HSK -" when unknown (click to AI-fill)
+  // HSK badge — Chinese-only concept; hidden entirely for non-zh decks.
+  // Otherwise always visible; "HSK -" when unknown (click to AI-fill)
   const hskBadge = document.getElementById('card-hsk-badge');
-  hskBadge.textContent = card.hsk_level ? `HSK ${card.hsk_level}` : 'HSK -';
-  hskBadge.classList.toggle('hsk-unknown', !card.hsk_level);
-  hskBadge.disabled = false;
-  hskBadge.style.display = 'inline';
+  if (currentCardLang() !== 'zh') {
+    hskBadge.style.display = 'none';
+  } else {
+    hskBadge.textContent = card.hsk_level ? `HSK ${card.hsk_level}` : 'HSK -';
+    hskBadge.classList.toggle('hsk-unknown', !card.hsk_level);
+    hskBadge.disabled = false;
+    hskBadge.style.display = 'inline';
+  }
 
   // Reset pinyin (clear content + hide revealed state)
   const _pr = document.getElementById('pinyin-row');
@@ -3786,9 +3807,10 @@ function revealAnswer() {
   document.getElementById('back-meta-play-btn').style.display = isCreating ? 'none' : 'flex';
   _updateListenCounters();
 
-  // Pre-load pinyin in background (shown blurred until p is pressed)
+  // Pre-load pinyin in background (shown blurred until p is pressed).
+  // Pinyin is a Chinese-only concept — pypinyin garbles French text.
   const _pinyinText = sentence?.sentence_zh || card?.word_zh;
-  if (_pinyinText) _loadPinyinRow(_pinyinText);
+  if (_pinyinText && currentCardLang() === 'zh') _loadPinyinRow(_pinyinText);
 
   const isSentenceNote = card.note_type === 'sentence';
 
@@ -5342,6 +5364,7 @@ async function _loadPinyinRow(text) {
 }
 
 async function togglePinyin() {
+  if (currentCardLang() !== 'zh') return; // no-op for non-Chinese decks
   const row = document.getElementById('pinyin-row');
   const text = sentence?.sentence_zh || card?.word_zh;
   if (!text) return;

--- a/static/index.html
+++ b/static/index.html
@@ -672,10 +672,10 @@
         <option value="story">📖 Story — narrative with characters</option>
         <option value="qa">❓ Q&amp;A — answer a question</option>
         <option value="expository">📚 Expository — informative text</option>
-        <option value="kahneman">🧠 Kahneman — cognitive bias style</option>
-        <option value="news">📰 News briefing — today's news, auto-fetched</option>
-        <option value="briefing">🗞️ News flow — summary with German context</option>
-        <option value="paste">📋 Paste content — summarize anything</option>
+        <option value="kahneman" class="setup-mode-zh-only">🧠 Kahneman — cognitive bias style</option>
+        <option value="news" class="setup-mode-zh-only">📰 News briefing — today's news, auto-fetched</option>
+        <option value="briefing" class="setup-mode-zh-only">🗞️ News flow — summary with German context</option>
+        <option value="paste" class="setup-mode-zh-only">📋 Paste content — summarize anything</option>
       </select>
     </label>
     <!-- Kahneman chapter selector (shown only in kahneman mode) -->
@@ -706,7 +706,7 @@
     <label class="edit-label" id="setup-topic-label">Topic <span style="font-weight:400;text-transform:none">(optional)</span>
       <input class="edit-input" id="setup-topic" type="text" placeholder="e.g. a day at a coffee shop" onkeydown="if(event.key==='Enter')confirmStorySetup()">
     </label>
-    <label class="edit-label">Grammar focus <span style="font-weight:400;text-transform:none">(optional)</span>
+    <label class="edit-label" id="setup-grammar-label">Grammar focus <span style="font-weight:400;text-transform:none">(optional)</span>
       <div style="display:flex;gap:8px;align-items:center">
         <input class="edit-input" id="setup-grammar" type="text" placeholder="e.g. 把字句, 是...的结构" style="flex:1" onkeydown="if(event.key==='Enter')confirmStorySetup()">
         <input class="edit-input" id="setup-grammar-pct" type="number" min="0" max="100" value="75" style="width:64px;text-align:center" title="% of sentences">

--- a/static/style.css
+++ b/static/style.css
@@ -1862,6 +1862,16 @@ main.browse-open {
   color: #9ca3af;
   white-space: nowrap;
 }
+.deck-lang-chip {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--primary);
+  border: 1px solid var(--primary);
+  border-radius: 4px;
+  padding: 1px 4px;
+  line-height: 1.4;
+  white-space: nowrap;
+}
 .tree-counts { font-size: 13px; font-weight: 700; white-space: nowrap; }
 .tree-card {
   background: var(--card);


### PR DESCRIPTION
## 变更内容
由 Sonnet 子代理在隔离 worktree 中实现，Fable 审查并补充 iOS Safari 兼容修复：

- **牌组创建**：路径提示后增加语言选择（zh/fr，默认 zh 一键回车）；后端补齐 `get_or_create_deck_path(lang=...)`，`Parent::Child` 路径创建也能正确设置语言
- **牌组列表**：法语牌组名后显示小小的 `FR` 徽章（中文牌组外观完全不变）
- **复习界面**（新增 `currentCardLang()` 辅助函数 + `_deckLangById` 映射）：非中文卡片完全隐藏 HSK 徽章；跳过拼音预加载，`p` 快捷键无操作（pypinyin 对法语文本会输出乱码）
- **写作词库（word bank）**：法语按非空白 token 生成词块，空白 token 保持预置，不会出现空词块
- **TTS**：`/api/tts-file` 调用带上 `lang`（法语语音 `fr-FR-DeniseNeural`）
- **故事设置弹窗**：非中文牌组隐藏 kahneman/news/briefing/paste 模式与语法焦点输入框（`hidden` + `disabled` 双保险——iOS Safari 不支持隐藏 `<option>`，Daniel 主要用手机访问）；已选中被隐藏模式时重置为 story

## 测试方法
- `node --check static/app.js` 通过
- TestClient：`POST /api/decks?name=X::Y&lang=fr` → 树中 X、Y 均为 lang='fr'；GET / 与静态文件 200
- 浏览页确认现有 `|| ''` 模式对空拼音/HSK 已优雅降级，无需改动

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)