### PR TITLE
fix: News flow 卡片正面在所有类别显示"标题 · 来源"行

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -6044,8 +6044,6 @@ function _newsSourceHtml(s) {
 
 // Front side: context (above the Chinese sentence) + source line (below it).
 function _renderNewsFront() {
-  const isListening = category === 'listening';
-  const isCreating  = category === 'creating';
   const ctxDe = document.getElementById('sentence-context-de');
   const ctxText = _newsContextText(sentence);
   ctxDe.textContent = ctxText;
@@ -6055,9 +6053,11 @@ function _renderNewsFront() {
   ctxDe.classList.toggle('clickable-sentence', ctxClickable);
   ctxDe.onclick = ctxClickable ? () => window.open(url, '_blank', 'noopener') : null;
 
+  // Title · publisher on the front for every category (issue #464) — listening
+  // and creating cards were previously excluded, matching nothing on the back.
   const srcEl = document.getElementById('news-source-front');
   if (srcEl) {
-    const html = (!isListening && !isCreating) ? _newsSourceHtml(sentence) : '';
+    const html = _newsSourceHtml(sentence);
     srcEl.innerHTML = html;
     srcEl.style.display = html ? 'block' : 'none';
   }


### PR DESCRIPTION
## 问题（Closes #464）

News flow 卡片背面所有类别都显示"文章标题 · 来源 ↗"，但正面的同一行（`news-source-front`）被 `_renderNewsFront()` 里的 `(!isListening && !isCreating)` 条件限制为**只在阅读类别显示**。听力和写作卡的正面看不到文章来源——除非该句恰好带上下文句（通常只有每篇文章的第一张卡）。

## 修改

`static/app.js` `_renderNewsFront()`：去掉类别条件，所有类别都渲染 `_newsSourceHtml(sentence)`。

## 不变的行为

- 显示语言开关（#452，g 键）继续生效
- 非 News flow 模式：`_newsSourceHtml` 无 source_title/source_name 时返回空字符串，元素保持隐藏
- 阅读类别行为完全不变

## 测试

- `node --check` 通过
- 改动仅 3 行，纯前端展示逻辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)