### PR TITLE
fix: 导入弹窗立即打开文件选择器，牌组列表并行加载

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -7078,27 +7078,9 @@ function importApplyGlobalDeck() {
   _importRenderTable();
 }
 
-async function openImportModal() {
-  // Hide modal in case this is a "Try Again" from an error state
-  document.getElementById('import-modal-overlay').style.display = 'none';
-  document.getElementById('import-modal').style.display = 'none';
+let _importDecksPromise = null;
 
-  importResolutions = {};
-  _previewEntries = [];
-  _cardConfigs = {};
-  _conflictData = [];
-  _conflictEdits = {};
-  _conflictSelections = {};
-  document.getElementById('import-file').value = '';
-  document.getElementById('import-preview').style.display = 'none';
-  document.getElementById('import-conflicts-section').style.display = 'none';
-  document.getElementById('import-result').style.display = 'none';
-  document.getElementById('import-submit-btn').style.display = '';
-  document.getElementById('import-deck-path').value = '';
-  document.getElementById('deck-picker-new-badge').style.display = 'none';
-  document.getElementById('deck-picker-dropdown').style.display = 'none';
-
-  // Build suggestion list for deck picker and per-card dropdown
+async function _loadImportDeckSuggestions() {
   const decks = await api('GET', '/api/decks');
   window._deckSuggestions = [];
   _importDeckOptions = [];
@@ -7120,9 +7102,34 @@ async function openImportModal() {
   // Populate datalist for duplicate move-target autocomplete
   const dl = document.getElementById('import-deck-datalist');
   if (dl) dl.innerHTML = _importDeckOptions.map(p => `<option value="${_ea(p)}">`).join('');
+}
 
-  // Open OS file picker — modal appears after file is chosen
+function openImportModal() {
+  // Hide modal in case this is a "Try Again" from an error state
+  document.getElementById('import-modal-overlay').style.display = 'none';
+  document.getElementById('import-modal').style.display = 'none';
+
+  importResolutions = {};
+  _previewEntries = [];
+  _cardConfigs = {};
+  _conflictData = [];
+  _conflictEdits = {};
+  _conflictSelections = {};
+  document.getElementById('import-file').value = '';
+  document.getElementById('import-preview').style.display = 'none';
+  document.getElementById('import-conflicts-section').style.display = 'none';
+  document.getElementById('import-result').style.display = 'none';
+  document.getElementById('import-submit-btn').style.display = '';
+  document.getElementById('import-deck-path').value = '';
+  document.getElementById('deck-picker-new-badge').style.display = 'none';
+  document.getElementById('deck-picker-dropdown').style.display = 'none';
+
+  // Open OS file picker immediately — .click() must stay synchronous within the
+  // user gesture; awaiting the network first delayed the picker by seconds (#466)
   document.getElementById('import-file').click();
+
+  // Deck suggestions load in parallel; previewImport awaits them before rendering
+  _importDecksPromise = _loadImportDeckSuggestions();
 }
 
 function closeImportModal() {
@@ -7238,6 +7245,10 @@ async function previewImport(yamlContent) {
         };
       }
     });
+
+    // Deck suggestions were kicked off in openImportModal; the table's per-card
+    // deck dropdowns need them, so wait here (usually already resolved)
+    if (_importDecksPromise) { try { await _importDecksPromise; } catch (e) { console.error('Deck suggestions failed to load:', e); } }
 
     _importRenderTable();
     document.getElementById('import-preview').style.display = 'block';


### PR DESCRIPTION
## 改了什么
- `openImportModal()` 不再在打开文件选择器之前 `await api('GET', '/api/decks')`，而是同步调用 `.click()`（保持在用户手势内），牌组建议列表改为后台并行加载并存入 `_importDecksPromise`
- `previewImport()` 在渲染每卡牌组下拉表格前 `await _importDecksPromise`（此时通常已加载完毕）；加载失败只记录 console 错误，不阻塞预览

## 为什么
点击 Import 后文件窗口要等 `/api/decks`（跨网络访问 VPS + 计算整棵牌组树到期数量）返回才弹出，体感延迟数秒。另外 `await` 之后浏览器的用户激活可能过期，部分浏览器会延迟或拒绝程序化打开文件选择器。

## 怎么测试
1. 打开网站，点击 Import（或 Cmd+I)——文件窗口应立即弹出
2. 选择一个 YAML 文件——预览表格正常渲染，每卡牌组下拉和 move-target 自动补全内容齐全
3. YAML 解析错误时点 Try Again——文件窗口同样立即弹出

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)