### PR TITLE
feat: briefing 调优——背景词汇 HSK 1–5、文章挑选统一 BRIEFING_MODEL、锁定模型下拉框

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -1239,7 +1239,10 @@ def generate_briefing_sentences(
     cards: list[dict],
     articles: list[dict],
     model: str = "gpt-5-mini",
-    max_hsk: int = 2,
+    # HSK 1-5 background vocabulary (issue #448): Daniel is HSK 4-5 — capping
+    # the non-target words at HSK 1-2 made sentences childish and was the
+    # tightest remaining constraint after the #444 rework.
+    max_hsk: int = 5,
     progress_key: str | None = None,
     attempt_label: str = "",
     progress_extra: dict | None = None,

--- a/routes/story.py
+++ b/routes/story.py
@@ -201,6 +201,14 @@ def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
             sentences, prompt_text = _generate_kahneman_story_sentences(
                 cards, parsed_chapter_ids, model=model, progress_key=progress_key)
         elif mode in ("news", "paste", "briefing"):
+            if mode == "briefing":
+                # Briefing (issue #444) ignores the frontend's model selection —
+                # it always uses BRIEFING_MODEL (env, default gpt-5.1, verified/
+                # cached via ai.resolve_briefing_model()), OpenAI only. Resolved
+                # before the article-selection call so summarize_news_items uses
+                # the same model as the sentence generation (issue #448).
+                model = ai.resolve_briefing_model()
+                logger.info("story  briefing model in use: %s", model)
             if mode in ("news", "briefing") and not articles:
                 # News/briefing modes always auto-fetch today's news and let the
                 # AI condense it into briefing source articles (issue #387).
@@ -210,11 +218,6 @@ def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
                 # (raised inside _generate_news_story_sentences).
                 articles = _auto_news_articles(model=model, progress_key=progress_key)
             if mode == "briefing":
-                # Briefing (issue #444) ignores the frontend's model selection —
-                # it always uses BRIEFING_MODEL (env, default gpt-5.1, verified/
-                # cached via ai.resolve_briefing_model()), OpenAI only.
-                model = ai.resolve_briefing_model()
-                logger.info("story  briefing model in use: %s", model)
                 sentences, prompt_text = _generate_briefing_story_sentences(
                     cards, articles, model=model, progress_key=progress_key)
             else:

--- a/static/app.js
+++ b/static/app.js
@@ -5761,7 +5761,37 @@ let _modelBeforeNewsMode = null;
 function _autoSwitchModelForMode(mode) {
   const modelSel = document.getElementById('setup-model');
   if (!modelSel) return;
-  const isNewsFamily = mode === 'news' || mode === 'briefing' || mode === 'paste';
+
+  // Briefing ignores this dropdown server-side — the server always resolves
+  // BRIEFING_MODEL (env, default gpt-5.1). Lock the control and show that
+  // honestly instead of a stale gpt-5-mini selection (issue #448).
+  const serverOpt = document.getElementById('setup-model-server-opt');
+  if (mode === 'briefing') {
+    if (!serverOpt) {
+      const opt = document.createElement('option');
+      opt.id = 'setup-model-server-opt';
+      opt.value = 'briefing-server';   // ignored by the server for briefing
+      opt.textContent = 'Server: BRIEFING_MODEL (gpt-5.1)';
+      modelSel.appendChild(opt);
+    }
+    if (modelSel.value !== 'briefing-server') {
+      if (_modelBeforeNewsMode === null) _modelBeforeNewsMode = modelSel.value;
+      modelSel.value = 'briefing-server';
+    }
+    modelSel.disabled = true;
+    modelSel.title = 'News flow always uses BRIEFING_MODEL on the server (default gpt-5.1)';
+    return;
+  }
+  modelSel.disabled = false;
+  modelSel.title = '';
+  if (serverOpt) {
+    if (modelSel.value === 'briefing-server') {
+      modelSel.value = _modelBeforeNewsMode || 'gpt-5-mini';
+    }
+    serverOpt.remove();
+  }
+
+  const isNewsFamily = mode === 'news' || mode === 'paste';
   if (isNewsFamily) {
     if (modelSel.value !== 'gpt-5-mini') {
       _modelBeforeNewsMode = modelSel.value;


### PR DESCRIPTION
## 变更内容

- `generate_briefing_sentences` 的 `max_hsk` 默认 2 → 5：目标句里的背景词汇放宽到 HSK 1–5（Daniel 水平 HSK 4–5，1–2 过于幼稚且是 #444 重做后最紧的剩余约束）
- briefing 模式下模型解析提前到文章挑选之前：`summarize_news_items` 现在也用 `resolve_briefing_model()`（gpt-5.1），与句子生成一致
- 前端：briefing 模式下模型下拉框禁用并显示「Server: BRIEFING_MODEL (gpt-5.1)」占位项；切走时恢复原值与原有 news/paste 自动切换逻辑

## 测试方法

- `py_compile` / `import main` / `node --check app.js` 通过；`tests/test_briefing.py` 19 个测试全绿
- 生成质量由 Daniel 在生产环境自测（议题第 4 点的自动测试按 Daniel 要求跳过）

Closes #448