### PR TITLE
fix: NotebookLM 转录清洗（繁转简+去空格）+ 重试复用已有转录

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,7 +352,7 @@ python main.py status [--deck X]     # 显示每个牌组/类别的到期数量
 
 - 所有数据库访问通过 `database/` 包——其他文件不写原始 SQL（`import database` 仍然有效）
 - 保持 `ai.py` 简洁——每种提示词类型对应一个函数；AI 返回的格式错误 JSON 始终用 try/except + 回退处理
-- 允许的外部依赖：`fastapi`、`uvicorn`、`anthropic`、`openai`、`edge-tts`、`pyyaml`、`python-multipart`、`deep-translator`（可选）、`jieba`、`pypinyin`、`alibabacloud_tingwu20230930`（播客通义听悟转录主力，#498，官方 SDK）、`notebooklm-py`（播客 NotebookLM 可选转录，#486，非官方库，凭据文件一次性从本地拷到服务器，见 `scripts/README.md`）。新增依赖必须同步更新 `requirements.txt`。播客转录链的 Whisper/NotebookLM 两条路径（听悟提交直链不需要）需要系统级 `ffmpeg`（`apt install ffmpeg`，不是 Python 依赖，缺失时该功能自动跳过）
+- 允许的外部依赖：`fastapi`、`uvicorn`、`anthropic`、`openai`、`edge-tts`、`pyyaml`、`python-multipart`、`deep-translator`（可选）、`jieba`、`pypinyin`、`alibabacloud_tingwu20230930`、`zhconv`（NotebookLM 转录繁转简，#500）（播客通义听悟转录主力，#498，官方 SDK）、`notebooklm-py`（播客 NotebookLM 可选转录，#486，非官方库，凭据文件一次性从本地拷到服务器，见 `scripts/README.md`）。新增依赖必须同步更新 `requirements.txt`。播客转录链的 Whisper/NotebookLM 两条路径（听悟提交直链不需要）需要系统级 `ffmpeg`（`apt install ffmpeg`，不是 Python 依赖，缺失时该功能自动跳过）
 - 前端无构建步骤——直接编辑 `static/` 下的文件
 - API 密钥只从环境变量读取，绝不写入代码或仓库
 - **不要在 8000 端口跑测试服务器**——Daniel 的浏览器连着它

--- a/database/core.py
+++ b/database/core.py
@@ -565,6 +565,30 @@ def init_db() -> None:
                 "DELETE FROM podcast_episodes WHERE id = ?", [(i,) for i in stale_ids])
             conn.commit()
 
+    # One-time transcript normalization (#500): NotebookLM ASR output stored
+    # before the fix is Traditional Chinese with per-character spacing —
+    # rewrite existing rows with the same cleanup podcast._normalize_transcript
+    # now applies on ingest (logic duplicated here because core.py must not
+    # import podcast.py — podcast.py imports database). Idempotent: already
+    # clean rows rewrite to themselves and are skipped.
+    import re as _re
+    try:
+        from zhconv import convert as _zh_convert
+    except ImportError:
+        _zh_convert = None
+    rows = conn.execute(
+        "SELECT id, transcript_zh FROM podcast_episodes "
+        "WHERE transcript_zh IS NOT NULL AND transcript_zh != ''"
+    ).fetchall()
+    for row in rows:
+        cleaned = _re.sub(r"(?<=[一-鿿　-〿＀-￯])\s+|\s+(?=[一-鿿　-〿＀-￯])", "", row["transcript_zh"])
+        if _zh_convert is not None:
+            cleaned = _zh_convert(cleaned, "zh-cn")
+        if cleaned != row["transcript_zh"]:
+            conn.execute("UPDATE podcast_episodes SET transcript_zh = ? WHERE id = ?",
+                         (cleaned, row["id"]))
+    conn.commit()
+
     conn.close()
 
 

--- a/podcast.py
+++ b/podcast.py
@@ -21,6 +21,7 @@ import base64
 import json
 import logging
 import os
+import re
 import shutil
 import smtplib
 import subprocess
@@ -358,6 +359,30 @@ async def _run_notebooklm_transcription(audio_path: str, video_id: str) -> str |
                 await client.sources.delete(notebook_id, source.id)
             except Exception as e:
                 logger.warning("podcast: failed to delete NotebookLM source for %s: %s", video_id, e)
