### PR TITLE
性能:修复聚合牌组接口的 N+1 查询，/api/today 提速约 30 倍

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -202,7 +202,24 @@ def get_card(card_id: int) -> dict | None:
 
 
 def _count_new_introduced_today_multi(conn, deck_ids: list[int], category: str, today: str) -> int:
-    return sum(_count_new_introduced_today(conn, did, category, today) for did in deck_ids)
+    """Batched: one grouped query instead of one query per deck (issue #513)."""
+    if not deck_ids:
+        return 0
+    ph = ",".join("?" * len(deck_ids))
+    row = conn.execute(
+        f"""SELECT COUNT(DISTINCT c.id) FROM cards c
+            WHERE c.deck_id IN ({ph}) AND c.category = ?
+              AND EXISTS (
+                SELECT 1 FROM review_log rl
+                WHERE rl.card_id = c.id AND date(rl.reviewed_at) = ?
+              )
+              AND NOT EXISTS (
+                SELECT 1 FROM review_log rl
+                WHERE rl.card_id = c.id AND date(rl.reviewed_at) < ?
+              )""",
+        deck_ids + [category, today, today],
+    ).fetchone()
+    return row[0]
 
 
 def _count_new_introduced_today(conn, deck_id: int, category: str, today: str) -> int:
@@ -326,8 +343,14 @@ def _interleave_cards(base: list, inserts: list) -> list:
     return result
 
 
-def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = False) -> list[dict]:
-    """All due cards for a category, ordered per preset display-order settings."""
+def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = False,
+                   _preset: dict | None = None, _new_done_today: int | None = None) -> list[dict]:
+    """All due cards for a category, ordered per preset display-order settings.
+
+    _preset / _new_done_today let callers that already batch-fetched these values
+    for many decks at once (get_due_cards_multi, issue #513) skip the per-deck
+    preset/new-count queries this function would otherwise run on every call.
+    """
     import random
     from itertools import groupby
 
@@ -340,9 +363,10 @@ def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = Fa
     now = datetime.now().isoformat(timespec="seconds")
     conn = get_db()
 
-    preset = get_preset_for_deck(deck_id, category)
+    preset = _preset if _preset is not None else get_preset_for_deck(deck_id, category)
     new_limit = preset["new_per_day"]
