### PR TITLE
feat: 播客通知改进——日期德国时区、Signal 消息重排、摘要 API 优先 DeepSeek

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Daniel 在中国需要 VPN 访问 GitHub。`gh` 命令报 `EOF` 错误时（`cur
 ├── importer.py            # YAML 词汇导入器（中文 + 法语格式）
 ├── ai.py                  # AI 提供商调用（每种提示词类型一个函数）
 ├── news_fetcher.py        # 新闻抓取（Tagesschau API + RSS；按天缓存 data/news_cache/）
-├── podcast.py              # 播客爬虫（#479）：播客 RSS 直链发现新单集（#497，退役 YouTube/yt-dlp）、每源 auto_process 开关+非自动源只入库元数据（#502，podcast_feeds 表）、转录链 NotebookLM 免费主力+听悟+Whisper 保底、单步异常不中止整链（#510 重排，链式降级，原 #498/#485/#486）、摘要 NotebookLM chat.ask 免费优先+gpt/DeepSeek API 链回退（#510）、HSK生词、邮件通知+Signal 通知（signal-cli 关联设备，发 Note to Self，#521，二者独立可选、互不影响）
+├── podcast.py              # 播客爬虫（#479）：播客 RSS 直链发现新单集（#497，退役 YouTube/yt-dlp）、每源 auto_process 开关+非自动源只入库元数据（#502，podcast_feeds 表）、转录链 NotebookLM 免费主力+听悟+Whisper 保底、单步异常不中止整链（#510 重排，链式降级，原 #498/#485/#486）、摘要 NotebookLM chat.ask 免费优先+DeepSeek/gpt API 链回退（api 路径内部 DeepSeek 优先省钱，#532）、HSK生词、邮件通知+Signal 通知（signal-cli 关联设备，发 Note to Self，#521，二者独立可选、互不影响；消息抬头播客名·星期·日期、链接在末尾，单集日期按 Europe/Berlin 显示，#532）
 ├── tts.py                 # edge-tts 封装
 ├── translator.py          # 翻译（Google Translate，deep-translator，可选）
 ├── yaml_fixer.py          # 修复 AI 生成的格式错误 YAML

--- a/ai.py
+++ b/ai.py
@@ -1986,13 +1986,12 @@ def summarize_podcast_transcript(transcript: str, title: str,
     transcript into a German summary + a list of HSK5+ vocabulary worth
     reviewing before listening.
 
-    Uses resolve_briefing_model() (OpenAI) first — the model is already
-    verified/cached there and gpt writes the best German. If that fails
-    (e.g. a 429 insufficient_quota on the OpenAI account, which blocked all
-    podcast summaries on 2026-07-12) it falls back to DEFAULT_MODEL
-    (DeepSeek) when its key is configured (#506): unlike the news briefing,
-    a podcast content summary isn't the censorship-sensitive case that
-    forced news onto OpenAI, so a cheap DeepSeek pass beats no summary.
+    Uses DEFAULT_MODEL (DeepSeek) first when DEEPSEEK_API_KEY is configured —
+    unlike the news briefing, a podcast content summary isn't the
+    censorship-sensitive case that forced news onto OpenAI, so a cheap
+    DeepSeek pass is preferred to save money (#532). Falls back to
+    resolve_briefing_model() (OpenAI/gpt) if DeepSeek is unavailable or its
+    reply fails to parse — gpt is the paid-but-reliable backstop.
 
     This is the "api" summarizer path — podcast.summarize() (#510) tries the
     free NotebookLM chat.ask path first when podcast_config.summarizer=auto,
@@ -2005,10 +2004,13 @@ def summarize_podcast_transcript(transcript: str, title: str,
     """
     prompt = build_podcast_summary_prompt(transcript, title, detail_level)
 
-    primary = resolve_briefing_model()
-    candidates = [primary]
-    if not primary.startswith("deepseek-") and os.environ.get("DEEPSEEK_API_KEY"):
+    candidates = []
+    if os.environ.get("DEEPSEEK_API_KEY"):
         candidates.append(DEFAULT_MODEL)
+    fallback = resolve_briefing_model()
+    if fallback not in candidates:
+        candidates.append(fallback)
+    primary = candidates[0]
     for model in candidates:
         try:
             raw = _call_api(model, [{"role": "user", "content": prompt}], 8192, purpose="podcast-summary")

--- a/database/podcast.py
+++ b/database/podcast.py
@@ -79,6 +79,15 @@ def get_feed(feed_id: int) -> dict | None:
     return dict(row) if row else None
 
 
+def get_feed_by_url(url: str) -> dict | None:
+    """Look up a feed by its RSS URL — episodes store the feed's url as
+    channel_id (#532: Signal notification needs the podcast title)."""
+    conn = get_db()
+    row = conn.execute("SELECT * FROM podcast_feeds WHERE url = ?", (url,)).fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
 def create_feed(url: str, title: str | None = None, auto_process: int = 0) -> int:
     """Insert a new feed row. Raises sqlite3.IntegrityError (caller/route
     turns it into a 400) if `url` is already subscribed (UNIQUE constraint)."""

--- a/podcast.py
+++ b/podcast.py
@@ -30,10 +30,12 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from datetime import datetime
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import parsedate_to_datetime
 from xml.etree import ElementTree
+from zoneinfo import ZoneInfo
 
 import ai
 import database
@@ -1055,9 +1057,28 @@ def send_signal(episode: dict) -> bool:
         for w in hsk_words[:10]
     )
 
-    lines = [f"🎙 {episode['title']}", transcript_link]
-    if episode.get("spotify_url"):
-        lines.append(episode["spotify_url"])
+    # 抬头行：播客名 · 星期几（德语） · 日期（#532）。播客名从 channel_id
+    # （feed 的 url）反查 podcast_feeds；查不到就省略播客名部分，只留星期+日期。
+    feed_title = None
+    channel_id = episode.get("channel_id")
+    if channel_id:
+        feed = database.get_feed_by_url(channel_id)
+        if feed:
+            feed_title = feed.get("title")
+
+    weekday_de = ["Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag", "Sonntag"]
+    date_part = None
+    raw_date = episode.get("published_at") or episode.get("created_at")
+    if raw_date:
+        try:
+            dt = datetime.fromisoformat(raw_date).astimezone(ZoneInfo("Europe/Berlin"))
+            date_part = f"{weekday_de[dt.weekday()]} · {dt.strftime('%d.%m.%Y')}"
+        except (ValueError, TypeError):
+            date_part = None
+
+    header_parts = [p for p in (feed_title, date_part) if p]
+    lines = [" · ".join(header_parts)] if header_parts else []
+    lines.append(f"🎙 {episode['title']}")
     if summary_de:
         lines.append("")
         lines.append(summary_de)
@@ -1065,6 +1086,10 @@ def send_signal(episode: dict) -> bool:
         lines.append("")
         lines.append("Neue HSK5+ Vokabeln:")
         lines.append(word_lines)
+    lines.append("")
+    lines.append(f"🔗 {transcript_link}")
+    if episode.get("spotify_url"):
+        lines.append(episode["spotify_url"])
     text = "\n".join(lines)
 
     try:

--- a/static/app.js
+++ b/static/app.js
@@ -2888,12 +2888,19 @@ function _formatPodcastDuration(seconds) {
   return `${Math.round(seconds / 60)} min`;
 }
 
+// 把 ISO 时间字符串转成柏林时区的 YYYY-MM-DD（#532：修正单集日期时区偏差）
+function _localDate(iso) {
+  if (!iso) return '';
+  try { return new Date(iso).toLocaleDateString('sv-SE', { timeZone: 'Europe/Berlin' }); }
+  catch (e) { return String(iso).slice(0, 10); }
+}
+
 function _renderPodcastEpisodeList() {
   const el = document.getElementById('view-podcast-content');
   if (!el) return;
   const feed = _podcastFeeds.find(f => f.id === _podcastCurrentFeedId);
   const rows = _podcastEpisodes.map(ep => {
-    const date = (ep.published_at || ep.created_at || '').slice(0, 10);
+    const date = _localDate(ep.published_at || ep.created_at || '');
     const status = ep.status || 'pending';
     const label = PODCAST_STATUS_LABEL[status] || status;
     const cls = PODCAST_STATUS_CLASS[status] || 'podcast-badge-muted';
@@ -2975,7 +2982,7 @@ function closePodcastDetail() {
 function _renderPodcastDetail(ep) {
   const el = document.getElementById('view-podcast-content');
   if (!el) return;
-  const date = (ep.published_at || ep.created_at || '').slice(0, 10);
+  const date = _localDate(ep.published_at || ep.created_at || '');
   // Keep the raw word objects around so click handlers can look them up by
   // index instead of serializing them into onclick attributes (avoids
   // quote/apostrophe escaping issues in word_zh/definition_de text).
@@ -6908,7 +6915,7 @@ function _renderPodcastEpisodes() {
       <input type="radio" class="podcast-episode-radio" name="podcast-episode" value="${ep.id}">
       <div class="kahneman-chapter-info">
         <span class="kahneman-chapter-title">${esc(ep.title || '(untitled)')}</span>
-        <span class="kahneman-chapter-concept">${esc((ep.published_at || '').slice(0, 10))} · ${esc(ep.summary_de || '')}</span>
+        <span class="kahneman-chapter-concept">${esc(_localDate(ep.published_at || ''))} · ${esc(ep.summary_de || '')}</span>
       </div>
     </label>`).join('');
 }


