### PR TITLE
fix: 预生成跳过无标记的遗留 pregen 故事——按生成时间早于故事日期识别

### DIFF
--- a/database/stories.py
+++ b/database/stories.py
@@ -359,6 +359,14 @@ def get_recent_story_keys(before_date: str, max_lookback_days: int = 14) -> list
             continue
         if gen_params.get("origin") == "pregen":
             continue
+        # Legacy rows (pre-#469) have no "origin" key at all. The morning pregen
+        # cron runs at 06:0x Beijing = 22:0x UTC the previous day, so a story
+        # generated (UTC) before its own anki date can only be pregen output —
+        # user generations happen during the day with both on the same date.
+        # Without this, the untagged 07-08/07-09 leaf-deck batches keep getting
+        # reproduced until they age out of the lookback window (issue #471).
+        if "origin" not in gen_params and (row["generated_at"] or "")[:10] < row["date"]:
+            continue
         if target_date is None:
             target_date = row["date"]  # most recent day with a user-initiated story
         elif row["date"] != target_date:


### PR DESCRIPTION
## 问题（Closes #471）

#469 的 `origin: "pregen"` 标记只覆盖新生成的行。07-08（88 篇）和 07-09 22:0x UTC（55 篇）的旧 pregen 批次没有标记，在 14 天回看窗口内会被 `get_recent_story_keys` 当作用户键：明早会再复制 55 篇叶子废故事，之后每天回退逻辑还会反复落回这些无标记行，直到 07-24 才老化出窗口。

## 修改

`database/stories.py` `get_recent_story_keys()` 新增一个只作用于遗留行的启发式判断：

- gen_params 中**没有 origin 键**（= #469 之前的行）**且** `generated_at[:10] < date` → 视为 pregen，跳过
- 依据：预生成 cron 在北京时间 06:0x = UTC 前一天 22:0x 运行，故事的 generated_at（UTC）日期必然早于其 anki 日期；用户白天生成的故事两者同日
- #469 之后的新行 gen_params 一定含 origin 键（None 或 "pregen"），不受启发式影响

## 测试

临时数据库覆盖 5 种行：遗留 pregen（无 origin + 时间早于日期）→ 跳过；遗留用户行（无 origin、同日）→ 保留；新 pregen（origin=pregen）→ 跳过；新用户行（origin=None）→ 保留。断言全部通过。

## 效果

明早（07-11 06:01）预生成只复制 07-10 的用户键：13:43 的 briefing（听力）和其他当天手动生成的故事。Daniel 醒来即有 News flow，不再烧 55 篇废故事。

🤖 Generated with [Claude Code](https://claude.com/claude-code)