### PR TITLE
feat: 播客管理页——RSS 源增删、每源自动开关、按单集手动转录

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Daniel 在中国需要 VPN 访问 GitHub。`gh` 命令报 `EOF` 错误时（`cur
 ├── importer.py            # YAML 词汇导入器（中文 + 法语格式）
 ├── ai.py                  # AI 提供商调用（每种提示词类型一个函数）
 ├── news_fetcher.py        # 新闻抓取（Tagesschau API + RSS；按天缓存 data/news_cache/）
-├── podcast.py              # 播客爬虫（#479）：播客 RSS 直链发现新单集（#497，退役 YouTube/yt-dlp）、转录链听悟主力+Whisper保底+NotebookLM可选（#498/#485/#486）、AI 德语摘要+HSK生词、邮件通知
+├── podcast.py              # 播客爬虫（#479）：播客 RSS 直链发现新单集（#497，退役 YouTube/yt-dlp）、每源 auto_process 开关+非自动源只入库元数据（#502，podcast_feeds 表）、转录链听悟主力+Whisper保底+NotebookLM可选（#498/#485/#486）、AI 德语摘要+HSK生词、邮件通知
 ├── tts.py                 # edge-tts 封装
 ├── translator.py          # 翻译（Google Translate，deep-translator，可选）
 ├── yaml_fixer.py          # 修复 AI 生成的格式错误 YAML
@@ -304,12 +304,14 @@ GET  /api/tts-file ；POST /api/preload ；POST /api/preload-session/{deck_id}/{
 GET  /api/tts-progress/{deck_id}/{category} ；GET /api/story-progress/{deck_id}/{category}
 GET  /api/news/status                                → 当日新闻缓存状态 {cached, count}
 
-# 播客爬虫（#479，仅后端；复习模式/设置界面见后续议题）
+# 播客爬虫（#479）+ 播客管理页（#502）
 POST /api/podcast/check                              → 跑一轮抓取，返回汇总 {new, summarized, emailed, failed}
-GET  /api/podcast/episodes                            → 列表（不含转录全文）
+GET  /api/podcast/episodes                            → 列表（不含转录全文；?feed_id= 按源过滤；手动处理中的单集 status 显示为 processing）
 GET  /api/podcast/episodes/{id}                       → 详情（摘要 + 转录 + HSK 生词）
-POST /api/podcast/episodes/{id}/retry                 → 重跑失败单集（仅 error/no_transcript；#491）
-GET/PUT /api/podcast/config                           → 读/改设置（feeds/email_to/detail_level/enabled/transcriber/whisper_max_minutes；whisper_fallback、channel_url、channel_id、whisper_title_filter 已废弃但兼容，#497）
+POST /api/podcast/episodes/{id}/retry                 → 同步重跑单集（error/no_transcript/pending；#491/#500）
+POST /api/podcast/episodes/{id}/process               → 手动触发单集转录+摘要（后台线程，立即返回；重复提交 409；#502）
+GET/POST /api/podcast/feeds ；PUT/DELETE /api/podcast/feeds/{id} → RSS 源管理（#502；POST 抓取验证并提取节目标题；PUT 改 auto_process/title）
+GET/PUT /api/podcast/config                           → 读/改设置（email_to/detail_level/enabled/transcriber/whisper_max_minutes；feeds 已迁到 podcast_feeds 表（#502），whisper_fallback、channel_url、channel_id、whisper_title_filter 已废弃但兼容，#497）
 
 # 其他
 POST /api/import                                     → 触发 YAML 导入

--- a/database/core.py
+++ b/database/core.py
@@ -535,6 +535,31 @@ def init_db() -> None:
     )
     conn.commit()
 
+    # podcast_feeds migration (issue #502): one-time move of the JSON array
+    # in podcast_config.feeds into the new per-feed table (per-feed
+    # auto_process toggle). Idempotent: only runs while podcast_feeds is
+    # still empty, so it never re-inserts/duplicates on later startups (and
+    # never overwrites feeds added/edited via the UI afterwards). Daniel's
+    # existing 声动早咖啡 subscription (ximalaya) keeps its current
+    # fully-automatic behavior; any other legacy feed defaults to manual.
+    # title is left NULL here (no network request at startup) — the next
+    # crawl (fetch_new_videos) backfills it from the RSS channel <title>.
+    feeds_row_count = conn.execute("SELECT COUNT(*) FROM podcast_feeds").fetchone()[0]
+    if feeds_row_count == 0:
+        try:
+            legacy_feeds = json.loads(conn.execute(
+                "SELECT value FROM podcast_config WHERE key = 'feeds'"
+            ).fetchone()[0])
+        except (TypeError, ValueError, AttributeError):
+            legacy_feeds = []
+        for url in legacy_feeds:
+            auto_process = 1 if "ximalaya" in url else 0
+            conn.execute(
+                "INSERT OR IGNORE INTO podcast_feeds (url, auto_process) VALUES (?, ?)",
+                (url, auto_process),
+            )
+        conn.commit()
+
     # podcast_episodes column migrations (issue #486 transcript_source; #497
     # audio_url/duration_seconds for the RSS-direct pipeline).
     if "podcast_episodes" in existing:

--- a/database/podcast.py
+++ b/database/podcast.py
@@ -1,6 +1,8 @@
-"""Podcast crawler storage (issues #479, #497, #498): episodes discovered
-from podcast RSS feeds + a small key-value config table (feed list,
-notification email, summary detail level, enabled flag).
+"""Podcast crawler storage (issues #479, #497, #498, #502): episodes
+discovered from podcast RSS feeds (podcast_feeds, one row per source, #502)
++ a small key-value config table (notification email, summary detail level,
+enabled flag; the legacy `feeds` key is unused since #502 but kept for
+backward compat, see database/core.py's one-time migration).
 
 All SQL for the podcast feature lives here — podcast.py (the crawler logic)
 and routes/podcast.py only call into this module.
@@ -46,6 +48,71 @@ def set_podcast_config(key: str, value: str) -> None:
         "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
         (key, value),
     )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Feeds (issue #502)
+# ---------------------------------------------------------------------------
+
+def list_feeds() -> list[dict]:
+    """All configured RSS feeds, oldest-added first (created_at ASC) so the
+    list order stays stable as new feeds are appended, with each feed's
+    stored episode count attached."""
+    conn = get_db()
+    rows = conn.execute(
+        """SELECT f.*, COUNT(e.id) AS episode_count
+           FROM podcast_feeds f
+           LEFT JOIN podcast_episodes e ON e.channel_id = f.url
+           GROUP BY f.id
+           ORDER BY f.created_at, f.id"""
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def get_feed(feed_id: int) -> dict | None:
+    conn = get_db()
+    row = conn.execute("SELECT * FROM podcast_feeds WHERE id = ?", (feed_id,)).fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def create_feed(url: str, title: str | None = None, auto_process: int = 0) -> int:
+    """Insert a new feed row. Raises sqlite3.IntegrityError (caller/route
+    turns it into a 400) if `url` is already subscribed (UNIQUE constraint)."""
+    conn = get_db()
+    cur = conn.execute(
+        "INSERT INTO podcast_feeds (url, title, auto_process) VALUES (?, ?, ?)",
+        (url, title, int(auto_process)),
+    )
+    conn.commit()
+    feed_id = cur.lastrowid
+    conn.close()
+    return feed_id
+
+
+def update_feed(feed_id: int, **fields) -> None:
+    """Generic column update for a feed (title/auto_process)."""
+    if not fields:
+        return
+    conn = get_db()
+    set_clause = ", ".join(f"{k} = ?" for k in fields)
+    conn.execute(
+        f"UPDATE podcast_feeds SET {set_clause} WHERE id = ?",
+        (*fields.values(), feed_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+def delete_feed(feed_id: int) -> None:
+    """Remove a feed's subscription row. Episodes already ingested from it
+    are left in place as history (channel_id keeps pointing at the feed URL,
+    which no longer resolves to a podcast_feeds row)."""
+    conn = get_db()
+    conn.execute("DELETE FROM podcast_feeds WHERE id = ?", (feed_id,))
     conn.commit()
     conn.close()
 
@@ -144,19 +211,25 @@ def get_episode(episode_id: int) -> dict | None:
     return _hydrate(row) if row else None
 
 
-def list_episodes(limit: int = 100) -> list[dict]:
-    """Episode list without the transcript full text (kept out for payload size)."""
+def list_episodes(limit: int = 100, feed_url: str | None = None) -> list[dict]:
+    """Episode list without the transcript full text (kept out for payload
+    size). `feed_url` (#502, the podcast_feeds.url / episode's channel_id)
+    optionally restricts the list to one source, for the per-feed episode
+    list view."""
     conn = get_db()
-    rows = conn.execute(
-        """SELECT id, video_id, channel_id, title, published_at, youtube_url, spotify_url,
-                  summary_de, hsk_words, detail_level, status, error, email_sent_at, created_at,
-                  transcript_source,
-                  (transcript_zh IS NOT NULL AND transcript_zh != '') AS has_transcript
-           FROM podcast_episodes
-           ORDER BY COALESCE(published_at, created_at) DESC, id DESC
-           LIMIT ?""",
-        (limit,),
-    ).fetchall()
+    query = """SELECT id, video_id, channel_id, title, published_at, youtube_url, spotify_url,
+                      audio_url, duration_seconds,
+                      summary_de, hsk_words, detail_level, status, error, email_sent_at, created_at,
+                      transcript_source,
+                      (transcript_zh IS NOT NULL AND transcript_zh != '') AS has_transcript
+               FROM podcast_episodes"""
+    params: list = []
+    if feed_url:
+        query += " WHERE channel_id = ?"
+        params.append(feed_url)
+    query += " ORDER BY COALESCE(published_at, created_at) DESC, id DESC LIMIT ?"
+    params.append(limit)
+    rows = conn.execute(query, params).fetchall()
     conn.close()
     return [_hydrate(r) for r in rows]
 

--- a/podcast.py
+++ b/podcast.py
@@ -5,8 +5,8 @@ find a Spotify link, and email a notification.
 Style follows news_fetcher.py: mostly-pure functions + logger, one module for
 the whole pipeline.
 
-Source (#497): plain public RSS feeds (podcast_config.feeds, a JSON array of
-feed URLs) — the original YouTube-channel source (#479) was retired because
+Source (#497, feeds moved to the podcast_feeds table in #502): plain public
+RSS feeds — the original YouTube-channel source (#479) was retired because
 YouTube started bot-verifying the server's datacenter IP with no durable
 Cookie fix (#491). RSS gives a direct MP3 enclosure link, so there is no
 audio *download* step for the primary transcription path (Tingwu, #498)
@@ -43,8 +43,12 @@ logger = logging.getLogger(__name__)
 # On a feed's very first crawl (no episodes from that feed in the DB yet)
 # only backfill this many of its most recent episodes — otherwise
 # subscribing to an established feed would try to transcribe/summarize its
-# entire back catalog in one cycle (#497).
-FIRST_RUN_BACKFILL = 3
+# entire back catalog in one cycle (#497). Backfilled episodes are never
+# auto-processed (#502, see _run_check_locked's is_backfill check) — they're
+# metadata-only rows the UI lists for manual transcription — so this can be
+# generous (10, was 3 pre-#502) without risking a burst of paid/slow
+# transcription work on a freshly-added source.
+FIRST_RUN_BACKFILL = 10
 
 # itunes:duration namespace, used to read episode duration straight from the
 # RSS feed (#497) — this is what lets duration-based guardrails/gates run
@@ -138,41 +142,58 @@ def _parse_rss_pubdate(raw: str | None) -> str | None:
 
 def fetch_new_videos() -> list[dict]:
     """Return episodes from the configured podcast RSS feeds
-    (podcast_config.feeds, a JSON array of feed URLs, #497) that aren't in
-    the DB yet. Zero API keys needed — plain public RSS/XML, no bot walls.
+    (podcast_feeds table, #502 — one row per source with its own
+    auto_process flag) that aren't in the DB yet. Zero API keys needed —
+    plain public RSS/XML, no bot walls.
 
     Per feed: if that specific feed has zero episodes in the DB yet, only
-    its latest FIRST_RUN_BACKFILL episodes are returned (backfill mode).
-    Otherwise, RSS items are newest-first by convention, so items are walked
-    from the top and collection *stops at the first already-known guid* —
-    everything older than that was either already ingested or deliberately
-    left out of the initial backfill, and must stay left out forever (else
-    every subsequent crawl of a long-running feed like 声动早咖啡, which has
-    ~1000 back-catalog episodes, would dump the *entire* backlog as "new" in
-    one shot the very next cycle — this was caught by a real backfill+re-run
+    its latest FIRST_RUN_BACKFILL episodes are returned (backfill mode,
+    marked `is_backfill: True`, see below). Otherwise, RSS items are
+    newest-first by convention, so items are walked from the top and
+    collection *stops at the first already-known guid* — everything older
+    than that was either already ingested or deliberately left out of the
+    initial backfill, and must stay left out forever (else every subsequent
+    crawl of a long-running feed like 声动早咖啡, which has ~1000
+    back-catalog episodes, would dump the *entire* backlog as "new" in one
+    shot the very next cycle — this was caught by a real backfill+re-run
     test against both of Daniel's feeds during #497's implementation, not
     just theorized). A feed that fails to fetch/parse is logged and
     skipped — one broken feed must not block the others.
+
+    Each returned dict carries `auto_process` (bool, copied from the feed
+    row) and `is_backfill` (bool, True for episodes discovered on a feed's
+    very first crawl) — `_run_check_locked` uses both to decide whether to
+    immediately transcribe+summarize a newly-discovered episode (#502):
+    only non-backfill episodes from an auto_process feed are processed
+    automatically; everything else is stored metadata-only for manual
+    transcription from the UI.
+
+    If a feed's `title` is still unset (freshly added via the UI, no
+    network request made at add-time), it's backfilled here from the RSS
+    channel's own <title> element.
     """
-    cfg = database.get_podcast_config()
-    try:
-        feeds = json.loads(cfg.get("feeds") or "[]")
-    except (TypeError, ValueError):
-        feeds = []
+    feeds = database.list_feeds()
     if not feeds:
-        logger.warning("podcast: no feeds configured (podcast_config.feeds)")
+        logger.warning("podcast: no feeds configured (podcast_feeds table)")
         return []
 
     known = database.get_known_video_ids()
 
     videos: list[dict] = []
-    for feed_url in feeds:
+    for feed in feeds:
+        feed_url = feed["url"]
         try:
             root = ElementTree.fromstring(_http_get(feed_url, timeout=30))
         except (urllib.error.URLError, ElementTree.ParseError) as e:
             logger.warning("podcast: failed to fetch/parse feed %s: %s", feed_url, e)
             continue
 
+        if not feed.get("title"):
+            channel_title_el = root.find("channel/title")
+            if channel_title_el is not None and channel_title_el.text:
+                database.update_feed(feed["id"], title=channel_title_el.text.strip())
+
+        auto_process = bool(feed.get("auto_process"))
         is_first_run = not database.has_any_episode_for_feed(feed_url)
         feed_videos: list[dict] = []
         for item in root.findall(".//item"):
@@ -205,6 +226,8 @@ def fetch_new_videos() -> list[dict]:
                 "audio_url": audio_url,
                 "duration_seconds": _parse_itunes_duration(
                     duration_el.text if duration_el is not None else None),
+                "auto_process": auto_process,
+                "is_backfill": is_first_run,
             })
             if is_first_run and len(feed_videos) >= FIRST_RUN_BACKFILL:
                 break
@@ -1024,8 +1047,13 @@ def _run_check_locked(cfg: dict) -> dict:
             video.get("audio_url"), video.get("duration_seconds"),
         )
         summary["new"] += 1
-        processed_ids.add(episode_id)
-        _process_episode(episode_id, video, detail_level, summary)
+        # Auto-processing (#502): only immediately transcribe+summarize when
+        # the source feed has auto_process=1 *and* this isn't part of a
+        # feed's first-run backfill — a freshly-subscribed feed's back
+        # catalog is stored metadata-only, transcribed on demand from the UI.
+        if video.get("auto_process") and not video.get("is_backfill"):
+            processed_ids.add(episode_id)
+            _process_episode(episode_id, video, detail_level, summary)
 
     # Auto-retry pass (#491): give recent failures one more chance per cycle,
     # capped at _AUTO_RETRY_PER_CYCLE oldest-first (#495) so a big backlog is

--- a/routes/podcast.py
+++ b/routes/podcast.py
@@ -1,9 +1,10 @@
 """Podcast crawler API (issue #479, RSS source #497, Tingwu transcriber
-#498). Backend + scheduled-script only — the review/settings UI is a
-follow-up.
+#498, per-feed manager #502).
 """
 import json
 import logging
+import threading
+from xml.etree import ElementTree
 
 import database
 import podcast
@@ -12,6 +13,13 @@ from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+# Episode ids currently being manually processed (#502, POST
+# /api/podcast/episodes/{id}/process) — guards against double-submitting the
+# same episode (e.g. a double click) and lets the episode-list endpoints
+# report a "processing" status without writing anything to the DB for it.
+_PROCESSING_IDS: set[int] = set()
+_PROCESSING_LOCK = threading.Lock()
 
 
 @router.post("/api/podcast/check")
@@ -25,9 +33,26 @@ def check_podcast():
         raise HTTPException(500, str(e))
 
 
+def _overlay_processing_status(episode: dict) -> dict:
+    """Cosmetic-only: episodes currently being manually processed (#502) show
+    status='processing' in API responses without that ever being written to
+    the DB row (the DB status stays 'pending' until the background thread
+    finishes and updates it for real)."""
+    if episode["id"] in _PROCESSING_IDS:
+        episode = {**episode, "status": "processing"}
+    return episode
+
+
 @router.get("/api/podcast/episodes")
-def list_episodes(limit: int = 100):
-    return database.list_episodes(limit=limit)
+def list_episodes(limit: int = 100, feed_id: int | None = None):
+    feed_url = None
+    if feed_id is not None:
+        feed = database.get_feed(feed_id)
+        if not feed:
+            raise HTTPException(404, "Feed not found")
+        feed_url = feed["url"]
+    episodes = database.list_episodes(limit=limit, feed_url=feed_url)
+    return [_overlay_processing_status(e) for e in episodes]
 
 
 @router.get("/api/podcast/episodes/{episode_id}")
@@ -35,7 +60,7 @@ def get_episode(episode_id: int):
     episode = database.get_episode(episode_id)
     if not episode:
         raise HTTPException(404, "Episode not found")
-    return episode
+    return _overlay_processing_status(episode)
 
 
 @router.post("/api/podcast/episodes/{episode_id}/retry")
@@ -54,11 +79,104 @@ def retry_episode(episode_id: int):
     return podcast.retry_episode(episode_id)
 
 
+def _process_episode_thread(episode_id: int) -> None:
+    """Background thread body for POST /episodes/{id}/process (#502) — runs
+    the full pipeline via podcast.retry_episode (which itself never raises,
+    it stores status='error' on failure), but is wrapped again here anyway
+    since a raise inside a bare thread would otherwise vanish silently."""
+    try:
+        podcast.retry_episode(episode_id)
+    except Exception as e:
+        logger.error("podcast: manual processing failed for episode %s: %s", episode_id, e)
+    finally:
+        with _PROCESSING_LOCK:
+            _PROCESSING_IDS.discard(episode_id)
+
+
+@router.post("/api/podcast/episodes/{episode_id}/process")
+def process_episode(episode_id: int):
+    """Manually trigger transcription+summary for one episode (#502) — used
+    by the podcast manager UI for episodes from a non-auto-process feed (or
+    a feed's backfilled back catalog), which are stored metadata-only until
+    Daniel picks them to transcribe. Runs in a background thread; the
+    response returns immediately so the UI can start polling."""
+    episode = database.get_episode(episode_id)
+    if not episode:
+        raise HTTPException(404, "Episode not found")
+    if episode["status"] == "summarized":
+        raise HTTPException(400, "Episode is already summarized — nothing to process")
+    with _PROCESSING_LOCK:
+        if episode_id in _PROCESSING_IDS:
+            raise HTTPException(409, "Episode is already being processed")
+        _PROCESSING_IDS.add(episode_id)
+    threading.Thread(target=_process_episode_thread, args=(episode_id,), daemon=True).start()
+    return {"status": "processing"}
+
+
+@router.get("/api/podcast/feeds")
+def list_feeds():
+    return database.list_feeds()
+
+
+class FeedCreate(BaseModel):
+    url: str
+
+
+@router.post("/api/podcast/feeds")
+def create_feed(body: FeedCreate):
+    """Add a new RSS feed subscription. Validates the URL is a parseable RSS
+    feed (fetches it once, synchronously) and pulls the channel <title> for
+    display before storing — new feeds default to auto_process=0 (manual),
+    matching #502's "opt in to automation per-source" design."""
+    url = body.url.strip()
+    if not url:
+        raise HTTPException(400, "url is required")
+    try:
+        root = ElementTree.fromstring(podcast._http_get(url, timeout=30))
+    except Exception as e:
+        raise HTTPException(400, f"Not a valid RSS feed: {e}")
+    title_el = root.find("channel/title")
+    title = title_el.text.strip() if title_el is not None and title_el.text else None
+    try:
+        feed_id = database.create_feed(url, title=title, auto_process=0)
+    except Exception:
+        # sqlite3.IntegrityError on the UNIQUE(url) constraint — anything
+        # else here would be unexpected, but still just a 400 (bad input),
+        # not a 500 (server bug).
+        raise HTTPException(400, "Feed already exists")
+    return database.get_feed(feed_id)
+
+
+class FeedUpdate(BaseModel):
+    auto_process: bool | None = None
+    title: str | None = None
+
+
+@router.put("/api/podcast/feeds/{feed_id}")
+def update_feed(feed_id: int, body: FeedUpdate):
+    if not database.get_feed(feed_id):
+        raise HTTPException(404, "Feed not found")
+    updates = body.model_dump(exclude_none=True)
+    if "auto_process" in updates:
+        updates["auto_process"] = int(updates["auto_process"])
+    if updates:
+        database.update_feed(feed_id, **updates)
+    return database.get_feed(feed_id)
+
+
+@router.delete("/api/podcast/feeds/{feed_id}")
+def delete_feed(feed_id: int):
+    if not database.get_feed(feed_id):
+        raise HTTPException(404, "Feed not found")
+    database.delete_feed(feed_id)
+    return {"deleted": True}
+
+
 class PodcastConfigUpdate(BaseModel):
     detail_level: str | None = None
     enabled: str | None = None
     email_to: str | None = None
-    feeds: list[str] | None = None  # RSS feed URLs (#497), replaces channel_url
+    feeds: list[str] | None = None  # deprecated (#502) — feeds now live in podcast_feeds; kept only so old clients/scripts don't 422
     whisper_fallback: str | None = None  # deprecated (#485), superseded by transcriber (#486)
     transcriber: str | None = None
     whisper_max_minutes: str | None = None

--- a/schema.sql
+++ b/schema.sql
@@ -578,3 +578,15 @@ CREATE TABLE IF NOT EXISTS podcast_config (
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
+
+-- Podcast source list (issue #502): replaces podcast_config.feeds (a plain
+-- JSON array with no per-feed settings) with one row per RSS feed, so each
+-- source can be toggled between fully-automatic processing and manual
+-- (metadata-only ingestion, transcription triggered per-episode from the UI).
+CREATE TABLE IF NOT EXISTS podcast_feeds (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    url          TEXT NOT NULL UNIQUE,   -- RSS feed URL
+    title        TEXT,                   -- RSS channel <title>, fetched on add
+    auto_process INTEGER NOT NULL DEFAULT 0,  -- 1 = new episodes are transcribed+summarized automatically
+    created_at   TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/static/app.js
+++ b/static/app.js
@@ -826,6 +826,9 @@ function _triggerClapAnimation() {
 
 function showView(name) {
   if (name === 'done' && _sessionReviewedCount > 0) _triggerClapAnimation();
+  // Leaving the podcast view (#502): stop the episode-list "processing"
+  // poll loop — it has no reason to keep firing once the view isn't visible.
+  if (name !== 'podcast' && typeof _clearPodcastPoll === 'function') _clearPodcastPoll();
   ['loading', 'decks', 'review', 'done', 'browse', 'word-detail', 'hanzi-detail', 'stats', 'settings', 'podcast'].forEach(v => {
     document.getElementById(`view-${v}`).style.display = 'none';
   });
@@ -2692,66 +2695,83 @@ async function savePregenConfig() {
   }
 }
 
-// ── Podcasts (#480) ──────────────────────────────────────────────────────────
-// List view: GET /api/podcast/episodes (no transcript text — kept out for
-// payload size). Detail view: GET /api/podcast/episodes/{id} (full row,
-// including transcript_zh). Settings: GET/PUT /api/podcast/config.
+// ── Podcasts (#480, per-feed manager #502) ──────────────────────────────────
+// Three layers, hash-routed:
+//   #podcast              -> layer 1: feed list (GET /api/podcast/feeds)
+//   #podcast-feed-<id>    -> layer 2: one feed's episodes (GET /api/podcast/episodes?feed_id=)
+//   #podcast-<id>         -> layer 3: episode detail (GET /api/podcast/episodes/{id})
+// Settings: GET/PUT /api/podcast/config (detail_level only — feeds/auto now
+// live in the podcast_feeds table via /api/podcast/feeds).
 const PODCAST_STATUS_LABEL = {
   summarized:    'Summarized',
   no_transcript: 'No transcript',
   error:         'Error',
   pending:       'Pending',
+  processing:    'processing…',
 };
 const PODCAST_STATUS_CLASS = {
   summarized:    'podcast-badge-ok',
   no_transcript: 'podcast-badge-muted',
   error:         'podcast-badge-error',
   pending:       'podcast-badge-pending',
+  processing:    'podcast-badge-pending',
 };
 
+let _podcastFeeds = [];
 let _podcastEpisodes = [];
 let _podcastConfig = null;
+let _podcastCurrentFeedId = null;   // layer 2/3: which feed's episode list we're in
+let _podcastPollTimer = null;       // layer 2: re-poll while any episode is "processing"
+
+function _clearPodcastPoll() {
+  if (_podcastPollTimer) { clearTimeout(_podcastPollTimer); _podcastPollTimer = null; }
+}
+
+// Layer 1: feed list ----------------------------------------------------------
 
 async function openPodcasts() {
-  location.hash = '';
+  location.hash = 'podcast';
+  _clearPodcastPoll();
+  _podcastCurrentFeedId = null;
   setLoading('Loading podcasts…');
   try {
-    const [episodes, config] = await Promise.all([
-      api('GET', '/api/podcast/episodes'),
+    const [feeds, config] = await Promise.all([
+      api('GET', '/api/podcast/feeds'),
       api('GET', '/api/podcast/config'),
     ]);
-    _podcastEpisodes = episodes || [];
+    _podcastFeeds = feeds || [];
     _podcastConfig = config || {};
     showView('podcast');
-    _renderPodcastList();
+    _renderPodcastFeedList();
   } catch (e) {
     showError('Podcasts failed: ' + e.message);
     showView('decks');
   }
 }
 
-function _renderPodcastList() {
+function _renderPodcastFeedList() {
   const el = document.getElementById('view-podcast-content');
   if (!el) return;
   const detailLevel = _podcastConfig?.detail_level || 'medium';
-  const rows = _podcastEpisodes.map(ep => {
-    const date = (ep.published_at || ep.created_at || '').slice(0, 10);
-    const status = ep.status || 'pending';
-    const label = PODCAST_STATUS_LABEL[status] || status;
-    const cls = PODCAST_STATUS_CLASS[status] || 'podcast-badge-muted';
-    const clickable = status === 'summarized';
-    return `<div class="podcast-row${clickable ? ' podcast-row-clickable' : ''}"
-                 ${clickable ? `onclick="openPodcastEpisode(${ep.id})"` : ''}>
-      <span class="podcast-row-title">${_escHtml(ep.title || '(untitled)')}</span>
-      <span class="podcast-row-date">${date}</span>
-      <span class="podcast-badge ${cls}">${label}</span>
-    </div>`;
-  }).join('') || '<div class="keymap-hint">No episodes yet.</div>';
+  const cards = _podcastFeeds.map(f => `
+    <div class="podcast-feed-card">
+      <div class="podcast-feed-card-main" onclick="openPodcastFeed(${f.id})">
+        <span class="podcast-feed-card-title">${_escHtml(f.title || f.url)}</span>
+        <span class="podcast-feed-card-count">${f.episode_count} episode${f.episode_count === 1 ? '' : 's'}</span>
+      </div>
+      <div class="podcast-feed-card-controls">
+        <label class="podcast-feed-auto-toggle">
+          <input type="checkbox" ${f.auto_process ? 'checked' : ''} onchange="_toggleFeedAuto(${f.id}, this.checked)">
+          Auto-process new episodes
+        </label>
+        <button class="btn-secondary podcast-feed-delete" onclick="_deletePodcastFeed(${f.id})">Delete</button>
+      </div>
+    </div>`).join('') || '<div class="keymap-hint">No feeds yet — add one below.</div>';
 
   el.innerHTML = `
     <div class="keymap-panel">
       <h2 class="keymap-heading">Podcasts</h2>
