### PR TITLE
feat: 卡背加拼音/译文点击切换条，手机无键盘也能唤出

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -4682,6 +4682,7 @@ function revealAnswer() {
   _sentFrEl.style.display = (_alwaysTranslation && _sentFrEl.textContent) ? '' : 'none';
   _sentDeEl.style.display = (_alwaysTranslation && _sentDeEl.textContent) ? '' : 'none';
   _syncTransEye();
+  _syncCardToggleBar();
 
   // Kahneman concept box (compact: part + chapter title only) + reasoning light
   // bulb — Kahneman mode only. News flow shows context + clickable article
@@ -6154,6 +6155,36 @@ async function togglePinyin() {
   if (!text) return;
   await _loadPinyinRow(text);
   row.classList.toggle('pinyin-revealed');
+  _syncCardToggleBar();
+}
+
+// ── Back-side tap toggle bar (#535) ───────────────────────────────────────────
+// Gives touch/mouse users the p (pinyin) and t (translation) shortcuts on the
+// back of a card. Each button shows only when the card has that content and
+// highlights while it's currently visible, so tapping and pressing the key stay
+// in sync. Called on reveal and after every relevant toggle.
+function _syncCardToggleBar() {
+  const bar = document.getElementById('card-toggle-bar');
+  if (!bar) return;
+  const pinBtn   = document.getElementById('toggle-pinyin-btn');
+  const transBtn = document.getElementById('toggle-trans-btn');
+
+  // Pinyin: Chinese decks only (pypinyin garbles other scripts).
+  const pinAvail = currentCardLang() === 'zh' && !!(sentence?.sentence_zh || card?.word_zh);
+  pinBtn.style.display = pinAvail ? '' : 'none';
+  pinBtn.classList.toggle('active',
+    !!document.getElementById('pinyin-row')?.classList.contains('pinyin-revealed'));
+
+  // Translation: only when this card carries fr/de text.
+  const fr = document.getElementById('sentence-fr');
+  const de = document.getElementById('sentence-de');
+  const transAvail = !!(fr?.textContent || de?.textContent);
+  transBtn.style.display = transAvail ? '' : 'none';
+  const transVisible = (fr?.textContent && fr.style.display !== 'none') ||
+                       (de?.textContent && de.style.display !== 'none');
+  transBtn.classList.toggle('active', !!transVisible);
+
+  bar.style.display = (pinAvail || transAvail) ? '' : 'none';
 }
 
 // ── Translation toggle (German/French sentence translation) ───────────────────
@@ -6173,6 +6204,7 @@ function toggleTranslation() {
     localStorage.setItem('alwaysTranslation', '0');
   }
   _syncTransEye();
+  _syncCardToggleBar();
 }
 
 // Persistent "always show translation" preference (survives across sessions).

--- a/static/index.html
+++ b/static/index.html
@@ -216,6 +216,15 @@
               <div class="sentence" id="sentence-back"></div>
             </div>
 
+            <!-- Tap toggles for pinyin / translation — give touch/mouse users the
+                 p and t shortcuts on the back (mobile has no keyboard, #535). Each
+                 button appears only when the card has that content and highlights
+                 while it's showing; both mirror the keys and stay in sync. -->
+            <div class="card-toggle-bar" id="card-toggle-bar" style="display:none">
+              <button class="card-toggle-btn" id="toggle-pinyin-btn" onclick="togglePinyin()" style="display:none">拼音</button>
+              <button class="card-toggle-btn" id="toggle-trans-btn" onclick="toggleTranslation()" style="display:none">译文</button>
+            </div>
+
             <!-- 2. Pinyin row (hidden by default; press p to toggle) -->
             <div class="pinyin-row" id="pinyin-row"></div>
             <!-- French and German translation (hidden by default; press u to toggle).

--- a/static/style.css
+++ b/static/style.css
@@ -1415,6 +1415,36 @@ main.browse-open {
   filter: none;
 }
 
+/* Back-side tap toggles (#535): compact pills that mirror the p/t keys so
+   touch/mouse users can reveal pinyin and translation without a keyboard. */
+.card-toggle-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin: 4px 0 2px;
+}
+.card-toggle-btn {
+  flex: 0 0 auto;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  padding: 4px 11px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  opacity: 0.75;
+  transition: opacity 0.15s, color 0.15s, border-color 0.15s;
+  user-select: none;
+}
+.card-toggle-btn:hover { opacity: 1; }
+.card-toggle-btn.active { /* highlighted = content is currently showing */
+  opacity: 1;
+  color: var(--primary);
+  border-color: var(--primary);
+}
+
 .char-row:last-child { border-bottom: none; }
 .char-row-link  { cursor: pointer; }
 .char-row-link:hover { background: var(--bg); }


### PR DESCRIPTION
## 改了什么
在复习卡背面（句子下方）加了一个极小的胶囊切换条——`拼音` / `译文` 两个小按钮，点击即调用与快捷键完全相同的 `togglePinyin()` / `toggleTranslation()`。

## 为什么
拼音（`p`）、翻译（`t`）原先只能用键盘快捷键切换。手机和浏览器无键盘时，**听力/阅读/混合卡的背面**无法唤出拼音和句子翻译——现有的 👀 眼睛图标只在翻译已显示时才出现（它管的是永久显示偏好，不是首次唤出）。创建模式正面本就有可点按钮，不受影响。

## 细节
- 按钮只在该卡确有对应内容时出现：拼音仅中文牌组（`currentCardLang()==='zh'`）；译文仅有 fr/de 文本时
- 对应内容正在显示时按钮高亮（`.active`，用 `--primary` 色），与键盘操作状态实时同步
- 切换条物理上位于 `side-back` 内，卡片正面自动隐藏，无副作用
- 复用 `_syncCardToggleBar()`：在 `revealAnswer`、`togglePinyin`、`toggleTranslation` 三处调用
- 占用空间极小，风格（胶囊/muted 描边）与现有 UI 一致

## 怎么测
手机或浏览器上开始一张听力/阅读卡的复习 → 翻面 → 句子下方出现拼音/译文小按钮 → 点击可显示/隐藏对应内容，再次点击隐藏；桌面按 p/t 与点击状态保持同步。

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)