### PR TITLE
feat: API 费用弹窗改为操作流水（时间倒序+展开明细+提示词查看）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -71,6 +71,17 @@ def _openai_client(model: str) -> openai.OpenAI:
     raise ValueError(f"Unknown provider for model: {model}")
 
 
+def _extract_prompt(messages: list) -> str:
+    """Join the content of all user-role messages (for cost-modal display).
+
+    Truncation to a display-safe length happens in database.log_api_call, not
+    here — never trust the caller to have already truncated.
+    """
+    return "\n\n".join(
+        m.get("content", "") for m in messages if m.get("role") == "user"
+    )
+
+
 def _call_api(model: str, messages: list, max_tokens: int, purpose: str,
               thinking: bool = False) -> str:
     """Call the appropriate provider, log usage, and return the raw text response.
@@ -80,6 +91,7 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str,
               explicitly disable it for tasks that don't need chain-of-thought.
     """
     t0 = time.time()
+    prompt_text = _extract_prompt(messages)
     if model.startswith("claude-"):
         client = anthropic.Anthropic()
         msg = client.messages.create(model=model, max_tokens=max_tokens, messages=messages)
@@ -96,6 +108,7 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str,
             output_tokens=msg.usage.output_tokens,
             purpose=purpose,
             cached_input_tokens=cached_tokens,
+            prompt=prompt_text,
         )
         return msg.content[0].text.strip()
     else:
@@ -153,6 +166,7 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str,
             output_tokens=resp.usage.completion_tokens,
             purpose=purpose,
             cached_input_tokens=cached_tokens,
+            prompt=prompt_text,
         )
 
         if choice.finish_reason == "length":

--- a/database/core.py
+++ b/database/core.py
@@ -167,6 +167,12 @@ def init_db() -> None:
     api_call_log_cols = {r["name"] for r in conn.execute("PRAGMA table_info(api_call_log)").fetchall()}
     if "cached_input_tokens" not in api_call_log_cols:
         conn.execute("ALTER TABLE api_call_log ADD COLUMN cached_input_tokens INTEGER NOT NULL DEFAULT 0")
+    if "action_id" not in api_call_log_cols:
+        conn.execute("ALTER TABLE api_call_log ADD COLUMN action_id TEXT")
+    if "action_label" not in api_call_log_cols:
+        conn.execute("ALTER TABLE api_call_log ADD COLUMN action_label TEXT")
+    if "prompt" not in api_call_log_cols:
+        conn.execute("ALTER TABLE api_call_log ADD COLUMN prompt TEXT")
 
     story_cols = {r["name"] for r in conn.execute("PRAGMA table_info(stories)").fetchall()}
     if "prompt_text" not in story_cols:

--- a/database/stats.py
+++ b/database/stats.py
@@ -1,6 +1,9 @@
 import re
 import sqlite3
+import uuid
 import datetime as _dt
+from contextlib import contextmanager
+from contextvars import ContextVar
 from datetime import date, datetime
 from .core import get_db, anki_today
 
@@ -154,39 +157,79 @@ def _row_cost(row: dict) -> float | None:
             row["output_tokens"] * pricing["output"]) / 1_000_000
 
 
