### PR TITLE
feat: 设置里配置早晨预生成的故事类型；同日多类别 briefing 使用不同文章

### DIFF
--- a/database/core.py
+++ b/database/core.py
@@ -464,6 +464,24 @@ def init_db() -> None:
     # Remove the legacy "Sentences" deck tree if it holds no cards (issue #394)
     _drop_sentences_decks(conn)
     conn.commit()
+
+    # pregen_config seeding (issue #473): when the table is first created, seed
+    # the actual usage — News flow every morning for the aggregate "All" deck's
+    # listening + creating categories. No-op when no root deck named "All"
+    # exists (fresh installs, dev databases).
+    if "pregen_config" not in existing:
+        all_deck = conn.execute(
+            "SELECT id FROM decks WHERE name = 'All' AND parent_id IS NULL "
+            "AND deleted_at IS NULL LIMIT 1"
+        ).fetchone()
+        if all_deck:
+            for cat in ("listening", "creating"):
+                conn.execute(
+                    """INSERT OR IGNORE INTO pregen_config
+                       (deck_id, category, lang, mode, max_hsk)
+                       VALUES (?, ?, 'zh', 'briefing', 2)""",
+                    (all_deck["id"], cat))
+            conn.commit()
     conn.close()
 
 

--- a/database/stories.py
+++ b/database/stories.py
@@ -384,6 +384,73 @@ def get_recent_story_keys(before_date: str, max_lookback_days: int = 14) -> list
     return result
 
 
+def get_pregen_config() -> list[dict]:
+    """All morning-pregen config rows (issue #473). Each row fixes the story
+    mode the 06:00 pregen uses for one (deck, category, lang) — independent of
+    whatever was regenerated during the day."""
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT deck_id, category, lang, mode, max_hsk FROM pregen_config "
+        "ORDER BY deck_id, category"
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def set_pregen_config(deck_id: int, entries: list[dict]) -> None:
+    """Replace the pregen config rows for one deck. entries: [{category, mode,
+    max_hsk, lang?}] — categories omitted from the list are removed (mode
+    'off' in the UI simply isn't sent)."""
+    conn = get_db()
+    conn.execute("DELETE FROM pregen_config WHERE deck_id = ?", (deck_id,))
+    for e in entries:
+        conn.execute(
+            """INSERT INTO pregen_config (deck_id, category, lang, mode, max_hsk)
+               VALUES (?, ?, ?, ?, ?)""",
+            (deck_id, e["category"], e.get("lang") or "zh",
+             e["mode"], int(e.get("max_hsk") or 3)))
+    conn.commit()
+    conn.close()
+
+
+def get_today_used_article_urls(date_str: str, lang: str | None,
+                                exclude_deck_id: int, exclude_category: str) -> set:
+    """URLs of news articles already used by today's active news/briefing
+    stories of OTHER (deck, category) keys — so a second category generated the
+    same day picks different articles (issue #473). The excluded key is the one
+    about to generate: regenerating a category may reuse its own articles."""
+    conn = get_db()
+    rows = conn.execute(
+        """SELECT deck_id, category, lang, gen_params FROM stories
+           WHERE date = ? AND gen_params IS NOT NULL
+           ORDER BY generated_at DESC""",
+        (date_str,),
+    ).fetchall()
+    conn.close()
+
+    urls: set = set()
+    seen_keys: set = set()
+    for row in rows:
+        key = (row["deck_id"], row["category"], row["lang"])
+        if key in seen_keys:
+            continue  # only the active (latest) story per key counts
+        seen_keys.add(key)
+        if (row["deck_id"], row["category"]) == (exclude_deck_id, exclude_category):
+            continue
+        if lang and row["lang"] and row["lang"] != lang:
+            continue
+        try:
+            gp = json.loads(row["gen_params"])
+        except (ValueError, TypeError):
+            continue
+        if gp.get("mode") not in ("news", "briefing"):
+            continue
+        for art in gp.get("articles") or []:
+            if art.get("url"):
+                urls.add(art["url"])
+    return urls
+
+
 def get_due_cards_unified(deck_id: int, lang: str | None = None) -> list[dict]:
     """Collect due cards from all 3 categories for a unified story, deduplicated by word_id.
     Order matches review priority (state → category → due) so story sentence positions

--- a/routes/story.py
+++ b/routes/story.py
@@ -218,7 +218,12 @@ def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
                 # in gen_params below, so Again-regeneration reuses them.
                 # Paste mode never auto-fetches: no pasted content is an error
                 # (raised inside _generate_news_story_sentences).
-                articles = _auto_news_articles(model=model, progress_key=progress_key)
+                # Articles already used by another category's story today are
+                # excluded so each category covers different news (issue #473).
+                used = database.get_today_used_article_urls(
+                    today, lang, exclude_deck_id=deck_id, exclude_category=category)
+                articles = _auto_news_articles(model=model, progress_key=progress_key,
+                                               exclude_urls=used)
             if mode == "briefing":
                 sentences, prompt_text = _generate_briefing_story_sentences(
                     cards, articles, model=model, progress_key=progress_key,
@@ -724,16 +729,29 @@ def _generate_briefing_story_sentences(
     return _group_sentences_by_article(all_sentences, articles), prompt_summary
 
 
-def _auto_news_articles(model: str, progress_key: str | None) -> list[dict]:
+def _auto_news_articles(model: str, progress_key: str | None,
+                        exclude_urls: set | None = None) -> list[dict]:
     """News auto mode: fetch today's news (sources per data/news_sources.json,
     cached per day) and have the AI pick + condense the most important items
     into briefing source articles ({url, title, text} — the pasted-articles shape).