-      <p class="keymap-hint">Weekly episodes crawled from the configured YouTube channel — German summary, HSK vocabulary and Chinese transcript for each.</p>
+      <p class="keymap-hint">RSS feeds crawled hourly for new episodes — German summary, HSK vocabulary and Chinese transcript for each. Auto-process feeds are transcribed+summarized automatically; other feeds only store new episodes' metadata until you pick one to transcribe.</p>
       <div class="keymap-row">
         <span class="keymap-label">Summary detail level</span>
         <select class="opt-input" id="podcast-detail-level" style="flex:1" onchange="_savePodcastDetailLevel(this.value)">
@@ -2762,7 +2782,52 @@ function _renderPodcastList() {
         <span id="podcast-detail-save-msg" style="font-size:12px;color:var(--muted);min-width:60px"></span>
       </div>
     </div>
-    <div class="podcast-list">${rows}</div>`;
+    <div class="podcast-feed-list">${cards}</div>
+    <div class="keymap-panel podcast-add-feed-panel">
+      <h2 class="keymap-heading">Add feed</h2>
+      <div class="keymap-row">
+        <input type="text" class="opt-input" id="podcast-add-feed-url" placeholder="RSS feed URL" style="flex:1">
+        <button class="btn-secondary" onclick="_addPodcastFeed()">Add</button>
+      </div>
+      <span id="podcast-add-feed-msg" style="font-size:12px;color:var(--muted)"></span>
+    </div>`;
+}
+
+async function _toggleFeedAuto(feedId, checked) {
+  try {
+    await api('PUT', `/api/podcast/feeds/${feedId}`, { auto_process: checked });
+    const f = _podcastFeeds.find(x => x.id === feedId);
+    if (f) f.auto_process = checked ? 1 : 0;
+  } catch (e) {
+    showError('Failed to update feed: ' + e.message);
+    _renderPodcastFeedList();
+  }
+}
+
+async function _deletePodcastFeed(feedId) {
+  if (!confirm('Delete this feed? Already-ingested episodes are kept as history.')) return;
+  try {
+    await api('DELETE', `/api/podcast/feeds/${feedId}`);
+    _podcastFeeds = _podcastFeeds.filter(f => f.id !== feedId);
+    _renderPodcastFeedList();
+  } catch (e) {
+    showError('Failed to delete feed: ' + e.message);
+  }
+}
+
+async function _addPodcastFeed() {
+  const input = document.getElementById('podcast-add-feed-url');
+  const msg = document.getElementById('podcast-add-feed-msg');
+  const url = (input?.value || '').trim();
+  if (!url) return;
+  if (msg) msg.textContent = 'Adding…';
+  try {
+    const feed = await api('POST', '/api/podcast/feeds', { url });
+    _podcastFeeds.push({ ...feed, episode_count: 0 });
+    _renderPodcastFeedList();
+  } catch (e) {
+    if (msg) msg.textContent = 'Error: ' + e.message;
+  }
 }
 
 async function _savePodcastDetailLevel(value) {
@@ -2776,11 +2841,98 @@ async function _savePodcastDetailLevel(value) {
   }
 }
 
