### PR TITLE
feat: 个人主页静态骨架 + 子域名部署文档（#445）

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -169,6 +169,26 @@ sudo systemctl enable caddy
 确认域名的 DNS A 记录已指向服务器 IP。Caddy 会自动申请 Let's Encrypt 证书，
 首次访问 `https://your-domain.example.com` 时可能需要等待几十秒完成证书签发。
 
+### 可选：同一台服务器托管个人主页（子域名）
+
+DuckDNS 支持通配符解析——`*.你的域名.duckdns.org` 全部自动指向同一个 IP，
+不需要注册新域名。仓库 `homepage/` 目录里的静态主页这样上线：
+
+```caddyfile
+# 追加到 /etc/caddy/Caddyfile（完整示例见 deploy/Caddyfile.example）
+home.your-domain.duckdns.org {
+	root * /home/anki/AnkiAdvanced/homepage
+	file_server
+}
+```
+
+```bash
+sudo systemctl reload caddy
+```
+
+主页不经过 FastAPI，因此**没有 Basic Auth，公开可见**。之后修改主页走正常
+PR 流程即可——自动部署会连同主页一起拉取更新，详见 `homepage/README.md`。
+
 ---
 
 ## 7. 配置自动部署（cron + deploy.sh）

--- a/deploy/Caddyfile.example
+++ b/deploy/Caddyfile.example
@@ -9,3 +9,11 @@ your-domain.example.com {
 		output file /var/log/caddy/ankiadvanced.log
 	}
 }
+
+# 个人主页——同一台服务器、同一个 IP，用子域名区分站点。
+# DuckDNS 通配符解析让 *.your-domain.duckdns.org 自动指向同一 IP，无需注册。
+# 静态文件由 Caddy 直接提供（无 Basic Auth，公开访问），证书同样自动申请。
+home.your-domain.example.com {
+	root * /home/anki/AnkiAdvanced/homepage
+	file_server
+}

--- a/homepage/README.md
+++ b/homepage/README.md
@@ -1,0 +1,59 @@
+# 个人主页（home.powerdaniel3000.duckdns.org）
+
+这个目录是 Daniel 的个人主页——纯静态文件，由服务器上的 Caddy 直接提供，
+和 SRS 应用共用同一台服务器、同一个 IP，但走不同的子域名。
+
+| | SRS 应用 | 个人主页 |
+|---|---|---|
+| 地址 | https://powerdaniel3000.duckdns.org | https://home.powerdaniel3000.duckdns.org |
+| 提供方式 | Caddy 反向代理 → FastAPI（端口 8000） | Caddy 直接提供本目录的静态文件 |
+| 访问控制 | HTTP Basic Auth（FastAPI 中间件） | **公开**，无密码 |
+
+## 为什么子域名能用？
+
+DuckDNS 支持通配符解析：`*.powerdaniel3000.duckdns.org` 全部自动指向同一个
+IP（207.180.204.135），**不需要注册任何新域名**。想再加一个站点（比如
+`blog.powerdaniel3000.duckdns.org`）只需在服务器 `/etc/caddy/Caddyfile`
+里加一个站点块，Caddy 会自动申请 HTTPS 证书。
+
+## 怎么修改主页？
+
+和改 SRS 应用完全一样的流程：
+
+1. 在本目录改文件（`index.html` / `style.css` / `script.js`）
+2. 开分支 → 提交 → 开 PR → CI 通过 → 合并到 `main`
+3. 服务器 cron 每 2 分钟运行 `deploy/deploy.sh` 拉取 main
+   → **合并后约 2 分钟主页自动更新**，无需登录服务器
+
+注意：`deploy.sh` 合并后会重启 SRS 服务（`systemctl restart ankiadvanced`）。
+只改主页时这个重启无害（几秒钟），但如果正在复习卡片，等复习完再合并更稳妥。
+
+## 文件结构
+
+```
+homepage/
+├── index.html   # 页面结构（导航 / Hero / 关于我 / 项目 / 联系方式 / 页脚）
+├── style.css    # 全部样式；颜色集中在顶部 :root 变量里，自动深浅色
+├── script.js    # 交互脚本（目前只有页脚年份）
+└── README.md    # 本文件
+```
+
+## 常见扩展
+
+- **换配色**：只改 `style.css` 顶部 `:root` 里的 `--accent` 等变量
+- **加一个新页面**：新建 `blog.html` 之类的文件，用 `<a href="/blog.html">` 链接过去——Caddy 的 `file_server` 会自动提供目录里的所有文件
+- **加图片**：建一个 `homepage/images/` 目录放图片，HTML 里用相对路径 `<img src="images/foto.jpg">`。注意仓库是公开的，放上去的图片全世界可见
+- **加新项目卡片**：复制 `index.html` 里的一个 `<article class="card">` 块
+
+## 服务器端配置（已完成的一次性步骤，记录备查）
+
+`/etc/caddy/Caddyfile` 里的站点块（完整示例见 `deploy/Caddyfile.example`）：
+
+```caddyfile
+home.powerdaniel3000.duckdns.org {
+    root * /home/anki/AnkiAdvanced/homepage
+    file_server
+}
+```
+
+改完执行 `sudo systemctl reload caddy` 生效。

