### PR TITLE
News Flow 第二批：按摘要顺序复习、逐篇生成+事实核查、快捷键重排、日志查看器、自动播放延迟

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -1211,6 +1211,21 @@ def validate_briefing_items(items: list[dict], cards: list[dict]) -> list[str]:
     if len(items) > 2 * len(cards):
         issues.append(f"句子总数（{len(items)}）超过目标词数量两倍的上限（{2 * len(cards)}）")
 
+    # article_idx must be non-decreasing across the sequence (issue #454) —
+    # the AI is told to process articles one at a time, in order. None/missing
+    # article_idx is not a violation (just skipped when tracking the max seen).
+    max_idx_seen = None
+    for pos, item in enumerate(items):
+        idx = item.get("article_idx")
+        if not isinstance(idx, int):
+            continue
+        if max_idx_seen is not None and idx < max_idx_seen:
+            issues.append(
+                f"文章顺序回跳：句子{pos}属于文章{idx}但之前已进入文章{max_idx_seen}"
+            )
+            break
+        max_idx_seen = idx if max_idx_seen is None else max(max_idx_seen, idx)
+
     for item in items:
         s_zh = (item.get("sentence_zh") or "").strip()
         if s_zh and any(_briefing_word_match(c["word_zh"], s_zh) for c in cards) and len(s_zh) > 18:
@@ -1238,6 +1253,57 @@ def _dedupe_consecutive_briefing_context(items: list[dict], cards: list[dict]) -
     if buf:
         fixed.append(buf[-1])
     return fixed
