### PR TITLE
feat: 播客通知支持 Signal（signal-cli 关联设备，Note to Self）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Daniel 在中国需要 VPN 访问 GitHub。`gh` 命令报 `EOF` 错误时（`cur
 ├── importer.py            # YAML 词汇导入器（中文 + 法语格式）
 ├── ai.py                  # AI 提供商调用（每种提示词类型一个函数）
 ├── news_fetcher.py        # 新闻抓取（Tagesschau API + RSS；按天缓存 data/news_cache/）
-├── podcast.py              # 播客爬虫（#479）：播客 RSS 直链发现新单集（#497，退役 YouTube/yt-dlp）、每源 auto_process 开关+非自动源只入库元数据（#502，podcast_feeds 表）、转录链 NotebookLM 免费主力+听悟+Whisper 保底、单步异常不中止整链（#510 重排，链式降级，原 #498/#485/#486）、摘要 NotebookLM chat.ask 免费优先+gpt/DeepSeek API 链回退（#510）、HSK生词、邮件通知
+├── podcast.py              # 播客爬虫（#479）：播客 RSS 直链发现新单集（#497，退役 YouTube/yt-dlp）、每源 auto_process 开关+非自动源只入库元数据（#502，podcast_feeds 表）、转录链 NotebookLM 免费主力+听悟+Whisper 保底、单步异常不中止整链（#510 重排，链式降级，原 #498/#485/#486）、摘要 NotebookLM chat.ask 免费优先+gpt/DeepSeek API 链回退（#510）、HSK生词、邮件通知+Signal 通知（signal-cli 关联设备，发 Note to Self，#521，二者独立可选、互不影响）
 ├── tts.py                 # edge-tts 封装
 ├── translator.py          # 翻译（Google Translate，deep-translator，可选）
 ├── yaml_fixer.py          # 修复 AI 生成的格式错误 YAML
@@ -342,7 +342,8 @@ python main.py status [--deck X]     # 显示每个牌组/类别的到期数量
 | `AUTH_USERNAME` / `AUTH_PASSWORD` | 可选 | 两者都设置时启用 HTTP Basic Auth（保护所有路径） |
 | `SMTP_HOST` / `SMTP_PORT` / `SMTP_USERNAME` / `SMTP_PASSWORD` / `SMTP_FROM` | 可选 | 播客爬虫（#479）邮件通知用；`SMTP_PORT` 默认 587（STARTTLS）；未配置时跳过发信，记日志，不算失败 |
 | `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` | 可选 | 播客爬虫用 Spotify Web API 搜索单集链接；未配置时退化为 Spotify 搜索链接 |
-| `PUBLIC_BASE_URL` | `https://powerdaniel3000.duckdns.org` | 播客邮件里转录页链接的域名前缀 |
+| `PUBLIC_BASE_URL` | `https://powerdaniel3000.duckdns.org` | 播客邮件/Signal 通知里转录页链接的域名前缀 |
+| `SIGNAL_ACCOUNT` / `SIGNAL_CLI_PATH` | 可选 | 播客爬虫（#521）Signal 通知用；`SIGNAL_ACCOUNT` 是 Daniel 关联设备所属号码（如 `+49…`），`SIGNAL_CLI_PATH` 默认 `signal-cli`；`SIGNAL_ACCOUNT` 未配置时跳过发送，记日志，不算失败。一次性 signal-cli 安装/扫码关联步骤见 `scripts/README.md` |
 | `ALIBABA_CLOUD_ACCESS_KEY_ID` / `ALIBABA_CLOUD_ACCESS_KEY_SECRET` | 可选 | 播客爬虫（#498）通义听悟（转录主力）用的阿里云 AccessKey；未配置时自动跳过，落到 Whisper/NotebookLM |
 | `TINGWU_APP_KEY` | 可选 | 播客爬虫（#498）通义听悟控制台创建的应用 AppKey；与上面两个 AccessKey 变量任一缺失都会跳过听悟。一次性开通步骤见 `scripts/README.md` |
 

--- a/podcast.py
+++ b/podcast.py
@@ -1019,6 +1019,73 @@ def send_email(episode: dict) -> bool:
     return True
 
 
