### PR TITLE
briefing 分批拼接后按文章重排——修复话题每批循环一轮

### DIFF
--- a/routes/story.py
+++ b/routes/story.py
@@ -624,6 +624,24 @@ def _generate_kahneman_story_sentences(
     return all_sentences, prompt_summary
 
 
+def _group_sentences_by_article(sentences: list[dict], articles: list[dict]) -> list[dict]:
+    """Regroup chunked news-family sentences topic-by-topic (issue #456).
+
+    Every batch of ai.MAX_NEWS_BATCH words is an independent AI call that
+    cycles through ALL articles once, so the concatenated story revisits every
+    topic once per batch (production story 1225: article 1 at positions 0, 10,
+    20, …). The #454 monotonic-article rule only constrains a single call, not
+    the concatenation — this stable sort fixes the whole story: sentences are
+    keyed by their article's index in `articles`, so each article becomes one
+    contiguous block while batch order is preserved within a block. Sentences
+    without a source_url keep their relative order at the end. Batches are
+    independent mini-summaries anyway, so regrouping breaks no narrative flow —
+    and since the review queue follows sentence positions (#454), reviewing
+    becomes topic-by-topic as well."""
+    order = {a.get("url"): i for i, a in enumerate(articles) if a.get("url")}
+    return sorted(sentences, key=lambda s: order.get(s.get("source_url"), len(articles)))
+
+
 def _generate_news_story_sentences(
     cards: list, articles: list[dict], model: str, progress_key: str | None,
     generic: bool = False,
@@ -653,7 +671,7 @@ def _generate_news_story_sentences(
         )
         all_sentences.extend(chunk_sentences)
 
-    return all_sentences, prompt_summary
+    return _group_sentences_by_article(all_sentences, articles), prompt_summary
 
 
 def _generate_briefing_story_sentences(
@@ -692,7 +710,7 @@ def _generate_briefing_story_sentences(
         all_sentences.extend(chunk_sentences)
         words_done += len(chunk)
 
-    return all_sentences, prompt_summary
+    return _group_sentences_by_article(all_sentences, articles), prompt_summary
 
 
 def _auto_news_articles(model: str, progress_key: str | None) -> list[dict]:

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -378,3 +378,47 @@ class TestGetStoryPositionMap:
         deck_id = database.get_or_create_deck("TestDeck")
         today = database.anki_today().isoformat()
         assert database.get_story_position_map(deck_id, "reading", today, lang="zh") == {}
+
+
+# ---------------------------------------------------------------------------
+# routes.story._group_sentences_by_article (issue #456)
+# ---------------------------------------------------------------------------
+
+from routes.story import _group_sentences_by_article  # noqa: E402
+
+
+class TestGroupSentencesByArticle:
+    ARTS = [
+        {"url": "https://ex.com/a", "title": "A"},
+        {"url": "https://ex.com/b", "title": "B"},
+        {"url": "https://ex.com/c", "title": "C"},
+    ]
+
+    def test_batch_cycling_regrouped_into_article_blocks(self):
+        # Two concatenated batches, each cycling A→B→C (the #456 bug shape)
+        sents = [
+            {"sentence_zh": "a1", "source_url": "https://ex.com/a"},
+            {"sentence_zh": "b1", "source_url": "https://ex.com/b"},
+            {"sentence_zh": "c1", "source_url": "https://ex.com/c"},
+            {"sentence_zh": "a2", "source_url": "https://ex.com/a"},
+            {"sentence_zh": "b2", "source_url": "https://ex.com/b"},
+            {"sentence_zh": "c2", "source_url": "https://ex.com/c"},
+        ]
+        out = [s["sentence_zh"] for s in _group_sentences_by_article(sents, self.ARTS)]
+        # One contiguous block per article; batch order preserved inside a block
+        assert out == ["a1", "a2", "b1", "b2", "c1", "c2"]
+
+    def test_unknown_or_missing_url_kept_last_in_relative_order(self):
+        sents = [
+            {"sentence_zh": "x1", "source_url": None},
+            {"sentence_zh": "b1", "source_url": "https://ex.com/b"},
+            {"sentence_zh": "x2", "source_url": "https://other.com/z"},
+            {"sentence_zh": "a1", "source_url": "https://ex.com/a"},
+        ]
+        out = [s["sentence_zh"] for s in _group_sentences_by_article(sents, self.ARTS)]
+        assert out == ["a1", "b1", "x1", "x2"]
+
+    def test_empty_inputs_are_noops(self):
+        assert _group_sentences_by_article([], self.ARTS) == []
+        sents = [{"sentence_zh": "a1", "source_url": "https://ex.com/a"}]
+        assert _group_sentences_by_article(sents, []) == sents


### PR DESCRIPTION
Closes #456

## 改了什么

Daniel 追问"话题分散是不是复习顺序造成的"后，用生产数据（故事 1225，83 句）实证检查：话题以 ~10 句为周期循环 8 轮——根因是 `MAX_NEWS_BATCH=10` 分批：每批是独立 AI 调用、各自循环全部文章，最后直接拼接。**#454 的单调规则只约束单次调用内部，对拼接无效。**

修复：新增 `_group_sentences_by_article`（routes/story.py），在 briefing 与 news/paste 的分批循环结束后、position 编号之前，把句子按 `source_url` 在文章列表中的下标**稳定排序**：
- 每篇文章聚成一个连续块，块内保留批次顺序
- 无 `source_url` / 未知 URL 的句子按原相对顺序排在最后
- `word_ids` 在句子字典里随句子移动，词↔句映射不受影响；`position` 在排序之后才编号（story.py:232）
- 各批次本就是互不衔接的迷你摘要，重排不破坏叙事；配合 #454 的队列按位置排序，复习自动变成逐话题进行

## 怎么测试
- `DISABLE_AI=1 pytest tests/test_briefing.py -q` → **29 passed**（新增 3 个用例：批次循环重组、未知/缺失 URL 兜底、空输入）
- 手动验收：明早（或手动重新生成）的 briefing 里，Full story 每篇文章只出现一个 📰 分节头

## 注意
- 只影响**新生成**的故事；今天已存的故事顺序不变
- kahneman/普通 story 模式不经过此路径，不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)
