### PR TITLE
feat: 正面播放按钮移入卡片头部 + 头部显示故事模式名

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3615,6 +3615,12 @@ function loadCard(c, counts) {
   const noteLabel = { vocabulary: 'Word', sentence: 'Sentence', chengyu: '成语', expression: '表达' }[card.note_type] || card.note_type;
   document.getElementById('card-type-badge').textContent = noteLabel;
 
+  // Story-mode badge (special modes only; plain story/qa/expository show nothing)
+  const modeBadge = document.getElementById('card-mode-badge');
+  const modeName = { kahneman: 'Kahneman', news: 'News', briefing: 'News flow', paste: 'Paste' }[_activeStoryMode()];
+  modeBadge.textContent = modeName || '';
+  modeBadge.style.display = modeName ? 'block' : 'none';
+
   // Deck path bar
   const deckPath = document.getElementById('card-deck-path');
   if (card.deck_path) {
@@ -3704,9 +3710,8 @@ function showFront() {
   const _vc = document.getElementById('vocab-content');
   if (_vc) _vc.style.display = 'none';
 
-  // Listening elements
-  document.getElementById('front-listen-icon').style.display = isListening ? 'flex' : 'none';
-  document.getElementById('back-meta-play-btn').style.display = 'none';
+  // Listening: play button lives in the card header (same spot as on the back)
+  document.getElementById('meta-play-btn').style.display = isListening ? 'flex' : 'none';
   _listenCount = 0;
   _updateListenCounters();
 
@@ -3852,7 +3857,7 @@ function revealAnswer() {
   if (_mascotBack) _mascotBack.style.display = 'none';
   const _vcBack = document.getElementById('vocab-content');
   if (_vcBack) _vcBack.style.display = 'block';
-  document.getElementById('back-meta-play-btn').style.display = isCreating ? 'none' : 'flex';
+  document.getElementById('meta-play-btn').style.display = isCreating ? 'none' : 'flex';
   _updateListenCounters();
 
   // Pre-load pinyin in background (shown blurred until p is pressed).
@@ -5863,6 +5868,16 @@ let _currentReasoningIsNews = false;
 // session was resumed without it) — only used to pick the background-popup title.
 let _currentStoryMode = '';
 
+// Mode of the currently loaded story — reads the story's stored gen_params
+// (survives session resume, unlike _currentStoryMode).
+function _activeStoryMode() {
+  try {
+    const gp = story?.gen_params;
+    if (gp) return (typeof gp === 'string' ? JSON.parse(gp) : gp).mode || '';
+  } catch { /* malformed gen_params — fall through */ }
+  return _currentStoryMode || '';
+}
+
 function openReasoning() {
   if (!_currentReasoning && !_currentSourceUrl) return;
   document.getElementById('reasoning-modal-title').textContent =
@@ -6363,7 +6378,7 @@ let _listenCount = 0;
 function _updateListenCounters() {
   const label = _listenCount > 0 ? `×${_listenCount}` : '';
   const show  = _listenCount > 0;
-  ['listen-counter', 'listen-counter-back'].forEach(id => {
+  ['listen-counter-meta'].forEach(id => {
     const el = document.getElementById(id);
     if (!el) return;
     el.textContent = label;

--- a/static/index.html
+++ b/static/index.html
@@ -99,11 +99,12 @@
             <div id="review-cat-row" style="flex:1"></div>
             <div class="card-meta-right">
               <button id="card-hsk-badge" class="card-hsk-badge" onclick="enrichCard()" title="Ask AI to fill HSK level &amp; character data" style="display:none"></button>
-              <div class="back-play-group">
-                <button id="back-meta-play-btn" class="play-icon-btn play-icon-sm" onclick="playSentence()" style="display:none" title="Play audio">🔊</button>
-                <span class="listen-counter listen-counter-back" id="listen-counter-back" style="display:none"></span>
+              <div class="meta-play-group">
+                <button id="meta-play-btn" class="play-icon-btn play-icon-sm" onclick="playSentence()" style="display:none" title="Play audio">🔊</button>
+                <span class="listen-counter listen-counter-meta" id="listen-counter-meta" style="display:none"></span>
               </div>
               <div id="card-timer" style="display:none"></div>
+              <div id="card-mode-badge" style="display:none"></div>
               <div id="card-type-badge"></div>
               <div class="wd-card-menu-wrap" id="review-card-menu-wrap">
                 <button class="wd-menu-btn" onclick="toggleReviewCardMenu(event)">⋯</button>
@@ -121,11 +122,6 @@
           <div id="side-front">
             <!-- News flow: German context of the preceding summary sentences (always above the Chinese sentence) -->
             <div class="sentence-context-de" id="sentence-context-de" style="display:none"></div>
-            <!-- Listening: small replay button + repeat counter (issue #411: no big speaker emoji) -->
-            <div class="listen-icon-wrap" id="front-listen-icon" style="display:none">
-              <button class="play-icon-btn play-icon-sm" onclick="playSentence()" title="Play audio">🔊</button>
-              <span class="listen-counter" id="listen-counter" style="display:none"></span>
-            </div>
             <!-- Listening: hint sentence with slider (shows % of non-target chars) -->
             <div id="listen-hint-wrap" style="display:none">
               <div class="listen-hint-sentence" id="listen-hint-sentence"></div>

--- a/static/style.css
+++ b/static/style.css
@@ -466,30 +466,6 @@ main.browse-open {
 }
 .play-icon-btn:hover { color: var(--primary); }
 
-/* Listen icon (front of listening card) — now a clickable button */
-.listen-icon-wrap {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  min-height: 120px;
-  gap: 8px;
-}
-.listen-icon {
-  font-size: 72px;
-  text-align: center;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  transition: transform 0.1s, opacity 0.15s;
-}
-.listen-icon:hover { opacity: 0.75; transform: scale(1.05); }
-.listen-icon:active { transform: scale(0.95); }
 .listen-counter {
   font-size: 15px;
   color: var(--text-muted, #888);
@@ -557,13 +533,20 @@ main.browse-open {
 }
 .hint-save-btn:hover { color: #f5a623; }
 .hint-save-btn.saved { color: #f5a623; }
-.back-play-group {
+.meta-play-group {
   display: flex;
   align-items: center;
   gap: 2px;
 }
-.listen-counter-back {
+.listen-counter-meta {
   font-size: 13px;
+}
+#card-mode-badge {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--primary);
+  letter-spacing: 0.5px;
+  opacity: 0.8;
 }
 
 /* Play button (front of listening card) */


### PR DESCRIPTION
## 变更内容
- 听力卡正面不再有独立的播放按钮区（#front-listen-icon 删除），播放按钮与次数计数统一显示在卡片头部——和背面同一个位置、同一个按钮
- 头部元素改中性命名：back-meta-play-btn → meta-play-btn、back-play-group → meta-play-group、listen-counter-back → listen-counter-meta（正反两面共用）
- 头部右侧新增 #card-mode-badge：故事模式为 kahneman/news/briefing/paste 时显示 'Kahneman'/'News'/'News flow'/'Paste'，普通模式隐藏
- 模式从当前故事的 gen_params 读取（新增 _activeStoryMode()），比只在设置弹窗赋值的 _currentStoryMode 可靠（会话恢复后也正确）
- 清理不再使用的 .listen-icon-wrap/.listen-icon 样式

## 测试方法
- node --check static/app.js 通过；grep 确认旧 id 零残留
- 需 Daniel 浏览器实测：听力卡正面头部有 🔊 和播放计数；reading/creating 正面无播放按钮；背面照旧；News flow 会话头部右侧显示 'News flow'

Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)