+// Layer 2: one feed's episode list ---------------------------------------------
+
+async function openPodcastFeed(feedId) {
+  location.hash = `podcast-feed-${feedId}`;
+  _clearPodcastPoll();
+  _podcastCurrentFeedId = feedId;
+  setLoading('Loading episodes…');
+  try {
+    const episodes = await api('GET', `/api/podcast/episodes?feed_id=${feedId}`);
+    _podcastEpisodes = episodes || [];
+    showView('podcast');
+    _renderPodcastEpisodeList();
+    _schedulePodcastPollIfNeeded();
+  } catch (e) {
+    showError('Episodes failed: ' + e.message);
+    openPodcasts();
+  }
+}
+
+function _formatPodcastDuration(seconds) {
+  if (!seconds) return '';
+  return `${Math.round(seconds / 60)} min`;
+}
+
+function _renderPodcastEpisodeList() {
+  const el = document.getElementById('view-podcast-content');
+  if (!el) return;
+  const feed = _podcastFeeds.find(f => f.id === _podcastCurrentFeedId);
+  const rows = _podcastEpisodes.map(ep => {
+    const date = (ep.published_at || ep.created_at || '').slice(0, 10);
+    const status = ep.status || 'pending';
+    const label = PODCAST_STATUS_LABEL[status] || status;
+    const cls = PODCAST_STATUS_CLASS[status] || 'podcast-badge-muted';
+    const clickable = status === 'summarized';
+    const duration = _formatPodcastDuration(ep.duration_seconds);
+    const transcribable = ['pending', 'no_transcript', 'error'].includes(status);
+    const transcribeBtn = transcribable
+      ? `<button class="btn-secondary podcast-transcribe-btn" onclick="event.stopPropagation(); _transcribePodcastEpisode(${ep.id})">Transcribe</button>`
+      : '';
+    return `<div class="podcast-row${clickable ? ' podcast-row-clickable' : ''}"
+                 ${clickable ? `onclick="openPodcastEpisode(${ep.id})"` : ''}>
+      <span class="podcast-row-title">${_escHtml(ep.title || '(untitled)')}</span>
+      <span class="podcast-row-date">${date}</span>
+      ${duration ? `<span class="podcast-row-date">${duration}</span>` : ''}
+      <span class="podcast-badge ${cls}">${label}</span>
+      ${transcribeBtn}
+    </div>`;
+  }).join('') || '<div class="keymap-hint">No episodes yet.</div>';
+
+  el.innerHTML = `
+    <button class="keymap-reset-all" onclick="openPodcasts()">← Podcasts</button>
+    <div class="keymap-panel">
+      <h2 class="keymap-heading">${_escHtml(feed?.title || feed?.url || 'Feed')}</h2>
+    </div>
+    <div class="podcast-list">${rows}</div>`;
+}
+
+async function _transcribePodcastEpisode(episodeId) {
+  try {
+    await api('POST', `/api/podcast/episodes/${episodeId}/process`);
+    const ep = _podcastEpisodes.find(e => e.id === episodeId);
+    if (ep) ep.status = 'processing';
+    _renderPodcastEpisodeList();
+    _schedulePodcastPollIfNeeded();
+  } catch (e) {
+    showError('Failed to start transcription: ' + e.message);
+  }
+}
+
+function _schedulePodcastPollIfNeeded() {
+  _clearPodcastPoll();
+  const hasProcessing = _podcastEpisodes.some(ep => ep.status === 'processing');
+  if (!hasProcessing || _podcastCurrentFeedId == null) return;
+  _podcastPollTimer = setTimeout(async () => {
+    if (_podcastCurrentFeedId == null) return;  // left this view meanwhile
+    try {
+      const episodes = await api('GET', `/api/podcast/episodes?feed_id=${_podcastCurrentFeedId}`);
+      _podcastEpisodes = episodes || [];
+      _renderPodcastEpisodeList();
+      _schedulePodcastPollIfNeeded();
+    } catch (e) { /* transient error — next poll cycle will retry */ }
+  }, 10000);
+}
+
+// Layer 3: episode detail -------------------------------------------------------
+
 async function openPodcastEpisode(id) {
   setLoading('Loading episode…');
   try {
     const ep = await api('GET', `/api/podcast/episodes/${id}`);
     location.hash = `podcast-${id}`;
+    _clearPodcastPoll();
     showView('podcast');
     _renderPodcastDetail(ep);
   } catch (e) {
@@ -2790,7 +2942,11 @@ async function openPodcastEpisode(id) {
 }
 
 function closePodcastDetail() {
-  openPodcasts();
+  if (_podcastCurrentFeedId != null) {
+    openPodcastFeed(_podcastCurrentFeedId);
+  } else {
+    openPodcasts();
+  }
 }
 
 function _renderPodcastDetail(ep) {
@@ -2840,9 +2996,14 @@ function _togglePodcastTranscript() {
   body.style.display = body.style.display === 'none' ? 'block' : 'none';
 }
 
-// Hash direct-link support: emails link to /#podcast-<id>. Called once at
-// boot, after the deck list has loaded, so the podcast view replaces it.
+// Hash direct-link support: emails link to /#podcast-<id> (episode detail).
+// Called once at boot, after the deck list has loaded, so the podcast view
+// replaces it. #podcast-feed-<id> must be checked *before* #podcast-<id> —
+// otherwise the plain episode-detail regex below never gets a chance to
+// reject it, since both start with "#podcast-".
 function _openPodcastFromHash() {
+  const feedMatch = /^#podcast-feed-(\d+)$/.exec(location.hash);
+  if (feedMatch) { openPodcastFeed(parseInt(feedMatch[1])); return; }
   const m = /^#podcast-(\d+)$/.exec(location.hash);
   if (m) openPodcastEpisode(parseInt(m[1]));
 }
@@ -9002,9 +9163,11 @@ async function _loadVersionBadge() {
 }
 
 // ── Boot ─────────────────────────────────────────────────────────────────────
-// Hash direct-link (#480): if the URL already points at a podcast episode
-// (link from an email), open it straight away instead of the deck list.
-if (/^#podcast-\d+$/.test(location.hash)) {
+// Hash direct-link (#480, feed layer #502): if the URL already points at a
+// podcast episode (link from an email) or feed, open it straight away
+// instead of the deck list. #podcast-feed- must be checked first — it also
+// matches the plain #podcast-\d+ shape's prefix.
+if (/^#podcast-feed-\d+$/.test(location.hash) || /^#podcast-\d+$/.test(location.hash)) {
   _openPodcastFromHash();
 } else {
   loadDecks();

--- a/static/style.css
+++ b/static/style.css
@@ -2974,7 +2974,49 @@ a.news-source-line:hover {
 .podcast-badge-muted   { background: #f1f5f9; color: #64748b; }
 .podcast-badge-error   { background: #fee2e2; color: #b91c1c; }
 .podcast-badge-pending { background: #fef3c7; color: #b45309; }
+.podcast-transcribe-btn { font-size: 12px; padding: 3px 10px; }
 #podcast-summary-de { line-height: 1.6; color: var(--text); }
+
+/* — Podcast feed manager (#502) — */
+.podcast-feed-list { display: flex; flex-direction: column; gap: 6px; margin-top: 12px; }
+.podcast-feed-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card, var(--bg));
+  flex-wrap: wrap;
+}
+.podcast-feed-card-main {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+  min-width: 200px;
+  cursor: pointer;
+}
+.podcast-feed-card-main:hover .podcast-feed-card-title { color: var(--primary); }
+.podcast-feed-card-title { flex: 1; color: var(--text); word-break: break-word; }
+.podcast-feed-card-count { font-size: 12px; color: var(--muted); white-space: nowrap; }
+.podcast-feed-card-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+.podcast-feed-auto-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--muted);
+  white-space: nowrap;
+  cursor: pointer;
+}
+.podcast-add-feed-panel { margin-top: 12px; }
 .podcast-transcript-wrap { margin-top: 4px; }
 .podcast-transcript {
   margin-top: 10px;


### PR DESCRIPTION
Closes #502

## 改了什么
- **`podcast_feeds` 新表**（url UNIQUE/title/auto_process/created_at），`init_db` 一次性幂等迁移 `podcast_config.feeds` JSON：ximalaya 源（声动早咖啡）auto_process=1 保持现有全自动行为，fireside 源（声东击西）0（60 分钟节目改为按需手动，Daniel 的要求）
- **爬虫分流**：每小时所有源的新单集照常入库（status=pending 元数据），但只有 `auto_process=1` **且非首抓回填**的才自动转录+摘要+邮件；首抓回填 3→10 条（只存元数据，绝不自动烧钱转录）；源标题懒回填自 RSS 的 channel `<title>`（添加源时同步抓一次做验证）
- **新 API**：`GET/POST /api/podcast/feeds`、`PUT/DELETE /api/podcast/feeds/{id}`；`POST /api/podcast/episodes/{id}/process`（后台线程跑完整管线立即返回，模块级 `_PROCESSING_IDS`+锁防双击，409 重复提交；列表/详情接口对进行中单集叠加 `status=processing`，不写库）；`GET /api/podcast/episodes?feed_id=` 过滤 + 返回 duration_seconds
- **前端三层 hash 路由**：`#podcast` 源列表（标题/单集数/自动开关/删除/RSS 添加表单/摘要详细度下拉）→ `#podcast-feed-<id>` 单集列表（日期/时长/状态徽章 + pending/no_transcript/error 行的 Transcribe 按钮，存在 processing 时每 10 秒轮询，离开视图清定时器）→ `#podcast-<id>` 详情（不变，返回按钮回到来源单集列表）。启动时 hash 匹配 feed 层优先于详情层
- CLAUDE.md 项目结构与 API 部分同步更新

## 怎么测试的
- py_compile + `import main` + `node --check static/app.js` 全绿
- 临时库迁移测试：旧式 feeds JSON → 两行 podcast_feeds（ximalaya auto=1 / fireside auto=0），二次 init_db 幂等不重插
- 分流测试：monkeypatch 假 videos（auto/manual/backfill 各一）+ 记录 `_process_episode` 调用——3 条全部入库、仅 auto 且非回填的 1 条被处理
- 未动 8000 端口与真实数据库

由 Sonnet 子代理按施工图实现，主代理逐行审查 diff 并独立复跑验证。