+
+    exclude_urls: articles already used by another category's story today —
+    removed from the pool so the two categories cover different news (issue
+    #473). Skipped when filtering would leave an empty pool.
 
     news_fetcher.NewsFetchError propagates when every source fails, so the
     caller reports a clear error instead of silently using another mode."""
     ai._set_progress(progress_key, phase="request", msg="Fetching today's news…", percent=8)
     items = news_fetcher.fetch_all()
     logger.info("news auto: fetched %d items from sources", len(items))
+    if exclude_urls:
+        remaining = [i for i in items if i.get("url") not in exclude_urls]
+        if remaining:
+            logger.info("news auto: excluded %d already-used articles, %d remain",
+                        len(items) - len(remaining), len(remaining))
+            items = remaining
+        else:
+            logger.warning("news auto: exclusion would empty the pool — keeping all items")
     return ai.summarize_news_items(items, model=model, progress_key=progress_key)
 
 
@@ -860,6 +878,17 @@ async def pregen_today():
     """
     today = database.anki_today().isoformat()
     keys = database.get_recent_story_keys(today)
+    # Explicit pregen config (issue #473) takes priority: its gen_params come
+    # straight from the settings, never from whatever was regenerated during
+    # the day. Heuristic keys (reproduce the user's most recent generations)
+    # still fill in anything not configured.
+    config = database.get_pregen_config()
+    cfg_keys = {(c["deck_id"], c["category"], c["lang"]) for c in config}
+    keys = ([{"deck_id": c["deck_id"], "category": c["category"], "lang": c["lang"],
+              "gen_params": {"mode": c["mode"], "max_hsk": c["max_hsk"]}}
+             for c in config]
+            + [k for k in keys
+               if (k["deck_id"], k["category"], k["lang"]) not in cfg_keys])
     generated: list[str] = []
     skipped_cached: list[str] = []
     skipped_no_due: list[str] = []
@@ -924,6 +953,37 @@ async def pregen_today():
         today, len(keys), len(generated), len(skipped_cached), len(skipped_no_due), len(failed))
     return {"date": today, "keys": len(keys), "generated": generated,
             "skipped_cached": skipped_cached, "skipped_no_due": skipped_no_due, "failed": failed}
+
+
+_PREGEN_MODES = {"story", "qa", "expository", "kahneman", "news", "briefing"}
+_PREGEN_CATEGORIES = {"listening", "reading", "creating", "unified"}
+
+
+@router.get("/api/pregen-config")
+def get_pregen_config_endpoint():
+    """Morning-pregen config rows (issue #473) — what the 06:00 pregen generates
+    per (deck, category), independent of the day's ad-hoc regenerations."""
+    return {"entries": database.get_pregen_config()}
+
+
+@router.put("/api/pregen-config")
+def put_pregen_config(body: dict):
+    """Replace the config rows for one deck. body: {"deck_id": int,
+    "entries": [{"category", "mode", "max_hsk", "lang"?}]} — an empty entries
+    list clears the deck's config (every category back to heuristic pregen)."""
+    deck_id = body.get("deck_id")
+    entries = body.get("entries") or []
+    if not deck_id or not database.get_deck(deck_id):
+        return {"error": True, "reason": f"unknown deck_id {deck_id!r}"}
+    for e in entries:
+        if e.get("category") not in _PREGEN_CATEGORIES:
+            return {"error": True, "reason": f"invalid category {e.get('category')!r}"}
+        if e.get("mode") not in _PREGEN_MODES:
+            return {"error": True, "reason": f"invalid mode {e.get('mode')!r}"}
+    database.set_pregen_config(deck_id, entries)
+    logger.info("pregen-config  deck=%s set to %s", deck_id,
+                [(e["category"], e["mode"]) for e in entries])
+    return {"ok": True, "entries": database.get_pregen_config()}
 
 
 @router.get("/api/story-progress/{deck_id}/{category}")