+def send_signal(episode: dict) -> bool:
+    """Send a plain-text Signal "Note to Self" notification for a freshly-
+    summarized episode via a linked-device signal-cli install (#521).
+    Returns True if sent, False if skipped (SIGNAL_ACCOUNT not configured)
+    — skipping is not an error, mirrors send_email. Never raises."""
+    account = os.environ.get("SIGNAL_ACCOUNT")
+    if not account:
+        logger.info("podcast: SIGNAL_ACCOUNT not configured, skipping Signal notification for %s",
+                     episode["video_id"])
+        return False
+
+    cli_path = os.environ.get("SIGNAL_CLI_PATH", "signal-cli")
+    public_base = os.environ.get("PUBLIC_BASE_URL", "https://powerdaniel3000.duckdns.org")
+    transcript_link = f"{public_base}/#podcast-{episode['id']}"
+
+    # summary_de may be None; strip HTML tags (the email version is HTML)
+    # and cap length so the Signal message stays readable.
+    summary_de = re.sub(r"<[^>]+>", "", episode.get("summary_de") or "").strip()
+    if len(summary_de) > 1500:
+        summary_de = summary_de[:1500].rstrip() + "…"
+
+    # hsk_words comes back as a list from database.get_episode (_hydrate
+    # parses the stored JSON), but be defensive in case a raw row or a
+    # pre-hydration dict is ever passed in.
+    hsk_words = episode.get("hsk_words") or []
+    if isinstance(hsk_words, str):
+        try:
+            hsk_words = json.loads(hsk_words) if hsk_words else []
+        except (ValueError, TypeError):
+            hsk_words = []
+
+    word_lines = "\n".join(
+        f"- {w.get('word', '')} ({w.get('pinyin', '')}) – {w.get('definition_de', '')}"
+        for w in hsk_words[:10]
+    )
+
+    lines = [f"🎙 {episode['title']}", transcript_link]
+    if episode.get("spotify_url"):
+        lines.append(episode["spotify_url"])
+    if summary_de:
+        lines.append("")
+        lines.append(summary_de)
+    if word_lines:
+        lines.append("")
+        lines.append("Neue HSK5+ Vokabeln:")
+        lines.append(word_lines)
+    text = "\n".join(lines)
+
+    try:
+        result = subprocess.run(
+            [cli_path, "-a", account, "send", "--note-to-self", "-m", text],
+            capture_output=True, timeout=60,
+        )
+    except Exception as e:
+        logger.warning("podcast: signal-cli invocation failed for %s: %s", episode["video_id"], e)
+        return False
+
+    if result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", "replace") if isinstance(result.stderr, bytes) else result.stderr
+        logger.warning("podcast: signal-cli exited %s for %s: %s",
+                        result.returncode, episode["video_id"], stderr)
+        return False
+
+    logger.info("podcast: Signal notification sent for %s", episode["video_id"])
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Orchestration
 # ---------------------------------------------------------------------------