--- a/homepage/index.html
+++ b/homepage/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Daniel — Persönliche Seite</title>
+    <meta name="description" content="Persönliche Homepage von Daniel">
+    <link rel="stylesheet" href="style.css">
+    <!-- Favicon：一个内联 emoji，之后可以换成自己的图标文件 -->
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🏔️</text></svg>">
+</head>
+<body>
+
+    <!-- ===== 顶部导航 ===== -->
+    <header class="site-header">
+        <nav class="nav container">
+            <a href="/" class="nav-logo">Daniel</a>
+            <ul class="nav-links">
+                <li><a href="#about">Über mich</a></li>
+                <li><a href="#projects">Projekte</a></li>
+                <li><a href="#contact">Kontakt</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+
+        <!-- ===== Hero：访客看到的第一屏 ===== -->
+        <section class="hero container">
+            <h1>Hallo, ich bin Daniel.</h1>
+            <p class="hero-subtitle">
+                <!-- 在这里用一两句话介绍自己：你是谁、你在做什么 -->
+                Ich lerne Chinesisch und Französisch und baue Software, die mir dabei hilft.
+            </p>
+        </section>
+
+        <!-- ===== 关于我 ===== -->
+        <section id="about" class="section container">
+            <h2>Über mich</h2>
+            <p>
+                <!-- 占位内容——替换成你自己的介绍 -->
+                Hier kannst du ein paar Absätze über dich schreiben: dein Hintergrund,
+                deine Interessen, was dich antreibt.
+            </p>
+        </section>
+
+        <!-- ===== 项目 ===== -->
+        <section id="projects" class="section container">
+            <h2>Projekte</h2>
+            <div class="card-grid">
+                <!-- 每个项目一张卡片；复制 <article> 块即可添加新项目 -->
+                <article class="card">
+                    <h3>AnkiAdvanced</h3>
+                    <p>Ein KI-gestütztes Spaced-Repetition-System für Chinesisch und Französisch —
+                       jeden Tag eine Geschichte aus den fälligen Vokabeln.</p>
+                    <a href="https://powerdaniel3000.duckdns.org" class="card-link">Zur App →</a>
+                </article>
+                <article class="card">
+                    <h3>Nächstes Projekt</h3>
+                    <p>Platzhalter — ersetze diese Karte durch dein nächstes Projekt.</p>
+                </article>
+            </div>
+        </section>
+
+        <!-- ===== 联系方式 ===== -->
+        <section id="contact" class="section container">
+            <h2>Kontakt</h2>
+            <p>
+                <!-- 想公开哪个联系方式就写哪个；不想公开就删掉整个 section -->
+                E-Mail: <a href="mailto:deine-adresse@example.com">deine-adresse@example.com</a>
+            </p>
+        </section>
+
+    </main>
+
+    <footer class="site-footer">
+        <div class="container">
+            <p>© <span id="year">2026</span> Daniel · Gebaut ohne Framework, ohne Build-Schritt.</p>
+        </div>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/homepage/script.js
+++ b/homepage/script.js
@@ -1,0 +1,3 @@
+// 主页脚本——目前只做一件事：页脚年份自动更新。
+// 以后需要交互功能（主题切换按钮、动画等）就往这里加。
+document.getElementById("year").textContent = new Date().getFullYear();

