### PR TITLE
创作模式正面译文改用 t 键切换，取代悬停去模糊

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -4094,17 +4094,21 @@ function loadCard(c, counts) {
         const sentFront = document.getElementById('sentence-front');
         if (sentFront.style.display !== 'none') sentFront.innerHTML = renderSentence();
       } else if (isCloze) {
-        // Word bank: sentence just loaded — update hint and rebuild token bank
+        // Word bank: sentence just loaded — update hint text and rebuild token bank.
+        // Visibility (hidden unless "always show translation" is on) is controlled
+        // by toggleCreatingFrontTranslation() / the t key, not here (#515).
         const enFront = document.getElementById('sentence-en-front');
-        enFront.style.display = 'flex';
         enFront.textContent = sentence.sentence_de || sentence.sentence_fr || sentence.sentence_en || '';
+        enFront.style.display = _alwaysTranslation && enFront.textContent ? 'block' : 'none';
+        _syncFrontTransToggle();
         if (document.getElementById('word-bank-wrap').style.display !== 'none') {
           renderWordBankUI();
         }
       } else if (isCreating && isSentenceNt) {
-        // Sentence notes: update English prompt
+        // Sentence notes: update translation prompt text (visibility unchanged here).
         const inp = document.getElementById('sentence-en-front');
-        if (inp.style.display !== 'none') inp.textContent = sentence.sentence_de || sentence.sentence_fr || '';
+        inp.textContent = sentence.sentence_de || sentence.sentence_fr || '';
+        _syncFrontTransToggle();
       }
     };
     // In unfinished "existing story" mode, only fetch a cached story (never generate).
@@ -4282,8 +4286,12 @@ function showFront() {
   sentFront.onclick = _sentClickable ? () => window.open(_sourceUrl, '_blank', 'noopener') : null;
   _renderNewsFront();
 
-  // Creating: show English hint + appropriate input
-  document.getElementById('sentence-en-front').style.display   = isCreating ? 'flex' : 'none';
+  // Creating: show translation row + appropriate input. The translation text
+  // itself starts hidden (no blur-on-hover any more, #515) — press t to reveal
+  // it, or tap the 🇩🇪 button on mobile; shown by default only when the
+  // persistent "always show translation" preference is on.
+  document.getElementById('sentence-en-front-row').style.display = isCreating ? 'flex' : 'none';
+  document.getElementById('sentence-en-front').style.display     = 'none';
   document.getElementById('creating-input-wrap').style.display = (isCreating && !isCloze) ? 'flex' : 'none';
   document.getElementById('word-bank-wrap').style.display      = isCloze ? 'flex' : 'none';
   if (isCloze) _initWordBankSlider();
@@ -4338,6 +4346,11 @@ function showFront() {
       userInput = '';
       renderWordBankUI();
     }
+    // Default visibility: shown when "always show translation" is on, else hidden
+    // (press t to toggle, or tap the 🇩🇪 button on mobile).
+    const _enFront = document.getElementById('sentence-en-front');
+    _enFront.style.display = (_alwaysTranslation && _enFront.textContent) ? 'block' : 'none';
+    _syncFrontTransToggle();
   }
 
   // Rename reveal button for creating
@@ -6020,8 +6033,38 @@ function setAlwaysTranslation(on) {
     const de = document.getElementById('sentence-de');
     if (fr.textContent) fr.style.display = '';
     if (de.textContent) de.style.display = '';
+    const enFront = document.getElementById('sentence-en-front');
+    if (enFront.textContent) enFront.style.display = 'block';
   }
   _syncTransEye();
+  _syncFrontTransToggle();
+}
+
+// ── Creating-mode front translation toggle (replaces the old blur-on-hover, #515) ──
+// Same shortcut ('t') and persistent "always show" preference as the back-side
+// toggle above — pressing t on the front (creating mode, card not flipped) or
+// tapping the 🇩🇪 button (mobile, no keyboard) shows/hides this element only.
+function toggleCreatingFrontTranslation() {
+  const front = document.getElementById('sentence-en-front');
+  if (!front || !front.textContent) return;
+  const show = front.style.display === 'none';
+  front.style.display = show ? 'block' : 'none';
+  // Hiding it while "always show" is on deactivates the preference (mirrors toggleTranslation).
+  if (!show && _alwaysTranslation) {
+    _alwaysTranslation = false;
+    localStorage.setItem('alwaysTranslation', '0');
+  }
+  _syncFrontTransToggle();
+}
+
+// The tap button stays visible at all times in creating mode (it's the only way to
+// reveal the translation on mobile), but highlights when the translation is showing.
+function _syncFrontTransToggle() {
+  const front = document.getElementById('sentence-en-front');
+  const btn   = document.getElementById('sentence-en-front-toggle');
+  if (!btn) return;
+  const visible = !!(front && front.textContent && front.style.display !== 'none');
+  btn.classList.toggle('active', visible);
 }
 
 // ── Creating-mode translation hint toggle (🇬🇧/🇫🇷/🇩🇪) ───────────────────────