-def _service_for_purpose(purpose: str) -> str:
-    """Map an api_call_log.purpose value to a UI-facing service grouping."""
-    if purpose == "story" or purpose == "kahneman" or purpose == "fix_commas" \
-            or purpose.startswith("regen:"):
-        return "Stories"
-    if purpose in ("news", "news-select", "briefing", "briefing_fact_check"):
-        return "News briefing"
-    if purpose == "paste":
-        return "Paste"
-    if purpose in ("podcast-summary", "podcast-transcribe"):
-        return "Podcast"
-    if purpose.startswith("enrich:") or purpose.startswith("hanzi:"):
-        return "Word enrichment"
-    return "Other"
+# Current "action" (a coherent unit of work that may make several API calls,
+# e.g. "generate a story" or "transcribe & summarize an episode") — issue #525.
+# Module-level ContextVar so log_api_call can tag calls without every caller
+# threading an action id/label through its call chain. contextvars are
+# per-thread/per-task by default and do NOT propagate into a thread started
+# with threading.Thread — callers running work in a background thread must
+# enter action_context() from *inside* that thread, not the thread that
+# spawned it.
+_ACTION_CTX: ContextVar[tuple[str, str] | None] = ContextVar("_action_ctx", default=None)
+
+
+@contextmanager
+def action_context(label: str):
+    """Tag every database.log_api_call() made inside this block with a shared
+    action_id/action_label, so the cost modal can group them as one operation.
+
+    Must be entered in the thread that will actually run the API calls.
+    """
+    token = _ACTION_CTX.set((uuid.uuid4().hex, label))
+    try:
+        yield
+    finally:
+        _ACTION_CTX.reset(token)
+
+
+# Prompts are stored for the cost-modal "show prompt" button but must not
+# bloat api_call_log or the /api/costs payload indefinitely — truncate here,
+# in the single place every log_api_call() caller funnels through, rather
+# than trusting each call site to have already truncated.
+_PROMPT_MAX_CHARS = 10000
 
 
 def log_api_call(model: str, input_tokens: int, output_tokens: int,
-                 purpose: str = "story", cached_input_tokens: int = 0) -> None:
+                 purpose: str = "story", cached_input_tokens: int = 0,
+                 prompt: str | None = None) -> None:
+    action = _ACTION_CTX.get()
+    action_id, action_label = action if action else (None, None)
+    if prompt is not None and len(prompt) > _PROMPT_MAX_CHARS:
+        prompt = prompt[:_PROMPT_MAX_CHARS]
+
     conn = get_db()
     conn.execute(
         """INSERT INTO api_call_log
-           (model, input_tokens, output_tokens, purpose, cached_input_tokens)
-           VALUES (?, ?, ?, ?, ?)""",
-        (model, input_tokens, output_tokens, purpose, cached_input_tokens),
+           (model, input_tokens, output_tokens, purpose, cached_input_tokens,
+            action_id, action_label, prompt)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (model, input_tokens, output_tokens, purpose, cached_input_tokens,
+         action_id, action_label, prompt),
     )
     conn.commit()
     conn.close()
 
 
-def get_api_costs() -> dict:
+def get_api_call_prompt(call_id: int) -> str | None:
     conn = get_db()
+    row = conn.execute(
+        "SELECT prompt FROM api_call_log WHERE id = ?", (call_id,)
+    ).fetchone()
+    conn.close()
+    if row is None:
+        return None
+    return row["prompt"]
+
+
+def get_api_costs(limit: int = 100) -> dict:
+    conn = get_db()
+    # Never SELECT prompt here — actions/calls feed the /api/costs payload and
+    # prompts are fetched on demand via get_api_call_prompt() instead.
     rows = [dict(r) for r in conn.execute(
-        "SELECT * FROM api_call_log ORDER BY called_at DESC"
+        """SELECT id, called_at, model, input_tokens, output_tokens, purpose,
+                  cached_input_tokens, action_id, action_label,
+                  (prompt IS NOT NULL) AS has_prompt
+           FROM api_call_log ORDER BY called_at DESC"""
     ).fetchall()]
     conn.close()
 
@@ -200,8 +243,12 @@ def get_api_costs() -> dict:
     unknown_calls = 0
     unknown_models: list[str] = []
 
-    # groups[(service, model)] -> aggregate dict
-    groups: dict[tuple[str, str], dict] = {}
+    # Group calls into "actions" — a shared action_id groups its calls into
+    # one operation; a NULL action_id (calls made outside action_context(),
+    # e.g. legacy rows predating #525) becomes its own single-call action,
+    # labeled by purpose.
+    actions: dict[str, dict] = {}
+    order: list[str] = []  # preserves first-seen order per synthetic key
 
     for r in rows:
         cost = _row_cost(r)
