### PR TITLE
feat: 学习/重学步骤接入 FSRS 短期记忆——Good 毕业间隔自适应 (#470)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,7 @@ decks → stories → story_sentences → entries（外键）
 - **Hard** → `learning_hard_1d` 开关（默认开）：任意步一律延迟 `learning_hard_days`（默认 1 天，可为小数）——让半记住的卡明天再现；开关关闭时用 Anki 经典行为（步骤均值/×1.5）
 - **Good** → 推进一步；最后一步 → 毕业
 - **Easy** → 立即毕业
+- **短期记忆（#470）**：FSRS 开启时，步骤阶段每次作答都更新 S/D——新卡第一次作答即播种，之后 Again ×0.50 / Hard ×0.84 / 推进步骤的 Good ×1.41（短期公式 w17/w18）；毕业间隔与按钮预览因此随作答历史自适应（先 Again 再 Good ≈ 1 天，纯 Good 仍 ≈ 3 天）
 
 ### 毕业间隔
 FSRS 用毕业评分播种初始 stability/difficulty：默认权重下 **Good ≈ 3 天，Easy ≈ 16 天**（`fsrs.init_stability`）。FSRS 关闭时用预设的 `graduating_interval`（1）/ `easy_interval`（4）。

--- a/srs.py
+++ b/srs.py
@@ -67,13 +67,19 @@ def _elapsed_days(card: dict) -> int:
 def _graduate_interval(card: dict, rating: int) -> int:
     """Day-interval when a learning card graduates with the given rating.
 
-    Under FSRS this comes from the initial stability; otherwise the legacy
-    graduating/easy interval preset values."""
+    Mirrors _handle_learning's _graduate: an already-seeded stability (from
+    step answers) drives the interval directly; otherwise it is seeded from
+    the graduating rating. FSRS off falls back to the preset values."""
     if not _fsrs_enabled(card):
         base = card.get("easy_interval", 4) if rating == 4 else card.get("graduating_interval", 1)
         return max(1, base)
     w, dr, mx = _fsrs_cfg(card)
-    s = fsrs.init_stability(w, rating)
+    s = card.get("stability")
+    if s:
+        if rating == 4:
+            s = fsrs.next_short_term_stability(w, s, 4)
+    else:
+        s = fsrs.init_stability(w, rating)
     return fsrs.next_interval(s, dr, mx)
 
 
@@ -87,6 +93,25 @@ def _relearn_graduate_interval(card: dict, rating: int) -> int:
     if rating == 4:
         s = fsrs.next_short_term_stability(w, s, 4)
     return max(card.get("minimum_interval", 1), fsrs.next_interval(s, dr, mx))
+
+
+def _touch_learning_memory(c: dict, preset: dict, rating: int) -> None:
+    """Short-term (same-day) FSRS memory update for a non-graduating step answer.
+
+    The first answer on a fresh card seeds S/D from that rating (FSRS-5
+    behaviour); later step answers nudge stability via the short-term formula
+    and update difficulty, so the graduation interval adapts to how the card
+    is actually going. No-op when FSRS is off."""
+    if not _fsrs_enabled(preset):
+        return
+    w, _, _ = _fsrs_cfg(preset)
+    if c.get("stability"):
+        c["stability"] = fsrs.next_short_term_stability(w, c["stability"], rating)
+        if c.get("difficulty") is not None:
+            c["difficulty"] = fsrs.next_difficulty(w, c["difficulty"], rating)
+    else:
+        c["stability"] = fsrs.init_stability(w, rating)
+        c["difficulty"] = fsrs.init_difficulty(w, rating)
 
 
 # ---------------------------------------------------------------------------
@@ -484,6 +509,7 @@ def _handle_learning(card: dict, preset: dict, rating: int) -> dict:
         c["state"] = "learning"
         c["step_index"] = 0
         c["due"] = next_learning_due(steps, 0)
+        _touch_learning_memory(c, preset, rating)
         return c
 
     if rating == 2:  # Hard — stay on current step, slow delay
@@ -498,6 +524,7 @@ def _handle_learning(card: dict, preset: dict, rating: int) -> dict:
         else:
             delay = steps[idx]
         c["due"] = _smart_due(datetime.now() + timedelta(minutes=delay))
+        _touch_learning_memory(c, preset, rating)
         return c
 
     # rating == 3: Good — advance step
@@ -510,6 +537,7 @@ def _handle_learning(card: dict, preset: dict, rating: int) -> dict:
         c["step_index"] = idx + 1
         c["state"] = "learning"
         c["due"] = next_learning_due(steps, c["step_index"])
+        _touch_learning_memory(c, preset, rating)
 
     return c
 
@@ -588,6 +616,7 @@ def _handle_relearn(card: dict, preset: dict, rating: int) -> dict:
         c["state"] = "relearn"
         c["step_index"] = 0
         c["due"] = next_learning_due(steps, 0)
+        _touch_learning_memory(c, preset, rating)
         return c
 
     if rating == 2:  # Hard — repeat current step
@@ -602,6 +631,7 @@ def _handle_relearn(card: dict, preset: dict, rating: int) -> dict:
         else:
             delay = steps[idx]
         c["due"] = _smart_due(datetime.now() + timedelta(minutes=delay))
+        _touch_learning_memory(c, preset, rating)
         return c
 
     idx = c["step_index"]
@@ -632,6 +662,7 @@ def _handle_relearn(card: dict, preset: dict, rating: int) -> dict:
         c["step_index"] = idx + 1
         c["state"] = "relearn"
         c["due"] = next_learning_due(steps, c["step_index"])
+        _touch_learning_memory(c, preset, rating)
 
     return c
 

--- a/tests/test_srs_logic.py
+++ b/tests/test_srs_logic.py
@@ -11,7 +11,10 @@ import os
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
+import pytest
+
 import srs
+import fsrs
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -248,6 +251,89 @@ class TestHandleProbation:
         assert result["state"] == "review"
         assert result["probation"] == 0
         assert result["lapses"] == 1            # unchanged by passing
+
+
+# ---------------------------------------------------------------------------
+# Learning-phase FSRS short-term memory (#470)
+# ---------------------------------------------------------------------------
+
+FSRS_PRESET = {
+    "learning_steps":           "10",
+    "graduating_interval":      1,
+    "easy_interval":            4,
+    "relearning_steps":         "10",
+    "minimum_interval":         1,
+    "learned_interval":         3,
+    "leech_threshold":          8,
+    "learning_leech_threshold": 6,
+    "leech_action":             "suspend",
+    "enable_fsrs":              1,
+    "enable_probation":         0,
+    "desired_retention":        0.9,
+    "maximum_interval":         36500,
+    "fsrs_weights":             None,
+    "learning_hard_1d":         0,
+    "learning_hard_days":       1,
+}
+
+W = fsrs.DEFAULT_WEIGHTS
+
+
+class TestLearningShortTermMemory:
+    def test_learning_again_seeds_memory(self):
+        card = make_card(state="new", step_index=0)
+        card["stability"] = None
+        card["difficulty"] = None
+        result = srs._handle_learning(card, FSRS_PRESET, rating=1)
+        assert result["stability"] == pytest.approx(W[0])  # w[0] = 0.40255
+        assert result["difficulty"] == pytest.approx(fsrs.init_difficulty(W, 1))
+
+    def test_learning_hard_shrinks_stability(self):
+        card = make_card(state="learning", step_index=0)
+        card["stability"] = 3.173
+        card["difficulty"] = 5.0
+        result = srs._handle_learning(card, FSRS_PRESET, rating=2)
+        expected = 3.173 * math.exp(0.51655 * (-1 + 0.6621))
+        assert result["stability"] == pytest.approx(expected)
+
+    def test_again_then_good_graduates_at_1d(self):
+        card = make_card(state="new", step_index=0)
+        card["stability"] = None
+        card["difficulty"] = None
+        after_again = srs._handle_learning(card, FSRS_PRESET, rating=1)
+        graduated = srs._handle_learning(after_again, FSRS_PRESET, rating=3)
+        assert graduated["state"] == "review"
+        assert graduated["interval"] == 1
+
+    def test_pure_good_graduation_unchanged(self, monkeypatch):
+        monkeypatch.setattr(srs, "_fuzz_interval", lambda x: x)
+        card = make_card(state="new", step_index=0)
+        card["stability"] = None
+        card["difficulty"] = None
+        result = srs._handle_learning(card, FSRS_PRESET, rating=3)
+        assert result["state"] == "review"
+        assert result["interval"] == 3
+
+        preview_card = make_card(state="new", step_index=0)
+        preview_card["stability"] = None
+        preview_card["difficulty"] = None
+        preview_card = {**preview_card, **FSRS_PRESET}
+        assert srs.preview_intervals(preview_card)[3] == "3d"
+
+    def test_fsrs_off_no_seeding(self):
+        preset = {**FSRS_PRESET, "enable_fsrs": 0}
+        card = make_card(state="new", step_index=0)
+        card["stability"] = None
+        card["difficulty"] = None
+        result = srs._handle_learning(card, preset, rating=1)
+        assert result.get("stability") is None
+
+    def test_preview_adapts_after_seeding(self):
+        card = make_card(state="learning", step_index=0)
+        card["stability"] = 0.57
+        card["difficulty"] = 5.0
+        card = {**card, **FSRS_PRESET}
+        assert srs.preview_intervals(card)[3] == "1d"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #470

## 改了什么

步骤阶段（learning/relearn）的每次**不毕业**作答现在会更新卡片的 FSRS 记忆状态：

- 新增 `srs._touch_learning_memory`：新卡第一次作答即播种 S/D（`init_stability`/`init_difficulty`）；已有 S 的卡用短期公式 `next_short_term_stability`（Again ×0.50 / Hard ×0.84 / Good ×1.41）+ `next_difficulty` 更新
- `_handle_learning` 与 `_handle_relearn` 的 Again / Hard / 推进步骤的 Good 六个分支接入该函数
- `_graduate_interval`（按钮预览）与 `_graduate` 实际毕业行为对齐：卡片已有 stability 时直接用它算间隔（Easy 加短期加成）

## 为什么

Daniel 反馈：重学卡连按 Hard，Good 按钮永远显示 3d，不自适应。完整 FSRS-5 本有同日短期记忆机制，我们已实现公式但没接入步骤阶段。接入后：先 Again 再 Good 毕业 ≈1d，先 Hard 再 Good ≈2d，纯 Good 不变（3d）。

## 不改的

毕业分支本体、`_handle_probation`、`_handle_review`、undo（快照已含 S/D）、前端；`enable_fsrs=0` 时全部跳过。

## 怎么测试

- `tests/test_srs_logic.py` 新增 6 用例（播种、Hard 缩减、Again→Good=1d、纯 Good 不变、FSRS 关不播种、预览自适应）：`python -m pytest tests/test_srs_logic.py -q` → 34 passed, 1 failed（`TestKouyuHskToInt::test_slash_takes_higher` 在干净 main 上同样失败，与本 PR 无关）
- `python -m py_compile srs.py` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)