@@ -1118,6 +1185,14 @@ def _process_episode(episode_id: int, video: dict, detail_level: str, summary: d
             from datetime import datetime
             database.update_episode(episode_id, email_sent_at=datetime.now().isoformat())
             summary["emailed"] += 1
+
+        try:
+            send_signal(episode)
+        except Exception as e:
+            # Signal and email are independent, best-effort channels — a
+            # signal-cli hiccup must not downgrade a successfully
+            # summarized episode to 'error' either.
+            logger.warning("podcast: Signal notification failed for %s: %s", video["video_id"], e)
     except Exception as e:
         logger.error("podcast: episode %s failed: %s", video["video_id"], e)
         database.update_episode(episode_id, status="error", error=str(e))

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -263,10 +263,48 @@ notebooklm auth check --test
 返回 `None`（视为"未认证"）——NotebookLM 是转录链最后一级，失败即
 `no_transcript`——**不会**让爬虫报错。
 
+### Signal 通知一次性安装/关联设置（issue #521）
+
+播客通知除了邮件还可以发到 Signal（Daniel 自己账号的"给自己的备忘 /
+Note to Self"），走 `signal-cli` 以**关联设备**方式挂在 Daniel 的手机号
+下——像 Signal Desktop 一样扫码配对，不需要第二个手机号，也不需要额外
+付费。以下步骤在**服务器**上、以运行播客爬虫的 `anki` 用户执行：
+
+```bash
+# 1. 装依赖：Java 运行时（signal-cli 需要）+ qrencode（终端里显示二维码）
+sudo apt install openjdk-21-jre-headless qrencode
+
+# 2. 从 GitHub releases 下载 signal-cli 并解压到 /opt/signal-cli
+#    （版本号去 https://github.com/AsamK/signal-cli/releases 查最新的）
+SIGNAL_CLI_VERSION=0.13.x
+curl -L -o /tmp/signal-cli.tar.gz \
+  https://github.com/AsamK/signal-cli/releases/download/v${SIGNAL_CLI_VERSION}/signal-cli-${SIGNAL_CLI_VERSION}.tar.gz
+sudo tar xf /tmp/signal-cli.tar.gz -C /opt
+sudo mv /opt/signal-cli-${SIGNAL_CLI_VERSION} /opt/signal-cli
+sudo ln -sf /opt/signal-cli/bin/signal-cli /usr/local/bin/signal-cli
+
+# 3. 以 anki 用户关联设备：打印出一个 sgnl:// URI，
+#    用 qrencode 转成终端二维码，然后用手机 Signal App
+#    「关联新设备」扫码（必须由 anki 用户运行——关联数据存在
+#    anki 用户的 home 目录下，其他用户跑 signal-cli 看不到这个账号）
+sudo -u anki signal-cli link -n "AnkiAdvanced" | qrencode -t ansiutf8
+
+# 4. 关联成功后，把号码写进服务器的 .env（或 systemd 环境文件）：
+SIGNAL_ACCOUNT=+49xxxxxxxxx
+SIGNAL_CLI_PATH=/usr/local/bin/signal-cli   # 可省略，默认就是 "signal-cli"
+```
+
+关联数据（session/身份密钥）存在 `/home/anki/.local/share/signal-cli`——
+**必须**始终以 `anki` 用户执行 `signal-cli` 命令（包括手动测试），换用户
+会看不到这个已关联的账号，需要重新扫码关联。`SIGNAL_ACCOUNT` 未配置时
+`send_signal` 只记 info 日志并返回 `False`（视为"未启用"）——**不会**让
+爬虫报错，与邮件通知完全独立、互不影响。
+
 用法与环境变量同 `morning_pregen.py`（`BASE_URL`/`AUTH_USERNAME`/`AUTH_PASSWORD`）。
 另外邮件发送需要 SMTP 环境变量（`SMTP_HOST`/`SMTP_PORT`/`SMTP_USERNAME`/
-`SMTP_PASSWORD`/`SMTP_FROM`/`PUBLIC_BASE_URL`，见 CLAUDE.md 环境变量表）——
-未配置时服务器只是跳过发信并记日志，不算失败。
+`SMTP_PASSWORD`/`SMTP_FROM`/`PUBLIC_BASE_URL`，见 CLAUDE.md 环境变量表），
+Signal 通知需要 `SIGNAL_ACCOUNT`/`SIGNAL_CLI_PATH`（见上）——两者任一未配置时
+服务器只是跳过对应通道并记日志，不算失败。
 
 ```bash
 python scripts/podcast_check.py


### PR DESCRIPTION
Closes #521

## 改了什么
- `podcast.send_signal(episode)`：以 signal-cli（关联设备模式，挂在 Daniel 自己的 Signal 账号上，无需第二个号码）发纯文本通知到'给自己的备忘'：🎙 标题 + `PUBLIC_BASE_URL/#podcast-<id>` + Spotify 链接 + 剥 HTML、截断 1500 字符的德语摘要 + 最多 10 行 HSK 生词
- 环境变量 `SIGNAL_ACCOUNT`（未配置→跳过并记日志，不算失败，与 SMTP 同逻辑）、`SIGNAL_CLI_PATH`（默认 signal-cli）
- `_process_episode` 里与邮件并列、各自独立 try/except——两条通知渠道互不影响，任一失败都不降级 summarized 状态
- `scripts/README.md`：signal-cli 一次性安装+QR 扫码关联教程（openjdk-21 + qrencode + /opt/signal-cli + 必须以 anki 用户执行）
- 为什么不用 OpenClaw：整套 AI 助手框架对'每天发一条通知'过重，且近期有网关暴露/提示词注入的安全争议；signal-cli 是此场景的标准工具

## 怎么测试的
子代理实现 + 主代理审查 + 独立复测三项：未配置跳过且不调 subprocess；配置后命令参数（-a/+4912345/--note-to-self）与消息文本断言（无 HTML、含标题与 #podcast-42 链接与生词、3000 字符摘要被截断）；returncode=1 返回 False 不抛异常。py_compile + import main 全绿。