### PR TITLE
HSK 滑块对 briefing/news 生效；上下文句不受词汇限制；默认 HSK 3

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -1313,7 +1313,7 @@ def generate_briefing_sentences(
     # HSK 1-5 background vocabulary (issue #448): Daniel is HSK 4-5 — capping
     # the non-target words at HSK 1-2 made sentences childish and was the
     # tightest remaining constraint after the #444 rework.
-    max_hsk: int = 5,
+    max_hsk: int = 3,
     progress_key: str | None = None,
     attempt_label: str = "",
     progress_extra: dict | None = None,
@@ -1393,12 +1393,14 @@ def generate_briefing_sentences(
   用来交代事实、数字和背景，让摘要自然连贯——绝对不允许连续出现两个或以上不含目标词的上下文句子
 - 因此句子总数不能超过目标词数量的两倍
 - 一句话最多包含一个目标词汇
-- 含目标词汇的句子长度为8到18个字，其中非目标词汇只用HSK 1-{max_hsk}的词汇
+- 【难度控制，严格遵守】含目标词汇的句子长度为8到18个字，其中除目标词外只允许
+  HSK 1-{max_hsk} 的词汇——这是学习者自己选择的难度上限，超纲词会让句子无法学习。
+  如果某个事实需要更难的词才能表达，把它放进上下文句子里，目标句只保留简单的部分
 - 【重要】含目标词汇的句子也必须传达该新闻中的一个具体事实（谁、做了什么、在哪里、多少），
   读者只看这一句也能学到新闻内容。严禁没有信息量的空洞句子，
   例如"组织很大。""火箭很快。""它指代。""未知很大。"这类句子绝对不可以出现
-- 上下文句子同样使用简单中文（可以包含具体数字和事实），不要写得比目标句复杂太多——
-  它最终会被翻译成德文显示在卡片正面，太长太难会打断学习
+- 上下文句子【不受 HSK 词汇限制】——它最终会被翻译成德文显示在卡片正面，可以自由
+  使用专有名词、数字和任何词汇来准确传达事实；长度保持一两句话的合理范围即可
 - 所有输出只用简体中文，绝对不要出现繁体字
 - 不要使用markdown格式
 - article_idx 是该句子所涉及的文章编号（上面的 0 开始编号）

--- a/routes/story.py
+++ b/routes/story.py
@@ -220,11 +220,12 @@ def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
                 articles = _auto_news_articles(model=model, progress_key=progress_key)
             if mode == "briefing":
                 sentences, prompt_text = _generate_briefing_story_sentences(
-                    cards, articles, model=model, progress_key=progress_key)
+                    cards, articles, model=model, progress_key=progress_key,
+                    max_hsk=max_hsk)
             else:
                 sentences, prompt_text = _generate_news_story_sentences(
                     cards, articles, model=model, progress_key=progress_key,
-                    generic=(mode == "paste"))
+                    generic=(mode == "paste"), max_hsk=max_hsk)
         else:
             sentences, prompt_text = _generate_story_sentences(
                 cards, topic=topic, max_hsk=max_hsk, model=model,
@@ -645,7 +646,7 @@ def _group_sentences_by_article(sentences: list[dict], articles: list[dict]) -> 
 
 def _generate_news_story_sentences(
     cards: list, articles: list[dict], model: str, progress_key: str | None,
-    generic: bool = False,
+    generic: bool = False, max_hsk: int = 3,
 ) -> tuple[list, str]:
     """Split cards into batches of ai.MAX_NEWS_BATCH, call AI once per batch, merge
     results. All batches share the same `articles` context so the sentences form
@@ -668,7 +669,7 @@ def _generate_news_story_sentences(
         label = f" ({idx + 1}/{len(chunks)})"
         chunk_sentences = ai.generate_news_sentences(
             chunk, articles, model=model, progress_key=progress_key,
-            attempt_label=label, generic=generic
+            attempt_label=label, generic=generic, max_hsk=max_hsk
         )
         all_sentences.extend(chunk_sentences)
 
@@ -677,6 +678,7 @@ def _generate_news_story_sentences(
 
 def _generate_briefing_story_sentences(
     cards: list, articles: list[dict], model: str, progress_key: str | None,
+    max_hsk: int = 3,
 ) -> tuple[list, str]:
     """News flow mode (issue #399): split cards into batches of ai.MAX_NEWS_BATCH,
     each batch produces its own flowing mini-summary (target-word sentences +
@@ -702,6 +704,7 @@ def _generate_briefing_story_sentences(
         label = f" ({idx + 1}/{len(chunks)})"
         chunk_sentences = ai.generate_briefing_sentences(
             chunk, articles, model=model, progress_key=progress_key, attempt_label=label,
+            max_hsk=max_hsk,
             progress_extra={
                 "words_done": words_done,
                 "words_total": len(cards),


### PR DESCRIPTION
Closes #460

## 改了什么
- **接通断点**：前端 HSK 滑块的值一直传到了 `GET /api/story?max_hsk=N`，但 routes/story.py 的 briefing/news 分支没转发给 AI 函数，滑块从未生效（briefing 一直用死默认 HSK 5）。现在转发
- **规则按 Daniel 要求调整**：HSK 上限只约束**含目标词的句子**（超纲事实挪进上下文句）；**上下文句不受词汇限制**（正面显示德语翻译）
- **默认 HSK 3**（滑块/URL/函数三处一致）；gen_params 存 max_hsk → 早晨预生成自动沿用上次滑块值

## 怎么测试
- test_briefing 32 passed；AST/导入检查通过；inspect 签名断言 max_hsk/progress_extra/generic 均被接受
- 手动验收：设置弹窗把滑块调到 HSK 2 重新生成——目标句应明显变简单；上下文句仍可含专有名词/数字
