### PR TITLE
功能: 早晨自动生成总开关——设置里可完全禁用

### DIFF
--- a/database/core.py
+++ b/database/core.py
@@ -537,6 +537,14 @@ def init_db() -> None:
         "INSERT OR IGNORE INTO podcast_config (key, value) VALUES ('summarizer', 'auto')")
     conn.commit()
 
+    # pregen_enabled seeding (issue #528): the master switch for morning
+    # pre-generation. Unconditional INSERT OR IGNORE (same pattern as the
+    # podcast_config keys above) so existing installs — including production —
+    # pick the default '1' (enabled) up without a migration.
+    conn.execute(
+        "INSERT OR IGNORE INTO app_settings (key, value) VALUES ('pregen_enabled', '1')")
+    conn.commit()
+
     # feeds (#497) seeding: RSS direct-link sources replacing the dead
     # YouTube channel_url (YouTube started bot-verifying the server's IP with
     # no Cookie fix that stuck, #491/#497). Same unconditional INSERT OR

--- a/database/stories.py
+++ b/database/stories.py
@@ -397,6 +397,28 @@ def get_pregen_config() -> list[dict]:
     return [dict(r) for r in rows]
 
 
+def get_app_setting(key: str, default: str | None = None) -> str | None:
+    """Read one generic app_settings value (issue #528), or `default` if the
+    key isn't present."""
+    conn = get_db()
+    row = conn.execute(
+        "SELECT value FROM app_settings WHERE key = ?", (key,)
+    ).fetchone()
+    conn.close()
+    return row["value"] if row else default
+
+
+def set_app_setting(key: str, value: str) -> None:
+    """Insert or update one generic app_settings value (issue #528)."""
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO app_settings (key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (key, value))
+    conn.commit()
+    conn.close()
+
+
 def set_pregen_config(deck_id: int, entries: list[dict]) -> None:
     """Replace the pregen config rows for one deck. entries: [{category, mode,
     max_hsk, lang?}] — categories omitted from the list are removed (mode

--- a/routes/story.py
+++ b/routes/story.py
@@ -933,6 +933,16 @@ async def pregen_today():
     A failure on one key is logged and does not stop the remaining keys.
     """
     today = database.anki_today().isoformat()
+
+    # Master switch (issue #528): when the user has turned morning pre-generation
+    # off in the settings, short-circuit before doing any work — the server-side
+    # cron still fires POST /api/pregen-today, but nothing is generated and no
+    # AI cost is incurred.
+    if database.get_app_setting("pregen_enabled", "1") != "1":
+        logger.info("pregen-today  DISABLED (pregen_enabled=0, user turned it off)")
+        return {"date": today, "disabled": True, "keys": 0, "generated": [],
+                "skipped_cached": [], "skipped_no_due": [], "failed": []}
+
     keys = database.get_recent_story_keys(today)
     # Explicit pregen config (issue #473) takes priority: its gen_params come
     # straight from the settings, never from whatever was regenerated during