@@ -216,44 +263,47 @@ def get_api_costs() -> dict:
             if is_recent:
                 total_cost_30d += cost
 
-        service = _service_for_purpose(r["purpose"])
-        key = (service, r["model"])
-        g = groups.get(key)
-        if g is None:
-            g = groups[key] = {
-                "service": service, "model": r["model"],
-                "calls": 0, "input_tokens": 0, "output_tokens": 0,
-                "cached_tokens": 0, "cost": None,
-                "calls_30d": 0, "cost_30d": None,
+        if r["action_id"] is not None:
+            key = r["action_id"]
+            label = r["action_label"] or r["purpose"]
+        else:
+            key = f"call:{r['id']}"
+            label = r["purpose"]
+
+        a = actions.get(key)
+        if a is None:
+            a = actions[key] = {
+                "action_id": r["action_id"], "label": label,
+                "started_at": r["called_at"], "calls": [],
+                "call_count": 0, "total_cost": None,
             }
-        g["calls"] += 1
-        g["input_tokens"] += r["input_tokens"]
-        g["output_tokens"] += r["output_tokens"]
-        g["cached_tokens"] += r.get("cached_input_tokens") or 0
+            order.append(key)
+        # rows are in called_at DESC order, so the *last* row seen for this
+        # action has the earliest timestamp — keep that as started_at.
+        a["started_at"] = r["called_at"]
+        a["calls"].append({
+            "id": r["id"], "called_at": r["called_at"], "model": r["model"],
+            "purpose": r["purpose"], "input_tokens": r["input_tokens"],
+            "output_tokens": r["output_tokens"],
+            "cached_input_tokens": r["cached_input_tokens"] or 0,
+            "cost": round(cost, 6) if cost is not None else None,
+            "has_prompt": bool(r["has_prompt"]),
+        })
+        a["call_count"] += 1
         if cost is not None:
-            g["cost"] = (g["cost"] or 0.0) + cost
-        if is_recent:
-            g["calls_30d"] += 1
-            if cost is not None:
-                g["cost_30d"] = (g["cost_30d"] or 0.0) + cost
+            a["total_cost"] = (a["total_cost"] or 0.0) + cost
 
-    for g in groups.values():
-        if g["cost"] is not None:
-            g["cost"] = round(g["cost"], 6)
-        if g["cost_30d"] is not None:
-            g["cost_30d"] = round(g["cost_30d"], 6)
+    for a in actions.values():
+        if a["total_cost"] is not None:
+            a["total_cost"] = round(a["total_cost"], 6)
 
-    # Sort services as contiguous blocks (most expensive service first, then
-    # most expensive model within it) — the UI only prints the service name
-    # on the first row of each block, so blocks must stay together.
-    service_totals: dict[str, float] = {}
-    for g in groups.values():
-        service_totals[g["service"]] = service_totals.get(g["service"], 0.0) + (g["cost"] or 0.0)
-    groups_list = sorted(
-        groups.values(),
-        key=lambda g: (-service_totals[g["service"]], g["service"],
-                       -(g["cost"] if g["cost"] is not None else -1)),
-    )
+    # rows (and thus order) are already called_at DESC, and an action's
+    # started_at is its earliest call — sort actions by that so the most
+    # recently-started operation shows first, matching the flat log's order.
+    actions_list = sorted(
+        (actions[k] for k in order),
+        key=lambda a: a["started_at"], reverse=True,
+    )[:limit]
 
     return {
         "pricing_as_of": _PRICING_AS_OF,
@@ -261,7 +311,7 @@ def get_api_costs() -> dict:
         "total_cost_30d": round(total_cost_30d, 6),
         "unknown_calls": unknown_calls,
         "unknown_models": unknown_models,
-        "groups": groups_list,
+        "actions": actions_list,
     }
 
 

--- a/podcast.py
+++ b/podcast.py
@@ -1123,80 +1123,82 @@ def _process_episode(episode_id: int, video: dict, detail_level: str, summary: d
     """
     from routes.utils import DISABLE_AI
 
-    try:
-        # Reuse an already-stored transcript (#500): after e.g. an OpenAI-quota
-        # failure in the summary step, the retry must not re-run the whole
-        # transcription (a NotebookLM upload+indexing round takes ~10 minutes
-        # and Tingwu/Whisper cost money) — the transcript is already good.
-        existing = database.get_episode(episode_id) or {}
-        stored = (existing.get("transcript_zh") or "").strip()
-        if stored:
-            transcript = _normalize_transcript(stored)
-            meta = {"transcript_source": existing.get("transcript_source")}
-            logger.info("podcast: reusing existing transcript for %s (%d chars)",
-                        video["video_id"], len(transcript))
-            if transcript != stored:
-                database.update_episode(episode_id, transcript_zh=transcript)
-        else:
-            transcript, meta = fetch_transcript(video)
-            transcript = _normalize_transcript(transcript) if transcript else transcript
-            if not transcript:
-                database.update_episode(episode_id, status="no_transcript")
+    label = f"Transcribe & Summarize: {video['title'][:30]}"
+    with database.action_context(label):
+        try:
+            # Reuse an already-stored transcript (#500): after e.g. an OpenAI-quota
+            # failure in the summary step, the retry must not re-run the whole
+            # transcription (a NotebookLM upload+indexing round takes ~10 minutes
+            # and Tingwu/Whisper cost money) — the transcript is already good.
+            existing = database.get_episode(episode_id) or {}
+            stored = (existing.get("transcript_zh") or "").strip()
+            if stored:
+                transcript = _normalize_transcript(stored)
+                meta = {"transcript_source": existing.get("transcript_source")}
+                logger.info("podcast: reusing existing transcript for %s (%d chars)",
+                            video["video_id"], len(transcript))
+                if transcript != stored:
+                    database.update_episode(episode_id, transcript_zh=transcript)
+            else:
+                transcript, meta = fetch_transcript(video)
+                transcript = _normalize_transcript(transcript) if transcript else transcript
+                if not transcript:
+                    database.update_episode(episode_id, status="no_transcript")
+                    return
+                database.update_episode(
+                    episode_id, transcript_zh=transcript,
+                    transcript_source=meta.get("transcript_source"),
+                )
+
+            if DISABLE_AI:
+                # Dev mode: stop at pending with the transcript stored, no AI
+                # call, no email — matches DISABLE_AI's behavior for stories.
                 return
+
+            result = summarize(transcript, video["title"], detail_level)
+            if not result.get("summary_de"):
+                database.update_episode(episode_id, status="error",
+                                        error="AI summary failed or empty")
+                summary["failed"] += 1
+                return
+
+            words = filter_new_words(result.get("words") or [])
+            spotify_url = find_spotify_url(video["title"])
             database.update_episode(
-                episode_id, transcript_zh=transcript,
-                transcript_source=meta.get("transcript_source"),
+                episode_id,
+                summary_de=result["summary_de"],
+                hsk_words=words,
+                detail_level=detail_level,
+                spotify_url=spotify_url,
+                status="summarized",
             )
+            summary["summarized"] += 1
 
-        if DISABLE_AI:
-            # Dev mode: stop at pending with the transcript stored, no AI
-            # call, no email — matches DISABLE_AI's behavior for stories.
-            return
+            episode = database.get_episode(episode_id)
+            try:
+                sent = send_email(episode)
+            except Exception as e:
+                # An SMTP hiccup must not downgrade a successfully summarized
+                # episode to 'error' — the summary is stored and viewable on
+                # the website regardless; only email_sent_at stays unset.
+                logger.warning("podcast: email failed for %s: %s", video["video_id"], e)
+                sent = False
+            if sent:
+                from datetime import datetime
+                database.update_episode(episode_id, email_sent_at=datetime.now().isoformat())
+                summary["emailed"] += 1
 
-        result = summarize(transcript, video["title"], detail_level)
-        if not result.get("summary_de"):
-            database.update_episode(episode_id, status="error",
-                                    error="AI summary failed or empty")
+            try:
+                send_signal(episode)
+            except Exception as e:
+                # Signal and email are independent, best-effort channels — a
+                # signal-cli hiccup must not downgrade a successfully
+                # summarized episode to 'error' either.
+                logger.warning("podcast: Signal notification failed for %s: %s", video["video_id"], e)
+        except Exception as e:
+            logger.error("podcast: episode %s failed: %s", video["video_id"], e)
+            database.update_episode(episode_id, status="error", error=str(e))
             summary["failed"] += 1
-            return
-
-        words = filter_new_words(result.get("words") or [])
-        spotify_url = find_spotify_url(video["title"])
-        database.update_episode(
-            episode_id,
-            summary_de=result["summary_de"],
-            hsk_words=words,
-            detail_level=detail_level,
-            spotify_url=spotify_url,
-            status="summarized",
-        )
-        summary["summarized"] += 1
-
-        episode = database.get_episode(episode_id)
-        try:
-            sent = send_email(episode)
-        except Exception as e:
-            # An SMTP hiccup must not downgrade a successfully summarized
-            # episode to 'error' — the summary is stored and viewable on
-            # the website regardless; only email_sent_at stays unset.
-            logger.warning("podcast: email failed for %s: %s", video["video_id"], e)
-            sent = False
-        if sent:
-            from datetime import datetime
-            database.update_episode(episode_id, email_sent_at=datetime.now().isoformat())
-            summary["emailed"] += 1
-
-        try:
-            send_signal(episode)
-        except Exception as e:
-            # Signal and email are independent, best-effort channels — a
-            # signal-cli hiccup must not downgrade a successfully
-            # summarized episode to 'error' either.
-            logger.warning("podcast: Signal notification failed for %s: %s", video["video_id"], e)
-    except Exception as e:
-        logger.error("podcast: episode %s failed: %s", video["video_id"], e)
-        database.update_episode(episode_id, status="error", error=str(e))
-        summary["failed"] += 1
 
 
 def retry_episode(episode_id: int) -> dict:

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -502,8 +502,16 @@ def get_card_evolution(days: int = 365, deck_id: int | None = None, lang: str | 
 
 
 @router.get("/api/costs")
-def get_api_costs():
-    return {**database.get_api_costs(), "deepseek_balance": ai.get_deepseek_balance()}
+def get_api_costs(limit: int = 100):
+    return {**database.get_api_costs(limit=limit), "deepseek_balance": ai.get_deepseek_balance()}
+
+
+@router.get("/api/costs/call/{call_id}")
+def get_api_cost_call_prompt(call_id: int):
+    prompt = database.get_api_call_prompt(call_id)
+    if prompt is None:
+        raise HTTPException(status_code=404, detail="Call not found or has no stored prompt")
+    return {"id": call_id, "prompt": prompt}
 
 
 @router.get("/api/pinyin")

--- a/routes/story.py
+++ b/routes/story.py
@@ -195,6 +195,37 @@ def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
     lang = lang or database.get_deck_lang(deck_id)
     ai.fix_definition_commas(cards)
     ai._story_progress[progress_key] = {"phase": "starting", "msg": "Starting…", "percent": 5}
+    with database.action_context(_action_label_for_story(mode, deck_id)):
+        return _generate_and_store_body(
+            deck_id, category, today, cards,
+            topic=topic, max_hsk=max_hsk, model=model, grammar_focus=grammar_focus,
+            grammar_pct=grammar_pct, mode=mode, chapter_ids=chapter_ids,
+            articles=articles, progress_key=progress_key, lang=lang,
+            origin=origin, episode_id=episode_id,
+        )
+
+
+def _action_label_for_story(mode: str, deck_id: int) -> str:
+    """Cost-modal action label for a story generation run (issue #525)."""
+    if mode == "briefing":
+        return "Generate News Flash"
+    if mode == "news":
+        return "Generate News"
+    if mode == "kahneman":
+        return "Generate Kahneman Story"
+    if mode == "paste":
+        return "Generate Paste Story"
+    if mode == "podcast":
+        return "Generate Podcast Review"
+    deck = database.get_deck(deck_id)
+    deck_name = deck["name"] if deck else str(deck_id)
+    return f"Generate Story: {deck_name}"
+
+
+def _generate_and_store_body(deck_id: int, category: str, today: str, cards: list, *,
+                             topic, max_hsk, model, grammar_focus, grammar_pct, mode,
+                             chapter_ids, articles, progress_key, lang: str,
+                             origin: str | None, episode_id: int | None) -> dict | None:
     try:
         if mode == "news":
             # Issue #512: the old auto-fetch-only "news" mode has been removed

--- a/schema.sql
+++ b/schema.sql
@@ -412,7 +412,10 @@ CREATE TABLE IF NOT EXISTS api_call_log (
     input_tokens         INTEGER NOT NULL,
     output_tokens        INTEGER NOT NULL,
     purpose              TEXT NOT NULL DEFAULT 'story',
-    cached_input_tokens  INTEGER NOT NULL DEFAULT 0
+    cached_input_tokens  INTEGER NOT NULL DEFAULT 0,
+    action_id            TEXT,
+    action_label         TEXT,
+    prompt               TEXT
 );
 
 -- ---------------------------------------------------------------------------

--- a/static/app.js
+++ b/static/app.js
@@ -3160,6 +3160,21 @@ function _prettyModel(model) {
     .replace('qwen-plus', 'Qwen Plus');
 }
 
+// called_at is stored as UTC "YYYY-MM-DD HH:MM:SS" (SQLite datetime('now'),
+// no timezone marker) — append 'Z' so Date parses it as UTC, then format in
+// the viewer's local time. Today's calls show just HH:MM; older ones get the
+// date prefixed.
+function _fmtCostTime(calledAt) {
+  const d = new Date(calledAt.replace(' ', 'T') + 'Z');
+  const now = new Date();
+  const pad = n => String(n).padStart(2, '0');
+  const hhmm = `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  const sameDay = d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() && d.getDate() === now.getDate();
+  if (sameDay) return hhmm;
+  return `${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${hhmm}`;
+}
+
 function renderCostModal(data) {
   const fmt = n => '$' + n.toFixed(2);
   const fmtCost = n => (n === null || n === undefined) ? '?' : '$' + n.toFixed(4);
@@ -3180,35 +3195,93 @@ function renderCostModal(data) {
       `(unknown models: ${data.unknown_models.join(', ')})</div>`;
   }
 
-  if (!data.groups.length) {
+  if (!data.actions.length) {
     html += '<div class="cost-empty">No API calls logged yet.</div>';
   } else {
-    html += `<table class="cost-table">
-      <thead><tr>
-        <th>Service</th><th>Model</th><th>Calls</th><th>Tokens in / out</th>
-        <th style="text-align:right">Cost (30d)</th><th style="text-align:right">Cost (all)</th>
-      </tr></thead><tbody>`;
-    let lastService = null;
-    for (const g of data.groups) {
-      const model = _prettyModel(g.model);
-      const showService = g.service !== lastService;
-      lastService = g.service;
-      const cachedTitle = g.cached_tokens > 0 ? ` title="(${g.cached_tokens.toLocaleString()} cached)"` : '';
-      html += `<tr>
-        <td>${showService ? g.service : ''}</td>
-        <td><span class="cost-model">${model}</span></td>
-        <td class="cost-num" style="color:var(--muted)">${g.calls.toLocaleString()}</td>
-        <td class="cost-num" style="color:var(--muted)"${cachedTitle}>${g.input_tokens.toLocaleString()} / ${g.output_tokens.toLocaleString()}</td>
-        <td class="cost-num" style="color:var(--muted)">${fmtCost(g.cost_30d)}</td>
-        <td class="cost-num cost-value">${fmtCost(g.cost)}</td>
+    html += '<table class="cost-table cost-actions-table"><tbody>';
+    data.actions.forEach((a, idx) => {
+      const callWord = a.call_count === 1 ? 'call' : 'calls';
+      html += `<tr class="cost-action-row" onclick="toggleCostAction(${idx})">
+        <td class="cost-action-arrow" id="cost-action-arrow-${idx}">&#9656;</td>
+        <td class="cost-action-time">${_fmtCostTime(a.started_at)}</td>
+        <td class="cost-action-label">${_escHtml(a.label)}</td>
+        <td class="cost-num" style="color:var(--muted)">${a.call_count} ${callWord}</td>
+        <td class="cost-num cost-value">${fmtCost(a.total_cost)}</td>
       </tr>`;
-    }
+      html += `<tr class="cost-action-detail" id="cost-action-${idx}" style="display:none">
+        <td colspan="5">
+          <table class="cost-table cost-calls-table">
+            <thead><tr>
+              <th>Time</th><th>Model</th><th>Purpose</th><th>Tokens in / out</th>
+              <th style="text-align:right">Cost</th><th></th>
+            </tr></thead>
+            <tbody>`;
+      for (const c of a.calls) {
+        const model = _prettyModel(c.model);
+        const cachedTitle = c.cached_input_tokens > 0
+          ? ` title="(${c.cached_input_tokens.toLocaleString()} cached)"` : '';
+        const promptBtn = c.has_prompt
+          ? `<button class="cost-prompt-btn" onclick="event.stopPropagation(); showCostPrompt(${c.id})">Prompt</button>`
+          : '';
+        html += `<tr>
+          <td>${_fmtCostTime(c.called_at)}</td>
+          <td><span class="cost-model">${model}</span></td>
+          <td style="color:var(--muted)">${_escHtml(c.purpose)}</td>
+          <td class="cost-num" style="color:var(--muted)"${cachedTitle}>${c.input_tokens.toLocaleString()} / ${c.output_tokens.toLocaleString()}</td>
+          <td class="cost-num cost-value">${fmtCost(c.cost)}</td>
+          <td>${promptBtn}</td>
+        </tr>`;
+      }
+      html += '</tbody></table></td></tr>';
+    });
     html += '</tbody></table>';
   }
 
   html += `<div class="cost-footnote">Prices as of ${data.pricing_as_of} — edit database/stats.py when providers change pricing.</div>`;
 
   document.getElementById('cost-modal-body').innerHTML = html;
+}
+
+function toggleCostAction(idx) {
+  const row = document.getElementById('cost-action-' + idx);
+  const arrow = document.getElementById('cost-action-arrow-' + idx);
+  if (!row) return;
+  const open = row.style.display !== 'none';
+  row.style.display = open ? 'none' : 'table-row';
+  arrow.innerHTML = open ? '&#9656;' : '&#9662;';
+}
+
+async function showCostPrompt(callId) {
+  let overlay = document.getElementById('cost-prompt-overlay');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'cost-prompt-overlay';
+    overlay.className = 'cost-prompt-overlay';
+    overlay.innerHTML = `
+      <div class="cost-prompt-box">
+        <div class="cost-prompt-header">
+          <span>Prompt</span>
+          <button class="cost-prompt-close" onclick="closeCostPrompt()">&times;</button>
+        </div>
+        <pre class="cost-prompt-body" id="cost-prompt-body">Loading…</pre>
+      </div>`;
+    overlay.addEventListener('click', e => { if (e.target === overlay) closeCostPrompt(); });
+    document.body.appendChild(overlay);
+  }
+  overlay.style.display = 'flex';
+  const body = document.getElementById('cost-prompt-body');
+  body.textContent = 'Loading…';
+  try {
+    const data = await api('GET', `/api/costs/call/${callId}`);
+    body.textContent = data.prompt || '(no prompt stored)';
+  } catch (e) {
+    body.textContent = 'Failed to load prompt: ' + e.message;
+  }
+}
+
+function closeCostPrompt() {
+  const overlay = document.getElementById('cost-prompt-overlay');
+  if (overlay) overlay.style.display = 'none';
 }
 
 function renderStats(data) {

--- a/static/style.css
+++ b/static/style.css
@@ -3567,6 +3567,90 @@ select.opt-input {
 .cost-num { text-align: right; font-variant-numeric: tabular-nums; }
 .cost-value { color: var(--primary); font-weight: 600; }
 
+/* ── Cost modal: action timeline (issue #525) ───────────────────────────── */
+.cost-action-row { cursor: pointer; }
+.cost-action-arrow {
+  width: 16px;
+  color: var(--muted);
+  font-size: 11px;
+}
+.cost-action-time {
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+  white-space: nowrap;
+}
+.cost-action-label { font-weight: 500; }
+.cost-action-detail td { padding: 0 12px 12px; background: var(--bg); }
+.cost-calls-table { font-size: 12.5px; margin: 0; }
+.cost-calls-table th { background: transparent; padding: 6px 10px; }
+.cost-calls-table td { padding: 7px 10px; border-bottom: 1px solid var(--border); }
+.cost-calls-table tbody tr:last-child td { border-bottom: none; }
+.cost-prompt-btn {
+  background: var(--border);
+  border: none;
+  border-radius: 6px;
+  padding: 3px 9px;
+  font-size: 11px;
+  cursor: pointer;
+  color: var(--text);
+}
+.cost-prompt-btn:hover { background: var(--primary); color: #fff; }
+
+/* ── Cost modal: prompt viewer overlay ──────────────────────────────────── */
+.cost-prompt-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1100;
+  align-items: center;
+  justify-content: center;
+}
+.cost-prompt-box {
+  background: var(--card-bg, #fff);
+  border-radius: 12px;
+  width: min(720px, 92vw);
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+}
+.cost-prompt-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  font-weight: 600;
+  color: var(--text);
+}
+.cost-prompt-close {
+  background: none;
+  border: none;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--muted);
+  padding: 0 4px;
+}
+.cost-prompt-body {
+  margin: 0;
+  padding: 14px 16px;
+  overflow: auto;
+  max-height: 60vh;
+  font-family: monospace;
+  font-size: 12.5px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text);
+  background: var(--bg);
+}
+
+@media (prefers-color-scheme: dark) {
+  .cost-prompt-box { background: var(--card-bg, #1e1e1e); }
+}
+
 /* ── Model price info popup ─────────────────────────────────────────────── */
 .price-info-btn {
   background: none; border: none; cursor: pointer;


### PR DESCRIPTION
Closes #525

## 改了什么
Daniel 反馈 #508 的按服务归类'对我没用'——他要按时间倒序的**操作**列表。本 PR：
- **操作关联**：`database.action_context(label)`（contextvars），块内所有 AI 调用共享 action_id；故事各模式与播客管线已打标；无上下文的调用（含全部历史旧数据）自成单调用操作
- **提示词存储**：_call_api 把用户消息存入新 prompt 列（统一截断 10000 字符），前端按需经 `GET /api/costs/call/{id}` 拉取，费用列表载荷不受影响
- **前端**：▸ 09:42 Transcribe & Summarize: … · 3 calls · $0.021 → 点击展开每次调用（时间/模型/用途/tokens 含缓存/单价/Prompt 浮层）；操作标签与用途经 _escHtml 转义（主代理审查时补上——播客标题会进标签）
- 顶部总计/30 天/DeepSeek 余额/未知模型警告/价格日期保留

## 怎么测试的
子代理实现 + 主代理审查（补了两处 HTML 转义）+ 独立复测：迁移幂等、上下文分组（含后台线程内打标）、操作按时间倒序、总费用聚合、calls 不含 prompt 本体、20000 字符提示词截断到 10000、按需取回与 404。py_compile + import main + node --check 全绿。