### PR TITLE
早晨预生成重复昨日故事键 + 导入后台化 + 请求计时中间件

### DIFF
--- a/database/stories.py
+++ b/database/stories.py
@@ -1,5 +1,6 @@
 import json
 import sqlite3
+from datetime import date, timedelta
 from .core import get_db
 
 
@@ -314,6 +315,64 @@ def get_story_position_map(deck_id: int, category: str, date_str: str,
     ).fetchall()
     conn.close()
     return {r["word_id"]: r["position"] for r in rows}
+
+
+def get_recent_story_keys(before_date: str, max_lookback_days: int = 14) -> list[dict]:
+    """Morning pregen (issue #458): find the most recent day before `before_date`
+    (looking back up to `max_lookback_days`) that had "real" stories, and return
+    the one active (deck_id, category, lang) key per story that day, each with its
+    parsed gen_params — so today's pregen can reproduce yesterday's actual usage
+    instead of blindly generating for every leaf deck.
+
+    "Real" story = gen_params is non-empty AND it has >= 2 sentences — this
+    excludes the single-sentence "again" regeneration rows (see AGAIN_CATEGORY)
+    without needing to special-case that category by name.
+
+    Returns [] if no matching day is found in the lookback window.
+    """
+    before = date.fromisoformat(before_date)
+    earliest = before - timedelta(days=max_lookback_days)
+
+    conn = get_db()
+    date_row = conn.execute(
+        """SELECT s.date FROM stories s
+           WHERE s.date < ? AND s.date >= ? AND s.gen_params IS NOT NULL
+             AND (SELECT COUNT(*) FROM story_sentences ss WHERE ss.story_id = s.id) >= 2
+           ORDER BY s.date DESC LIMIT 1""",
+        (before_date, earliest.isoformat()),
+    ).fetchone()
+    if not date_row:
+        conn.close()
+        return []
+    target_date = date_row["date"]
+
+    story_rows = conn.execute(
+        """SELECT * FROM stories s
+           WHERE s.date = ? AND s.gen_params IS NOT NULL
+             AND (SELECT COUNT(*) FROM story_sentences ss WHERE ss.story_id = s.id) >= 2
+           ORDER BY s.generated_at DESC""",
+        (target_date,),
+    ).fetchall()
+    conn.close()
+
+    seen: set[tuple] = set()
+    result: list[dict] = []
+    for row in story_rows:
+        key = (row["deck_id"], row["category"], row["lang"])
+        if key in seen:
+            continue  # keep only the latest generated_at per key (rows are DESC-ordered)
+        seen.add(key)
+        try:
+            gen_params = json.loads(row["gen_params"])
+        except (ValueError, TypeError):
+            continue
+        result.append({
+            "deck_id": row["deck_id"],
+            "category": row["category"],
+            "lang": row["lang"],
+            "gen_params": gen_params,
+        })
+    return result
 
 
 def get_due_cards_unified(deck_id: int, lang: str | None = None) -> list[dict]:

--- a/main.py
+++ b/main.py
@@ -266,6 +266,42 @@ try:
                         response.status_code, ms)
         return response
 
+    # Request-timing middleware (issue #458 measurement) — logs how long every
+    # /api/ request actually takes, so slow endpoints show up in /api/logs
+    # without needing SSH access. High-frequency polling endpoints are
+    # excluded from routine logging (only surfaced if they somehow go slow),
+    # since logging every poll would flood the ring buffer.
+    _TIMING_QUIET_PREFIXES = (
+        "/api/logs",
+        "/api/story-progress",
+        "/api/tts-progress",
+        "/api/speak-status",
+    )
+
+    @app.middleware("http")
+    async def request_timing(request: Request, call_next):
+        path = request.url.path
+        if not path.startswith("/api/"):
+            return await call_next(request)
+
+        start = time.time()
+        response = await call_next(request)
+        ms = round((time.time() - start) * 1000)
+
+        quiet = any(path.startswith(p) for p in _TIMING_QUIET_PREFIXES)
+        if quiet:
+            if ms > 500:
+                logger.warning("SLOW %s %s: %d ms", request.method, path, ms)
+            return response
+
+        if ms > 500:
+            logger.warning("SLOW %s %s: %d ms", request.method, path, ms)
+        elif ms >= 100:
+            logger.info("%s %s: %d ms", request.method, path, ms)
+        else:
+            logger.debug("%s %s: %d ms", request.method, path, ms)
+        return response
+
     if os.path.exists("static"):
         app.mount("/static", StaticFiles(directory="static"), name="static")
 

