### PR TITLE
播客摘要改进：公司加中文名、更详细、Signal 发完整摘要（#541）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -1908,7 +1908,7 @@ idx is the item number in square brackets above."""
 _PODCAST_DETAIL_WORDS = {
     "short": "~150",
     "medium": "~300",
-    "detailed": "500-700",
+    "detailed": "900-1300",
 }
 
 
@@ -1920,8 +1920,9 @@ def build_podcast_summary_prompt(transcript: str, title: str, detail_level: str)
     either response the same way."""
     words_target = _PODCAST_DETAIL_WORDS.get(detail_level, _PODCAST_DETAIL_WORDS["detailed"])
     # Transcripts can be long (auto-captions of a 30-60min episode) — cap input
-    # to keep the request within a reasonable token budget.
-    excerpt = transcript[:20000]
+    # to keep the request within a reasonable token budget. Raised to 30000
+    # (#541) so a "detailed" summary can actually cover the whole episode.
+    excerpt = transcript[:30000]
 
     return f"""You are summarizing a Chinese-language podcast episode for a German-speaking
 learner of Chinese (HSK 4-5 level, learning towards HSK 6).
@@ -1934,8 +1935,16 @@ Transcript (Chinese, auto/manual captions, may contain minor recognition errors)
 Task:
 1. Write a detailed German-language summary of what is discussed in the episode, so the
    listener understands the content before listening. Target length: {words_target} words.
-   Structure it into multiple paragraphs. Wrap the most important vocabulary/terms/names in
-   <strong>...</strong> HTML tags (these become the highlighted words in the email).
+   Structure it into multiple paragraphs. Be concrete: include the specific facts, numbers,
+   names and arguments actually mentioned in the episode — do not stay generic or vague.
+   - Whenever you name a company, organization, brand or institution, add its common Chinese
+     name in parentheses right after it, e.g. "Airbnb (爱彼迎)", "Lawn Tennis Association
+     (英国草地网球协会)". If no established Chinese name exists, give a natural Chinese rendering.
+   - If (and ONLY if) the transcript contains timestamps, add an approximate timestamp in
+     parentheses when you introduce each major topic, e.g. "(ca. 12:30)", so the listener can
+     jump to it. If the transcript contains no timestamps, do NOT invent any.
+   Wrap the most important vocabulary/terms/names in <strong>...</strong> HTML tags (these
+   become the highlighted words in the email).
 2. Extract the 10-20 most important Chinese words/phrases from the transcript that are HSK
    level 5 or above (i.e. non-basic vocabulary Daniel would benefit from pre-learning). For
    each, give pinyin and a German definition.

--- a/podcast.py
+++ b/podcast.py
@@ -1036,11 +1036,14 @@ def send_signal(episode: dict) -> bool:
     public_base = os.environ.get("PUBLIC_BASE_URL", "https://powerdaniel3000.duckdns.org")
     transcript_link = f"{public_base}/#podcast-{episode['id']}"
 
-    # summary_de may be None; strip HTML tags (the email version is HTML)
-    # and cap length so the Signal message stays readable.
+    # summary_de may be None; strip HTML tags (the email version is HTML).
+    # Send the FULL summary (#541) — Daniel reads it directly in Signal and the
+    # old 1500-char cap cut it off mid-sentence. Keep only a high safety cap so
+    # a pathologically long summary can't produce a runaway message; a normal
+    # "detailed" summary (~900-1300 words ≈ up to ~9000 chars) fits well under it.
     summary_de = re.sub(r"<[^>]+>", "", episode.get("summary_de") or "").strip()
-    if len(summary_de) > 1500:
-        summary_de = summary_de[:1500].rstrip() + "…"
+    if len(summary_de) > 12000:
+        summary_de = summary_de[:12000].rstrip() + "…"
 
     # hsk_words comes back as a list from database.get_episode (_hydrate
     # parses the stored JSON), but be defensive in case a raw row or a


### PR DESCRIPTION
## 改了什么
针对播客邮件/Signal 摘要的三项改进（Closes #541）：

1. **公司名加中文名** —— `ai.build_podcast_summary_prompt` 新增规则：出现公司/机构/品牌时紧跟常用中文名，如 `Airbnb (爱彼迎)`。
2. **摘要更详细** —— `_PODCAST_DETAIL_WORDS['detailed']` 500-700 → 900-1300 字；提示词要求更具体（含事实/数字/名称）；输入 excerpt 上限 20000 → 30000，让详细摘要能覆盖整集。
3. **Signal 不再截断** —— `send_signal` 去掉 1500 字硬截断，发送完整摘要（保留 12000 字高位安全上限防极端超长）。

额外：提示词加入**条件式时间戳指令**（转录含时间戳才标注、否则不编造），为后续'转录时间戳数据落地'的 Issue 铺路，本 PR 不改转录逻辑。

## 为什么
Daniel 反馈：Signal 摘要在句中被切断、摘要偏短、公司名缺中文对照。

## 怎么测试
- 语法 + 导入检查已通过（`py_compile` / `import ai, podcast`）。
- 提示词纯文本改动 + Signal 字符上限调整，无接口/数据结构变化，向后兼容。

🤖 Generated with [Claude Code](https://claude.com/claude-code)