--- a/schema.sql
+++ b/schema.sql
@@ -533,3 +533,16 @@ CREATE INDEX IF NOT EXISTS idx_cards_due
 
 CREATE INDEX IF NOT EXISTS idx_review_log_card_date
     ON review_log(card_id, reviewed_at);
+
+-- ---------------------------------------------------------------------------
+-- Morning pregen configuration (issue #473): per deck+category story mode the
+-- 06:00 pregen uses — independent of whatever was regenerated during the day
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS pregen_config (
+    deck_id  INTEGER NOT NULL REFERENCES decks(id) ON DELETE CASCADE,
+    category TEXT NOT NULL CHECK(category IN ('listening', 'reading', 'creating', 'unified')),
+    lang     TEXT NOT NULL DEFAULT 'zh',
+    mode     TEXT NOT NULL,
+    max_hsk  INTEGER NOT NULL DEFAULT 3,
+    PRIMARY KEY (deck_id, category, lang)
+);

--- a/static/app.js
+++ b/static/app.js
@@ -2587,10 +2587,106 @@ function renderSettings() {
       </div>
     </div>
     <div class="keymap-panel">
+      <h2 class="keymap-heading">Morning pre-generation</h2>
+      <p class="keymap-hint">Story type generated automatically each morning, per category. Independent of the style you pick when regenerating during the day. <b>Off</b> = repeat whatever you last generated manually.</p>
+      <div id="pregen-config-body">Loading…</div>
+    </div>
+    <div class="keymap-panel">
       <h2 class="keymap-heading">Server logs</h2>
       <p class="keymap-hint">View the last lines of the server log (helpful for debugging story generation, TTS, etc).</p>
       <button class="keymap-reset-all" onclick="openLogsViewer()">Open logs</button>
     </div>`;
+  _loadPregenSettings();
+}
+
+// ── Morning pre-generation config (issue #473) ──────────────────────────────
+const PREGEN_MODE_OPTIONS = [
+  ['', 'Off (repeat last manual)'],
+  ['story', 'Story'],
+  ['briefing', 'News flow'],
+  ['news', 'News briefing'],
+  ['kahneman', 'Kahneman'],
+];
+let _pregenDecks = [];
+let _pregenEntries = [];
+let _pregenDeckId = null;
+
+async function _loadPregenSettings() {
+  try {
+    const [cfg, decks] = await Promise.all([
+      api('GET', '/api/pregen-config'),
+      api('GET', '/api/decks'),
+    ]);
+    _pregenEntries = cfg.entries || [];
+    _pregenDecks = [];
+    const walk = (nodes, depth) => (nodes || []).forEach(d => {
+      _pregenDecks.push({ id: d.id, name: '  '.repeat(depth) + d.name });
+      walk(d.children, depth + 1);
+    });
+    walk(decks, 0);
+    if (_pregenDeckId == null || !_pregenDecks.some(d => d.id === _pregenDeckId)) {
+      _pregenDeckId = _pregenEntries[0]?.deck_id ?? _pregenDecks[0]?.id ?? null;
+    }
+    _renderPregenPanel();
+  } catch (e) {
+    const el = document.getElementById('pregen-config-body');
+    if (el) el.textContent = 'Failed to load: ' + e.message;
+  }
+}
+
+function _pregenSelectDeck(id) {
+  _pregenDeckId = parseInt(id);
+  _renderPregenPanel();
+}
+
+function _renderPregenPanel() {
+  const el = document.getElementById('pregen-config-body');
+  if (!el) return;
+  const deckOpts = _pregenDecks.map(d =>
+    `<option value="${d.id}" ${d.id === _pregenDeckId ? 'selected' : ''}>${d.name}</option>`).join('');
+  const rows = ['listening', 'creating', 'reading'].map(cat => {
+    const e = _pregenEntries.find(x => x.deck_id === _pregenDeckId && x.category === cat);
+    const modeOpts = PREGEN_MODE_OPTIONS.map(([v, label]) =>
+      `<option value="${v}" ${(e?.mode || '') === v ? 'selected' : ''}>${label}</option>`).join('');
+    return `<div class="keymap-row">
+      <span class="keymap-label">${cat[0].toUpperCase() + cat.slice(1)}</span>
+      <select class="opt-input" id="pregen-mode-${cat}" style="flex:1">${modeOpts}</select>
+      <input class="opt-input" id="pregen-hsk-${cat}" type="number" min="1" max="6"
+             value="${e?.max_hsk ?? 3}" title="Max HSK for background vocabulary" style="width:56px">
+    </div>`;
+  }).join('');
+  el.innerHTML = `
+    <div class="keymap-row">
+      <span class="keymap-label">Deck</span>
+      <select class="opt-input" id="pregen-deck-select" style="flex:1" onchange="_pregenSelectDeck(this.value)">${deckOpts}</select>
+    </div>
+    ${rows}
+    <div class="keymap-row">
+      <button class="keymap-reset-all" onclick="savePregenConfig()">Save morning settings</button>
+      <span id="pregen-save-msg" class="keymap-label"></span>
+    </div>`;
+}
+
+async function savePregenConfig() {
+  const entries = [];
+  for (const cat of ['listening', 'creating', 'reading']) {
+    const mode = document.getElementById(`pregen-mode-${cat}`)?.value;
+    if (!mode) continue; // Off → no row for this category
+    const hsk = parseInt(document.getElementById(`pregen-hsk-${cat}`)?.value) || 3;
+    entries.push({ category: cat, mode, max_hsk: hsk });
+  }
+  const msg = document.getElementById('pregen-save-msg');
+  try {
+    const res = await api('PUT', '/api/pregen-config', { deck_id: _pregenDeckId, entries });
+    if (res?.ok) {
+      _pregenEntries = res.entries || [];
+      if (msg) msg.textContent = '✓ Saved';
+    } else if (msg) {
+      msg.textContent = 'Error: ' + (res?.reason || 'save failed');
+    }
+  } catch (e) {
+    if (msg) msg.textContent = 'Error: ' + e.message;
+  }
 }
 function startKeyCapture(id) {
   _capturingAction = id; _settingsMsg = ''; renderSettings();


### PR DESCRIPTION
## 需求（Closes #473）

Daniel：早晨醒来每个类别都要有指定类型的故事，且**不受白天临时重新生成的影响**；听力和写作都设为 News flow；两个类别用**不同的新闻文章**。

## 修改

**数据库**
- 新表 `pregen_config(deck_id, category, lang, mode, max_hsk, PK(deck_id,category,lang))`（schema.sql + 迁移）
- 迁移在表首次创建时给 'All' 根牌组播种听力+写作 `mode=briefing, max_hsk=2`——**部署当晚 06:01 即生效，Daniel 无需任何操作**
- `get_pregen_config` / `set_pregen_config`（按牌组整体替换）
- `get_today_used_article_urls`：当天其他类别活跃 news/briefing 故事（每键最新一条）的文章 URL 集合

**后端**
- `pregen_today`：配置的键优先，gen_params 直接来自配置（与昨天的故事无关）；未配置的键继续 #458/#468/#471 启发式
- `_auto_news_articles(exclude_urls=…)`：从候选池排除已用文章；排除后为空则保留全部（宁可重复不可失败）
- `GET/PUT /api/pregen-config`（含 category/mode 校验）

**前端**
- 设置页新增 **Morning pre-generation** 面板：牌组下拉框（树形缩进）+ 听力/写作/阅读各一行（模式下拉框 Off/Story/News flow/News briefing/Kahneman + HSK 输入）+ 保存按钮；Off = 该类别沿用启发式

## 测试

- Python/JS 语法 + 导入检查通过
- 临时数据库功能测试全部通过：迁移播种（creating+listening 各一行 briefing/2）；set/get 往返 + 清空；文章排除（只算每键**活跃**故事、普通故事不贡献 URL、重新生成同类别不排除自己）

## 说明

CLAUDE.md 的 API 清单补充留待下一个文档 PR（当时工作区有其他会话的未提交改动，避免混入）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)