### PR TITLE
feat: 页面角落显示当前运行版本（分支@提交、部署时间、提交信息）

### DIFF
--- a/main.py
+++ b/main.py
@@ -246,6 +246,35 @@ try:
             "Expires": "0",
         })
 
+    # Running-version info (issue #450): read the current commit once at
+    # startup — deploy.sh restarts the process on every deploy, so process
+    # start time ≈ deploy time. Never fails: without git (or outside a
+    # checkout) the badge just shows "unknown".
+    def _read_version() -> dict:
+        import subprocess
+        try:
+            log_out = subprocess.run(
+                ["git", "log", "-1", "--format=%h%n%s%n%cI"],
+                capture_output=True, text=True, timeout=5, check=True,
+            ).stdout.strip().split("\n")
+            branch = subprocess.run(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                capture_output=True, text=True, timeout=5, check=True,
+            ).stdout.strip()
+            return {"commit": log_out[0], "message": log_out[1],
+                    "commit_date": log_out[2], "branch": branch}
+        except Exception as e:
+            logger.warning("version info unavailable (%s)", e)
+            return {"commit": "unknown", "message": "", "commit_date": "", "branch": "unknown"}
+
+    from datetime import datetime as _dt
+    _version_info = {**_read_version(),
+                     "deployed_at": _dt.now().isoformat(timespec="seconds")}
+
+    @app.get("/api/version")
+    def get_version():
+        return _version_info
+
     app.include_router(decks.router)
     app.include_router(review.router)
     app.include_router(story.router)

--- a/static/app.js
+++ b/static/app.js
@@ -8346,8 +8346,34 @@ async function _restartServer() {
   setTimeout(poll, 600);
 }
 
+// ── Running-version badge (issue #450) ──────────────────────────────────────
+// Bottom-right corner: branch@commit · deploy time. Hover shows the commit
+// message (title); a click/tap toggles it inline for mobile.
+async function _loadVersionBadge() {
+  try {
+    const v = await api('GET', '/api/version');
+    const el = document.getElementById('version-badge');
+    if (!el || !v.commit) return;
+    let when = '';
+    if (v.deployed_at) {
+      const d = new Date(v.deployed_at);
+      const p = n => String(n).padStart(2, '0');
+      when = ` · ${p(d.getDate())}.${p(d.getMonth() + 1)}. ${p(d.getHours())}:${p(d.getMinutes())}`;
+    }
+    const short = `${v.branch}@${v.commit}${when}`;
+    el.textContent = short;
+    el.title = v.message ? `${v.message}\n(deployed ${v.deployed_at})` : '';
+    el.onclick = () => {
+      const expanded = el.classList.toggle('expanded');
+      el.textContent = expanded && v.message ? `${short} — ${v.message}` : short;
+    };
+    el.style.display = 'block';
+  } catch (e) { /* badge is best-effort — never break the app over it */ }
+}
+
 // ── Boot ─────────────────────────────────────────────────────────────────────
 loadDecks();
+_loadVersionBadge();
 
 
 // ===== Home calendar heatmap (issue #307) — inlined here to dodge index.html caching =====

--- a/static/index.html
+++ b/static/index.html
@@ -1121,5 +1121,8 @@
   <div id="info-pop-title"></div>
   <div id="info-pop-body"></div>
 </div>
+
+<!-- Running-version badge (issue #450): branch@commit · deploy time; click/hover for commit message -->
+<div id="version-badge" style="display:none"></div>
 </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -4565,3 +4565,13 @@ table.fsrs-table td.ivl { font-weight: 700; }
 .next-note-input.has-note {
   border-color: #f59e0b; background: #fffbeb;
 }
+
+/* Running-version badge (issue #450) — bottom-right, unobtrusive */
+#version-badge {
+  position: fixed; right: 8px; bottom: 5px; z-index: 400;
+  font-size: 10px; line-height: 1.3; color: #64748b; opacity: 0.5;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  cursor: pointer; user-select: none; max-width: 80vw;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+#version-badge:hover, #version-badge.expanded { opacity: 1; }


### PR DESCRIPTION
## 变更内容

- 后端 `GET /api/version`：进程启动时用 git 读一次 HEAD（短哈希/分支/提交信息/提交时间）+ 进程启动时间（deploy.sh 每次部署都重启进程，故启动时间 ≈ 部署时间）；git 不可用时返回 unknown，不影响运行
- 前端右下角固定小徽章：`分支@短哈希 · 部署日期时间`，半透明小字等宽字体；悬停 title 显示提交信息，点击/轻触切换内联显示（手机无悬停）
- 徽章加载失败静默跳过，绝不影响应用

## 测试方法

- 本地烟雾测试（8799 端口 + dev.db）：接口返回 {commit, message, commit_date, branch, deployed_at} ✓
- node --check / py_compile / import main 通过
- 部署后：主页右下角应显示 main@<新提交> 与部署时间

Closes #450