--- a/routes/imports.py
+++ b/routes/imports.py
@@ -1,6 +1,9 @@
 import json
 import logging
 import os
+import threading
+import time
+import uuid
 from datetime import date, timedelta
 
 import ai
@@ -10,6 +13,30 @@ from fastapi import APIRouter, Form, HTTPException, UploadFile
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+# ---------------------------------------------------------------------------
+# Background import jobs (issue #458) — the previous /api/import/upload ran
+# the AI-heavy import synchronously, blocking the browser for 1-2 minutes.
+# Now the request just kicks off a daemon thread and returns a job id; the
+# frontend polls /api/import/progress/{job_id} for status.
+# ---------------------------------------------------------------------------
+_import_jobs: dict[str, dict] = {}
+_import_jobs_lock = threading.Lock()
+_MAX_IMPORT_JOBS = 10
+
+
+def _prune_import_jobs() -> None:
+    """Keep at most _MAX_IMPORT_JOBS entries, oldest-first, never evicting a
+    job that's still running."""
+    with _import_jobs_lock:
+        if len(_import_jobs) <= _MAX_IMPORT_JOBS:
+            return
+        for job_id in list(_import_jobs.keys()):
+            if len(_import_jobs) <= _MAX_IMPORT_JOBS:
+                break
+            if _import_jobs[job_id]["status"] == "running":
+                continue
+            del _import_jobs[job_id]
 
 
 @router.post("/api/import/preview")
