### PR TITLE
fix: 早晨预生成超时改为60分钟，OpenAI余额不足单独标注并回退Claude

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -30,6 +30,13 @@ DEFAULT_MODEL = "deepseek-v4-flash"
 BRIEFING_MODEL_FALLBACKS = ("gpt-5.1", "gpt-5", "gpt-5-mini")
 _briefing_model_cache: str | None = None
 
+# issue #514: if the OpenAI account runs out of quota mid-run (429
+# insufficient_quota), briefing/paste/podcast calls have no OpenAI fallback
+# model to try (DeepSeek can't be used — it censors news content). Rather
+# than fail the whole pregen key, retry once on Claude for these purposes only.
+_QUOTA_FALLBACK_MODEL = "claude-sonnet-5"
+_QUOTA_FALLBACK_PURPOSES = {"briefing", "briefing_fact_check"}
+
 # Per-session story generation progress: key → {phase, msg, percent, translate_warn?}
 _story_progress: dict[str, dict] = {}
 
@@ -97,19 +104,27 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str,
         if model.startswith("deepseek-"):
             extra["extra_body"] = {"thinking": {"type": "enabled" if thinking else "disabled"}}
             logger.debug("[%s] thinking=%s", model, thinking)
-        if model.startswith("gpt-"):
-            # gpt-5 series (Chat Completions): max_completion_tokens replaces max_tokens
-            # and is shared with internal reasoning tokens; custom temperature is not
-            # supported. reasoning_effort="low" — sentence generation needs no deep
-            # reasoning, and higher efforts can eat the whole token budget.
-            resp = client.chat.completions.create(
-                model=model, max_completion_tokens=max_tokens, messages=messages,
-                reasoning_effort="low",
-            )
-        else:
-            resp = client.chat.completions.create(
-                model=model, max_tokens=max_tokens, messages=messages, **extra
-            )
+        try:
+            if model.startswith("gpt-"):
+                # gpt-5 series (Chat Completions): max_completion_tokens replaces max_tokens
+                # and is shared with internal reasoning tokens; custom temperature is not
+                # supported. reasoning_effort="low" — sentence generation needs no deep
+                # reasoning, and higher efforts can eat the whole token budget.
+                resp = client.chat.completions.create(
+                    model=model, max_completion_tokens=max_tokens, messages=messages,
+                    reasoning_effort="low",
+                )
+            else:
+                resp = client.chat.completions.create(
+                    model=model, max_tokens=max_tokens, messages=messages, **extra
+                )
+        except Exception as e:
+            if (purpose in _QUOTA_FALLBACK_PURPOSES and "insufficient_quota" in str(e)
+                    and model != _QUOTA_FALLBACK_MODEL):
+                logger.warning("[%s] insufficient_quota on purpose=%s — falling back to %s",
+                               model, purpose, _QUOTA_FALLBACK_MODEL)
+                return _call_api(_QUOTA_FALLBACK_MODEL, messages, max_tokens, purpose, thinking)
+            raise
         elapsed = time.time() - t0
         choice = resp.choices[0]
         content = choice.message.content

--- a/scripts/morning_pregen.py
+++ b/scripts/morning_pregen.py
@@ -38,9 +38,11 @@ AUTH_USERNAME = os.environ.get("AUTH_USERNAME")
 AUTH_PASSWORD = os.environ.get("AUTH_PASSWORD")
 
 # /api/pregen-today 对每个键都可能同步生成故事——新闻/简报模式可能涉及多次
-# 串行 AI 调用，加上多个键顺序处理，耗时可达数分钟到十几分钟，因此设置较长
-# 的超时。
-STORY_TIMEOUT_SECONDS = 15 * 60
+# 串行 AI 调用（生成+核查+整篇重试+再核查，单个 briefing chunk 就要 2-3
+# 分钟），加上多个键顺序处理，实测可达 30 分钟以上，因此设置较长的超时
+# （issue #514：15 分钟曾在服务器仍在正常生成时就客户端超时，日志里看不到
+# 任何结果，误以为预生成坏了）。
+STORY_TIMEOUT_SECONDS = 60 * 60
 
 
 def _log(msg: str) -> None:
@@ -77,7 +79,21 @@ def main() -> int:
     try:
         summary = _request("POST", "/api/pregen-today", STORY_TIMEOUT_SECONDS)
     except urllib.error.URLError as e:
