### PR TITLE
feat: API 费用概览重做——按服务分组、修正价格表、缓存命中计价

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,3 +358,4 @@ python main.py status [--deck X]     # 显示每个牌组/类别的到期数量
 - 前端无构建步骤——直接编辑 `static/` 下的文件
 - API 密钥只从环境变量读取，绝不写入代码或仓库
 - **不要在 8000 端口跑测试服务器**——Daniel 的浏览器连着它
+- API 价格表在 `database/stats.py` 的 `_MODEL_PRICING`（含 `_PRICING_AS_OF` 生效日期）；各提供商都没有价格查询 API，价格变动或新模型上线时需手动更新该表，并同步 `static/index.html` 里的静态价格表（设置弹窗 `price-table-popup`）

--- a/ai.py
+++ b/ai.py
@@ -77,13 +77,18 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str,
         client = anthropic.Anthropic()
         msg = client.messages.create(model=model, max_tokens=max_tokens, messages=messages)
         elapsed = time.time() - t0
-        logger.info("[%s] API call done in %.1fs — in=%d out=%d purpose=%s",
-                    model, elapsed, msg.usage.input_tokens, msg.usage.output_tokens, purpose)
+        cached_tokens = getattr(msg.usage, "cache_read_input_tokens", 0) or 0
+        logger.info("[%s] API call done in %.1fs — in=%d out=%d cached=%d purpose=%s",
+                    model, elapsed, msg.usage.input_tokens, msg.usage.output_tokens, cached_tokens, purpose)
         database.log_api_call(
-            model=msg.model,
+            # Log the requested model id, not msg.model (the API returns a dated
+            # snapshot name like "claude-sonnet-4-6-20260115" that the pricing
+            # table can't match exactly — see database.stats._lookup_pricing).
+            model=model,
             input_tokens=msg.usage.input_tokens,
             output_tokens=msg.usage.output_tokens,
             purpose=purpose,
+            cached_input_tokens=cached_tokens,
         )
         return msg.content[0].text.strip()
     else:
@@ -111,15 +116,28 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str,
         reasoning = getattr(choice.message, "reasoning_content", None)
         reasoning_chars = len(reasoning) if reasoning else 0
 
-        logger.info("[%s] API call done in %.1fs — in=%d out=%d reasoning_chars=%d purpose=%s",
+        # Cache-hit tokens: DeepSeek reports prompt_cache_hit_tokens directly;
+        # OpenAI reports prompt_tokens_details.cached_tokens. Use whichever is
+        # present (nonzero) for this provider — the other is always 0/absent.
+        deepseek_cached = getattr(resp.usage, "prompt_cache_hit_tokens", 0) or 0
+        openai_cached = getattr(
+            getattr(resp.usage, "prompt_tokens_details", None), "cached_tokens", 0
+        ) or 0
+        cached_tokens = deepseek_cached or openai_cached
+
+        logger.info("[%s] API call done in %.1fs — in=%d out=%d cached=%d reasoning_chars=%d purpose=%s",
                     model, elapsed,
                     resp.usage.prompt_tokens, resp.usage.completion_tokens,
-                    reasoning_chars, purpose)
+                    cached_tokens, reasoning_chars, purpose)
         database.log_api_call(
-            model=resp.model,
+            # Log the requested model id, not resp.model (the API returns a
+            # dated snapshot name that the pricing table can't match exactly —
+            # see database.stats._lookup_pricing).
+            model=model,
             input_tokens=resp.usage.prompt_tokens,
             output_tokens=resp.usage.completion_tokens,
             purpose=purpose,
+            cached_input_tokens=cached_tokens,
         )
 
         if choice.finish_reason == "length":