--- a/homepage/style.css
+++ b/homepage/style.css
@@ -1,0 +1,168 @@
+/* ============================================================
+   个人主页样式
+   设计原则：CSS 变量集中管理颜色 → 想换配色只改 :root 一处；
+   自动跟随系统深浅色模式；移动端优先，无框架、无构建步骤。
+   ============================================================ */
+
+/* ---------- 颜色与字体变量（浅色模式默认值） ---------- */
+:root {
+    --bg: #faf9f7;
+    --bg-card: #ffffff;
+    --text: #1a1a1a;
+    --text-muted: #666666;
+    --accent: #2f6f4f;          /* 主题色——链接、强调；换一个颜色整站跟着变 */
+    --border: #e2e0dc;
+    --max-width: 720px;         /* 正文栏宽；窄栏更好读 */
+    --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+            "Helvetica Neue", Arial, sans-serif;
+}
+
+/* 深色模式：跟随系统设置自动切换 */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #17181a;
+        --bg-card: #1f2124;
+        --text: #e8e6e3;
+        --text-muted: #9a9a9a;
+        --accent: #6fbf94;
+        --border: #33363a;
+    }
+}
+
+/* ---------- 基础 ---------- */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;    /* 点导航锚点时平滑滚动 */
+}
+
+body {
+    font-family: var(--font);
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.7;
+}
+
+.container {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: 0 1.25rem;
+}
+
+a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+/* ---------- 顶部导航 ---------- */
+.site-header {
+    border-bottom: 1px solid var(--border);
+    position: sticky;
+    top: 0;
+    background: var(--bg);
+    z-index: 10;
+}
+
+.nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-top: 0.9rem;
+    padding-bottom: 0.9rem;
+}
+
+.nav-logo {
+    font-weight: 700;
+    font-size: 1.1rem;
+    color: var(--text);
+}
+
+.nav-links {
+    display: flex;
+    gap: 1.5rem;
+    list-style: none;
+}
+
+.nav-links a {
+    color: var(--text-muted);
+}
+
+.nav-links a:hover {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+/* ---------- Hero ---------- */
+.hero {
+    padding: 5rem 1.25rem 3rem;
+}
+
+.hero h1 {
+    font-size: 2.25rem;
+    line-height: 1.2;
+    margin-bottom: 1rem;
+}
+
+.hero-subtitle {
+    font-size: 1.15rem;
+    color: var(--text-muted);
+    max-width: 34em;
+}
+
+/* ---------- 通用 section ---------- */
+.section {
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+    border-top: 1px solid var(--border);
+}
+
+.section h2 {
+    font-size: 1.5rem;
+    margin-bottom: 1.25rem;
+}
+
+/* ---------- 项目卡片 ---------- */
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1rem;
+}
+
+.card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1.25rem;
+}
+
+.card h3 {
+    margin-bottom: 0.5rem;
+}
+
+.card p {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    margin-bottom: 0.75rem;
+}
+
+.card-link {
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+/* ---------- 页脚 ---------- */
+.site-footer {
+    border-top: 1px solid var(--border);
+    padding: 2rem 0;
+    margin-top: 3rem;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}


### PR DESCRIPTION
## 改了什么
- 新增 `homepage/` 目录：个人主页静态骨架（index.html + style.css + script.js + README.md），纯静态、无构建步骤，与主应用同仓库
- `deploy/Caddyfile.example`：增加 `home.*` 子域名站点块示例（`root` + `file_server`）
- `DEPLOY.md` 第 6 节：补充"同一台服务器托管个人主页"教程

## 为什么
Daniel 想在同一台 VPS、同一个 IP 上托管个人主页（议题 #445）。DuckDNS 通配符子域名已自动解析到服务器 IP，主页放本仓库可复用现有 cron 自动部署——合并 ≈ 2 分钟后自动上线，无需新基础设施。

## 怎么测试
- 本地直接用浏览器打开 `homepage/index.html` 查看页面（纯静态）
- 合并后：在服务器 `/etc/caddy/Caddyfile` 追加站点块并 `systemctl reload caddy`（一次性步骤，随后执行），访问 https://home.powerdaniel3000.duckdns.org 验证

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)