### PR TITLE
feat: 成本概览旧调用按时间聚合分组（#537）

### DIFF
--- a/database/stats.py
+++ b/database/stats.py
@@ -188,6 +188,19 @@ def action_context(label: str):
 # than trusting each call site to have already truncated.
 _PROMPT_MAX_CHARS = 10000
 
+# Rows predating the action_context() grouping (#525) have a NULL action_id.
+# Rather than list each on its own line, get_api_costs clusters NULL-action rows
+# that fired within this many seconds of each other into one synthetic "legacy"
+# action (#537) — a single story/briefing run made several calls seconds apart,
+# so time-adjacency reconstructs the action well enough for old history. Purely a
+# display-time heuristic (no DB write); such actions are flagged approx=True.
+_LEGACY_CLUSTER_GAP_SECONDS = 90
+
+# Auxiliary steps that ride along with a primary generation (comma cleanup, news
+# fact-check/repair) — excluded when labeling a legacy cluster so the row shows
+# the main action ("story"), not a 1:1 helper pass ("fix_commas").
+_AUX_PURPOSES = {"fix_commas", "briefing_fact_check", "briefing_repair"}
+
 
 def log_api_call(model: str, input_tokens: int, output_tokens: int,
                  purpose: str = "story", cached_input_tokens: int = 0,
@@ -221,6 +234,16 @@ def get_api_call_prompt(call_id: int) -> str | None:
     return row["prompt"]
 
 
+def _parse_log_time(called_at: str) -> _dt.datetime | None:
+    """Parse api_call_log.called_at ("YYYY-MM-DD HH:MM:SS", from SQLite's
+    datetime('now')) into a datetime, or None if it doesn't match — the caller
+    then treats the row as un-clusterable rather than crashing."""
+    try:
+        return _dt.datetime.strptime(called_at, "%Y-%m-%d %H:%M:%S")
+    except (ValueError, TypeError):
+        return None
+
+
 def get_api_costs(limit: int = 100) -> dict:
     conn = get_db()
     # Never SELECT prompt here — actions/calls feed the /api/costs payload and
@@ -243,12 +266,16 @@ def get_api_costs(limit: int = 100) -> dict:
     unknown_calls = 0
     unknown_models: list[str] = []
 
-    # Group calls into "actions" — a shared action_id groups its calls into
-    # one operation; a NULL action_id (calls made outside action_context(),
-    # e.g. legacy rows predating #525) becomes its own single-call action,
-    # labeled by purpose.
+    # Group calls into "actions". A shared action_id (database.action_context,
+    # #525) groups its calls into one operation. Rows with a NULL action_id
+    # predate #525; rather than list each on its own line, cluster the ones that
+    # fired close together in time into a synthetic "legacy" action (#537) — see
+    # _LEGACY_CLUSTER_GAP_SECONDS. Such actions are flagged approx=True and get
+    # labeled by their dominant purpose after the loop.
     actions: dict[str, dict] = {}
     order: list[str] = []  # preserves first-seen order per synthetic key
+    legacy_key: str | None = None            # open legacy cluster's key, or None
+    legacy_last: _dt.datetime | None = None  # timestamp of its most recent call
 
     for r in rows:
         cost = _row_cost(r)
@@ -266,16 +293,27 @@ def get_api_costs(limit: int = 100) -> dict:
         if r["action_id"] is not None:
             key = r["action_id"]
             label = r["action_label"] or r["purpose"]
+            approx = False
+            legacy_key = legacy_last = None  # a real action breaks any open cluster
         else:
-            key = f"call:{r['id']}"
-            label = r["purpose"]
+            ts = _parse_log_time(r["called_at"])
+            # rows are DESC, so legacy_last (the previous NULL row) is at or after
+            # ts — join the open cluster when the gap is small, else start a new one.
+            if (legacy_key is not None and legacy_last is not None and ts is not None
+                    and (legacy_last - ts).total_seconds() <= _LEGACY_CLUSTER_GAP_SECONDS):
+                key = legacy_key
+            else:
+                key = legacy_key = f"legacy:{r['id']}"
+            legacy_last = ts
+            label = None  # filled from dominant purpose after the loop
+            approx = True
 
         a = actions.get(key)
         if a is None:
             a = actions[key] = {
                 "action_id": r["action_id"], "label": label,
                 "started_at": r["called_at"], "calls": [],
-                "call_count": 0, "total_cost": None,
+                "call_count": 0, "total_cost": None, "approx": approx,
             }
             order.append(key)
         # rows are in called_at DESC order, so the *last* row seen for this
@@ -296,6 +334,15 @@ def get_api_costs(limit: int = 100) -> dict:
     for a in actions.values():
         if a["total_cost"] is not None:
             a["total_cost"] = round(a["total_cost"], 6)
+        # Legacy clusters have no stored label — name them by dominant purpose so
+        # the row reads e.g. "briefing · legacy" instead of a bare synthetic key.
+        # Ignore auxiliary steps (comma-fix, fact-check, repair) when picking the
+        # label so it reflects the primary action, not a cleanup pass tied 1:1 with it.
+        if a["label"] is None:
+            purposes = [c["purpose"] for c in a["calls"]]
+            primary = [p for p in purposes if p not in _AUX_PURPOSES] or purposes
+            dominant = max(set(primary), key=primary.count)
+            a["label"] = f"{dominant} · legacy"
 
     # rows (and thus order) are already called_at DESC, and an action's
     # started_at is its earliest call — sort actions by that so the most

--- a/static/app.js
+++ b/static/app.js
@@ -3264,10 +3264,15 @@ function renderCostModal(data) {
     html += '<table class="cost-table cost-actions-table"><tbody>';
     data.actions.forEach((a, idx) => {
       const callWord = a.call_count === 1 ? 'call' : 'calls';
+      // Legacy actions (#537) are reconstructed from time-adjacency, not a real
+      // action_id — flag them so the grouping reads as approximate, not exact.
+      const approxTag = a.approx
+        ? ` <span class="cost-approx-tag" title="Grouped by timing — these calls predate per-action tracking, so the grouping is approximate.">≈ grouped</span>`
+        : '';
       html += `<tr class="cost-action-row" onclick="toggleCostAction(${idx})">
         <td class="cost-action-arrow" id="cost-action-arrow-${idx}">&#9656;</td>
         <td class="cost-action-time">${_fmtCostTime(a.started_at)}</td>
-        <td class="cost-action-label">${_escHtml(a.label)}</td>
+        <td class="cost-action-label">${_escHtml(a.label)}${approxTag}</td>
         <td class="cost-num" style="color:var(--muted)">${a.call_count} ${callWord}</td>
         <td class="cost-num cost-value">${fmtCost(a.total_cost)}</td>
       </tr>`;

--- a/static/style.css
+++ b/static/style.css
@@ -3610,6 +3610,17 @@ select.opt-input {
   white-space: nowrap;
 }
 .cost-action-label { font-weight: 500; }
+.cost-approx-tag {
+  font-weight: 400;
+  font-size: 11px;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0 5px;
+  margin-left: 6px;
+  white-space: nowrap;
+  cursor: help;
+}
 .cost-action-detail td { padding: 0 12px 12px; background: var(--bg); }
 .cost-calls-table { font-size: 12.5px; margin: 0; }
 .cost-calls-table th { background: transparent; padding: 6px 10px; }


### PR DESCRIPTION
## 改了什么

成本概览弹窗里，**旧调用不再一行行平铺**——按时间相邻聚成可展开的动作。

议题 #525（今天 10:08 上线）的"按动作分组"只对上线后的新调用生效。诊断生产库发现全部 2952 行 `api_call_log` 的 `action_id` 都是 NULL（因为它们都产生于 #525 之前），所以概览全是平铺旧行。

- **`database.stats.get_api_costs`**：把 `action_id IS NULL` 且时间相邻（≤ `_LEGACY_CLUSTER_GAP_SECONDS`=90 秒）的旧行聚成一个合成 "legacy" 动作，`approx=True`，按**主用途**命名（排除 `fix_commas`/`briefing_fact_check`/`briefing_repair` 等辅助步骤），如 `story · legacy`。新增 `_parse_log_time` 辅助函数。
- **纯显示层**：不改数据库结构、不写任何数据、随时可回退。新调用仍以真实 `action_label` 精确分组，逻辑不变。
- **前端 `renderCostModal`**：近似聚合的动作显示 `≈ grouped` 标记（hover 有说明）；`has_prompt` 为假的旧调用不显示 Prompt 按钮（沿用既有逻辑）。

## 为什么

Daniel 反馈成本概览虽已按时间倒序，但把每一次 API 调用都单独列出，他希望**按动作**折叠（一次故事/一次新闻 = 一个动作，展开看内部每次调用）。分组功能其实已在 #525 做好，但只对新数据生效——本 PR 让历史数据也读起来一致。

## 怎么测试

临时库插入合成行（briefing burst、story+fix_commas burst、孤立 regen、带真实 action_id 的动作）跑 `get_api_costs`，验证：
- 时间相邻的旧行正确聚成一簇，标 `approx`；
- 标签取主用途（`story · legacy` 而非 `fix_commas · legacy`）；
- 带真实 `action_id` 的动作不受影响、`approx=false`。

`python -m py_compile` + 导入检查通过。未占用 8000 端口、未碰生产库。

Closes #537