@@ -8660,7 +8703,11 @@ document.addEventListener('keydown', async e => {
     } else if (e.key === _key('pinyin')) {
       e.preventDefault(); togglePinyin();
     } else if (e.key === _key('translation')) {
-      e.preventDefault(); toggleTranslation();
+      e.preventDefault();
+      // Front side of a creating-mode card: toggle the front translation hint
+      // instead of the back-side sentence-fr/sentence-de pair (#515).
+      if (!backVisible && category === 'creating') toggleCreatingFrontTranslation();
+      else toggleTranslation();
     } else if (e.key === _key('worddef')) {
       e.preventDefault(); toggleWordDef();
     } else if (e.key === _key('reveal')) {

--- a/static/index.html
+++ b/static/index.html
@@ -135,8 +135,14 @@
                 <button class="hint-save-btn" id="hint-save-btn" onclick="saveListenHintDefault()" title="Save as default">☆</button>
               </div>
             </div>
-            <!-- Creating: English/German context sentence (shown above Chinese for cloze) -->
-            <div class="sentence-en-front" id="sentence-en-front"></div>
+            <!-- Creating: English/German context sentence (shown above Chinese for cloze).
+                 Hidden by default (no space reserved); press t to toggle, or tap the
+                 🇩🇪 button — needed on mobile where there's no keyboard (#515). -->
+            <div class="sentence-en-front-row" id="sentence-en-front-row" style="display:none">
+              <div class="sentence-en-front" id="sentence-en-front"></div>
+              <span class="sentence-en-front-toggle" id="sentence-en-front-toggle" role="button" tabindex="0"
+                    onclick="toggleCreatingFrontTranslation()" title="Toggle translation (t)">🇩🇪</span>
+            </div>
             <!-- Creating: target word translation hint (FR > DE > EN).
                  Hidden by default; press k to toggle. The eye icon controls the
                  persistent "always show hint" preference (only visible while shown). -->

--- a/static/style.css
+++ b/static/style.css
@@ -1631,24 +1631,37 @@ main.browse-open {
 .quick-add-banner.qa-info    { background: #555; color: #fff; }
 
 /* ── Creating: front input ───────────────────────────── */
+/* Row wraps the translation text + the mobile tap toggle. Hidden entirely
+   outside creating mode; visible (flex) in creating mode regardless of
+   whether the translation text itself is shown (#515). */
+.sentence-en-front-row {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+/* Hidden by default (no min-height reserved) — press t to reveal, or tap the
+   toggle button below on mobile. No more blur-on-hover (#515). */
 .sentence-en-front {
+  display: none;
   font-size: 13px;
   line-height: 1.6;
   text-align: center;
   color: var(--muted);
-  min-height: 60px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  /* Fully blurred so the translation is completely unreadable by default.
-     Clears only on hover when you explicitly want to check it. */
-  opacity: 0.35;
-  filter: blur(7px);
   letter-spacing: 0.2px;
-  transition: opacity 0.15s, filter 0.15s;
 }
-.sentence-en-front:hover {
-  opacity: 0.9;
+.sentence-en-front-toggle {
+  flex: 0 0 auto;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  opacity: 0.3;
+  filter: grayscale(1);
+  transition: opacity 0.15s, filter 0.15s;
+  user-select: none;
+}
+.sentence-en-front-toggle.active {
+  opacity: 1;
   filter: none;
 }
 /* News flow: German context of the preceding summary sentences (readable at a glance) */


### PR DESCRIPTION
## 概述

- 移除 `.sentence-en-front`（创作模式正面德/法/英译文提示）的悬停去模糊机制（blur(7px)+opacity 0.35+min-height 60px），手机上没有 hover，之前一直占空间且视觉不适
- 默认 `display:none`，不占用任何布局空间
- 按 `t` 键在正面（未翻面、创作模式）与背面均可切换译文显示；与背面已有的 `_alwaysTranslation`（always show translation）持久偏好统一——打开该偏好时正面译文也默认显示；用 t 隐藏时会像背面一样自动关闭该偏好
- 手机端（无键盘）新增一个小的 🇩🇪 点按开关，效果等同按 t；文字未加载时禁用（点击无效果）

## 改动文件

- `static/style.css`：删除 `.sentence-en-front:hover`；新增 `.sentence-en-front-row`（容纳文字+点按开关）与 `.sentence-en-front-toggle` 样式
- `static/index.html`：把 `#sentence-en-front` 包进新的 `#sentence-en-front-row`，加入 `#sentence-en-front-toggle` 按钮
- `static/app.js`：
  - 新增 `toggleCreatingFrontTranslation()` / `_syncFrontTransToggle()`
  - `showFront()`、异步补载故事的 `applySentenceToUI()`、`setAlwaysTranslation()` 里同步更新正面译文的默认可见性
  - `keydown` 里 `t` 键处理：正面（`!backVisible && category === 'creating'`）走新函数，其余场景保持原 `toggleTranslation()`

只动了创作模式正面相关逻辑，阅读/听力模式的行为未改动。

## 验证

- `node --check static/app.js` 通过
- 手动验证路径（本地起 `run.dev.sh` 走过）：
  - 创作模式（词库/cloze 与整句翻译两种子模式）正面按 `t` → 译文出现/消失，隐藏时不占空间（`display:none`，无残留 min-height）
  - 翻到背面后按 `t` → 原有的 `sentence-fr`/`sentence-de` 切换行为不受影响
  - 设置里打开 "always show translation" 后新卡片正面译文默认显示；用 t 隐藏后该偏好自动关闭（与背面行为一致）
  - 在创作模式输入框中打字母 `t` 不会触发切换（`inInput` 守卫已覆盖该 return 分支）
  - 点击正面 🇩🇪 小按钮效果与按 t 相同，激活态（`.active`）高亮同步

Closes #515