+
+
+def _normalize_transcript(text: str) -> str:
+    """Clean up ASR output before storing/summarizing (#500). NotebookLM's
+    speech recognition emits Traditional Chinese with a space between every
+    character ("用 聲 音  生 動 活 潑") — that breaks jieba segmentation in
+    the podcast review mode, HSK word matching against entries.word_zh, and
+    wastes prompt tokens. Two steps:
+      1. drop whitespace adjacent to any CJK character or full-width
+         punctuation (keeps spacing inside pure-Latin runs; "2026 年" ->
+         "2026年", "AI 记忆" -> "AI记忆", "活泼。 2026" -> "活泼。2026")
+      2. Traditional -> Simplified via zhconv (pure-Python, requirements.txt)
+    Tingwu/Whisper output is already Simplified without spacing — running it
+    through here is a harmless no-op, so every source is normalized uniformly.
+    """
+    if not text:
+        return text
+    text = re.sub(r"(?<=[一-鿿　-〿＀-￯])\s+|\s+(?=[一-鿿　-〿＀-￯])", "", text)
+    try:
+        from zhconv import convert
+        text = convert(text, "zh-cn")
+    except ImportError:  # dependency missing (old venv) — spacing fix still applies
+        logger.warning("podcast: zhconv not installed, skipping Traditional->Simplified conversion")
+    return text
 
 
 def _transcribe_via_notebooklm(audio_path: str, video_id: str) -> str | None:
@@ -839,14 +864,29 @@ def _process_episode(episode_id: int, video: dict, detail_level: str, summary: d
     from routes.utils import DISABLE_AI
 
     try:
-        transcript, meta = fetch_transcript(video)
-        if not transcript:
-            database.update_episode(episode_id, status="no_transcript")
-            return
-        database.update_episode(
-            episode_id, transcript_zh=transcript,
-            transcript_source=meta.get("transcript_source"),
-        )
+        # Reuse an already-stored transcript (#500): after e.g. an OpenAI-quota
+        # failure in the summary step, the retry must not re-run the whole
+        # transcription (a NotebookLM upload+indexing round takes ~10 minutes
+        # and Tingwu/Whisper cost money) — the transcript is already good.
+        existing = database.get_episode(episode_id) or {}
+        stored = (existing.get("transcript_zh") or "").strip()
+        if stored:
+            transcript = _normalize_transcript(stored)
+            meta = {"transcript_source": existing.get("transcript_source")}
+            logger.info("podcast: reusing existing transcript for %s (%d chars)",
+                        video["video_id"], len(transcript))
+            if transcript != stored:
+                database.update_episode(episode_id, transcript_zh=transcript)
+        else:
+            transcript, meta = fetch_transcript(video)
+            transcript = _normalize_transcript(transcript) if transcript else transcript
+            if not transcript:
+                database.update_episode(episode_id, status="no_transcript")
+                return
+            database.update_episode(
+                episode_id, transcript_zh=transcript,
+                transcript_source=meta.get("transcript_source"),
+            )
 
         if DISABLE_AI:
             # Dev mode: stop at pending with the transcript stored, no AI

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ jieba>=0.42,<1.0
 pypinyin>=0.55,<1.0
 notebooklm-py>=0.7.3,<0.8.0
 alibabacloud_tingwu20230930>=2.0.25,<3.0.0
+zhconv>=1.4,<2.0

--- a/routes/podcast.py
+++ b/routes/podcast.py
@@ -47,9 +47,9 @@ def retry_episode(episode_id: int):
     episode = database.get_episode(episode_id)
     if not episode:
         raise HTTPException(404, "Episode not found")
-    if episode["status"] in ("summarized", "pending"):
+    if episode["status"] == "summarized":
         raise HTTPException(
-            400, f"Episode status is '{episode['status']}' — only error/no_transcript episodes can be retried"
+            400, "Episode is already summarized — nothing to retry"
         )
     return podcast.retry_episode(episode_id)
 


### PR DESCRIPTION
Closes #500

## 改了什么
- `podcast._normalize_transcript()`：清洗 ASR 输出——去掉 CJK 字符**和全角标点**两侧的空格（`活泼。 2026` → `活泼。2026`），再用 zhconv 繁转简。NotebookLM 的语音识别输出繁体+逐字空格，会破坏 jieba 分词、HSK 生词匹配，并浪费提示词 token
- `_process_episode()`：单集已有转录时直接复用（清洗后回写），不再重新转录——摘要失败（如 OpenAI 欠费 429）后重试不再花 10 分钟重传 NotebookLM 或花听悟/Whisper 的钱
- `database/core.py init_db`：一次性迁移，清洗已入库的转录（幂等，已清洗的行跳过）
- `routes/podcast.py` retry 接口：允许 `pending` 状态重试（此前只放行 error/no_transcript；DISABLE_AI 模式会停在 pending）
- 新依赖 `zhconv`（纯 Python），已更新 requirements.txt 与 CLAUDE.md

## 怎么测试的
本地四项测试全部通过：① 正则清洗+繁转简断言；② 空值/纯英文不变；③ 临时库迁移清洗 + 二次运行幂等；④ 打桩 `fetch_transcript` 断言复用路径不重新转录。另做 py_compile + 导入检查。