+
+
+def fact_check_briefing(articles: list[dict], items: list[dict], model: str) -> list[str]:
+    """One extra AI call (issue #454) to catch hallucinated facts in the
+    generated briefing sentences — numbers, names, causality invented rather
+    than taken from the source articles.
+
+    Returns a list of Chinese issue descriptions ("句子N：问题描述"); an empty
+    list means either everything checked out or the check itself failed —
+    fact-checking is best-effort and must never block story generation.
+    """
+    if not articles or not items:
+        return []
+
+    articles_block = "\n\n".join(
+        f"文章{i}（标题：{a.get('title') or '（无标题）'}）：\n{a.get('text', '').strip()}"
+        for i, a in enumerate(articles)
+    )
+    sentences_block = "\n".join(
+        f"{i}. {item.get('sentence_zh', '')}" for i, item in enumerate(items)
+    )
+    prompt = f"""任务：核对下面每一句中文摘要句子是否符合原始新闻文章的事实。
+
+新闻文章（按 0 开始编号）：
+{articles_block}
+
+生成的摘要句子（按 0 开始编号）：
+{sentences_block}
+
+请重点检查：数字（金额、人数、日期等）、人名/地名/机构名、因果关系是否准确，
+以及是否有原文中完全没有提到、凭空捏造的内容。
+
+只返回如下 JSON，不加任何其他文字：
+- 全部符合事实：{{"ok": true}}
+- 存在问题：{{"ok": false, "issues": ["句子N：问题描述", ...]}}"""
+
+    try:
+        raw = _call_api(model, [{"role": "user", "content": prompt}], 2048, purpose="briefing_fact_check")
+        json_start = raw.find("{")
+        json_end = raw.rfind("}") + 1
+        if json_start == -1 or json_end == 0:
+            logger.warning("briefing fact-check: no JSON object found in response")
+            return []
+        result = json.loads(raw[json_start:json_end])
+        if result.get("ok"):
+            return []
+        issues = result.get("issues") or []
+        return [str(i) for i in issues]
+    except Exception as e:
+        logger.warning("briefing fact-check: call failed (%s) — skipping", e)
+        return []
 
 
 def generate_briefing_sentences(
@@ -1337,6 +1403,9 @@ def generate_briefing_sentences(
 - 不要使用markdown格式
 - article_idx 是该句子所涉及的文章编号（上面的 0 开始编号）
 - target_word 是该句包含的目标词汇原文；不含目标词的上下文句子填 null
+- 【逐篇处理】必须按文章编号顺序依次处理：先写完文章0涉及的所有句子（含其上下文句），
+  再开始写文章1的句子，以此类推——article_idx 在整个输出中只能递增或不变，绝不允许
+  写到文章1之后又跳回去写文章0的句子
 {extra_hint}
 
 仅返回如下JSON数组，不加任何其他文字：
@@ -1348,6 +1417,7 @@ def generate_briefing_sentences(
     sentences: list[dict] = []
     remaining = list(cards)
     validation_retried = False
+    fact_check_done = False
 
     _progress(f"生成新闻总结…{attempt_label}")
 
@@ -1407,6 +1477,41 @@ def generate_briefing_sentences(
                 # Fallback repair: collapse any remaining consecutive context runs
                 # to their last sentence — safe no-op if already valid.
                 items = _dedupe_consecutive_briefing_context(items, expected_cards)
+
+        # AI fact-check against the source articles (issue #454) — runs once,
+        # right after Python validation and before any translation. On issues,
+        # retry generation once with the concrete problems fed back in; the
+        # retry's own fact-check result (if any) is logged only, never retried
+        # again, to avoid an unbounded loop.
+        if not fact_check_done:
+            fact_check_done = True
+            _progress(f"核对事实…{attempt_label}")
+            fc_issues = fact_check_briefing(articles, items, model)
+            if fc_issues:
+                logger.warning("briefing attempt %d: fact-check issues, retrying once: %s",
+                               attempt + 1, fc_issues)
+                fc_hint = "\n【事实核查发现以下问题，请修正后重新生成整篇摘要，确保严格符合原文事实】\n" + \
+                          "\n".join(f"- {i}" for i in fc_issues)
+                fc_retry_raw = _call_api(
+                    model, [{"role": "user", "content": _build_prompt(remaining, extra_hint=fc_hint)}],
+                    8192, purpose="briefing",
+                )
+                fc_r_start, fc_r_end = fc_retry_raw.find("["), fc_retry_raw.rfind("]") + 1
+                if fc_r_start != -1 and fc_r_end != 0:
+                    try:
+                        fc_retry_items = json.loads(fc_retry_raw[fc_r_start:fc_r_end])
+                        items = _dedupe_consecutive_briefing_context(fc_retry_items, expected_cards)
+                        second_fc_issues = fact_check_briefing(articles, items, model)
+                        if second_fc_issues:
+                            logger.warning(
+                                "briefing: fact-check issues persist after retry (accepting): %s",
+                                second_fc_issues)
+                    except json.JSONDecodeError as e:
+                        logger.warning("briefing: fact-check retry JSON parse error (%s) — "
+                                       "keeping original attempt", e)
+                else:
+                    logger.warning("briefing: fact-check retry produced no JSON array — "
+                                   "keeping original attempt")
 
         # Scan in reading order: context sentences accumulate until the next
         # sentence containing a still-uncovered target word, then attach to it.

--- a/database/core.py
+++ b/database/core.py
@@ -322,6 +322,8 @@ def init_db() -> None:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN enable_probation INTEGER NOT NULL DEFAULT 1")
     if "reading_enabled" not in preset_cols:
         conn.execute("ALTER TABLE deck_presets ADD COLUMN reading_enabled INTEGER NOT NULL DEFAULT 0")
+    if "autoplay_delay_ms" not in preset_cols:
+        conn.execute("ALTER TABLE deck_presets ADD COLUMN autoplay_delay_ms INTEGER NOT NULL DEFAULT 1000")
 
     conn.execute("""CREATE TABLE IF NOT EXISTS preset_category_overrides (
         id                  INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/database/presets.py
+++ b/database/presets.py
@@ -43,6 +43,7 @@ def default_preset() -> dict:
         "sibling_separation": 3,
         "sibling_factor": 0.2,
         "reading_enabled": 0,
+        "autoplay_delay_ms": 1000,
     }
 
 
@@ -213,6 +214,7 @@ def insert_preset(preset: dict) -> int:
     preset.setdefault("learned_interval", 4)
     preset.setdefault("enable_probation", 1)
     preset.setdefault("reading_enabled", 0)
+    preset.setdefault("autoplay_delay_ms", 1000)
     conn = get_db()
     cur = conn.execute(
         """INSERT INTO deck_presets
@@ -226,7 +228,7 @@ def insert_preset(preset: dict) -> int:
             interday_learning_review_order, review_sort_order,
             bury_new_siblings, bury_review_siblings, bury_interday_siblings,
             bury_quick_mode, category_order, sibling_separation, sibling_factor,
-            reading_enabled)
+            reading_enabled, autoplay_delay_ms)
            VALUES (:name, :new_per_day, :reviews_per_day,
                    :learning_steps, :graduating_interval, :easy_interval,
                    :relearning_steps, :minimum_interval, :learned_interval,
@@ -237,7 +239,7 @@ def insert_preset(preset: dict) -> int:
                    :interday_learning_review_order, :review_sort_order,
                    :bury_new_siblings, :bury_review_siblings, :bury_interday_siblings,
                    :bury_quick_mode, :category_order, :sibling_separation, :sibling_factor,
-                   :reading_enabled)""",
+                   :reading_enabled, :autoplay_delay_ms)""",
         preset,
     )
     conn.commit()
@@ -259,6 +261,7 @@ def update_preset(preset_id: int, fields: dict) -> None:
         "bury_new_siblings", "bury_review_siblings", "bury_interday_siblings",
         "bury_quick_mode", "category_order", "new_review_order_override",
         "sibling_separation", "sibling_factor", "reading_enabled",
+        "autoplay_delay_ms",
     }
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:

--- a/database/stories.py
+++ b/database/stories.py
@@ -283,6 +283,39 @@ def get_story_sentences(story_id: int) -> list[dict]:
     return result
 
 
+def get_story_position_map(deck_id: int, category: str, date_str: str,
+                            lang: str | None = None) -> dict[int, int]:
+    """Map word_id → story_sentences.position for today's active News-flow-style
+    story (briefing/news/paste — issue #454), used to order the review queue to
+    match the summary's reading order. Returns {} when there is no active story
+    or its gen_params.mode isn't one of those three (e.g. plain story/kahneman
+    modes, which don't have a meaningful "reading order" for review purposes).
+    """
+    story = get_active_story(date_str, category, deck_id, lang)
+    if not story:
+        return {}
+    gen_params = story.get("gen_params")
+    if not gen_params:
+        return {}
+    try:
+        mode = json.loads(gen_params).get("mode")
+    except (ValueError, TypeError):
+        return {}
+    if mode not in ("briefing", "news", "paste"):
+        return {}
+
+    conn = get_db()
+    rows = conn.execute(
+        """SELECT sw.word_id, ss.position
+           FROM story_sentence_words sw
+           JOIN story_sentences ss ON ss.id = sw.sentence_id
+           WHERE ss.story_id = ?""",
+        (story["id"],),
+    ).fetchall()
+    conn.close()
+    return {r["word_id"]: r["position"] for r in rows}
+
+
 def get_due_cards_unified(deck_id: int, lang: str | None = None) -> list[dict]:
     """Collect due cards from all 3 categories for a unified story, deduplicated by word_id.
     Order matches review priority (state → category → due) so story sentence positions

--- a/main.py
+++ b/main.py
@@ -96,6 +96,37 @@ logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 
 # ---------------------------------------------------------------------------
+# In-memory ring buffer of recent log lines, exposed via GET /api/logs
+# (issue #454) — lets Daniel check server logs from the settings page
+# without SSH access.
+# ---------------------------------------------------------------------------
+
+import collections
+
+
+class _RingBufferHandler(logging.Handler):
+    def __init__(self, maxlen: int = 4000):
+        super().__init__()
+        self.buffer: "collections.deque[str]" = collections.deque(maxlen=maxlen)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            self.buffer.append(self.format(record))
+        except Exception:
+            pass  # never let logging itself raise
+
+
+_log_buffer_handler = _RingBufferHandler(maxlen=4000)
+# Always use the plain (non-colored) formatter, regardless of whether stderr
+# is a tty, so the buffer never contains ANSI escape codes.
+_log_buffer_handler.setFormatter(logging.Formatter(
+    "%(asctime)s [%(levelname)-5s] %(name)s: %(message)s",
+    datefmt="%H:%M:%S",
+))
+logging.root.addHandler(_log_buffer_handler)
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -158,7 +189,7 @@ try:
     from contextlib import asynccontextmanager
     from fastapi import FastAPI, Request
     from fastapi.staticfiles import StaticFiles
-    from fastapi.responses import FileResponse, JSONResponse
+    from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse
     import uvicorn
 
     from routes import decks, review, story, browse, imports
@@ -293,6 +324,12 @@ try:
     def log_ui_action(body: LogBody):
         ui_logger.info("点击 → %s", body.action)
         return {"ok": True}
+
+    @app.get("/api/logs")
+    def get_logs(lines: int = 500):
+        n = max(1, min(lines, 4000))
+        recent = list(_log_buffer_handler.buffer)[-n:]
+        return PlainTextResponse("\n".join(recent))
 
     @app.post("/api/restart")
     def restart_server():

--- a/routes/review.py
+++ b/routes/review.py
@@ -58,6 +58,15 @@ def _spawn_again_regen(card: dict) -> None:
             # a random chapter for kahneman) so the new sentence matches its style
             # instead of always being a plain story sentence.
             gen_params = database.get_story_gen_params_for_word(card["word_id"], today)
+            if (gen_params or {}).get("mode") == "briefing":
+                # briefing sentences are part of a connected news summary — a
+                # standalone regenerated sentence would break that context, and
+                # the queue-ordering feature (issue #454) means the card still
+                # reappears at its original position in the summary anyway.
+                logger.info("again-regen  word=%s mode=briefing — skipping regen "
+                            "(briefing cards keep their original summary sentence)",
+                            card.get("word_zh"))
+                return
             sentence = generate_sentence_for_word(card, gen_params)
             if not sentence:
                 return
@@ -78,6 +87,30 @@ def _spawn_again_regen(card: dict) -> None:
 # Queue key / build-function helpers
 # ---------------------------------------------------------------------------
 
+def _order_by_story(cards: list[dict], story_deck_id: int | None,
+                    story_category: str | None, lang: str | None) -> list[dict]:
+    """Reorder due cards to match today's News-flow-style story (briefing/news/
+    paste — issue #454): word_id → story_sentences.position, via
+    database.get_story_position_map(). `sorted` is stable, so cards whose word
+    isn't in the story (or when there's no such story at all) keep their
+    existing interleaved order and sort after everything that is in the story.
+
+    Single-category sessions that don't find a per-category story also try the
+    'unified' story — a unified story (from a mixed/"All" review session)
+    drives ordering for per-category sessions too, since it covers every word
+    due that day regardless of category.
+    """
+    if not story_deck_id or not story_category or not cards:
+        return cards
+    today = database.anki_today().isoformat()
+    pos = database.get_story_position_map(story_deck_id, story_category, today, lang)
+    if not pos and story_category != "unified":
+        pos = database.get_story_position_map(story_deck_id, "unified", today, lang)
+    if not pos:
+        return cards
+    return sorted(cards, key=lambda c: pos.get(c.get("word_id"), float("inf")))
+
+
 def _key_and_build(
     *,
     ids: list[int] | None = None,
@@ -91,18 +124,31 @@ def _key_and_build(
 
     `lang` is appended to every key tuple so 'All zh' and 'All fr' (or any other
     lang split of the same deck/id set) never share a cached in-memory queue.
+
+    build_fn's output is reordered to match the active News-flow story's
+    sentence order (issue #454, see _order_by_story) — this only runs once per
+    Anki day / queue invalidation, so the extra position-map lookup is cheap.
     """
     if root_deck_id:
         key = ("any_cat", root_deck_id, lang)