@@ -1018,8 +1028,22 @@ _PREGEN_CATEGORIES = {"listening", "reading", "creating", "unified"}
 @router.get("/api/pregen-config")
 def get_pregen_config_endpoint():
     """Morning-pregen config rows (issue #473) — what the 06:00 pregen generates
-    per (deck, category), independent of the day's ad-hoc regenerations."""
-    return {"entries": database.get_pregen_config()}
+    per (deck, category), independent of the day's ad-hoc regenerations.
+    `enabled` (issue #528) is the master switch: when false, pregen-today does
+    nothing regardless of these rows."""
+    return {"entries": database.get_pregen_config(),
+            "enabled": database.get_app_setting("pregen_enabled", "1") == "1"}
+
+
+@router.put("/api/pregen-enabled")
+def put_pregen_enabled(body: dict):
+    """Master switch for morning pre-generation (issue #528). body: {"enabled":
+    bool}. When off, POST /api/pregen-today short-circuits and generates
+    nothing."""
+    enabled = bool(body.get("enabled"))
+    database.set_app_setting("pregen_enabled", "1" if enabled else "0")
+    logger.info("pregen-enabled  set to %s", enabled)
+    return {"ok": True, "enabled": enabled}
 
 
 @router.put("/api/pregen-config")

--- a/schema.sql
+++ b/schema.sql
@@ -557,6 +557,17 @@ CREATE TABLE IF NOT EXISTS pregen_config (
 );
 
 -- ---------------------------------------------------------------------------
+-- Generic key/value app settings (issue #528): global scalar toggles that
+-- don't belong to any deck/category. First key: pregen_enabled — the master
+-- switch for morning pre-generation (POST /api/pregen-today short-circuits
+-- when it's not '1').
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS app_settings (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+-- ---------------------------------------------------------------------------
 -- Podcast crawler (issue #479): discover new episodes from podcast RSS feeds
 -- (#497 — replaced the original YouTube-channel source), transcribe them,
 -- summarize into German, extract HSK5+ vocabulary, and email a notification.

--- a/scripts/morning_pregen.py
+++ b/scripts/morning_pregen.py
@@ -103,6 +103,10 @@ def main() -> int:
         _log("服务器没有返回汇总结果（响应为空），视为失败。")
         return 1
 
+    if summary.get("disabled"):
+        _log("早晨预生成已被用户在设置里关闭（pregen_enabled=0），本次不生成任何故事。")
+        return 0
+
     keys = summary.get("keys", 0)
     generated = summary.get("generated", [])
     skipped_cached = summary.get("skipped_cached", [])

--- a/static/app.js
+++ b/static/app.js
@@ -2614,6 +2614,7 @@ const PREGEN_MODE_OPTIONS = [
 let _pregenDecks = [];
 let _pregenEntries = [];
 let _pregenDeckId = null;
+let _pregenEnabled = true;
 
 async function _loadPregenSettings() {
   try {
@@ -2622,6 +2623,7 @@ async function _loadPregenSettings() {
       api('GET', '/api/decks'),
     ]);
     _pregenEntries = cfg.entries || [];
+    _pregenEnabled = cfg.enabled !== false;
     _pregenDecks = [];
     const walk = (nodes, depth) => (nodes || []).forEach(d => {
       _pregenDecks.push({ id: d.id, name: '  '.repeat(depth) + d.name });
@@ -2660,16 +2662,38 @@ function _renderPregenPanel() {
              value="${e?.max_hsk ?? 3}" title="Max HSK level for background vocabulary in the generated story" style="width:56px">
     </div>`;
   }).join('');
+  const dimmed = _pregenEnabled ? '' : 'opacity:0.4;pointer-events:none';
   el.innerHTML = `
     <div class="keymap-row">
-      <span class="keymap-label">Deck</span>
-      <select class="opt-input" id="pregen-deck-select" style="flex:1" onchange="_pregenSelectDeck(this.value)">${deckOpts}</select>
+      <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+        <input type="checkbox" id="pregen-enabled-switch" ${_pregenEnabled ? 'checked' : ''}
+               onchange="setPregenEnabled(this.checked)" style="width:18px;height:18px;cursor:pointer">
+        <span class="keymap-label">Enable morning pre-generation</span>
+      </label>
     </div>
-    ${rows}
-    <div class="keymap-row">
-      <button class="keymap-reset-all" onclick="savePregenConfig()">Save morning settings</button>
-      <span id="pregen-save-msg" class="keymap-label"></span>
+    ${_pregenEnabled ? '' :
+      '<p class="keymap-hint" style="margin:2px 0 8px">Off — the server generates nothing in the morning; open a category during the day to generate on demand.</p>'}
+    <div style="${dimmed}">
+      <div class="keymap-row">
+        <span class="keymap-label">Deck</span>
+        <select class="opt-input" id="pregen-deck-select" style="flex:1" onchange="_pregenSelectDeck(this.value)">${deckOpts}</select>
+      </div>
+      ${rows}
+      <div class="keymap-row">
+        <button class="keymap-reset-all" onclick="savePregenConfig()">Save morning settings</button>
+        <span id="pregen-save-msg" class="keymap-label"></span>
+      </div>
     </div>`;
+}
+
+async function setPregenEnabled(enabled) {
+  try {
+    const res = await api('PUT', '/api/pregen-enabled', { enabled });
+    _pregenEnabled = res?.enabled !== false && enabled;
+  } catch (e) {
+    _pregenEnabled = !enabled; // revert optimistic state on failure
+  }
+  _renderPregenPanel();
 }
 
 async function savePregenConfig() {


### PR DESCRIPTION
## 背景

早晨自动生成（故事预生成）由服务器 cron 06:00 跑 `scripts/morning_pregen.py` → `POST /api/pregen-today`。原来只能在 "Morning pre-generation" 面板按牌组/类别配置生成哪种故事，**没有一个全局总开关**能彻底关掉整个早晨生成。cron 在服务器上、Daniel 无法通过网页改 cron，所以禁用必须在端点层面拦截。

Closes #528

## 改动

- **新表 `app_settings(key, value)`**（通用键值设置）存 `pregen_enabled`，默认 `'1'`（开启）；无条件 `INSERT OR IGNORE` 播种，生产环境免迁移拾取。
- **`POST /api/pregen-today`**：开关关闭时在任何生成逻辑之前记日志并返回 `{disabled:true, keys:0, …}`——cron 照跑但零 AI 费用。
- **`GET /api/pregen-config`** 返回体附带 `enabled`；新增 **`PUT /api/pregen-enabled`** 切换。
- **`scripts/morning_pregen.py`** 识别 `disabled` 字段，日志提示"已被用户关闭"，返回码 0（不算失败）。
- **设置页面板顶部**加复选框总开关；关闭时下方 per-类别配置行灰显并给出说明。

## 测试

- Python + JS 语法检查通过。
- 临时数据库上验证 `get/set_app_setting` 读写与默认值。
- FastAPI TestClient 端到端验证：GET 带 `enabled` → PUT 关闭 → `pregen-today` 短路返回 `disabled:true`（1ms，未进入生成）→ 重新开启后恢复正常。
- 未在 8000 端口起服务，用独立临时库测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)