### PR TITLE
fix: News flow 会话中已到期学习卡不再插队——保持故事句子顺序

### DIFF
--- a/routes/queue_manager.py
+++ b/routes/queue_manager.py
@@ -72,7 +72,7 @@ class QueueManager:
         """
         rebuilt = False
         if key not in self._queues or self._queues[key].built_date != today:
-            self._build(key, build_fn, today)
+            self._build(key, build_fn, today, now)
             rebuilt = True
 
         q = self._queues[key]
@@ -244,12 +244,23 @@ class QueueManager:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _build(self, key: tuple, build_fn, today: str) -> None:
-        """Call build_fn() and split the result into intraday / main."""
+    def _build(self, key: tuple, build_fn, today: str, now: str = "") -> None:
+        """Call build_fn() and split the result into intraday / main.
+
+        When build_fn's output is story-ordered (News-flow session, issue #462),
+        learning cards whose timestamp has already passed stay in main at their
+        story position instead of jumping the queue — only future timestamps
+        (e.g. the 10-minute re-show after Again) go intraday.
+        """
         cards = build_fn()
+        story_ordered = any(c.get("_story_ordered") for c in cards)
 
         def _is_intraday(c: dict) -> bool:
-            return c["state"] in ("learning", "relearn") and "T" in c.get("due", "")
+            if c["state"] not in ("learning", "relearn") or "T" not in c.get("due", ""):
+                return False
+            if story_ordered and now and c["due"] <= now:
+                return False
+            return True
 
         intraday = [
             {"id": c["id"], "due": c["due"]}

--- a/routes/review.py
+++ b/routes/review.py
@@ -108,7 +108,12 @@ def _order_by_story(cards: list[dict], story_deck_id: int | None,
         pos = database.get_story_position_map(story_deck_id, "unified", today, lang)
     if not pos:
         return cards
-    return sorted(cards, key=lambda c: pos.get(c.get("word_id"), float("inf")))
+    ordered = sorted(cards, key=lambda c: pos.get(c.get("word_id"), float("inf")))
+    # Mark the result so QueueManager._build() knows story order is in effect:
+    # already-due intraday learning cards must NOT jump ahead of it (issue #462).
+    for c in ordered:
+        c["_story_ordered"] = True
+    return ordered
 
 
 def _key_and_build(


### PR DESCRIPTION
## 问题（Closes #462）

#454 让 News flow 会话的复习顺序等于故事句子顺序，但 `queue_manager._build()` 把 learning/relearn 状态、带同日时间戳的卡片全部放进日内学习队列（intraday），而 `get_next()` 每次取卡都优先检查该队列——时间戳已过的学习卡**永远插队**，整体排在故事顺序的主队列前面。Daniel 有 29 张学习卡时，会话开头全是故事中间/靠后的句子，句子 1、2、3 反而排在后面。

## 修改

- `routes/review.py` `_order_by_story()`：找到位置映射时给每张卡打 `_story_ordered` 标记
- `routes/queue_manager.py` `_build()`：收到标记时，**已到期**（due ≤ now）的日内学习卡不再进 intraday，而是留在主队列的故事位置上；只有 due 在未来的卡（如按 Again 后的 10 分钟重现）才继续插队
- `get_next()` 把 `now` 传给 `_build()`

## 不变的行为

- 无 News-flow 故事的会话：学习卡照旧优先（intraday 逻辑不变）
- 会话中按 Again → 10 分钟后重现：`after_review()` 路径未动
- 撤销、埋藏、软重排（soft_requeue）均不受影响

## 测试

- 本地语法 + 导入检查通过
- 逻辑变更集中在 `_is_intraday` 的两个新条件分支，非 story-ordered 队列走原路径

🤖 Generated with [Claude Code](https://claude.com/claude-code)