### PR TITLE
fix: 设置弹窗预填活跃故事的 mode/HSK；预生成打 origin 标记防自我延续

### DIFF
--- a/database/stories.py
+++ b/database/stories.py
@@ -328,44 +328,45 @@ def get_recent_story_keys(before_date: str, max_lookback_days: int = 14) -> list
     excludes the single-sentence "again" regeneration rows (see AGAIN_CATEGORY)
     without needing to special-case that category by name.
 
+    Stories whose gen_params has origin == "pregen" are skipped everywhere —
+    both when picking the target day and when collecting its keys. Otherwise
+    pregen's own output becomes the next day's input and one accidental batch
+    (or one accidental mode) self-perpetuates forever (issue #468). Only
+    user-initiated generations are reproduced.
+
     Returns [] if no matching day is found in the lookback window.
     """
     before = date.fromisoformat(before_date)
     earliest = before - timedelta(days=max_lookback_days)
 
     conn = get_db()
-    date_row = conn.execute(
-        """SELECT s.date FROM stories s
+    rows = conn.execute(
+        """SELECT * FROM stories s
            WHERE s.date < ? AND s.date >= ? AND s.gen_params IS NOT NULL
              AND (SELECT COUNT(*) FROM story_sentences ss WHERE ss.story_id = s.id) >= 2
-           ORDER BY s.date DESC LIMIT 1""",
+           ORDER BY s.date DESC, s.generated_at DESC""",
         (before_date, earliest.isoformat()),
-    ).fetchone()
-    if not date_row:
-        conn.close()
-        return []
-    target_date = date_row["date"]
-
-    story_rows = conn.execute(
-        """SELECT * FROM stories s
-           WHERE s.date = ? AND s.gen_params IS NOT NULL
-             AND (SELECT COUNT(*) FROM story_sentences ss WHERE ss.story_id = s.id) >= 2
-           ORDER BY s.generated_at DESC""",
-        (target_date,),
     ).fetchall()
     conn.close()
 
+    target_date = None
     seen: set[tuple] = set()
     result: list[dict] = []
-    for row in story_rows:
-        key = (row["deck_id"], row["category"], row["lang"])
-        if key in seen:
-            continue  # keep only the latest generated_at per key (rows are DESC-ordered)
-        seen.add(key)
+    for row in rows:
         try:
             gen_params = json.loads(row["gen_params"])
         except (ValueError, TypeError):
             continue
+        if gen_params.get("origin") == "pregen":
+            continue
+        if target_date is None:
+            target_date = row["date"]  # most recent day with a user-initiated story
+        elif row["date"] != target_date:
+            break  # rows are date DESC — we're past the target day
+        key = (row["deck_id"], row["category"], row["lang"])
+        if key in seen:
+            continue  # keep only the latest generated_at per key (rows are DESC-ordered)
+        seen.add(key)
         result.append({
             "deck_id": row["deck_id"],
             "category": row["category"],

--- a/routes/story.py
+++ b/routes/story.py
@@ -177,7 +177,8 @@ def _validated_model(model: str | None) -> str:
 
 def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
                         topic, max_hsk, model, grammar_focus, grammar_pct, mode,
-                        chapter_ids, articles=None, progress_key, lang: str | None = None) -> dict | None:
+                        chapter_ids, articles=None, progress_key, lang: str | None = None,
+                        origin: str | None = None) -> dict | None:
     """Generate a story for `cards`, persist it, and return the stored story
     (with sentences) — or an error dict on failure, or None if there is nothing
     to generate. Shared by the synchronous GET, the background thread, and regenerate.
@@ -236,7 +237,8 @@ def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
         gen_params = _gen_params_dict(
             topic=topic, max_hsk=max_hsk, model=model,
             grammar_focus=grammar_focus, grammar_pct=grammar_pct,
-            mode=mode, chapter_ids=chapter_ids, articles=articles, lang=lang)
+            mode=mode, chapter_ids=chapter_ids, articles=articles, lang=lang,
+            origin=origin)
         database.create_story(today, category, deck_id, sentences, prompt_text, topic, gen_params, lang=lang)
         story = database.get_active_story(today, category, deck_id, lang=lang)
     except Exception as e:
@@ -290,12 +292,16 @@ def _start_background_generation(deck_id: int, category: str, today: str, cards:
 
 
 def _gen_params_dict(*, topic, max_hsk, model, grammar_focus, grammar_pct,
-                     mode, chapter_ids, articles=None, lang="zh") -> dict:
+                     mode, chapter_ids, articles=None, lang="zh",
+                     origin=None) -> dict:
     """Bundle the story generation settings persisted on each story row, so the
     Again regeneration can reproduce the same style (see generate_sentence_for_word).
 
     articles: news mode's pasted article list ({url, title, text}), stored so
     single-word "Again" regenerations reuse the same news context.
+    origin: "pregen" when the story was created by the morning pregen —
+    get_recent_story_keys skips those rows so pregen only ever reproduces
+    user-initiated generations instead of feeding on its own output (issue #468).
     """
     return {
         "mode": mode,
@@ -307,6 +313,7 @@ def _gen_params_dict(*, topic, max_hsk, model, grammar_focus, grammar_pct,
         "chapter_ids": chapter_ids,
         "articles": articles,
         "lang": lang,
+        "origin": origin,
     }
 
 
@@ -892,7 +899,7 @@ async def pregen_today():
                 topic=gp.get("topic"), max_hsk=gp.get("max_hsk", 3), model=chosen_model,
                 grammar_focus=gp.get("grammar_focus"), grammar_pct=gp.get("grammar_pct", 75),
                 mode=mode, chapter_ids=gp.get("chapter_ids"), articles=None,
-                progress_key=progress_key, lang=lang)
+                progress_key=progress_key, lang=lang, origin="pregen")
             ai._story_progress.pop(progress_key, None)
             if isinstance(result, dict) and result.get("error"):
                 raise RuntimeError(result.get("reason", "generation failed"))