@@ -76,17 +103,53 @@ async def upload_import(
         except json.JSONDecodeError:
             raise HTTPException(status_code=400, detail="custom_fields must be valid JSON")
 
-    try:
-        result = importer.import_yaml_content(
-            content, deck_id,
-            resolutions=resolution_map,
-            card_configs=card_configs_map,
-            custom_fields=custom_fields_map,
-        )
-    except Exception as e:
-        logger.exception("Unhandled error during import (deck_id=%s): %s", deck_id, e)
-        raise HTTPException(status_code=500, detail=f"Import failed: {e}")
-    return {"deck_id": deck_id, **result}
+    job_id = uuid.uuid4().hex[:8]
+    with _import_jobs_lock:
+        _import_jobs[job_id] = {
+            "status": "running",
+            "message": "Importing…",
+            "started_at": time.time(),
+        }
+    _prune_import_jobs()
+
+    def _run_import():
+        try:
+            result = importer.import_yaml_content(
+                content, deck_id,
+                resolutions=resolution_map,
+                card_configs=card_configs_map,
+                custom_fields=custom_fields_map,
+            )
+            with _import_jobs_lock:
+                started_at = _import_jobs[job_id]["started_at"]
+                _import_jobs[job_id] = {
+                    "status": "done",
+                    "message": "Import complete",
+                    "summary": {"deck_id": deck_id, **result},
+                    "started_at": started_at,
+                }
+        except Exception as e:
+            logger.exception("Unhandled error during import (deck_id=%s): %s", deck_id, e)
+            with _import_jobs_lock:
+                started_at = _import_jobs.get(job_id, {}).get("started_at", time.time())
+                _import_jobs[job_id] = {
+                    "status": "error",
+                    "message": "Import failed",
+                    "error": str(e),
+                    "started_at": started_at,
+                }
+
+    threading.Thread(target=_run_import, daemon=True).start()
+    return {"job_id": job_id}
+
+
+@router.get("/api/import/progress/{job_id}")
+def import_progress(job_id: str):
+    """Poll status for a background import job started by /api/import/upload."""
+    job = _import_jobs.get(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Unknown job id")
+    return job
 
 
 @router.post("/api/import/directory")

--- a/routes/story.py
+++ b/routes/story.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import math
@@ -831,6 +832,88 @@ async def tts_progress(deck_id: int, category: str, lang: str | None = None):
     lang = lang or database.get_deck_lang(deck_id)
     key = f"{deck_id}/{category}/{lang}"
     return tts._preload_progress.get(key, {"done": 0, "total": 0})
+
+
+@router.post("/api/pregen-today")
+async def pregen_today():
+    """Morning pregen (issue #458): instead of blindly generating a story for
+    every leaf deck (the old behavior — 88 useless mode="story" stories, none
+    of which matched what Daniel actually reviews), reproduce the story keys
+    (deck_id, category, lang) that were really used on the most recent day with
+    real stories (database.get_recent_story_keys), each with its own gen_params
+    (mode/topic/grammar/…). `articles` is deliberately dropped so news/briefing
+    modes re-fetch today's news instead of replaying stale content.
+
+    For each key: skip if today's story is already cached, skip if there are no
+    due cards today, otherwise generate synchronously and warm the TTS cache.
+    A failure on one key is logged and does not stop the remaining keys.
+    """
+    today = database.anki_today().isoformat()
+    keys = database.get_recent_story_keys(today)
+    generated: list[str] = []
+    skipped_cached: list[str] = []
+    skipped_no_due: list[str] = []
+    failed: list[dict] = []
+
+    if DISABLE_AI:
+        logger.info("pregen-today  DISABLED (DISABLE_AI=1), %d candidate keys skipped", len(keys))
+        skipped_no_due = [f"{k['deck_id']}/{k['category']}/{k['lang']}" for k in keys]
+        return {"date": today, "keys": len(keys), "generated": generated,
+                "skipped_cached": skipped_cached, "skipped_no_due": skipped_no_due, "failed": failed}
+
+    for k in keys:
+        deck_id, category, lang = k["deck_id"], k["category"], k["lang"]
+        label = f"{deck_id}/{category}/{lang}"
+
+        if database.get_active_story(today, category, deck_id, lang=lang):
+            logger.info("pregen-today  SKIP-CACHED  %s", label)
+            skipped_cached.append(label)
+            continue
+
+        cards = _get_cards_for_story(deck_id, category, lang=lang)
+        if not cards:
+            logger.info("pregen-today  SKIP-NO-DUE  %s", label)
+            skipped_no_due.append(label)
+            continue
+
+        gp = k["gen_params"] or {}
+        mode = gp.get("mode", "story")
+        progress_key = f"{deck_id}/{category}/{lang}"
+        try:
+            chosen_model = _validated_model(gp.get("model"))
+            # _generate_and_store blocks for minutes (serial AI calls) — run it
+            # off the event loop so the server stays responsive during pregen.
+            result = await asyncio.to_thread(
+                _generate_and_store,
+                deck_id, category, today, cards,
+                topic=gp.get("topic"), max_hsk=gp.get("max_hsk", 3), model=chosen_model,
+                grammar_focus=gp.get("grammar_focus"), grammar_pct=gp.get("grammar_pct", 75),
+                mode=mode, chapter_ids=gp.get("chapter_ids"), articles=None,
+                progress_key=progress_key, lang=lang)
+            ai._story_progress.pop(progress_key, None)
+            if isinstance(result, dict) and result.get("error"):
+                raise RuntimeError(result.get("reason", "generation failed"))
+            n_sentences = len((result or {}).get("sentences", []))
+            logger.info("pregen-today  OK  %s mode=%s sentences=%d", label, mode, n_sentences)
+            generated.append(label)
+        except Exception as e:
+            logger.warning("pregen-today  FAIL  %s: %s", label, e)
+            failed.append({"key": label, "error": str(e)})
+            continue
+
+        try:
+            await preload_session(deck_id, category, quick=False, lang=lang)
+            logger.info("pregen-today  TTS-DONE  %s", label)
+        except Exception as e:
+            # Story generation already succeeded — a TTS preload failure is only
+            # logged, not counted as a failed key.
+            logger.warning("pregen-today  TTS-FAIL  %s: %s", label, e)
+
+    logger.info(
+        "pregen-today  SUMMARY  date=%s keys=%d generated=%d skipped_cached=%d skipped_no_due=%d failed=%d",
+        today, len(keys), len(generated), len(skipped_cached), len(skipped_no_due), len(failed))
+    return {"date": today, "keys": len(keys), "generated": generated,
+            "skipped_cached": skipped_cached, "skipped_no_due": skipped_no_due, "failed": failed}
 
 
 @router.get("/api/story-progress/{deck_id}/{category}")

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,10 +1,19 @@
 # scripts/
 
-## morning_pregen.py（issue #420）
+## morning_pregen.py（issue #420，issue #458 重构）
 
 新闻 / 简报模式的故事生成很慢（多次串行 AI 调用），Daniel 早上打开页面时
-不想等。这个脚本对**运行中的服务器**发请求，提前把今天所有有到期卡片的
-（牌组, 类别）的故事生成好，并预热对应的 TTS 音频缓存。
+不想等。这个脚本对**运行中的服务器**发一次 `POST /api/pregen-today` 请求，
+由服务器端"重复最近一天真正用过的故事键"：
+
+- 服务器找到最近一天（今天除外，最多回看 14 天）所有真正生成过的故事键
+  `(deck_id, category, lang)`——即 Daniel 昨天实际复习用到的牌组/类别/模式
+  组合（包括 briefing/news 等聚合牌组模式），各键沿用上次的生成参数
+  （mode/topic/grammar 等；news/briefing 的 articles 被丢弃，重新抓当天新闻）
+- 每个键：今天已有缓存故事→跳过；没有到期卡→跳过；否则同步生成故事并
+  预热 TTS 音频缓存
+- 旧版（#420）遍历全部叶子牌组、一律用默认 `mode="story"` 生成——每天产出
+  大量没人看的故事，真正用到的聚合牌组反而漏掉，已废弃
 
 只依赖 Python 标准库（`urllib.request`、`base64`、`json` 等），不需要安装
 任何依赖，本地（launchd）和服务器（cron，见 issue #417）都可以直接用同一
@@ -14,17 +23,9 @@
 
 - 服务器（`bash run.sh` 或对应 systemd 服务）必须已经在运行——脚本只发
   HTTP 请求，不会自己启动服务器。
-- 脚本读取 `GET /api/decks`，找出所有**叶子牌组**（没有子牌组的节点）里
-  到期数量（`counts.new + learning + review + learning_future`）大于 0、
-  且**未被暂停**（`all_suspended` 不为真）的（牌组, 类别）。
-  类别键名固定为 `listening`（听力）/ `reading`（阅读）/ `creating`（写作），
-  与 `routes/decks.py` 中的 `VALID_CATEGORIES` 一致。
-- 对每一项：`GET /api/story/{deck_id}/{category}`（已有今天的缓存故事则
-  秒回，否则同步生成——新闻/简报模式可能耗时数分钟，脚本设置了 15 分钟
-  超时），成功后再 `POST /api/preload-session/{deck_id}/{category}` 预热
-  TTS 音频缓存。
-- 串行执行（一次只处理一个），单项失败只记录错误、不中断整体，最后打印
-  成功/失败/跳过（已暂停）数量的汇总。
+- 服务器串行处理各键（新闻/简报模式可能耗时数分钟，脚本设置了 15 分钟
+  超时），单键失败只记录错误、不中断整体；脚本把返回的汇总
+  （generated / skipped_cached / skipped_no_due / failed）逐项打印。
 
 ### 用法
 

--- a/scripts/morning_pregen.py
+++ b/scripts/morning_pregen.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python3
-"""早晨自动预生成脚本（issue #420）。
+"""早晨自动预生成脚本（issue #420，issue #458 重构）。
 
-对一台运行中的服务器发请求，提前生成"今天"所有有到期卡片的叶子牌组
-（牌组+类别）的故事，并预热对应的 TTS 音频缓存，这样 Daniel 早上打开
-页面时，故事和语音都已经就绪（新闻/简报模式尤其慢，多次串行 AI 调用）。
+对一台运行中的服务器发送一次 POST /api/pregen-today 请求。该端点在服务器端
+找到"最近一天（今天除外，最多回看14天）"真正生成过故事的所有 (deck_id,
+category, lang) 键——也就是 Daniel 昨天实际复习用到的牌组/类别/模式组合
+（包括 briefing/news 等聚合牌组模式），而不是像旧版那样遍历全部叶子牌组、
+一律用默认 mode="story" 生成——那样会生成大量没人看的故事，真正用到的
+聚合牌组反而漏掉。
+
+服务器对每个键：今天已有缓存故事则跳过；没有到期卡片则跳过；否则用该键
+上次的生成参数（mode/topic/grammar 等；news/briefing 的 articles 会被丢弃，
+让它们重新抓取当天新闻）同步生成故事并预热 TTS 音频缓存，这样 Daniel 早上
+打开页面时故事和语音都已经就绪。
 
 只使用 Python 标准库（urllib.request 等），本地用 launchd、服务器用
 cron 都可以直接运行，见 scripts/README.md。
@@ -29,15 +37,10 @@ BASE_URL = os.environ.get("BASE_URL", "http://127.0.0.1:8000").rstrip("/")
 AUTH_USERNAME = os.environ.get("AUTH_USERNAME")
 AUTH_PASSWORD = os.environ.get("AUTH_PASSWORD")
 
-# /api/story/{deck_id}/{category} 在没有缓存故事时会同步生成——新闻/简报模式
-# 可能涉及多次串行 AI 调用，耗时可达数分钟，因此设置较长的超时。
+# /api/pregen-today 对每个键都可能同步生成故事——新闻/简报模式可能涉及多次
+# 串行 AI 调用，加上多个键顺序处理，耗时可达数分钟到十几分钟，因此设置较长
+# 的超时。
 STORY_TIMEOUT_SECONDS = 15 * 60
-# 牌组列表、预热 TTS 等轻量请求的超时。
-SHORT_TIMEOUT_SECONDS = 60
-
-# 叶子牌组分类键名（阅读=reading，听力=listening，写作=creating）——
-# 与 routes/decks.py 的 VALID_CATEGORIES / _leaf_pairs 保持一致。
-CATEGORIES = ("listening", "reading", "creating")
 
 
 def _log(msg: str) -> None:
@@ -68,115 +71,44 @@ def _request(method: str, path: str, timeout: int, body: dict | None = None):
         return json.loads(raw)
 
 
-def _flatten(tree: list) -> list:
-    result = []
-    for node in tree:
-        result.append(node)
-        result.extend(_flatten(node.get("children") or []))
-    return result
-
-
-def _due_count(deck: dict) -> int:
-    counts = deck.get("counts") or {}
-    return sum(counts.get(k, 0) for k in ("new", "learning", "review", "learning_future"))
-
-
-def find_due_leaf_pairs() -> tuple[list[tuple[int, str, str]], int]:
-    """Return ([(deck_id, category, deck_name), ...], n_skipped_suspended) for
-    leaf decks with due cards in a non-suspended category. Reads GET /api/decks
-    (see routes/decks.py:_leaf_pairs / _attach_counts for the tree shape)."""
-    tree = _request("GET", "/api/decks", SHORT_TIMEOUT_SECONDS)
-    if not tree:
-        return [], 0
-    pairs = []
-    n_skipped = 0
-    for deck in _flatten(tree):
-        if deck.get("children"):
-            continue  # only leaf decks carry a category
-        category = deck.get("category")
-        if category not in CATEGORIES:
-            continue
-        if deck.get("all_suspended"):
-            _log(f"跳过 已暂停  牌组={deck.get('name')!r} 类别={category}")
-            n_skipped += 1
-            continue
-        if _due_count(deck) <= 0:
-            continue
-        pairs.append((deck["id"], category, deck.get("name", f"deck#{deck['id']}")))
-    return pairs, n_skipped
-
-
-def pregen_one(deck_id: int, category: str, name: str) -> tuple[bool, str]:
-    """Generate (or reuse cached) story for one (deck, category), then preload
-    TTS. Returns (success, message)."""
-    label = f"牌组={name!r} 类别={category}"
-    try:
-        story = _request("GET", f"/api/story/{deck_id}/{category}", STORY_TIMEOUT_SECONDS)
-    except urllib.error.URLError as e:
-        return False, f"{label} 故事生成请求失败: {e}"
-    except Exception as e:
-        return False, f"{label} 故事生成异常: {e}"
-
-    if isinstance(story, dict) and story.get("error"):
-        return False, f"{label} 故事生成返回错误: {story.get('reason')}"
-    if not story:
-        return False, f"{label} 没有返回故事（可能没有到期卡片或 AI 已禁用）"
-
-    n_sentences = len(story.get("sentences") or [])
-    _log(f"  {label} 故事就绪（{n_sentences} 句），开始预热语音…")
-
-    try:
-        _request("POST", f"/api/preload-session/{deck_id}/{category}", STORY_TIMEOUT_SECONDS)
-    except Exception as e:
-        # 故事已经生成成功——语音预热失败不算整体失败，但要记录。
-        return True, f"{label} 故事已生成，但语音预热失败: {e}"
-
-    return True, f"{label} 完成（{n_sentences} 句 + 语音预热）"
-
-
 def main() -> int:
     _log(f"早晨预生成开始  BASE_URL={BASE_URL}")
 
     try:
-        pairs, n_skipped = find_due_leaf_pairs()
+        summary = _request("POST", "/api/pregen-today", STORY_TIMEOUT_SECONDS)
     except urllib.error.URLError as e:
         _log(f"无法连接服务器 {BASE_URL}: {e}")
         return 1
     except Exception as e:
-        _log(f"读取牌组列表失败: {e}")
+        _log(f"预生成请求失败: {e}")
         return 1
 
-    if not pairs:
-        _log(f"没有找到任何有到期卡片的（牌组, 类别）（跳过已暂停 {n_skipped} 个），无需生成，退出。")
-        return 0
+    if not summary:
+        _log("服务器没有返回汇总结果（响应为空），视为失败。")
+        return 1
 
-    _log(f"共 {len(pairs)} 个（牌组, 类别）待处理:")
-    for deck_id, category, name in pairs:
-        _log(f"  - {name!r} / {category} (deck_id={deck_id})")
+    keys = summary.get("keys", 0)
+    generated = summary.get("generated", [])
+    skipped_cached = summary.get("skipped_cached", [])
+    skipped_no_due = summary.get("skipped_no_due", [])
+    failed = summary.get("failed", [])
 
-    n_ok = 0
-    n_fail = 0
-    failures: list[str] = []
+    _log(f"日期={summary.get('date')}  候选键={keys}")
 
-    for deck_id, category, name in pairs:
-        _log(f"处理中 牌组={name!r} 类别={category} (deck_id={deck_id})…")
-        ok, msg = pregen_one(deck_id, category, name)
-        if ok:
-            n_ok += 1
-            _log(f"  ✓ {msg}")
-        else:
-            n_fail += 1
-            failures.append(msg)
-            _log(f"  ✗ {msg}")
+    for label in generated:
+        _log(f"  ✓ 已生成 {label}")
+    for label in skipped_cached:
+        _log(f"  - 跳过（今天已有故事） {label}")
+    for label in skipped_no_due:
+        _log(f"  - 跳过（无到期卡片，或 AI 已禁用） {label}")
+    for item in failed:
+        _log(f"  ✗ 失败 {item.get('key')}: {item.get('error')}")
 
     _log("---- 汇总 ----")
-    _log(f"成功: {n_ok}  失败: {n_fail}  跳过(已暂停): {n_skipped}  总计处理: {len(pairs)}")
-    if failures:
-        _log("失败详情:")
-        for f in failures:
-            _log(f"  - {f}")
+    _log(f"候选键: {keys}  已生成: {len(generated)}  跳过(已缓存): {len(skipped_cached)}  "
+         f"跳过(无到期): {len(skipped_no_due)}  失败: {len(failed)}")
 
-    return 0 if n_fail == 0 else 1
+    return 0 if not failed else 1
 
 
 if __name__ == "__main__":

--- a/static/app.js
+++ b/static/app.js
@@ -7343,6 +7343,29 @@ async function doImport() {
   }
 }
 
+// Poll /api/import/progress/{jobId} until the background import thread
+// finishes (issue #458 — upload no longer blocks the request). Resolves with
+// the import summary dict, or throws on error/timeout.
+async function _pollImportJob(jobId, { timeoutMs = 5 * 60 * 1000, intervalMs = 1000 } = {}) {
+  const start = Date.now();
+  while (true) {
+    if (Date.now() - start > timeoutMs) throw new Error('Import timed out after 5 minutes.');
+    const res = await fetch(`/api/import/progress/${jobId}`);
+    if (!res.ok) throw new Error((await res.json().catch(() => ({}))).detail || res.statusText);
+    const job = await res.json();
+    if (job.status === 'done') return job.summary;
+    if (job.status === 'error') throw new Error(job.error || 'Import failed');
+    await new Promise(r => setTimeout(r, intervalMs));
+  }
+}
+
+function _showImportPollingSpinner(resultEl) {
+  resultEl.style.display = 'block';
+  resultEl.innerHTML = '<div style="display:flex;align-items:center;gap:10px;padding:4px 0">'
+    + '<div class="spinner" style="width:18px;height:18px;border-width:2px;margin:0"></div>'
+    + '<span>Importing…</span></div>';
+}
+
 async function _doUploadImport() {
   // Legacy flow: used when YAML editor previews a file via file input
   const fileInput = document.getElementById('import-file');
@@ -7396,7 +7419,10 @@ async function _doUploadImport() {
       const err = await res.json().catch(() => ({}));
       throw new Error(err.detail || res.statusText);
     }
-    const data = await res.json();
+    const { job_id } = await res.json();
+    _showImportPollingSpinner(resultEl);
+    const data = await _pollImportJob(job_id);
+    resultEl.style.display = 'none';
     closeImportModal();
     loadDecks();
 
@@ -7781,7 +7807,12 @@ async function importYamlEntry() {
     form.append('deck_path', _yamlEditDeckPath);
     const res = await fetch('/api/import/upload', { method: 'POST', body: form });
     if (!res.ok) throw new Error((await res.json().catch(() => ({}))).detail || res.statusText);
-    const data = await res.json();
+    const { job_id } = await res.json();
+    feedbackEl.style.display = 'block';
+    feedbackEl.innerHTML = '<div style="display:flex;align-items:center;gap:8px">'
+      + '<div class="spinner" style="width:16px;height:16px;border-width:2px;margin:0"></div>'
+      + '<span>Importing…</span></div>';
+    const data = await _pollImportJob(job_id);
 
     feedbackEl.style.display = 'block';
     if (data.imported > 0) {

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -10,6 +10,7 @@ Tests for the briefing mode rework (issue #444) and News flow v2 (issue #454):
 """
 
 import json
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -378,6 +379,58 @@ class TestGetStoryPositionMap:
         deck_id = database.get_or_create_deck("TestDeck")
         today = database.anki_today().isoformat()
         assert database.get_story_position_map(deck_id, "reading", today, lang="zh") == {}
+
+
+# ---------------------------------------------------------------------------
+# database.get_recent_story_keys (issue #458 — morning pregen reproduces the
+# most recent real story keys instead of blindly generating for every leaf deck)
+# ---------------------------------------------------------------------------
+
+class TestGetRecentStoryKeys:
+
+    def _make_word(self):
+        return database.insert_word({"word_zh": "担心", "lang": "zh", "definition": "to worry"})
+
+    def test_finds_yesterdays_briefing_key_with_parsed_gen_params(self, tmp_db):
+        deck_id = database.get_or_create_deck("TestDeck")
+        w1 = self._make_word()
+        w2 = database.insert_word({"word_zh": "努力", "lang": "zh", "definition": "to work hard"})
+        today = database.anki_today()
+        yesterday = (today - timedelta(days=1)).isoformat()
+
+        sentences = [
+            {"position": 0, "sentence_zh": "她很担心考试。", "word_ids": [w1]},
+            {"position": 1, "sentence_zh": "他每天努力学习。", "word_ids": [w2]},
+        ]
+        database.create_story(yesterday, "listening", deck_id, sentences,
+                              gen_params={"mode": "briefing", "model": "gpt-5.1"}, lang="zh")
+
+        keys = database.get_recent_story_keys(today.isoformat())
+        assert len(keys) == 1
+        assert keys[0]["deck_id"] == deck_id
+        assert keys[0]["category"] == "listening"
+        assert keys[0]["lang"] == "zh"
+        assert keys[0]["gen_params"] == {"mode": "briefing", "model": "gpt-5.1"}
+
+    def test_single_sentence_again_row_is_filtered_out(self, tmp_db):
+        deck_id = database.get_or_create_deck("TestDeck")
+        w1 = self._make_word()
+        today = database.anki_today()
+        yesterday = (today - timedelta(days=1)).isoformat()
+
+        # Simulates database.store_again_sentence(): single-sentence row, real
+        # category, real-looking gen_params — must still be excluded because it
+        # only has 1 sentence (the actual again-sentinel uses AGAIN_CATEGORY too,
+        # but the < 2 sentence filter is what get_recent_story_keys relies on).
+        sentences = [{"position": 0, "sentence_zh": "她很担心考试。", "word_ids": [w1]}]
+        database.create_story(yesterday, "listening", deck_id, sentences,
+                              gen_params={"mode": "briefing", "model": "gpt-5.1"}, lang="zh")
+
+        assert database.get_recent_story_keys(today.isoformat()) == []
+
+    def test_no_history_returns_empty_list(self, tmp_db):
+        today = database.anki_today().isoformat()
+        assert database.get_recent_story_keys(today) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #458

## 改了什么

### 早晨预生成重构（核心）
实测证据：2026-07-09 06:01–06:07 cron 生成了 88 篇故事——全部 `mode="story"`、全部叶子牌组，Daniel 实际用的聚合牌组（deck 24 listening briefing）0 篇。根因：旧脚本遍历叶子牌组 + `GET /api/story` 默认 `mode="story"`。

- `database.get_recent_story_keys(before_date)`：最近一个有"正经故事"（gen_params 非空且 ≥2 句，排除 Again 单句行）的日期上，每个 `(deck_id, category, lang)` 键取最新解析后的 gen_params
- `POST /api/pregen-today`：逐键处理——今天已有故事跳过、无到期卡跳过、否则用上次的参数（mode/topic/max_hsk/grammar/chapter_ids；**articles 丢弃**让 briefing/news 重抓当天新闻）同步生成 + TTS 预热；生成跑在 `asyncio.to_thread` 里（不卡事件循环，预生成期间服务器保持可用）；单键失败记日志继续；返回汇总 JSON
- `scripts/morning_pregen.py` 变薄：一次 POST + 打印汇总；`scripts/README.md` 同步更新

### 导入上传后台化
`POST /api/import/upload` 立即返回 `{job_id}`，导入在 daemon 线程执行；新增 `GET /api/import/progress/{job_id}`；前端两条导入路径（导入弹窗 + YAML 快速编辑）轮询进度、显示 spinner，完成后复用原有汇总 UI。job 表最多保留 10 条（running 永不清除）。

### 请求计时中间件
所有 `/api` 请求记录耗时：>500ms WARNING、100–500ms INFO、<100ms DEBUG；高频轮询端点静默（仅 >500ms 时告警）。今后"哪里慢"直接看 Server logs。

## 怎么测试
- `DISABLE_AI=1 pytest tests/test_briefing.py -q` → **32 passed**（新增 3 个 get_recent_story_keys 用例）
- AST/导入/node --check 全过；后台导入冒烟测试（临时库，job running→done，summary 正确）
- 手动验收：明早 06:00 后看 `data/morning-pregen.log`（或网页 Server logs 搜 pregen-today）应只生成昨天用过的键；白天点开牌组直接有故事；导入点击立即出现进度

## 注意
- 预生成的键来源是"最近一天的真实使用"——如果 Daniel 昨天没复习，会回看最多 14 天
- 今天（07-09）的 88 篇废故事已在库里，无害（故事从不自动删除）；明天起不再产生
