### PR TITLE
fix: 早晨预生成面板的 HSK 输入框加 'HSK ≤' 标签

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2651,8 +2651,9 @@ function _renderPregenPanel() {
     return `<div class="keymap-row">
       <span class="keymap-label">${cat[0].toUpperCase() + cat.slice(1)}</span>
       <select class="opt-input" id="pregen-mode-${cat}" style="flex:1">${modeOpts}</select>
+      <span style="font-size:12px;color:var(--muted);white-space:nowrap" title="Max HSK level for background vocabulary in the generated story">HSK&nbsp;≤</span>
       <input class="opt-input" id="pregen-hsk-${cat}" type="number" min="1" max="6"
-             value="${e?.max_hsk ?? 3}" title="Max HSK for background vocabulary" style="width:56px">
+             value="${e?.max_hsk ?? 3}" title="Max HSK level for background vocabulary in the generated story" style="width:56px">
     </div>`;
   }).join('');
   el.innerHTML = `


### PR DESCRIPTION
## 问题（Closes #477）

Morning pre-generation 面板每行右侧的数字输入框（背景词汇 HSK 上限）没有可见标签，Daniel 不得不问那一列是什么。

## 修改

`static/app.js` `_renderPregenPanel()`：输入框前加灰色小字 `HSK ≤`，并统一悬停提示文案。

## 测试

`node --check` 通过；纯展示改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)