--- a/static/app.js
+++ b/static/app.js
@@ -5747,8 +5747,22 @@ function openStorySetup(sentenceCount, { isMixed = false, isUnfinished = false, 
   document.getElementById('setup-topic').value = '';
   document.getElementById('setup-grammar').value = '';
   document.getElementById('setup-grammar-pct').value = 50;
-  document.getElementById('setup-hsk-slider').value = 3;
-  document.getElementById('setup-mode').value = 'story';
+  // In-session regenerate: prefill mode + HSK from the active story's gen_params
+  // so a quick regenerate keeps News flow / kahneman / … instead of silently
+  // downgrading to mode=story (issue #468 — a briefing was overwritten exactly
+  // this way). Other entry points (fresh session, unfinished mode) keep the
+  // 'story' default so another deck's mode is never carried over by accident.
+  let _prefillGp = null;
+  if (_setupIsRegen) {
+    try {
+      const raw = story?.gen_params;
+      _prefillGp = raw ? (typeof raw === 'string' ? JSON.parse(raw) : raw) : null;
+    } catch { _prefillGp = null; }
+  }
+  document.getElementById('setup-hsk-slider').value = _prefillGp?.max_hsk ?? 3;
+  const _modeSel = document.getElementById('setup-mode');
+  _modeSel.value = _prefillGp?.mode || 'story';
+  if (_modeSel.selectedIndex < 0) _modeSel.value = 'story'; // unknown mode in gen_params
   updateHskLabel();
   _applySetupLangRestrictions();
   updateSetupMode();


### PR DESCRIPTION
## 问题（Closes #468）

2026-07-10 早晨预生成产出普通故事而非 News flow。服务器日志 + stories 表确认的时间线（北京时间）：07-09 20:50 用户生成 briefing → 21:19 用户在会话里打开设置弹窗点生成（弹窗把 mode 硬重置成了 story）→ briefing 被普通故事覆盖 → 07-10 06:01 预生成复制了这个 mode。同时发现预生成还在每天复制 07-08 旧版预生成遗留的 55+ 篇叶子牌组故事（自我延续，永不终止）。

## 修改

**`static/app.js` `openStorySetup()`**：会话内重新生成（`_setupIsRegen`）时用当前故事的 gen_params 预填 mode 和 HSK 滑块；未知 mode 回退 story；其他入口保持 story 默认（不把上一个会话的 briefing 模式带到别的牌组，避免意外触发 gpt-5.1 生成）。

**`routes/story.py`**：`_generate_and_store` / `_gen_params_dict` 新增 `origin` 参数；`pregen_today` 传 `origin="pregen"`。

**`database/stories.py` `get_recent_story_keys()`**：改为单查询 + Python 过滤；选目标日期和收集键时都跳过 `origin == "pregen"` 的行——预生成只复制用户主动生成的键；最近一天全是 pregen 行时自动回退到更早的用户生成日。

## 过渡说明

今晚的预生成读取的还是今天未打标记的行，会最后复制一次叶子故事；那批新故事已带标记，后天起链条自动断掉。（可选：服务器上一次性 UPDATE 给今天的 pregen 批次打标记，今晚即停——见议题。）

## 测试

- Python/JS 语法 + 导入检查通过
- 临时数据库逻辑测试两个场景通过：① 最近一天有用户故事 → 只复制该键（briefing）；② 最近一天全是 pregen 行 → 回退到上一个用户生成日

🤖 Generated with [Claude Code](https://claude.com/claude-code)