@@ -1834,3 +1852,34 @@ def estimate_story_tokens(num_cards: int) -> int:
     Output: ~75 tokens/card + 100 overhead
     """
     return 200 + 13 * num_cards + 75 * num_cards + 100
+
+
+def get_deepseek_balance() -> dict | None:
+    """Fetch the current DeepSeek account balance (issue #508 — a 'real anchor'
+    shown alongside the estimated cost breakdown in the API Costs modal).
+
+    Returns {"balance": str, "currency": str} or None if the key isn't
+    configured or the request fails for any reason. This is a nice-to-have —
+    it must never raise or block the cost modal from rendering.
+    """
+    api_key = os.environ.get("DEEPSEEK_API_KEY")
+    if not api_key:
+        return None
+    try:
+        import urllib.request
+
+        req = urllib.request.Request(
+            "https://api.deepseek.com/user/balance",
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read())
+        info = (data.get("balance_infos") or [{}])[0]
+        balance = info.get("total_balance")
+        currency = info.get("currency")
+        if balance is None or currency is None:
+            return None
+        return {"balance": balance, "currency": currency}
+    except Exception as e:
+        logger.debug("get_deepseek_balance failed: %s", e)
+        return None

--- a/database/core.py
+++ b/database/core.py
@@ -164,6 +164,9 @@ def init_db() -> None:
         output_tokens INTEGER NOT NULL,
         purpose       TEXT NOT NULL DEFAULT 'story'
     )""")
+    api_call_log_cols = {r["name"] for r in conn.execute("PRAGMA table_info(api_call_log)").fetchall()}
+    if "cached_input_tokens" not in api_call_log_cols:
+        conn.execute("ALTER TABLE api_call_log ADD COLUMN cached_input_tokens INTEGER NOT NULL DEFAULT 0")
 
     story_cols = {r["name"] for r in conn.execute("PRAGMA table_info(stories)").fetchall()}
     if "prompt_text" not in story_cols:

--- a/database/stats.py
+++ b/database/stats.py
@@ -1,3 +1,4 @@
+import re
 import sqlite3
 import datetime as _dt
 from datetime import date, datetime
@@ -81,30 +82,102 @@ def get_stats(deck_id: int | None = None, lang: str | None = None) -> dict:
 # API cost tracking
 # ---------------------------------------------------------------------------
 
-# Prices per million tokens (USD) as of 2026
+# Prices per million tokens (USD). Providers don't expose a pricing API, so
+# this table is hand-maintained — update it (and the static price table in
+# static/index.html's story-setup modal) whenever a provider changes pricing
+# or a new model is adopted. See CLAUDE.md "规范与约束".
+_PRICING_AS_OF = "2026-07-12"
 _MODEL_PRICING: dict[str, dict[str, float]] = {
-    # Anthropic
-    "claude-haiku-4-5-20251001": {"input": 0.80,  "output": 4.00},
-    "claude-sonnet-4-6":         {"input": 3.00,  "output": 15.00},
-    "claude-opus-4-6":           {"input": 15.00, "output": 75.00},
-    # Zhipu (glm-4-flash is free)
-    "glm-4-flash":               {"input": 0.00,  "output": 0.00},
-    "glm-4-air":                 {"input": 0.06,  "output": 0.06},
-    # DeepSeek
-    "deepseek-chat":             {"input": 0.28,  "output": 0.42},
-    "deepseek-reasoner":         {"input": 0.50,  "output": 2.18},
-    # Qwen / DashScope
-    "qwen-turbo":                {"input": 0.065, "output": 0.26},
-    "qwen-plus":                 {"input": 0.40,  "output": 1.20},
+    # OpenAI (news/briefing/podcast summaries)
+    "gpt-5.1":      {"input": 1.25, "cached": 0.125, "output": 10.00},
+    "gpt-5":        {"input": 1.25, "cached": 0.125, "output": 10.00},
+    "gpt-5-mini":   {"input": 0.25, "cached": 0.025, "output": 2.00},
+    # OpenAI audio transcription (podcast Whisper path) — billed per minute;
+    # input_tokens stores audio *seconds* for these rows (see podcast.py).
+    "gpt-4o-mini-transcribe": {"per_minute": 0.003},
+    # DeepSeek (default story/enrichment models)
+    "deepseek-v4-flash": {"input": 0.14,  "cached": 0.0028,   "output": 0.28},
+    "deepseek-v4-pro":   {"input": 0.435, "cached": 0.003625, "output": 0.87},
+    # Legacy models kept so old api_call_log rows still price correctly
+    "deepseek-chat":     {"input": 0.28, "output": 0.42},
+    "deepseek-reasoner": {"input": 0.50, "output": 2.18},
+    "glm-4-flash":       {"input": 0.00, "output": 0.00},
+    "glm-4-air":         {"input": 0.06, "output": 0.06},
+    "qwen-turbo":        {"input": 0.065, "output": 0.26},
+    "qwen-plus":         {"input": 0.40, "output": 1.20},
+    "claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.00},
+    "claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
+    "claude-opus-4-6":   {"input": 15.00, "output": 75.00},
 }
