### PR TITLE
feat: 网站播客页面——摘要/转录查看与详细程度设置

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -826,7 +826,7 @@ function _triggerClapAnimation() {
 
 function showView(name) {
   if (name === 'done' && _sessionReviewedCount > 0) _triggerClapAnimation();
-  ['loading', 'decks', 'review', 'done', 'browse', 'word-detail', 'hanzi-detail', 'stats', 'settings'].forEach(v => {
+  ['loading', 'decks', 'review', 'done', 'browse', 'word-detail', 'hanzi-detail', 'stats', 'settings', 'podcast'].forEach(v => {
     document.getElementById(`view-${v}`).style.display = 'none';
   });
   document.getElementById(`view-${name}`).style.display =
@@ -842,7 +842,8 @@ function showView(name) {
     name === 'word-detail'  ? 'Word Detail' :
     name === 'hanzi-detail' ? 'Hanzi Detail' :
     name === 'stats'        ? 'Stats' :
-    name === 'settings'     ? 'Settings' : 'AnkiAdvanced';
+    name === 'settings'     ? 'Settings' :
+    name === 'podcast'      ? 'Podcasts' : 'AnkiAdvanced';
   if (name === 'decks') quickMode = false;
   const headerRegenBtn = document.getElementById('header-regen-btn');
   if (headerRegenBtn) headerRegenBtn.style.display = (name === 'review' && !unfinishedMode && !quickMode) ? '' : 'none';
@@ -1280,6 +1281,7 @@ function renderDecks(decks) {
     <div class="nav-row">
       <button class="nav-btn" onclick="openBrowse()" title="Shortcut: B">Browse Cards</button>
       <button class="nav-btn" onclick="openStats()">Stats</button>
+      <button class="nav-btn" onclick="openPodcasts()">🎙 Podcasts</button>
       <button class="nav-btn" onclick="openSettings()" title="Customize shortcuts">⚙ Settings</button>
       <button class="nav-btn" onclick="openCostModal()">API Costs</button>
       <button class="nav-btn" onclick="openImportModal()" title="Shortcut: Command+I">Import</button>
@@ -2689,6 +2691,162 @@ async function savePregenConfig() {
     if (msg) msg.textContent = 'Error: ' + e.message;
   }
 }
+
+// ── Podcasts (#480) ──────────────────────────────────────────────────────────
+// List view: GET /api/podcast/episodes (no transcript text — kept out for
+// payload size). Detail view: GET /api/podcast/episodes/{id} (full row,
+// including transcript_zh). Settings: GET/PUT /api/podcast/config.
+const PODCAST_STATUS_LABEL = {
+  summarized:    'Summarized',
+  no_transcript: 'No transcript',
+  error:         'Error',
+  pending:       'Pending',
+};
+const PODCAST_STATUS_CLASS = {
+  summarized:    'podcast-badge-ok',
+  no_transcript: 'podcast-badge-muted',
+  error:         'podcast-badge-error',
+  pending:       'podcast-badge-pending',
+};
+
+let _podcastEpisodes = [];
+let _podcastConfig = null;
+
+async function openPodcasts() {
+  location.hash = '';
+  setLoading('Loading podcasts…');
+  try {
+    const [episodes, config] = await Promise.all([
+      api('GET', '/api/podcast/episodes'),
+      api('GET', '/api/podcast/config'),
+    ]);
+    _podcastEpisodes = episodes || [];
+    _podcastConfig = config || {};
+    showView('podcast');
+    _renderPodcastList();
+  } catch (e) {
+    showError('Podcasts failed: ' + e.message);
+    showView('decks');
+  }
+}
+
+function _renderPodcastList() {
+  const el = document.getElementById('view-podcast-content');
+  if (!el) return;
+  const detailLevel = _podcastConfig?.detail_level || 'medium';
+  const rows = _podcastEpisodes.map(ep => {
+    const date = (ep.published_at || ep.created_at || '').slice(0, 10);
+    const status = ep.status || 'pending';
+    const label = PODCAST_STATUS_LABEL[status] || status;
+    const cls = PODCAST_STATUS_CLASS[status] || 'podcast-badge-muted';
+    const clickable = status === 'summarized';
+    return `<div class="podcast-row${clickable ? ' podcast-row-clickable' : ''}"
+                 ${clickable ? `onclick="openPodcastEpisode(${ep.id})"` : ''}>
+      <span class="podcast-row-title">${_escHtml(ep.title || '(untitled)')}</span>
+      <span class="podcast-row-date">${date}</span>
+      <span class="podcast-badge ${cls}">${label}</span>
+    </div>`;
+  }).join('') || '<div class="keymap-hint">No episodes yet.</div>';
+
+  el.innerHTML = `
+    <div class="keymap-panel">
+      <h2 class="keymap-heading">Podcasts</h2>
+      <p class="keymap-hint">Weekly episodes crawled from the configured YouTube channel — German summary, HSK vocabulary and Chinese transcript for each.</p>
+      <div class="keymap-row">
+        <span class="keymap-label">Summary detail level</span>
+        <select class="opt-input" id="podcast-detail-level" style="flex:1" onchange="_savePodcastDetailLevel(this.value)">
+          <option value="short" ${detailLevel === 'short' ? 'selected' : ''}>Short</option>
+          <option value="medium" ${detailLevel === 'medium' ? 'selected' : ''}>Medium</option>
+          <option value="detailed" ${detailLevel === 'detailed' ? 'selected' : ''}>Detailed</option>
+        </select>
+        <span id="podcast-detail-save-msg" style="font-size:12px;color:var(--muted);min-width:60px"></span>
+      </div>
+    </div>
+    <div class="podcast-list">${rows}</div>`;
+}
+
+async function _savePodcastDetailLevel(value) {
+  const msg = document.getElementById('podcast-detail-save-msg');
+  try {
+    const res = await api('PUT', '/api/podcast/config', { detail_level: value });
+    _podcastConfig = res || _podcastConfig;
+    if (msg) msg.textContent = '✓ Saved';
+  } catch (e) {
+    if (msg) msg.textContent = 'Error: ' + e.message;
+  }
+}
+
+async function openPodcastEpisode(id) {
+  setLoading('Loading episode…');
+  try {
+    const ep = await api('GET', `/api/podcast/episodes/${id}`);
+    location.hash = `podcast-${id}`;
+    showView('podcast');
+    _renderPodcastDetail(ep);
+  } catch (e) {
+    showError('Episode failed: ' + e.message);
+    openPodcasts();
+  }
+}
+
+function closePodcastDetail() {
+  openPodcasts();
+}
+
+function _renderPodcastDetail(ep) {
+  const el = document.getElementById('view-podcast-content');
+  if (!el) return;
+  const date = (ep.published_at || ep.created_at || '').slice(0, 10);
+  const hskRows = (ep.hsk_words || []).map(w => `<tr>
+      <td>${_escHtml(w.word || w.word_zh || '')}</td>
+      <td>${_escHtml(w.pinyin || '')}</td>
+      <td>${_escHtml(w.definition_de || w.definition || '')}</td>
+    </tr>`).join('');
+  const hskTable = hskRows
+    ? `<table class="cost-table"><thead><tr><th>Word</th><th>Pinyin</th><th>German</th></tr></thead><tbody>${hskRows}</tbody></table>`
+    : '<p class="keymap-hint">No HSK vocabulary extracted.</p>';
+  const links = [
+    ep.youtube_url ? `<a href="${_escHtml(ep.youtube_url)}" target="_blank" rel="noopener" class="btn-secondary">YouTube ↗</a>` : '',
+    ep.spotify_url ? `<a href="${_escHtml(ep.spotify_url)}" target="_blank" rel="noopener" class="btn-secondary">Spotify ↗</a>` : '',
+  ].filter(Boolean).join(' ');
+  const transcript = ep.transcript_zh
+    ? `<div class="podcast-transcript-wrap">
+         <button class="keymap-reset-all" onclick="_togglePodcastTranscript()">Show/hide transcript</button>
+         <div id="podcast-transcript-body" class="podcast-transcript" style="display:none">${_escHtml(ep.transcript_zh).replace(/\n/g, '<br>')}</div>
+       </div>`
+    : '';
+
+  el.innerHTML = `
+    <button class="keymap-reset-all" onclick="closePodcastDetail()">← Back to Podcasts</button>
+    <div class="keymap-panel">
+      <h2 class="keymap-heading">${_escHtml(ep.title || '(untitled)')}</h2>
+      <p class="keymap-hint">${date}</p>
+      <div style="margin:4px 0 10px">${links}</div>
+      <div id="podcast-summary-de">${ep.summary_de || ''}</div>
+    </div>
+    <div class="keymap-panel">
+      <h2 class="keymap-heading">HSK vocabulary</h2>
+      ${hskTable}
+    </div>
+    <div class="keymap-panel">
+      <h2 class="keymap-heading">Transcript</h2>
+      ${transcript || '<p class="keymap-hint">No transcript available.</p>'}
+    </div>`;
+}
+
+function _togglePodcastTranscript() {
+  const body = document.getElementById('podcast-transcript-body');
+  if (!body) return;
+  body.style.display = body.style.display === 'none' ? 'block' : 'none';
+}
+
+// Hash direct-link support: emails link to /#podcast-<id>. Called once at
+// boot, after the deck list has loaded, so the podcast view replaces it.
+function _openPodcastFromHash() {
+  const m = /^#podcast-(\d+)$/.exec(location.hash);
+  if (m) openPodcastEpisode(parseInt(m[1]));
+}
+
 function startKeyCapture(id) {
   _capturingAction = id; _settingsMsg = ''; renderSettings();
 }
@@ -8775,7 +8933,13 @@ async function _loadVersionBadge() {
 }
 
 // ── Boot ─────────────────────────────────────────────────────────────────────
-loadDecks();
+// Hash direct-link (#480): if the URL already points at a podcast episode
+// (link from an email), open it straight away instead of the deck list.
+if (/^#podcast-\d+$/.test(location.hash)) {
+  _openPodcastFromHash();
+} else {
+  loadDecks();
+}
 _loadVersionBadge();
 
 

--- a/static/index.html
+++ b/static/index.html
@@ -434,6 +434,11 @@
   <div id="view-settings">
     <div id="view-settings-content"></div>
   </div>
+
+  <!-- Podcasts (#480) -->
+  <div id="view-podcast">
+    <div id="view-podcast-content"></div>
+  </div>
 </main>
 
 <!-- Options modal -->

--- a/static/style.css
+++ b/static/style.css
@@ -2944,6 +2944,50 @@ a.news-source-line:hover {
 .keymap-reset-all { margin-top: 16px; align-self: flex-start; padding: 8px 14px; border: 1px solid var(--border, #ccc); border-radius: 6px; background: none; color: inherit; cursor: pointer; }
 .keymap-reset-all:hover { border-color: var(--primary); color: var(--primary); }
 
+/* — Podcasts view (#480) — */
+#view-podcast { display: none; }
+#view-podcast-content { max-width: 720px; margin: 0 auto; padding: 16px; }
+.podcast-list { display: flex; flex-direction: column; gap: 6px; margin-top: 12px; }
+.podcast-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card, var(--bg));
+}
+.podcast-row-clickable { cursor: pointer; }
+.podcast-row-clickable:hover { border-color: var(--primary); }
+.podcast-row-title { flex: 1; color: var(--text); }
+.podcast-row-date { font-size: 12px; color: var(--muted); white-space: nowrap; }
+.podcast-badge {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  white-space: nowrap;
+}
+.podcast-badge-ok      { background: #dcfce7; color: #15803d; }
+.podcast-badge-muted   { background: #f1f5f9; color: #64748b; }
+.podcast-badge-error   { background: #fee2e2; color: #b91c1c; }
+.podcast-badge-pending { background: #fef3c7; color: #b45309; }
+#podcast-summary-de { line-height: 1.6; color: var(--text); }
+.podcast-transcript-wrap { margin-top: 4px; }
+.podcast-transcript {
+  margin-top: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.8;
+  max-height: 480px;
+  overflow-y: auto;
+}
+
 .stat-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
Closes #480

## 改了什么
- `static/index.html`：新增 `view-podcast` 容器（仿 view-settings 模式）
- `static/app.js`：主页导航加 "🎙 Podcasts" 按钮；列表视图（GET /api/podcast/episodes，状态徽章 summarized/no_transcript/error/pending）；详情视图（GET /api/podcast/episodes/{id}：德语摘要 innerHTML 渲染保留加粗、HSK 生词表、默认折叠的中文转录、YouTube/Spotify 链接）；hash 直达 `/#podcast-<id>`（邮件里的链接，启动时若匹配则直接打开详情，返回主页走 goBack→loadDecks 无空页面问题）；detail_level 下拉即时 PUT 保存
- `static/style.css`：podcast 列表/徽章/转录样式，全部用现有 CSS 变量，暗色主题兼容

## 怎么测试
- `node --check static/app.js` 通过
- 临时端口 + 临时 DB 起服务器，插入一条假 summarized 单集，curl 验证四个接口；文本字段全部经 `_escHtml` 转义（summary_de 按规格保留 HTML）

🤖 Generated with [Claude Code](https://claude.com/claude-code)