### PR TITLE
修复翻牌后音频延迟：#454 的 1 秒延迟只保留听力正面（#539）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -4786,14 +4786,13 @@ function revealAnswer() {
   renderVocabDetail();
   renderReviewCatRow();
 
-  // Auto-play audio on reveal for all categories, delayed per deck preset
-  // (issue #454). Clear any still-pending front-side autoplay first so the
-  // two timers can't both fire.
+  // Auto-play audio immediately on reveal (all categories). The autoplay delay
+  // (issue #454) exists only so the user can read the context before hearing
+  // the audio on the listening *front* — after flipping there's nothing left to
+  // read first, so play right away (issue #539). Clear any still-pending
+  // front-side autoplay first so the two timers can't both fire.
   clearTimeout(_autoplayTimer);
-  const _revealSnap = card;
-  _getAutoplayDelay().then(d => {
-    _autoplayTimer = setTimeout(() => { if (card === _revealSnap) playSentence(); }, d);
-  });
+  playSentence();
 }
 
 // ── Populate vocab detail (chars + examples) ────────────────────────────────


### PR DESCRIPTION
## 问题

议题 #454 引入自动播放延迟（`autoplay_delay_ms`，默认 1000ms），初衷是让**听力模式卡片正面**先延迟 1 秒再播放，方便先读上下文（新闻流的德语译文/背景）。但翻牌后（reveal / 卡背）的自动播放把同一延迟套用到了**所有类别**，结果读/写/听任何卡片一翻面音频都要等 1 秒——Daniel 反馈"感觉到处都被延迟了，这不是我要的"。

## 改动

`static/app.js` 翻牌逻辑（原 4789-4796）：翻牌后直接 `playSentence()` 立即播放，不再走 `_getAutoplayDelay()`。仍保留 `clearTimeout(_autoplayTimer)` 清除待触发的正面 autoplay 定时器。

延迟只保留在**听力正面**——三处 `category === 'listening'` 守卫的正面自动播放不变。

## 测试

- 听力卡：正面仍延迟 1 秒（先读上下文）✓
- 翻牌后（所有类别）：音频立即播放 ✓
- 读/写卡翻面：不再有 1 秒延迟 ✓

Closes #539