+
+_SNAPSHOT_SUFFIX_RE = re.compile(r"(-\d{4}-\d{2}-\d{2}|-\d{8})$")
+
+
+def _lookup_pricing(model: str) -> dict | None:
+    """Resolve a model id to its pricing entry.
+
+    Tries, in order: exact match; the id with a trailing date-snapshot suffix
+    (-YYYY-MM-DD or -YYYYMMDD) stripped; the longest pricing-table key that is
+    a prefix of the model id (so "gpt-5.1-2026-04-14" matches "gpt-5.1" before
+    the shorter "gpt-5"). Returns None if nothing matches.
+    """
+    if model in _MODEL_PRICING:
+        return _MODEL_PRICING[model]
+
+    stripped = _SNAPSHOT_SUFFIX_RE.sub("", model)
+    if stripped in _MODEL_PRICING:
+        return _MODEL_PRICING[stripped]
+
+    matches = [k for k in _MODEL_PRICING if stripped.startswith(k) or model.startswith(k)]
+    if matches:
+        best = max(matches, key=len)
+        return _MODEL_PRICING[best]
+
+    return None
+
+
+def _row_cost(row: dict) -> float | None:
+    """Compute the USD cost of one api_call_log row, or None if the model's
+    pricing is unknown."""
+    pricing = _lookup_pricing(row["model"])
+    if pricing is None:
+        return None
+
+    if "per_minute" in pricing:
+        # Audio transcription rows store duration in *seconds* in input_tokens.
+        return row["input_tokens"] / 60 * pricing["per_minute"]
+
+    cached = min(row.get("cached_input_tokens") or 0, row["input_tokens"])
+    miss = row["input_tokens"] - cached
+    cached_price = pricing.get("cached", pricing["input"])
+    return (miss * pricing["input"] + cached * cached_price +
+            row["output_tokens"] * pricing["output"]) / 1_000_000
+
+
+def _service_for_purpose(purpose: str) -> str:
+    """Map an api_call_log.purpose value to a UI-facing service grouping."""
+    if purpose == "story" or purpose == "kahneman" or purpose == "fix_commas" \
+            or purpose.startswith("regen:"):
+        return "Stories"
+    if purpose in ("news", "news-select", "briefing", "briefing_fact_check"):
+        return "News briefing"
+    if purpose == "paste":
+        return "Paste"
+    if purpose in ("podcast-summary", "podcast-transcribe"):
+        return "Podcast"
+    if purpose.startswith("enrich:") or purpose.startswith("hanzi:"):
+        return "Word enrichment"
+    return "Other"
 
 
 def log_api_call(model: str, input_tokens: int, output_tokens: int,
-                 purpose: str = "story") -> None:
+                 purpose: str = "story", cached_input_tokens: int = 0) -> None:
     conn = get_db()
     conn.execute(
-        "INSERT INTO api_call_log (model, input_tokens, output_tokens, purpose) VALUES (?, ?, ?, ?)",
-        (model, input_tokens, output_tokens, purpose),
+        """INSERT INTO api_call_log
+           (model, input_tokens, output_tokens, purpose, cached_input_tokens)
+           VALUES (?, ?, ?, ?, ?)""",
+        (model, input_tokens, output_tokens, purpose, cached_input_tokens),
     )
     conn.commit()
     conn.close()