-        _log(f"无法连接服务器 {BASE_URL}: {e}")
+        if isinstance(e, urllib.error.URLError) and isinstance(e.reason, TimeoutError):
+            _log(
+                f"客户端等待 {STORY_TIMEOUT_SECONDS // 60} 分钟后超时，但服务器"
+                f"可能仍在后台继续生成——请稍后查 journalctl（服务名 ankiadvanced）"
+                f"确认实际结果，不要立即当作失败重跑。"
+            )
+        else:
+            _log(f"无法连接服务器 {BASE_URL}: {e}")
+        return 1
+    except TimeoutError:
+        _log(
+            f"客户端等待 {STORY_TIMEOUT_SECONDS // 60} 分钟后超时，但服务器"
+            f"可能仍在后台继续生成——请稍后查 journalctl（服务名 ankiadvanced）"
+            f"确认实际结果，不要立即当作失败重跑。"
+        )
         return 1
     except Exception as e:
         _log(f"预生成请求失败: {e}")
@@ -101,12 +117,20 @@ def main() -> int:
         _log(f"  - 跳过（今天已有故事） {label}")
     for label in skipped_no_due:
         _log(f"  - 跳过（无到期卡片，或 AI 已禁用） {label}")
+    quota_failed = 0
     for item in failed:
-        _log(f"  ✗ 失败 {item.get('key')}: {item.get('error')}")
+        error = item.get("error") or ""
+        if "insufficient_quota" in error:
+            quota_failed += 1
+            _log(f"  ✗ 失败 {item.get('key')}: OpenAI 余额不足，请充值（{error}）")
+        else:
+            _log(f"  ✗ 失败 {item.get('key')}: {error}")
 
     _log("---- 汇总 ----")
     _log(f"候选键: {keys}  已生成: {len(generated)}  跳过(已缓存): {len(skipped_cached)}  "
          f"跳过(无到期): {len(skipped_no_due)}  失败: {len(failed)}")
+    if quota_failed:
+        _log(f"其中 {quota_failed} 个失败原因是 OpenAI 余额不足，请充值后重跑。")
 
     return 0 if not failed else 1
 


### PR DESCRIPTION
## 背景

早晨预生成连续两天（07-11、07-12）日志显示"预生成请求失败: timed out"。真实情况：
- 客户端超时是 15 分钟，但服务器实际跑了 31 分钟——briefing 一个 chunk 就要 2-3 分钟（生成+核查+整篇重试+再核查），客户端超时后服务器仍在继续生成，日志里看不到任何结果。
- 当天 `24/listening/zh` 真正失败原因是 OpenAI 429 insufficient_quota（账户余额用尽）。

## 改动

1. `scripts/morning_pregen.py`：`STORY_TIMEOUT_SECONDS` 从 15 分钟提高到 60 分钟。
2. 超时兜底文案改为提示"服务器可能仍在生成，请稍后查 journalctl 确认结果，不要立即当作失败重跑"（区分 socket 超时 vs 其他连接错误）。
3. 汇总输出里对含 `insufficient_quota` 的失败项单独标注"OpenAI 余额不足，请充值"，让 cron 日志一眼看出是钱的问题而不是代码问题。
4. `ai.py`：`_call_api` 对 `briefing`/`briefing_fact_check` 用途遇到 429 insufficient_quota 时，回退到 `claude-sonnet-5` 重试一次（记 warning）。DeepSeek 会审查新闻内容，不能作为这两个用途的回退模型；改动限制在 `_call_api` 一处（约24行），不改动 `generate_briefing_sentences` 内部多个调用点，符合 issue 里"≤40行能干净实现就做"的要求。`resolve_briefing_model()`（gpt-5.1→gpt-5→gpt-5-mini 链）、news/paste 旧管线（`generate_news_sentences`）与 `summarize_podcast_transcript`（已有独立的 DeepSeek 回退）均未改动。

## 测试

- `python3 -m py_compile ai.py scripts/morning_pregen.py` 通过
- `import ai` / `import database` 手动检查通过（未起 8000 端口服务器）
- 用小脚本 monkeypatch `morning_pregen._request`，模拟三种场景验证日志文案：
  - 汇总含 `insufficient_quota` 失败项 → 正确标注"OpenAI 余额不足，请充值"
  - `URLError(socket.timeout(...))` / 裸 `TimeoutError` → 正确提示"服务器可能仍在后台继续生成"
  - 普通连接错误（`ConnectionRefusedError`）→ 仍走"无法连接服务器"分支，未被误判为超时

Closes #514