### PR DESCRIPTION
Daniel 试用 #530 按钮后提的三点改进（第 4 点摘要时间标注因需改转录层，单独在 #533 处理）。

## 改了什么
1. **日期差一天修正**：`published_at` 存的是 UTC，前端/Signal 直接 `slice(0,10)` 取 UTC 日期，德国时间已是次日却显示前一天。前端加 `_localDate()` 转 `Europe/Berlin`（三处调用点），`send_signal` 用 `zoneinfo` 同样转柏林时区。
2. **Signal 消息重排**：抬头行改为 `播客名 · 星期几(德语) · 日期`（播客名按 `channel_id` 反查 `podcast_feeds`，新增 `database.get_feed_by_url`），链接挪到消息末尾加 `🔗` 前缀。日期解析 try/except 包住，绝不阻断发送。
3. **摘要 API 回退优先 DeepSeek**：`summarize_podcast_transcript` 现优先便宜的 DeepSeek，gpt 兜底（Daniel 选"免费优先，回退 DeepSeek"）。NotebookLM 免费路径（`summarizer=auto`）不变仍优先。

## 怎么测试
打桩测试（mock DB/subprocess/AI，不启服务器）：`_localDate` UTC→柏林次日、`send_signal` 抬头含播客名/德语星期/日期且链接在末尾带 🔗、`summarize` 优先 DeepSeek——全部通过。`node --check` + `py_compile` 通过。

Closes #532