-        build_fn = lambda: database.get_due_cards_any_cat(root_deck_id, lang=lang)
+
+        def build_fn():
+            cards = database.get_due_cards_any_cat(root_deck_id, lang=lang)
+            return _order_by_story(cards, root_deck_id, "unified", lang)
     elif ids and len(ids) > 1:
         key = ("multi", tuple(sorted(ids)), category, lang)
         _root = parent_for_multi
-        build_fn = lambda: database.get_due_cards_multi(ids, category, root_deck_id=_root)
+
+        def build_fn():
+            cards = database.get_due_cards_multi(ids, category, root_deck_id=_root)
+            return _order_by_story(cards, _root, category, lang)
     else:
         actual = (ids[0] if ids else deck_id)
         key = ("single", actual, category, lang)
-        build_fn = lambda: database.get_due_cards(actual, category)
+
+        def build_fn():
+            cards = database.get_due_cards(actual, category)
+            return _order_by_story(cards, actual, category, lang)
     return key, build_fn
 
 

--- a/routes/story.py
+++ b/routes/story.py
@@ -14,7 +14,7 @@ import tts
 from fastapi import APIRouter
 from fastapi.responses import FileResponse
 
-from .utils import DISABLE_AI, leaf_ids
+from .utils import DISABLE_AI, leaf_ids, queue_mgr
 
 KAHNEMAN_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "kahneman_chapters.json")
 
@@ -512,6 +512,12 @@ def regenerate_story(deck_id: int, category: str,
         grammar_focus=grammar_focus, grammar_pct=grammar_pct,
         mode=mode, chapter_ids=chapter_ids, articles=articles, progress_key=progress_key, lang=lang)
     ai._story_progress.pop(progress_key, None)
+    if result:
+        # A new story means word→position mapping changed — invalidate every
+        # in-memory session queue so review order picks up the new sentence
+        # order on next access (issue #454). Full invalidation is coarse but
+        # cheap: queues are just rebuilt lazily from cheap DB queries.
+        queue_mgr.invalidate()
     return result
 
 

--- a/schema.sql
+++ b/schema.sql
@@ -129,7 +129,11 @@ CREATE TABLE IF NOT EXISTS deck_presets (
 
     -- Fraction of current interval applied as additional sibling separation
     -- effective_separation = max(sibling_separation, floor(interval * sibling_factor))
-    sibling_factor          REAL NOT NULL DEFAULT 0.2
+    sibling_factor          REAL NOT NULL DEFAULT 0.2,
+
+    -- Delay (ms) before auto-playing audio when a new card is flipped.
+    -- Only affects auto-play; manual replay is never delayed.
+    autoplay_delay_ms       INTEGER NOT NULL DEFAULT 1000
 );
 
 -- ---------------------------------------------------------------------------