@@ -112,23 +185,84 @@ def log_api_call(model: str, input_tokens: int, output_tokens: int,
 
 def get_api_costs() -> dict:
     conn = get_db()
-    rows = conn.execute(
+    rows = [dict(r) for r in conn.execute(
         "SELECT * FROM api_call_log ORDER BY called_at DESC"
-    ).fetchall()
+    ).fetchall()]
     conn.close()
 
-    calls = []
-    total_cost = 0.0
-    for r in rows:
-        r = dict(r)
-        pricing = _MODEL_PRICING.get(r["model"], {"input": 0.0, "output": 0.0})
-        cost = (r["input_tokens"] * pricing["input"] +
-                r["output_tokens"] * pricing["output"]) / 1_000_000
-        r["cost"] = round(cost, 6)
-        total_cost += cost
-        calls.append(r)
+    # called_at is stored via SQLite's datetime('now') — "YYYY-MM-DD HH:MM:SS"
+    # (UTC, space-separated, no microseconds). Match that format exactly so
+    # the string comparison below is valid.
+    thirty_days_ago = (datetime.utcnow() - _dt.timedelta(days=30)).strftime("%Y-%m-%d %H:%M:%S")
 
-    return {"calls": calls, "total_cost": round(total_cost, 6)}
+    total_cost = 0.0
+    total_cost_30d = 0.0
+    unknown_calls = 0
+    unknown_models: list[str] = []
+
+    # groups[(service, model)] -> aggregate dict
+    groups: dict[tuple[str, str], dict] = {}
+
+    for r in rows:
+        cost = _row_cost(r)
+        is_recent = r["called_at"] >= thirty_days_ago
+
+        if cost is None:
+            unknown_calls += 1
+            if r["model"] not in unknown_models:
+                unknown_models.append(r["model"])
+        else:
+            total_cost += cost
+            if is_recent:
+                total_cost_30d += cost
+
+        service = _service_for_purpose(r["purpose"])
+        key = (service, r["model"])
+        g = groups.get(key)
+        if g is None:
+            g = groups[key] = {
+                "service": service, "model": r["model"],
+                "calls": 0, "input_tokens": 0, "output_tokens": 0,
+                "cached_tokens": 0, "cost": None,
+                "calls_30d": 0, "cost_30d": None,
+            }
+        g["calls"] += 1
+        g["input_tokens"] += r["input_tokens"]
+        g["output_tokens"] += r["output_tokens"]
+        g["cached_tokens"] += r.get("cached_input_tokens") or 0
+        if cost is not None:
+            g["cost"] = (g["cost"] or 0.0) + cost
+        if is_recent:
+            g["calls_30d"] += 1
+            if cost is not None:
+                g["cost_30d"] = (g["cost_30d"] or 0.0) + cost
+
+    for g in groups.values():
+        if g["cost"] is not None:
+            g["cost"] = round(g["cost"], 6)
+        if g["cost_30d"] is not None:
+            g["cost_30d"] = round(g["cost_30d"], 6)
+
+    # Sort services as contiguous blocks (most expensive service first, then
+    # most expensive model within it) — the UI only prints the service name
+    # on the first row of each block, so blocks must stay together.
+    service_totals: dict[str, float] = {}
+    for g in groups.values():
+        service_totals[g["service"]] = service_totals.get(g["service"], 0.0) + (g["cost"] or 0.0)
+    groups_list = sorted(
+        groups.values(),
+        key=lambda g: (-service_totals[g["service"]], g["service"],
+                       -(g["cost"] if g["cost"] is not None else -1)),
+    )
+
+    return {
+        "pricing_as_of": _PRICING_AS_OF,
+        "total_cost": round(total_cost, 6),
+        "total_cost_30d": round(total_cost_30d, 6),
+        "unknown_calls": unknown_calls,
+        "unknown_models": unknown_models,
+        "groups": groups_list,
+    }
 
 
 def get_retention_bulk(days: int = 30, lang: str | None = None) -> dict:

--- a/podcast.py
+++ b/podcast.py
@@ -340,6 +340,14 @@ def _transcribe_via_whisper(mp3_path: str, duration: float, video_id: str, tmp_d
         "podcast: Whisper transcribed %s (%d segment(s), %.0fmin)",
         video_id, len(segments), duration / 60,
     )
+    # Whisper is billed per minute, not per token. Log the audio duration (in
+    # seconds) as input_tokens so database.stats._row_cost can price it via
+    # the "per_minute" pricing entry — only on success, since a failed call
+    # above already raised before reaching here.
+    database.log_api_call(
+        model="gpt-4o-mini-transcribe", input_tokens=int(duration),
+        output_tokens=0, purpose="podcast-transcribe",
+    )
     return transcript or None
 
 

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -503,7 +503,7 @@ def get_card_evolution(days: int = 365, deck_id: int | None = None, lang: str | 
 
 @router.get("/api/costs")
 def get_api_costs():
-    return database.get_api_costs()
+    return {**database.get_api_costs(), "deepseek_balance": ai.get_deepseek_balance()}
 
 
 @router.get("/api/pinyin")

--- a/schema.sql
+++ b/schema.sql
@@ -406,12 +406,13 @@ CREATE TABLE IF NOT EXISTS story_sentence_words (
 -- api_call_log
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS api_call_log (
-    id              INTEGER PRIMARY KEY AUTOINCREMENT,
-    called_at       TEXT NOT NULL DEFAULT (datetime('now')),
-    model           TEXT NOT NULL,
-    input_tokens    INTEGER NOT NULL,
-    output_tokens   INTEGER NOT NULL,
-    purpose         TEXT NOT NULL DEFAULT 'story'
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    called_at            TEXT NOT NULL DEFAULT (datetime('now')),
+    model                TEXT NOT NULL,
+    input_tokens         INTEGER NOT NULL,
+    output_tokens        INTEGER NOT NULL,
+    purpose              TEXT NOT NULL DEFAULT 'story',
+    cached_input_tokens  INTEGER NOT NULL DEFAULT 0
 );
 
 -- ---------------------------------------------------------------------------

--- a/static/app.js
+++ b/static/app.js
@@ -3107,50 +3107,70 @@ function closeCostModal() {
   document.getElementById('cost-modal').style.display = 'none';
 }
 
-function _formatPurpose(p) {
-  if (!p || p === 'story') return 'Story';
-  if (p.startsWith('hanzi:')) return 'Hanzi ' + p.slice(6);
-  return p.charAt(0).toUpperCase() + p.slice(1);
+function _prettyModel(model) {
+  return model
+    .replace('claude-', '')
+    .replace('-20251001', '')
+    .replace('gpt-5.1', 'GPT-5.1')
+    .replace('gpt-5-mini', 'GPT-5 Mini')
+    .replace('gpt-4o-mini-transcribe', 'Whisper (audio)')
+    .replace('deepseek-v4-flash', 'DeepSeek V4 Flash')
+    .replace('deepseek-v4-pro', 'DeepSeek V4 Pro')
+    .replace('deepseek-chat', 'DeepSeek V3')
+    .replace('deepseek-reasoner', 'DeepSeek R1')
+    .replace('glm-4-flash', 'GLM-4-Flash')
+    .replace('glm-4-air', 'GLM-4-Air')
+    .replace('qwen-turbo', 'Qwen Turbo')
+    .replace('qwen-plus', 'Qwen Plus');
 }
 
 function renderCostModal(data) {
-  const fmt = n => '$' + n.toFixed(4);
-  const fmtFull = n => '$' + n.toFixed(6);
+  const fmt = n => '$' + n.toFixed(2);
+  const fmtCost = n => (n === null || n === undefined) ? '?' : '$' + n.toFixed(4);
 
-  let html = `<div class="cost-total">Total spent <b>${fmt(data.total_cost)}</b></div>`;
+  let html = `<div class="cost-total">
+    <span>Total spent <b>${fmt(data.total_cost)}</b></span>
+    <span>Last 30 days <b>${fmt(data.total_cost_30d)}</b></span>
+  </div>`;
 
-  if (!data.calls.length) {
+  if (data.deepseek_balance) {
+    const b = data.deepseek_balance;
+    const symbol = b.currency === 'CNY' ? '¥' : (b.currency === 'USD' ? '$' : (b.currency + ' '));
+    html += `<div class="cost-balance">DeepSeek balance: ${symbol}${b.balance}</div>`;
+  }
+
+  if (data.unknown_calls > 0) {
+    html += `<div class="cost-warning">⚠ ${data.unknown_calls} call(s) could not be priced ` +
+      `(unknown models: ${data.unknown_models.join(', ')})</div>`;
+  }
+
+  if (!data.groups.length) {
     html += '<div class="cost-empty">No API calls logged yet.</div>';
   } else {
     html += `<table class="cost-table">
       <thead><tr>
-        <th>Date</th><th>Model</th><th>Purpose</th><th>Tokens in / out</th>
-        <th style="text-align:right">Cost</th>
+        <th>Service</th><th>Model</th><th>Calls</th><th>Tokens in / out</th>
+        <th style="text-align:right">Cost (30d)</th><th style="text-align:right">Cost (all)</th>
       </tr></thead><tbody>`;
-    for (const c of data.calls) {
-      const dt = c.called_at.slice(0, 16).replace('T', ' ');
-      const model = c.model
-        .replace('claude-', '')
-        .replace('-20251001', '')
-        .replace('deepseek-v4-flash', 'DeepSeek V4 Flash')
-        .replace('deepseek-v4-pro', 'DeepSeek V4 Pro')
-        .replace('deepseek-chat', 'DeepSeek V3')
-        .replace('deepseek-reasoner', 'DeepSeek R1')
-        .replace('glm-4-flash', 'GLM-4-Flash')
-        .replace('glm-4-air', 'GLM-4-Air')
-        .replace('qwen-turbo', 'Qwen Turbo')
-        .replace('qwen-plus', 'Qwen Plus');
-      const purpose = _formatPurpose(c.purpose);
+    let lastService = null;
+    for (const g of data.groups) {
+      const model = _prettyModel(g.model);
+      const showService = g.service !== lastService;
+      lastService = g.service;
+      const cachedTitle = g.cached_tokens > 0 ? ` title="(${g.cached_tokens.toLocaleString()} cached)"` : '';
       html += `<tr>
-        <td style="color:var(--muted);font-size:12px;white-space:nowrap">${dt}</td>
+        <td>${showService ? g.service : ''}</td>
         <td><span class="cost-model">${model}</span></td>
-        <td style="color:var(--muted);font-size:12px">${purpose}</td>
-        <td class="cost-num" style="color:var(--muted)">${c.input_tokens.toLocaleString()} / ${c.output_tokens.toLocaleString()}</td>
-        <td class="cost-num cost-value">${fmtFull(c.cost)}</td>
+        <td class="cost-num" style="color:var(--muted)">${g.calls.toLocaleString()}</td>
+        <td class="cost-num" style="color:var(--muted)"${cachedTitle}>${g.input_tokens.toLocaleString()} / ${g.output_tokens.toLocaleString()}</td>
+        <td class="cost-num" style="color:var(--muted)">${fmtCost(g.cost_30d)}</td>
+        <td class="cost-num cost-value">${fmtCost(g.cost)}</td>
       </tr>`;
     }
     html += '</tbody></table>';
   }
+
+  html += `<div class="cost-footnote">Prices as of ${data.pricing_as_of} — edit database/stats.py when providers change pricing.</div>`;
 
   document.getElementById('cost-modal-body').innerHTML = html;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -749,11 +749,13 @@
           <tbody>
             <tr><td>GLM-4-Flash</td><td>Zhipu</td><td class="price-free">FREE</td><td class="price-free">FREE</td></tr>
             <tr><td>GLM-4-Air</td><td>Zhipu</td><td>$0.06</td><td>$0.06</td></tr>
-            <tr><td>DeepSeek V3</td><td>DeepSeek</td><td>$0.28</td><td>$0.42</td></tr>
+            <tr><td>DeepSeek V4 Flash</td><td>DeepSeek</td><td>$0.14</td><td>$0.28</td></tr>
+            <tr><td>DeepSeek V4 Pro</td><td>DeepSeek</td><td>$0.44</td><td>$0.87</td></tr>
             <tr><td>Qwen Turbo</td><td>Alibaba</td><td>$0.07</td><td>$0.26</td></tr>
             <tr><td>Haiku 4.5</td><td>Anthropic</td><td>$0.80</td><td>$4.00</td></tr>
             <tr><td>Sonnet 4.6</td><td>Anthropic</td><td>$3.00</td><td>$15.00</td></tr>
             <tr><td>GPT-5 Mini</td><td>OpenAI</td><td>$0.25</td><td>$2.00</td></tr>
+            <tr><td>GPT-5.1</td><td>OpenAI</td><td>$1.25</td><td>$10.00</td></tr>
           </tbody>
         </table>
         <p class="price-table-note">Prices per 1M tokens (USD)</p>

--- a/static/style.css
+++ b/static/style.css
@@ -3481,15 +3481,36 @@ select.opt-input {
 .cost-total {
   display: flex;
   align-items: baseline;
-  gap: 8px;
+  gap: 24px;
+  flex-wrap: wrap;
   font-size: 14px;
   color: var(--muted);
-  margin-bottom: 18px;
+  margin-bottom: 10px;
   padding: 14px 18px;
   background: var(--bg);
   border-radius: 10px;
 }
 .cost-total b { color: var(--primary); font-size: 22px; font-weight: 700; }
+.cost-balance {
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 12px;
+}
+.cost-warning {
+  font-size: 13px;
+  color: #8a6300;
+  background: #fff3cd;
+  border: 1px solid #ffe69c;
+  border-radius: 8px;
+  padding: 10px 14px;
+  margin-bottom: 14px;
+}
+.cost-footnote {
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 16px;
+  text-align: center;
+}
 .cost-empty {
   color: var(--muted);
   font-size: 14px;
@@ -4770,3 +4791,11 @@ table.fsrs-table td.ivl { font-weight: 700; }
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 #version-badge:hover, #version-badge.expanded { opacity: 1; }
+
+@media (prefers-color-scheme: dark) {
+  .cost-warning {
+    color: #ffe69c;
+    background: #4a3b00;
+    border-color: #6b5700;
+  }
+}


### PR DESCRIPTION
Closes #508

## 问题（Daniel 2026-07-12 反馈'数字不对'）
1. 价格表缺所有实际在用的模型（gpt-5.1/gpt-5-mini/deepseek-v4-flash/pro）——未知模型静默按 $0 计，DeepSeek 因此'看起来免费'
2. 记账存的是 API 返回的快照名（gpt-5.1-2026-04-14），精确匹配永远失败 → $0
3. Whisper 音频（$0.003/分钟）完全没记账
4. 缓存命中没记录（DeepSeek 缓存输入是正价的 2%、OpenAI 是 10%）——会高估成本数倍
5. 每次调用一行、无分组

## 改了什么
见提交信息。核心：`_lookup_pricing`（快照名/前缀兜底）、`_row_cost`（缓存命中公式 + per_minute 分支）、`_service_for_purpose`（Stories/News briefing/Paste/Podcast/Word enrichment/Other）、服务成块排序（UI 只在块首显示服务名）、DeepSeek 余额实时锚点。

## 怎么测试的
子代理实现 + 主代理逐行审查（发现并修复：全局按费用排序会拆散服务块）+ 独立复测：快照名同价、缓存计价公式、whisper 秒数计价、未知模型警告与总额剔除、story/regen 合组、服务块连续性断言。py_compile + import main + node --check 全绿。价格 2026-07-12 网查核实（openai/deepseek 官方定价页）。