-    new_done_today = _count_new_introduced_today(conn, deck_id, category, today)
+    new_done_today = (_new_done_today if _new_done_today is not None
+                       else _count_new_introduced_today(conn, deck_id, category, today))
     new_remaining = max(0, new_limit - new_done_today)
 
     rows = conn.execute(
@@ -484,6 +508,150 @@ def get_next_card(deck_id: int, category: str) -> dict | None:
         cards.sort(key=lambda c: story_pos.get(c["word_id"], NO_POS))
 
     return cards[0]
+
+
+def _get_presets_bulk(deck_ids: list[int], category: str | None = None) -> dict[int, dict]:
+    """Batched equivalent of calling get_preset_for_deck(did, category) for each
+    deck_id — one JOIN query + one override query instead of 2 queries per deck
+    (issue #513: aggregate decks with 100+ leaves were paying this N+1 on every
+    /api/today request)."""
+    if not deck_ids:
+        return {}
+    conn = get_db()
+    placeholders = ",".join("?" * len(deck_ids))
+    rows = conn.execute(
+        f"""SELECT d.id AS deck_id, p.*,
+                   d.new_review_order_override AS deck_nro_override,
+                   d.bury_quick_mode           AS deck_bury_quick_mode
+            FROM decks d JOIN deck_presets p ON p.id = d.preset_id
+            WHERE d.id IN ({placeholders})""",
+        deck_ids,
+    ).fetchall()
+
+    result: dict[int, dict] = {}
+    for row in rows:
+        d = dict(row)
+        did = d.pop("deck_id")
+        deck_nro = d.pop("deck_nro_override", None)
+        if deck_nro is not None:
+            d["new_review_order_override"] = deck_nro
+        deck_bury = d.pop("deck_bury_quick_mode", None)
+        if deck_bury is not None:
+            d["bury_quick_mode"] = deck_bury
+        result[did] = d
+
+    if category:
+        preset_ids = list({p["id"] for p in result.values()})
+        if preset_ids:
+            ph2 = ",".join("?" * len(preset_ids))
+            override_rows = conn.execute(
+                f"SELECT * FROM preset_category_overrides WHERE category = ? AND preset_id IN ({ph2})",
+                [category] + preset_ids,
+            ).fetchall()
+            overrides_by_preset = {r["preset_id"]: dict(r) for r in override_rows}
+            for preset in result.values():
+                override = overrides_by_preset.get(preset["id"])
+                if override:
+                    for key, val in override.items():
+                        if key not in ("id", "preset_id", "category") and val is not None:
+                            preset[key] = val
+    conn.close()
+    return result
+
+
+def _count_due_bulk(deck_ids: list[int], category: str) -> dict[int, dict]:
+    """Batched equivalent of calling count_due(did, category) for each deck_id.
+
+    Turns the O(N) per-deck queries (due rows / new-introduced-today / learning-
+    future / preset, each on its own connection) into a fixed handful of grouped
+    queries — this was the dominant cost of /api/today for aggregate decks with
+    many leaves (issue #513: ~1300 queries for a 111-leaf deck)."""
+    zero = {"new": 0, "learning": 0, "review": 0, "learning_future": 0}
+    result = {did: dict(zero) for did in deck_ids}
+    if not deck_ids:
+        return result
+
+    locked = get_locked_deck_ids()
+    active_ids = [did for did in deck_ids if did not in locked]
+    if not active_ids:
+        return result
+
+    today = anki_today().isoformat()
+    now = datetime.now().isoformat(timespec="seconds")
+    presets = _get_presets_bulk(active_ids, category)
+
+    conn = get_db()
+    ph = ",".join("?" * len(active_ids))
+
+    new_today_rows = conn.execute(
+        f"""SELECT c.deck_id, COUNT(DISTINCT c.id) AS cnt FROM cards c
+            WHERE c.deck_id IN ({ph}) AND c.category = ?
+              AND EXISTS (
+                SELECT 1 FROM review_log rl
+                WHERE rl.card_id = c.id AND date(rl.reviewed_at) = ?
+              )
+              AND NOT EXISTS (
+                SELECT 1 FROM review_log rl
+                WHERE rl.card_id = c.id AND date(rl.reviewed_at) < ?
+              )
+            GROUP BY c.deck_id""",
+        active_ids + [category, today, today],
+    ).fetchall()
+    new_today = {r["deck_id"]: r["cnt"] for r in new_today_rows}
+
+    due_rows = conn.execute(
+        f"""SELECT c.deck_id, c.state, c.due, c.interval FROM cards c
+            WHERE c.deck_id IN ({ph}) AND c.category = ?
+              AND c.state != 'suspended'
+              AND c.deleted_at IS NULL
+              AND (c.buried_until IS NULL OR c.buried_until < ?)
+              AND (
+                (c.state IN ('learning', 'relearn') AND c.due <= ?)
+                OR (c.state = 'review' AND c.due <= ?)
+                OR (c.state = 'new' AND c.due <= ?)
+              )""",
+        active_ids + [category, today, now, today, today],
+    ).fetchall()
+    by_deck_rows: dict[int, list] = {}
+    for r in due_rows:
+        by_deck_rows.setdefault(r["deck_id"], []).append(r)
+
+    learning_future_rows = conn.execute(
+        f"""SELECT deck_id, COUNT(*) AS cnt FROM cards
+            WHERE deck_id IN ({ph}) AND category = ?
+              AND state IN ('learning', 'relearn')
+              AND due > ?
+              AND deleted_at IS NULL
+              AND (buried_until IS NULL OR buried_until < ?)
+            GROUP BY deck_id""",
+        active_ids + [category, now, today],
+    ).fetchall()
+    learning_future = {r["deck_id"]: r["cnt"] for r in learning_future_rows}
+    conn.close()
+
+    for did in active_ids:
+        preset = presets.get(did) or {}
+        new_limit = preset.get("new_per_day", 20)
+        threshold = preset.get("learned_interval", 4)
+        new_done_today = new_today.get(did, 0)
+        new_remaining = max(0, new_limit - new_done_today)
+        rows = by_deck_rows.get(did, [])
+
+        def _is_learning(r) -> bool:
+            return (r["state"] in ("learning", "relearn")
+                    or (r["state"] == "review" and (r["interval"] or 0) < threshold))
+
+        learning = sum(1 for r in rows if _is_learning(r))
+        review = sum(1 for r in rows if r["state"] == "review" and not _is_learning(r))
+        new_avail = sum(1 for r in rows if r["state"] == "new")
+
+        result[did] = {
+            "new": min(new_avail, new_remaining),
+            "learning": learning,
+            "review": review,
+            "learning_future": learning_future.get(did, 0),
+        }
+    return result
 
 
 def count_due(deck_id: int, category: str) -> dict:
@@ -810,13 +978,18 @@ def count_due_any_cat(root_deck_id: int, lang: str | None = None) -> dict:
 def count_due_by_category(root_deck_id: int, lang: str | None = None) -> dict:
     """Per-category {new, learning, review} counts for mixed review display."""
     leaf_pairs = _leaf_decks_with_category(root_deck_id, lang=lang)
-    result: dict[str, dict[str, int]] = {}
+    ids_by_category: dict[str, list[int]] = {}
     for deck_id, category in leaf_pairs:
-        c = count_due(deck_id, category)
-        if category not in result:
-            result[category] = {"new": 0, "learning": 0, "review": 0}
-        for k in ("new", "learning", "review"):
-            result[category][k] += c[k]
+        ids_by_category.setdefault(category, []).append(deck_id)
+
+    result: dict[str, dict[str, int]] = {}
+    for category, cat_deck_ids in ids_by_category.items():
+        per_deck = _count_due_bulk(cat_deck_ids, category)
+        agg = {"new": 0, "learning": 0, "review": 0}
+        for c in per_deck.values():
+            for k in agg:
+                agg[k] += c[k]
+        result[category] = agg
 
     # Apply root deck's per-category new cap (Anki parent-deck behaviour)
     today = anki_today().isoformat()
@@ -847,14 +1020,45 @@ def get_due_cards_multi(deck_ids: list[int], category: str, *, root_deck_id: int
     root_deck_id: if provided, its new_per_day limit acts as a combined cap
     across all leaf decks (Anki parent-deck behaviour).
     """
+    # Batch-fetch what get_due_cards() would otherwise look up per deck (issue
+    # #513: this was 2 preset queries + 1 new-count query PER deck — for a
+    # 111-leaf aggregate deck that's 300+ queries just for these inputs).
+    presets_by_cat = _get_presets_bulk(deck_ids, category)
+    presets_base = _get_presets_bulk(deck_ids, None)
+    new_today_map: dict[int, int] = {}
+    if deck_ids:
+        today = anki_today().isoformat()
+        conn = get_db()
+        ph = ",".join("?" * len(deck_ids))
+        rows = conn.execute(
+            f"""SELECT c.deck_id, COUNT(DISTINCT c.id) AS cnt FROM cards c
+                WHERE c.deck_id IN ({ph}) AND c.category = ?
+                  AND EXISTS (
+                    SELECT 1 FROM review_log rl
+                    WHERE rl.card_id = c.id AND date(rl.reviewed_at) = ?
+                  )
+                  AND NOT EXISTS (
+                    SELECT 1 FROM review_log rl
+                    WHERE rl.card_id = c.id AND date(rl.reviewed_at) < ?
+                  )
+                GROUP BY c.deck_id""",
+            deck_ids + [category, today, today],
+        ).fetchall()
+        new_today_map = {r["deck_id"]: r["cnt"] for r in rows}
+        conn.close()
+
     all_cards = []
     for deck_id in deck_ids:
-        all_cards.extend(get_due_cards(deck_id, category, sibling_suppression=sibling_suppression))
+        all_cards.extend(get_due_cards(
+            deck_id, category, sibling_suppression=sibling_suppression,
+            _preset=presets_by_cat.get(deck_id),
+            _new_done_today=new_today_map.get(deck_id, 0),
+        ))
 
     # Each deck may have its own learned_interval; a review card below its deck's
     # threshold is still "learning" and queues with the learning group.
     thresholds = {
-        did: (get_preset_for_deck(did) or {}).get("learned_interval", 4)
+        did: (presets_base.get(did) or {}).get("learned_interval", 4)
         for did in deck_ids
     }
     def _lrn(c: dict) -> bool:
@@ -879,7 +1083,7 @@ def get_due_cards_multi(deck_ids: list[int], category: str, *, root_deck_id: int
     review_cards.sort(key=lambda c: c["due"])
     # new_cards keep the per-deck gather/sort order from get_due_cards
 
-    preset = get_preset_for_deck(deck_ids[0]) if deck_ids else {}
+    preset = presets_base.get(deck_ids[0], {}) if deck_ids else {}
     nr_o = preset.get("new_review_order_override") or preset.get("new_review_order", "mixed")
 
     if nr_o == "new_first":
@@ -901,8 +1105,9 @@ def get_next_card_multi(deck_ids: list[int], category: str) -> dict | None:
 def count_due_multi(deck_ids: list[int], category: str, *, root_deck_id: int | None = None) -> dict:
     """Aggregate due counts across multiple decks."""
     total = {"new": 0, "learning": 0, "review": 0}
+    per_deck = _count_due_bulk(deck_ids, category)
     for deck_id in deck_ids:
-        c = count_due(deck_id, category)
+        c = per_deck.get(deck_id, {"new": 0, "learning": 0, "review": 0})
         for k in total:
             total[k] += c[k]
 

--- a/database/decks.py
+++ b/database/decks.py
@@ -1,5 +1,6 @@
 import re
 import sqlite3
+import time
 from datetime import date
 
 from .core import anki_today, get_db, _ensure_default_preset
@@ -30,6 +31,7 @@ def insert_deck(name: str, parent_id: int | None, preset_id: int,
     conn.commit()
     deck_id = cur.lastrowid
     conn.close()
+    _invalidate_locked_deck_cache()
     return deck_id
 
 
@@ -103,6 +105,7 @@ def rename_deck(deck_id: int, name: str) -> None:
     conn.execute("UPDATE decks SET name = ? WHERE id = ?", (name, deck_id))
     conn.commit()
     conn.close()
+    _invalidate_locked_deck_cache()
 
 
 def delete_deck(deck_id: int) -> None:
@@ -111,6 +114,7 @@ def delete_deck(deck_id: int) -> None:
     conn.execute("UPDATE decks SET deleted_at = datetime('now') WHERE id = ?", (deck_id,))
     conn.commit()
     conn.close()
+    _invalidate_locked_deck_cache()
 
 
 def delete_all_deck_cards(deck_id: int) -> int:
@@ -168,6 +172,7 @@ def restore_deck(deck_id: int) -> None:
     conn.execute("UPDATE decks SET deleted_at = NULL WHERE id = ?", (deck_id,))
     conn.commit()
     conn.close()
+    _invalidate_locked_deck_cache()
 
 
 def purge_all_cards_from_deck(deck_id: int) -> int:
@@ -233,6 +238,7 @@ def get_or_create_deck(name: str, parent_id: int | None = None,
     conn.commit()
     deck_id = cur.lastrowid
     conn.close()
+    _invalidate_locked_deck_cache()
     return deck_id
 
 
@@ -336,11 +342,33 @@ def parse_daily_deck_date(name: str, today: date | None = None) -> date | None:
     return None
 
 
+# get_locked_deck_ids() is called dozens/hundreds of times per /api/today
+# request for aggregate decks with many leaves (issue #513: it was doing a
+# full decks-table scan + regex-heavy tree walk on every single call, ~50%
+# of that endpoint's latency). Locked status only changes when a deck is
+# created/renamed/restored or the calendar day rolls over, so a short TTL
+# cache collapses the N+1 to ~1 recompute per few seconds with negligible
+# staleness for a single-user app.
+_locked_deck_cache: dict = {"ts": 0.0, "value": None}
+_LOCKED_DECK_CACHE_TTL = 10.0  # seconds
+
+
+def _invalidate_locked_deck_cache() -> None:
+    """Force the next get_locked_deck_ids() call to recompute — called after any
+    write that can change deck name/parent/deleted_at (issue #513 cache)."""
+    _locked_deck_cache["value"] = None
+
+
 def get_locked_deck_ids() -> dict[int, str]:
     """Return {deck_id: unlock_date_iso} for every deck locked because it is a
     future-dated daily deck (a date-named child of a 'daily' root) or a descendant
     of one. Locked decks contribute no due cards and cannot be reviewed until then.
     """
+    now_ts = time.time()
+    if (_locked_deck_cache["value"] is not None
+            and now_ts - _locked_deck_cache["ts"] < _LOCKED_DECK_CACHE_TTL):
+        return _locked_deck_cache["value"]
+
     today = anki_today()
     conn = get_db()
     rows = conn.execute(
@@ -370,6 +398,9 @@ def get_locked_deck_ids() -> dict[int, str]:
             locked[cur] = iso
             for kid in children.get(cur, []):
                 stack.append(kid["id"])
+
+    _locked_deck_cache["value"] = locked
+    _locked_deck_cache["ts"] = now_ts
     return locked
 
 

--- a/main.py
+++ b/main.py
@@ -190,6 +190,7 @@ try:
     from fastapi import FastAPI, Request
     from fastapi.staticfiles import StaticFiles
     from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse
+    from starlette.middleware.gzip import GZipMiddleware
     import uvicorn
 
     from routes import decks, review, story, browse, imports, podcast as podcast_routes
@@ -211,6 +212,10 @@ try:
             logger.info("[dev] DB and TTS cache cleared on exit.")
 
     app = FastAPI(title="AnkiAdvanced", lifespan=lifespan)
+
+    # gzip JSON/JS/CSS responses over ~500 bytes (issue #513: app.js is ~9000
+    # lines uncompressed, and /api/decks etc. can also be sizeable JSON).
+    app.add_middleware(GZipMiddleware, minimum_size=500)
 
     ui_logger = logging.getLogger("ui")
 
@@ -300,6 +305,18 @@ try:
             logger.info("%s %s: %d ms", request.method, path, ms)
         else:
             logger.debug("%s %s: %d ms", request.method, path, ms)
+        return response
+
+    @app.middleware("http")
+    async def static_cache_headers(request: Request, call_next):
+        """Short max-age + must-revalidate for /static/* (issue #513): browsers
+        skip the request entirely for 60s instead of always round-tripping, but
+        deploys (~2min after a PR merges) are still picked up quickly since the
+        cache is short and StaticFiles' ETag/Last-Modified handle revalidation.
+        """
+        response = await call_next(request)
+        if request.url.path.startswith("/static/"):
+            response.headers["Cache-Control"] = "public, max-age=60, must-revalidate"
         return response
 
     if os.path.exists("static"):

--- a/routes/story.py
+++ b/routes/story.py
@@ -803,7 +803,10 @@ def story_count(deck_id: int, category: str, lang: str | None = None):
 async def tts_file(text: str, lang: str = "zh"):
     """Return the cached mp3 for text (generating it if needed). Used by the browser Audio API."""
     path = await tts.get_cached_path(text, lang=lang)
-    return FileResponse(path, media_type="audio/mpeg")
+    # Content-addressed by (text, lang) — the file at this path never changes,
+    # so it's safe to cache aggressively (issue #513).
+    return FileResponse(path, media_type="audio/mpeg",
+                         headers={"Cache-Control": "public, max-age=31536000, immutable"})
 
 
 # 以下四个端点（speak/speak-multi/speak-status/speak-stop）通过 afplay/say 在服务器端播放音频，

--- a/schema.sql
+++ b/schema.sql
@@ -535,6 +535,11 @@ CREATE INDEX IF NOT EXISTS idx_cards_due
 CREATE INDEX IF NOT EXISTS idx_review_log_card_date
     ON review_log(card_id, reviewed_at);
 
+-- Supports calendar-stats / card-evolution date-range scans over review_log
+-- that aren't filtered by a specific card_id (issue #513).
+CREATE INDEX IF NOT EXISTS idx_review_log_reviewed_at
+    ON review_log(reviewed_at);
+
 -- ---------------------------------------------------------------------------
 -- Morning pregen configuration (issue #473): per deck+category story mode the
 -- 06:00 pregen uses — independent of whatever was regenerated during the day


### PR DESCRIPTION
Closes #513

## 背景

生产日志显示聚合牌组（deck_id=24，111 个叶子牌组/类别）下：
- `/api/today/24/creating` 每张卡 2–4 秒
- `/api/story/24/creating/count` 1.4–1.9 秒
- `/api/card-evolution`、`/api/calendar-stats` 各 1.7–1.8 秒

## 根因

用 19MB 生产库快照（`/api/decks?...` 见 deck 24 下 111×3=333 个叶子牌组）本地
cProfile 定位：`/api/today/24/creating` 单次请求触发约 **1300 次 SQL 查询**，
主要来自两处 N+1：

1. **`get_locked_deck_ids()` 全表扫描 N+1**：`count_due()` 每次调用都会重新
   查询全部 decks 并重建"每日锁定牌组"树（正则解析日期）。111/333 个叶子牌组的
   请求触发 300+ 次重复的全表扫描，占请求总耗时 **~47%**。
2. **`count_due_multi()`/`count_due_by_category()`/`get_due_cards_multi()`
   逐牌组循环**：每个叶子牌组各自开连接、查预设（2 次）、查今日新卡数、查到期
   卡、查未来学习卡——完全没有批量化。

## 修复

1. `get_locked_deck_ids()` 加 10 秒 TTL 缓存 + 建牌组/改名/删除/恢复后主动失效
   （`database/decks.py`）
2. 新增 `_count_due_bulk()` / `_get_presets_bulk()`，用 `deck_id IN (...)` +
   `GROUP BY` 批量查询替代逐牌组循环，`count_due_multi()`、
   `count_due_by_category()`、`get_due_cards_multi()` 全部改用批量版本；
   `get_due_cards()` 新增可选 `_preset`/`_new_done_today` 参数供批量调用方跳过
   内部查询，单牌组调用路径不变（`database/cards.py`）
3. `review_log(reviewed_at)` 加索引，供 calendar-stats/card-evolution 的日期
   范围扫描使用（`schema.sql`）
4. `GZipMiddleware`（>500 字节响应压缩）+ `/static/*` 60 秒 Cache-Control +
   `/api/tts-file` 一年 immutable 缓存（内容按 text+lang 寻址，永不变）
   （`main.py`、`routes/story.py`）

**没有改变任何接口的返回内容/语义**——所有计数/排序逻辑原样保留，只是把
"逐牌组重复查询"改成"批量查询后按牌组分组"。

## 实测（同一份生产库快照，本地 8123 端口，3 次取值）

| 接口 | 修复前 | 修复后 | 倍数 |
|---|---|---|---|
| `GET /api/today/24/creating` | 0.87–1.56s | 0.03–0.04s | ~30x |
| `GET /api/today/24/listening` | 1.02–1.56s | 0.03–0.13s | ~15–30x |
| `GET /api/story/24/creating/count` | 0.36–0.43s | 0.09–0.14s | ~4x |
| `GET /api/decks` | 0.03–0.05s | 0.03–0.05s | 无明显变化（本就快） |
| `GET /api/card-evolution` | 0.06–0.08s | 0.06–0.08s | 无明显变化（本地库上本就快，见下） |
| `GET /api/calendar-stats` | 0.08–0.10s | 0.08–0.10s | 无明显变化（同上） |

`get_today()`（`/api/today/24/creating`）cProfile：**1.528s → 0.308s**（首次
构建队列，含一次性 `get_due_cards_multi`）；队列缓存命中后的稳定态请求降到
**~0.03s**。

`story_count()`（`/api/story/24/creating/count`）cProfile：**0.314s → 0.113s**。

## 验证

- `python3 -m py_compile` 全部改动文件通过
- `import main` 通过（导入检查）
- **`/api/decks`、`/api/today/24/creating`、`/api/today/24/listening`、
  `/api/story/24/creating/count` 的 JSON 输出在改动前后逐字节 diff 完全一致**
  （用 `git stash` 切回改动前代码、同一份数据库快照分别跑一遍对比）
- 8123 端口测试服务器已 kill，`data/perf_test.db` 快照已删除

## 未修复、值得后续跟进

- `/api/card-evolution`、`/api/calendar-stats` 在本地这份 19MB / 2.2 万条
  review_log 的快照上本来就只要 60–90ms，复现不出生产报告的 1.7–1.8 秒——
  怀疑生产库更大或服务器磁盘/CPU 更慢，值得日后在生产上加计时日志细查（已加
  `idx_review_log_reviewed_at` 索引作为预防性优化，但目前的日期分桶查询用了
  `date(datetime(rl.reviewed_at,'localtime','-4 hours'))` 表达式，SQLite 无法
  用普通索引加速——如果生产确认还是慢，需要改造成先用一个宽松的
  `reviewed_at >= ?` 走索引预过滤，再精确按天分桶）
- `POST /api/preload-session` 报告的 4.3 秒主要是 edge-tts 语音合成的网络 I/O，
  不是数据库问题，本次未处理
- `get_due_cards()` 内部仍是逐牌组各查一次到期卡行（`SELECT ... JOIN entries`），
  只是省掉了预设/新卡数查询；如果以后叶子牌组数继续增长，可以考虑把这一步也
  合并成一次 `deck_id IN (...)` 查询、按牌组分组后复用现有的逐牌组排序逻辑——
  这次评估后觉得排序逻辑（new_gather_order/review_sort_order 等）足够复杂，
  改动风险大于当前收益，先不动

🤖 Generated with [Claude Code](https://claude.com/claude-code)