--- a/static/app.js
+++ b/static/app.js
@@ -106,12 +106,15 @@ function currentCardLang() {
 // User overrides persist in localStorage('reviewKeymap'). Rating keys 1-4 stay fixed.
 const KEYMAP_DEFAULTS = {
   reveal:         ' ',
-  replay:         'a',
+  replay:         'q',
   pinyin:         'p',
   translation:    't',
   worddef:        'k',
   'new-sentence': '5',
   undo:           'z',
+  'hint-minus':   'a',
+  'hint-plus':    's',
+  'story-modal':  'x',
 };
 const KEYMAP_ACTIONS = [
   { id: 'reveal',       label: 'Reveal answer' },
@@ -121,9 +124,12 @@ const KEYMAP_ACTIONS = [
   { id: 'worddef',      label: 'Toggle word definition' },
   { id: 'new-sentence', label: 'New sentence (regenerate)' },
   { id: 'undo',         label: 'Undo last review' },
+  { id: 'hint-minus',   label: 'Listening hint −' },
+  { id: 'hint-plus',    label: 'Listening hint +' },
+  { id: 'story-modal',  label: 'Open summary (full story)' },
 ];
 // Keys hardcoded elsewhere in the review view — cannot be reassigned to.
-const KEYMAP_RESERVED = ['R','1','2','3','4','e','n','q','w','f','v','c','C','D','7','L','o','g','Enter','Tab'];
+const KEYMAP_RESERVED = ['R','1','2','3','4','e','n','w','f','v','c','C','D','7','L','o','g','Enter','Tab'];
 function _loadKeymap() {
   let saved = {};
   try { saved = JSON.parse(localStorage.getItem('reviewKeymap') || '{}'); } catch (e) {}
@@ -5988,9 +5994,9 @@ function _renderNewsBackSource(s) {
   const srcHtml = _newsSourceHtml(s);
   if (!ctx && !srcHtml) { el.style.display = 'none'; el.innerHTML = ''; return; }
   const url = s?.source_url || '';
-  let html = '';
+  // Title · publisher above the context (issue #454).
+  let html = srcHtml;
   if (ctx) html += `<div class="news-back-context${url ? ' clickable-sentence' : ''}">${_escHtml(ctx)}</div>`;
-  html += srcHtml;
   el.innerHTML = html;
   el.style.display = 'block';
   if (ctx && url) {
@@ -6178,14 +6184,34 @@ function _closeSetupModal() {
 }
 
 // ── Story modal ───────────────────────────────────────────────────────────────
+// Article section-header HTML shown once per article in the full-story modal
+// (replaces the old per-sentence source line, issue #454). Same title/label
+// logic as _newsSourceHtml, minus the trailing arrow.
+function _articleHeaderHtml(s, escAttr) {
+  const title = _newsflowLang === 'zh'
+    ? (s.concept_zh || s.source_title || '')
+    : (s.source_title || '');
+  const label = [title, s.source_name || ''].filter(Boolean).join(' · ');
+  if (!label) return '';
+  const url = s.source_url || '';
+  return `<div class="story-article-header"${url ? ` data-url="${escAttr(url)}"` : ''}>📰 ${escAttr(label)}</div>`;
+}
+
 function openStoryModal() {
   if (!story?.sentences?.length) return;
   const escAttr = s => String(s || '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
   const currentPos = sentence?.position ?? -1;
   const parts = [];
+  let prevUrl = null;
   for (const s of story.sentences) {
     const isCurrent = s.position === currentPos;
     const url = s.source_url || '';
+    // News flow: article section header, inserted once whenever a new source
+    // article starts (issue #454; replaces the old per-sentence source line).
+    if (url && url !== prevUrl) {
+      parts.push(_articleHeaderHtml(s, escAttr));
+      prevUrl = url;
+    }
     // News flow: context sentence(s) preceding this target — shown between the
     // target sentences (Chinese + German), clickable to the source (issue #452).
     const ctxZh = s.reasoning_zh || '';
@@ -6205,7 +6231,6 @@ function openStoryModal() {
            <span class="concept-name">${s.concept_zh}</span>
          </div>`
       : '';
-    const srcLine = _newsSourceHtml(s);
     parts.push(`<div class="story-sentence${isCurrent ? ' story-sentence-current' : ''}" data-idx="${s.position}">
       <span class="story-num">${s.position + 1}</span>
       <div class="story-content">
@@ -6213,7 +6238,6 @@ function openStoryModal() {
         ${conceptBadge}
         ${s.sentence_fr ? `<div class="story-fr">🇫🇷 ${s.sentence_fr}</div>` : ''}
         ${s.sentence_de ? `<div class="story-de">🇩🇪 ${s.sentence_de}</div>` : ''}
-        ${srcLine ? `<div class="news-source-line-wrap">${srcLine}</div>` : ''}
       </div>
       <button class="story-play-btn" onclick="storyJumpTo(${s.position})" title="Play">▶</button>
     </div>`);
@@ -6228,6 +6252,8 @@ function openStoryModal() {
   if (_storyPlaying && _currentPlayIdx >= 0) updateStoryHighlight(_currentPlayIdx);
   document.getElementById('story-modal-overlay').style.display = 'block';
   document.getElementById('story-modal').style.display = 'flex';
+  // Jump straight to the current sentence (issue #454).
+  document.querySelector('#story-modal-body .story-sentence-current')?.scrollIntoView({ block: 'center' });
 }
 
 let _storyPlaying = false;
@@ -8011,10 +8037,14 @@ document.addEventListener('keydown', async e => {
       e.preventDefault(); _toggleAndScroll('notes-section-body', 'notes-section');
     } else if (backVisible && e.key === 'w') {
       e.preventDefault(); _toggleAndScroll('word-analysis-section-body', 'word-analysis-section', 'end');
-    } else if (e.key === 'q') {
+    } else if (e.key === _key('hint-minus')) {
       e.preventDefault(); _adjustListenHintSlider(-1);
-    } else if (e.key === 'w') {
+    } else if (e.key === _key('hint-plus')) {
       e.preventDefault(); _adjustListenHintSlider(1);
+    } else if (e.key === _key('story-modal')) {
+      e.preventDefault();
+      const _storyOpen = document.getElementById('story-modal-overlay')?.style.display !== 'none';
+      if (_storyOpen) closeStoryModal(); else openStoryModal();
     } else if (e.key === 'f') {
       e.preventDefault(); _toggleSuspendCat('reading');
     } else if (e.key === 'v') {

--- a/static/app.js
+++ b/static/app.js
@@ -47,6 +47,24 @@ let story       = null;   // story dict with sentences[]
 let sentence    = null;   // current sentence from story (may be null)
 let wordDetails = null;   // full word data: examples + characters
 let _currentWordId = null; // word ID open in word-detail view
+
+// Autoplay delay for the listening category (issue #454). Cached per deck preset
+// so we don't re-fetch on every card; manual replay is never delayed.
+let _autoplayDelayMs = null;
+let _autoplayDeckId  = null;
+let _autoplayTimer   = null;
+async function _getAutoplayDelay() {
+  const id = rootDeckId || deckId;
+  if (id === _autoplayDeckId && _autoplayDelayMs != null) return _autoplayDelayMs;
+  try {
+    const preset = await api('GET', `/api/decks/${id}/preset`);
+    _autoplayDelayMs = preset?.autoplay_delay_ms ?? 1000;
+  } catch (e) {
+    _autoplayDelayMs = 1000;
+  }
+  _autoplayDeckId = id;
+  return _autoplayDelayMs;
+}
 let _prevView = null;      // view we came from before opening word-detail
 let _sessionReviewedCount = 0; // cards rated this session (for clap animation)
 let _sessionReviewedIds = [];  // card ids reviewed this session (for summary graph)
@@ -2567,6 +2585,11 @@ function renderSettings() {
           <span id="newsflow-lang-value">${nfZh ? '中文' : 'Original (DE)'}</span>
         </label>
       </div>
+    </div>
+    <div class="keymap-panel">
+      <h2 class="keymap-heading">Server logs</h2>
+      <p class="keymap-hint">View the last lines of the server log (helpful for debugging story generation, TTS, etc).</p>
+      <button class="keymap-reset-all" onclick="openLogsViewer()">Open logs</button>
     </div>`;
 }
 function startKeyCapture(id) {
@@ -2610,6 +2633,47 @@ function _settingsKeydown(e) {
   _capturingAction = null; _settingsMsg = ''; renderSettings();
 }
 document.addEventListener('keydown', _settingsKeydown, true);
+
+// ── Server logs viewer (issue #454) ─────────────────────────────────────────
+let _logsRawText = '';
+let _logsAutoTimer = null;
+
+async function openLogsViewer() {
+  document.getElementById('logs-modal-overlay').style.display = 'block';
+  document.getElementById('logs-modal').style.display = 'flex';
+  await refreshLogs();
+}
+
+function closeLogsViewer() {
+  document.getElementById('logs-modal-overlay').style.display = 'none';
+  document.getElementById('logs-modal').style.display = 'none';
+  if (_logsAutoTimer) { clearInterval(_logsAutoTimer); _logsAutoTimer = null; }
+}
+
+async function refreshLogs() {
+  try {
+    const res = await fetch('/api/logs?lines=800');
+    _logsRawText = res.ok ? await res.text() : `Failed to load logs (${res.status})`;
+  } catch (e) {
+    _logsRawText = 'Failed to load logs: ' + e.message;
+  }
+  _applyLogsFilter();
+}
+
+function _applyLogsFilter() {
+  const body = document.getElementById('logs-body');
+  const q = (document.getElementById('logs-filter')?.value || '').toLowerCase();
+  const text = q
+    ? _logsRawText.split('\n').filter(line => line.toLowerCase().includes(q)).join('\n')
+    : _logsRawText;
+  body.textContent = text;
+  body.scrollTop = body.scrollHeight;
+}
+
+function toggleLogsAuto(checked) {
+  if (_logsAutoTimer) { clearInterval(_logsAutoTimer); _logsAutoTimer = null; }
+  if (checked) _logsAutoTimer = setInterval(refreshLogs, 2000);
+}
 
 async function openCostModal() {
   try {
@@ -2851,6 +2915,7 @@ function loadPresetFields(preset) {
   document.getElementById('opt-desired-retention').value = Math.round((preset.desired_retention ?? 0.9) * 100);
   document.getElementById('opt-max-int').value         = preset.maximum_interval ?? 36500;
   document.getElementById('opt-reading-enabled').checked = !!preset.reading_enabled;
+  document.getElementById('opt-autoplay-delay').value = preset.autoplay_delay_ms ?? 1000;
   applySchedulerVisibility();
 
   // Category order
@@ -3022,6 +3087,10 @@ async function saveOptions() {
     maximum_interval:       Math.max(1, parseInt(document.getElementById('opt-max-int').value) || 36500),
     category_order: _getCategoryOrderUI(),
     reading_enabled:        document.getElementById('opt-reading-enabled').checked ? 1 : 0,
+    autoplay_delay_ms:      (() => {
+      const v = parseInt(document.getElementById('opt-autoplay-delay').value);
+      return Number.isFinite(v) && v >= 0 ? v : 1000; // 0 is a valid "play immediately" value
+    })(),
   };
   try {
     const [savedPreset] = await Promise.all([
@@ -3038,6 +3107,7 @@ async function saveOptions() {
         return api('DELETE', `/api/presets/${presetId}/categories/${cat}`).catch(() => {});
       }
     }));
+    _autoplayDelayMs = null; // invalidate cache so the next card picks up the new value
     closeModal();
     loadDecks();
   } catch (e) {
@@ -3502,6 +3572,7 @@ async function _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, gram
 
 // ── Load a card ─────────────────────────────────────────────────────────────
 function loadCard(c, counts) {
+  clearTimeout(_autoplayTimer);
   card = c;
   wordDetails = null;
   renderReviewCatRow(); // clear circles immediately when new card loads
@@ -3629,13 +3700,13 @@ function loadCard(c, counts) {
         }
         // Auto-play deferred from loadCard: play now that story is loaded
         if (snap.category === 'listening' && document.getElementById('side-back').style.display === 'none') {
-          playSentence();
+          _getAutoplayDelay().then(d => { if (card === snap) _autoplayTimer = setTimeout(playSentence, d); });
         }
       }).catch(() => {
         // On fetch error, still play audio (falls back to word_zh)
         if (card === snap && snap.category === 'listening' &&
             document.getElementById('side-back').style.display === 'none') {
-          playSentence();
+          _getAutoplayDelay().then(d => { if (card === snap) _autoplayTimer = setTimeout(playSentence, d); });
         }
       });
   }
@@ -3720,7 +3791,8 @@ function loadCard(c, counts) {
     if (!sentence && (unfinishedMode || rootDeckId)) {
       // Deferred — fetch callback will call playSentence() once story is loaded
     } else {
-      playSentence();
+      const snap = c;
+      _getAutoplayDelay().then(d => { if (card === snap) _autoplayTimer = setTimeout(playSentence, d); });
     }
   }
 }
@@ -4085,8 +4157,14 @@ function revealAnswer() {
   renderVocabDetail();
   renderReviewCatRow();
 
-  // Auto-play audio on reveal for all categories
-  playSentence();
+  // Auto-play audio on reveal for all categories, delayed per deck preset
+  // (issue #454). Clear any still-pending front-side autoplay first so the
+  // two timers can't both fire.
+  clearTimeout(_autoplayTimer);
+  const _revealSnap = card;
+  _getAutoplayDelay().then(d => {
+    _autoplayTimer = setTimeout(() => { if (card === _revealSnap) playSentence(); }, d);
+  });
 }
 
 // ── Populate vocab detail (chars + examples) ────────────────────────────────
@@ -7767,6 +7845,7 @@ function _hasOpenModal() {
     'conflict-modal-overlay',
     'kahneman-examples-overlay',
     'session-summary-overlay',
+    'logs-modal-overlay',
   ];
   return modalIds.some(_isVisible);
 }
@@ -7888,6 +7967,12 @@ document.addEventListener('keydown', async e => {
     if (reasoningModal && reasoningModal.style.display !== 'none') {
       e.preventDefault();
       closeReasoning();
+      return;
+    }
+    const logsOverlay = document.getElementById('logs-modal-overlay');
+    if (logsOverlay && logsOverlay.style.display !== 'none') {
+      e.preventDefault();
+      closeLogsViewer();
       return;
     }
     // Blur input fields in review view so space bar can flip the card

--- a/static/index.html
+++ b/static/index.html
@@ -120,6 +120,8 @@
 
           <!-- Front side (content varies by category) -->
           <div id="side-front">
+            <!-- News flow: clickable article title · publisher, above the context/sentence (issue #454) -->
+            <div class="news-source-line-wrap" id="news-source-front" style="display:none"></div>
             <!-- News flow: German context of the preceding summary sentences (always above the Chinese sentence) -->
             <div class="sentence-context-de" id="sentence-context-de" style="display:none"></div>
             <!-- Listening: hint sentence with slider (shows % of non-target chars) -->
@@ -145,8 +147,6 @@
             </div>
             <!-- Reading / Cloze: Chinese sentence on front (reading shows full, cloze shows blanked) -->
             <div class="sentence" id="sentence-front"></div>
-            <!-- News flow: clickable article title · publisher under the sentence (issue #452) -->
-            <div class="news-source-line-wrap" id="news-source-front" style="display:none"></div>
             <div class="creating-input-wrap" id="creating-input-wrap">
               <div class="input-label" id="creating-input-label">Fill in the blank</div>
               <input type="text" id="creating-input" placeholder="Type the missing word…"

--- a/static/index.html
+++ b/static/index.html
@@ -503,6 +503,11 @@
     </div>
 
     <div class="opt-group">
+      <div class="opt-group-label">Audio</div>
+      <div class="opt-row"><span class="opt-label">Autoplay delay (ms)</span><input class="opt-input" id="opt-autoplay-delay" type="number" min="0" step="100" title="Delay before audio auto-plays — when a listening card loads and after revealing the answer. Manual replay is never delayed."></div>
+    </div>
+
+    <div class="opt-group">
       <div class="opt-group-label">Category Overrides <span style="font-weight:400;font-size:11px;color:var(--muted)">— leave blank to use preset default</span></div>
       <div id="cat-overrides-container">
         <!-- Listening -->
@@ -798,6 +803,24 @@
     <button class="edit-modal-close" onclick="closeCostModal()">✕</button>
   </div>
   <div id="cost-modal-body"></div>
+</div>
+
+<!-- Server logs modal -->
+<div id="logs-modal-overlay" onclick="closeLogsViewer()" style="display:none"></div>
+<div id="logs-modal" style="display:none">
+  <div class="edit-modal-header">
+    <span class="edit-modal-title">Server logs</span>
+    <button class="edit-modal-close" onclick="closeLogsViewer()">✕</button>
+  </div>
+  <div class="logs-toolbar">
+    <input type="text" id="logs-filter" placeholder="Filter…" oninput="_applyLogsFilter()">
+    <button class="keymap-reset-all" onclick="refreshLogs()">Refresh</button>
+    <label class="switch-wrap">
+      <input type="checkbox" id="logs-auto" onchange="toggleLogsAuto(this.checked)" style="width:16px;height:16px;cursor:pointer">
+      <span>Auto</span>
+    </label>
+  </div>
+  <pre id="logs-body"></pre>
 </div>
 
 <!-- Import modal -->

--- a/static/style.css
+++ b/static/style.css
@@ -1287,6 +1287,17 @@ main.browse-open {
 }
 .story-context-zh { font-size: 14px; line-height: 1.5; color: var(--muted); }
 .story-context-de { font-size: 12px; color: var(--muted); margin-top: 2px; }
+/* News flow: article section header in the full-story modal, inserted once per
+   source article (issue #454, replaces the old per-sentence source line). */
+.story-article-header {
+  margin: 18px 0 6px;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--muted);
+  cursor: pointer;
+}
+.story-article-header:first-child { margin-top: 4px; }
+.story-article-header:hover { text-decoration: underline; }
 .story-controls {
   display: flex;
   align-items: center;
@@ -3325,6 +3336,61 @@ select.opt-input {
 #cost-modal-body {
   overflow-y: auto;
   padding: 16px 20px 24px;
+}
+
+/* ── Server logs modal (issue #454) ─────────────────────── */
+#logs-modal-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.45);
+  z-index: 200;
+}
+#logs-modal {
+  position: fixed;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(94vw, 960px);
+  height: min(86vh, 720px);
+  background: var(--card);
+  border-radius: 18px;
+  box-shadow: 0 12px 48px rgba(0,0,0,0.22);
+  z-index: 201;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+#logs-modal .edit-modal-header {
+  padding: 18px 20px 16px;
+  border-bottom: 1.5px solid var(--border);
+  flex-shrink: 0;
+}
+.logs-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 20px;
+  border-bottom: 1.5px solid var(--border);
+  flex-shrink: 0;
+}
+.logs-toolbar #logs-filter {
+  flex: 1;
+  padding: 6px 10px;
+  border: 1.5px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 13px;
+}
+#logs-body {
+  flex: 1;
+  overflow: auto;
+  margin: 0;
+  padding: 14px 20px 20px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text);
 }
 .cost-total {
   display: flex;

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -1,15 +1,22 @@
 """
-Tests for the briefing mode rework (issue #444):
-  - validate_briefing_items: Python-only (no AI) validation of raw AI output
+Tests for the briefing mode rework (issue #444) and News flow v2 (issue #454):
+  - validate_briefing_items: Python-only (no AI) validation of raw AI output,
+    including article_idx monotonicity (#454)
   - _dedupe_consecutive_briefing_context: fallback repair for consecutive context runs
-  - generate_briefing_sentences: single validation retry is triggered on violations
+  - generate_briefing_sentences: single validation retry is triggered on violations,
+    plus the AI fact-check retry path (#454)
   - resolve_briefing_model: env var + OpenAI models-API verification + fallback chain
+  - database.get_story_position_map: word_id → sentence position for queue ordering (#454)
 """
 
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import ai
+import database
+import database.core
 
 CARDS = [
     {"word_id": 1, "word_zh": "担心", "pinyin": "dān xīn", "definition": "to worry"},
@@ -95,6 +102,36 @@ class TestValidateBriefingItems:
         issues = ai.validate_briefing_items(items, CARDS)
         assert any("超过" in i for i in issues)
 
+    def test_monotonic_article_idx_is_fine(self):
+        items = [
+            {"sentence_zh": "今天天气很好。", "target_word": None, "article_idx": 0},
+            {"sentence_zh": "她很担心考试。", "target_word": "担心", "article_idx": 0},
+            {"sentence_zh": "他每天努力学习。", "target_word": "努力", "article_idx": 1},
+            {"sentence_zh": "她看到了他的进步。", "target_word": "进步", "article_idx": 1},
+        ]
+        issues = ai.validate_briefing_items(items, CARDS)
+        assert not any("回跳" in i for i in issues)
+
+    def test_article_idx_backtrack_detected(self):
+        items = [
+            {"sentence_zh": "今天天气很好。", "target_word": None, "article_idx": 1},
+            {"sentence_zh": "她很担心考试。", "target_word": "担心", "article_idx": 1},
+            {"sentence_zh": "他每天努力学习。", "target_word": "努力", "article_idx": 0},
+            {"sentence_zh": "她看到了他的进步。", "target_word": "进步", "article_idx": 1},
+        ]
+        issues = ai.validate_briefing_items(items, CARDS)
+        assert any("回跳" in i for i in issues)
+
+    def test_missing_article_idx_is_skipped_not_a_violation(self):
+        items = [
+            {"sentence_zh": "今天天气很好。", "target_word": None, "article_idx": 0},
+            {"sentence_zh": "她很担心考试。", "target_word": "担心"},  # no article_idx at all
+            {"sentence_zh": "他每天努力学习。", "target_word": "努力", "article_idx": 0},
+            {"sentence_zh": "她看到了他的进步。", "target_word": "进步", "article_idx": 1},
+        ]
+        issues = ai.validate_briefing_items(items, CARDS)
+        assert not any("回跳" in i for i in issues)
+
 
 # ---------------------------------------------------------------------------
 # _dedupe_consecutive_briefing_context
@@ -160,11 +197,15 @@ class TestGenerateBriefingSentencesRetry:
         response is valid. generate_briefing_sentences must call the AI
         exactly twice (initial + one validation retry) and return sentences
         built from the corrected (retry) response."""
+        # fact_check_briefing makes its own _call_api call — mocked separately
+        # (return []/"pass") since these tests only exercise the Python
+        # validation retry path, not the fact-check path (issue #454).
         responses = [
             json.dumps(INVALID_ITEMS_CONSECUTIVE_CONTEXT),
             json.dumps(VALID_ITEMS),
         ]
         with patch("ai._call_api", side_effect=responses) as mock_call, \
+             patch("ai.fact_check_briefing", return_value=[]), \
              patch("ai._fill_translations", lambda sentences, **kw: None):
             result = ai.generate_briefing_sentences(CARDS, ARTICLES, model="gpt-5.1")
 
@@ -178,6 +219,7 @@ class TestGenerateBriefingSentencesRetry:
         API call — only the (separate) missing-word retry loop may still run,
         and here there are no missing words so the loop exits after attempt 1."""
         with patch("ai._call_api", return_value=json.dumps(VALID_ITEMS)) as mock_call, \
+             patch("ai.fact_check_briefing", return_value=[]), \
              patch("ai._fill_translations", lambda sentences, **kw: None):
             result = ai.generate_briefing_sentences(CARDS, ARTICLES, model="gpt-5.1")
 
@@ -193,6 +235,7 @@ class TestGenerateBriefingSentencesRetry:
             json.dumps(INVALID_ITEMS_CONSECUTIVE_CONTEXT),
         ]
         with patch("ai._call_api", side_effect=responses) as mock_call, \
+             patch("ai.fact_check_briefing", return_value=[]), \
              patch("ai._fill_translations", lambda sentences, **kw: None):
             result = ai.generate_briefing_sentences(CARDS, ARTICLES, model="gpt-5.1")
 
@@ -200,6 +243,20 @@ class TestGenerateBriefingSentencesRetry:
         assert len(result) == len(CARDS)
         matched_words = {s["word_ids"][0] for s in result}
         assert matched_words == {c["word_id"] for c in CARDS}
+
+    def test_fact_check_issue_triggers_one_regeneration(self):
+        """When fact_check_briefing reports issues on the first pass, the
+        sentences are regenerated once more; a second fact-check pass (if any)
+        is logged only and never triggers a further retry."""
+        with patch("ai._call_api", return_value=json.dumps(VALID_ITEMS)) as mock_call, \
+             patch("ai.fact_check_briefing", side_effect=[["句子1：数字不符"], []]) as mock_fc, \
+             patch("ai._fill_translations", lambda sentences, **kw: None):
+            result = ai.generate_briefing_sentences(CARDS, ARTICLES, model="gpt-5.1")
+
+        # 1 initial generation + 1 fact-check-triggered regeneration = 2 calls
+        assert mock_call.call_count == 2
+        assert mock_fc.call_count == 2
+        assert len(result) == len(CARDS)
 
 
 # ---------------------------------------------------------------------------
@@ -258,3 +315,66 @@ class TestResolveBriefingModel:
             second = ai.resolve_briefing_model()
         assert first == second == "gpt-5.1"
         mock_cls.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# database.get_story_position_map (issue #454 — review queue ordering)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    """Isolated temp-DB fixture. NOTE: patches database.core.DB_PATH directly —
+    database.DB_PATH is just a wildcard-import copy (see database/__init__.py's
+    `from .core import *`) and does NOT affect what get_db() reads; patching
+    only the package-level name silently leaves get_db() pointed at the real
+    data/srs.db (test_api.py has this same pre-existing bug, out of scope here)."""
+    db_file = tmp_path / "test.db"
+    monkeypatch.setattr(database.core, "DB_PATH", str(db_file))
+    database.init_db()
+    return db_file
+
+
+class TestGetStoryPositionMap:
+
+    def _make_words(self):
+        w1 = database.insert_word({"word_zh": "担心", "lang": "zh", "definition": "to worry"})
+        w2 = database.insert_word({"word_zh": "努力", "lang": "zh", "definition": "to work hard"})
+        w3 = database.insert_word({"word_zh": "进步", "lang": "zh", "definition": "progress"})
+        return w1, w2, w3
+
+    def test_returns_word_id_to_position_map_for_briefing_story(self, tmp_db):
+        deck_id = database.get_or_create_deck("TestDeck")
+        w1, w2, w3 = self._make_words()
+        today = database.anki_today().isoformat()
+
+        sentences = [
+            {"position": 0, "sentence_zh": "她很担心考试。", "word_ids": [w1]},
+            {"position": 1, "sentence_zh": "他每天努力学习。", "word_ids": [w2]},
+            {"position": 2, "sentence_zh": "她看到了他的进步。", "word_ids": [w3]},
+        ]
+        database.create_story(today, "reading", deck_id, sentences,
+                              gen_params={"mode": "briefing", "model": "gpt-5.1"}, lang="zh")
+
+        pos_map = database.get_story_position_map(deck_id, "reading", today, lang="zh")
+        assert pos_map == {w1: 0, w2: 1, w3: 2}
+
+    def test_non_briefing_mode_returns_empty_map(self, tmp_db):
+        deck_id = database.get_or_create_deck("TestDeck")
+        w1, w2, w3 = self._make_words()
+        today = database.anki_today().isoformat()
+
+        sentences = [
+            {"position": 0, "sentence_zh": "她很担心考试。", "word_ids": [w1]},
+            {"position": 1, "sentence_zh": "他每天努力学习。", "word_ids": [w2]},
+            {"position": 2, "sentence_zh": "她看到了他的进步。", "word_ids": [w3]},
+        ]
+        database.create_story(today, "reading", deck_id, sentences,
+                              gen_params={"mode": "story", "model": "gpt-5.1"}, lang="zh")
+
+        pos_map = database.get_story_position_map(deck_id, "reading", today, lang="zh")
+        assert pos_map == {}
+
+    def test_no_active_story_returns_empty_map(self, tmp_db):
+        deck_id = database.get_or_create_deck("TestDeck")
+        today = database.anki_today().isoformat()
+        assert database.get_story_position_map(deck_id, "reading", today, lang="zh") == {}


### PR DESCRIPTION
Closes #454

## 改了什么

### 复习行为（核心）
- **briefing/news/paste 会话的队列顺序 = 摘要句子顺序**：`_key_and_build` 的三种会话（单牌组/多牌组/全类别）都在队列构建时按当日活跃故事的 `word_id→position` 稳定排序；不在故事里的卡保持原有交错顺序排在后面；单类别会话查不到本类别故事时回退 `unified` 故事。学习步计时卡（1/10分钟）照常按时间插队——这是 SRS 核心机制，有意保留
- **重新生成故事后全量失效内存队列**，新顺序立即生效
- **briefing 评 Again 不再后台重生成句子**（摘要句是连贯叙事的一部分，重生成反而破坏上下文；news/paste 保持原行为）

### 生成质量
- **逐篇处理文章**：提示词要求按文章编号顺序写完一篇再写下一篇；`validate_briefing_items` 新增 article_idx 单调不回头校验，违规走现有的带反馈重试
- **AI 事实核查**：生成通过 Python 校验后、翻译之前，用同一模型对照原文核查每句（数字/人名/因果/凭空捏造）；发现问题带反馈**重生成一次**，再有问题只记日志不再循环；核查自身故障绝不阻断生成

### 快捷键
- 听力提示滑块减/增从硬编码 `q`/`w` 改为可配置动作；默认：重放 `a→q`、提示减 `q→a`、提示增 `w→s`（`w` 保留背面词语分析）
- 新增"打开摘要"动作，默认 `x`，设置页可改

### 展示
- 文章标题·发布方（可点击）移到上下文**上方**（正反两面）
- Full story 弹窗：每篇新文章开始处插入可点击分节头（替代逐句来源行）；打开时直接跳到当前句
- 自动播放延迟：新预设 `autoplay_delay_ms`（默认 1000ms，0=立即），作用于听力卡加载与**翻面后**的自动播放；手动重放不延迟；牌组选项可改

### 运维
- `GET /api/logs?lines=N`：根 logger 挂内存环形缓冲（4000 行），设置页新增日志查看器（过滤/刷新/2秒自动刷新），Basic Auth 保护

## 怎么测试
- `DISABLE_AI=1 pytest tests/test_briefing.py -q` → **26 passed**（新增 7 个用例：单调校验×3、position map×3、事实核查重试×1）
- 语法/导入检查全过；临时库迁移验证 `autoplay_delay_ms` 列存在
- 手动验收：部署后开一个 News flow 会话——卡片顺序应与"Sentences"摘要一致；`x` 开摘要并自动定位当前句；翻面后约 1 秒才播音

## 注意事项
- **测试隔离缺陷（历史遗留）**：`test_api.py`/`test_importer.py` 的 fixture 补丁打在 `database.DB_PATH`（无效副本），实际跑在本地 `data/srs.db` 上。本 PR 只在新测试里用对了 `database.core.DB_PATH`，并清理了错误版本留下的测试数据；旧文件的修复留待单独议题
- 事实核查是同模型自检——能抓明显幻觉/翻译错乱，不是真理机器；每次生成多 1–2 次 AI 调用
- 逐篇分组/事实核查只影响下一次生成；队列重排对现有故事立即生效
- 若 Daniel 的 localStorage 存有旧自定义键位，会覆盖新默认（设置页可一键恢复默认）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
