### PR TITLE
播客转录：听悟段级时间戳，摘要可标注大致时间点（#543）

### DIFF
--- a/podcast.py
+++ b/podcast.py
@@ -568,10 +568,39 @@ def _summarize_via_notebooklm(transcript: str, title: str, detail_level: str) ->
     return result
 
 
+def _fmt_timestamp(ms: float) -> str:
+    """Milliseconds -> "[MM:SS]" (or "[H:MM:SS]" past the hour) for prefixing
+    a transcript paragraph (#543), so the summary AI can cite roughly when a
+    topic was discussed."""
+    total = int(ms // 1000)
+    h, rem = divmod(total, 3600)
+    m, s = divmod(rem, 60)
+    return f"[{h}:{m:02d}:{s:02d}]" if h else f"[{m:02d}:{s:02d}]"
+
+
+def _paragraph_start_ms(p: dict) -> int | None:
+    """Extract a paragraph's start time in milliseconds from a Tingwu
+    paragraph (#543). Tingwu's exact key isn't verified against a real
+    response (see _parse_tingwu_transcript), so try the plausible paragraph-
+    level keys, then fall back to the first word's start. Returns None when no
+    timing is present — the caller then emits that paragraph without a prefix."""
+    for key in ("Start", "BeginTime", "StartTime"):
+        v = p.get(key)
+        if isinstance(v, (int, float)):
+            return int(v)
+    for w in p.get("Words") or []:
+        for key in ("Start", "BeginTime", "StartTime"):
+            v = w.get(key)
+            if isinstance(v, (int, float)):
+                return int(v)
+    return None
+
+
 def _parse_tingwu_transcript(result_json: dict) -> str:
     """Best-effort flatten of the Tingwu offline transcription result JSON
     (fetched from the URL in Result.Transcription once the task completes)
-    into plain text.
+    into plain text, each paragraph prefixed with its start timestamp when
+    available (#543).
 
     The documented shape is Transcription.Paragraphs[], each either carrying
     a Text field directly or a Words[] list of {Text: ...} tokens to join —
@@ -589,13 +618,14 @@ def _parse_tingwu_transcript(result_json: dict) -> str:
     )
     lines: list[str] = []
     for p in paragraphs:
-        if p.get("Text"):
-            lines.append(p["Text"])
-        else:
+        text = p.get("Text")
+        if not text:
             words = p.get("Words") or []
             text = "".join(w.get("Text", "") for w in words)
-            if text:
-                lines.append(text)
+        if not text:
+            continue
+        start_ms = _paragraph_start_ms(p)
+        lines.append(f"{_fmt_timestamp(start_ms)} {text}" if start_ms is not None else text)
     if lines:
         return " ".join(lines)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -196,8 +196,9 @@ feed。每个 feed **首次**被爬到时（该 feed 在库里一集都没有）
    膨胀）。用的是非官方库 `notebooklm-py`（见下方一次性设置），未认证时
    自动跳过（不报错）。
 
-`transcriber` 可选值：`auto`（默认，依次尝试听悟 → Whisper → NotebookLM）
-| `tingwu`（只走听悟）| `whisper`（跳过听悟，只走 Whisper，仍受时长门槛）
+`transcriber` 可选值：`auto`（默认，免费优先依次尝试 NotebookLM → 听悟 →
+Whisper，#510）| `tingwu`（只走听悟；听悟带段级时间戳，摘要可标注大致时间点，
+#543）| `whisper`（跳过听悟，只走 Whisper，仍受时长门槛）
 | `notebooklm`（只走 NotebookLM）| `off`（整条转录链都不走）。旧键
 `whisper_fallback=0` 仍兼容，等价于 `off`。
 

--- a/tests/test_podcast.py
+++ b/tests/test_podcast.py
@@ -1,0 +1,51 @@
+"""
+Tests for podcast.py — Tingwu transcript parsing with paragraph timestamps (#543).
+
+Fast tests, no credentials/network: feed _parse_tingwu_transcript synthetic
+Tingwu-shaped JSON and assert the flattened text carries [MM:SS] prefixes.
+"""
+
+import podcast
+
+
+def test_paragraph_level_start_becomes_timestamp():
+    """Each paragraph is prefixed with its start time; past the hour the
+    format grows to [H:MM:SS]."""
+    result = {"Transcription": {"Paragraphs": [
+        {"Text": "大家好欢迎收听", "Start": 0},
+        {"Text": "今天聊一聊房价", "Start": 754000},   # 12:34
+        {"Text": "最后总结", "Start": 3661000},        # 1:01:01
+    ]}}
+    assert podcast._parse_tingwu_transcript(result) == (
+        "[00:00] 大家好欢迎收听 [12:34] 今天聊一聊房价 [1:01:01] 最后总结"
+    )
+
+
+def test_words_start_used_when_paragraph_has_no_text():
+    """A paragraph given only as Words[] is joined, and its timestamp falls
+    back to the first word's start."""
+    result = {"Paragraphs": [
+        {"Words": [{"Text": "再", "Start": 5000}, {"Text": "见", "Start": 5400}]},
+    ]}
+    assert podcast._parse_tingwu_transcript(result) == "[00:05] 再见"
+
+
+def test_paragraph_without_timing_stays_plain():
+    """No start field anywhere -> the paragraph is emitted without a prefix
+    (never a broken '[..]')."""
+    result = {"Paragraphs": [{"Text": "无时间戳的一段"}]}
+    assert podcast._parse_tingwu_transcript(result) == "无时间戳的一段"
+
+
+def test_unknown_shape_falls_back_to_recursive_text_collection():
+    """An undocumented shape with no Paragraphs still degrades to the
+    concatenated Text strings (the pre-#543 fallback, unchanged)."""
+    result = {"Weird": {"Nested": [{"Text": "abc"}, {"Text": "def"}]}}
+    assert podcast._parse_tingwu_transcript(result) == "abc def"
+
+
+def test_fmt_timestamp_boundaries():
+    assert podcast._fmt_timestamp(0) == "[00:00]"
+    assert podcast._fmt_timestamp(59999) == "[00:59]"
+    assert podcast._fmt_timestamp(60000) == "[01:00]"
+    assert podcast._fmt_timestamp(3600000) == "[1:00:00]"


### PR DESCRIPTION
## 改了什么（Closes #543）
- `_parse_tingwu_transcript`：每个段落前缀其起始时间 `[MM:SS]`（超 1 小时 `[H:MM:SS]`）。时间取段级 `Start`/`BeginTime`/`StartTime`，缺失则用首词的对应字段（毫秒→时分秒）；完全无时间字段的段落退化为纯文本，不加坏前缀。
- 新增 `_fmt_timestamp` / `_paragraph_start_ms` 两个辅助函数。
- `tests/test_podcast.py`：5 个单元测试（段级/词级回退/无时间戳/未知形状兜底/格式边界）。
- `scripts/README.md`：修正 `auto` 顺序（实际是 NotebookLM → 听悟 → Whisper，#510），并记录听悟时间戳。

## 为什么
Daniel 希望摘要能标注某事大约第几分钟说的。摘要提示词已在 #541 加了'含时间戳才标注'的条件指令；本 PR 让听悟转录真正带上时间戳数据。

## 怎么测试
- `pytest tests/test_podcast.py` → 5 passed。
- 时间戳仅在 `transcriber=tingwu`（或 auto 且听悟命中）时生效；其余转录器无时间字段，摘要按条件指令自动不标注，向后兼容。
- 凭据配置 + transcriber 切换由 Daniel 一次性脚本完成，不在本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)