### PR TITLE
故事生成失败时自动落到词汇模式（离线兜底，#545）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1018,9 +1018,20 @@ function cap(s) { return s.charAt(0).toUpperCase() + s.slice(1); }
 
 function showError(msg) {
   const el = document.getElementById('error-banner');
+  el.classList.remove('notice');
   el.textContent = msg;
   el.style.display = 'block';
   setTimeout(() => { el.style.display = 'none'; }, 6000);
+}
+
+// Non-alarming amber notice (reuses the error banner). Used e.g. when a story
+// fails to generate and we silently fall back to words-only quick mode.
+function showNotice(msg) {
+  const el = document.getElementById('error-banner');
+  el.classList.add('notice');
+  el.textContent = msg;
+  el.style.display = 'block';
+  setTimeout(() => { el.style.display = 'none'; el.classList.remove('notice'); }, 6000);
 }
 
 // ── Deck list ───────────────────────────────────────────────────────────────
@@ -3792,8 +3803,7 @@ async function startReview(id, cat, name, noStory = false, quick = false) {
       await openStorySetup(count, { learningCount: learning, estimatedTokens: estimated_tokens });
     }
   } catch (e) {
-    showError('Failed to start session: ' + e.message);
-    showView('decks');
+    await _startQuickFallback(e.message);
     return;
   }
 }
@@ -3925,11 +3935,7 @@ async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mo
       storyData = await _fetchStoryOrNewsRegen(storyDeckId, storyCategory, topic, maxHsk, model,
         grammarFocus, grammarPct, mode, chapterIds, articles, bgUrl, episodeId);
     } catch (e) {
-      _stopFakeProgress(); _stopStoryProgressPoll(); _hideLoadingBgButton();
-      _showLoadingError('AI request failed', e.message);
-      await new Promise(r => setTimeout(r, 2500));
-      showError('Failed to start session: ' + e.message);
-      showView('decks');
+      await _startQuickFallback(e.message);
       return;
     }
 
@@ -3959,9 +3965,41 @@ async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mo
     showView('review');
     loadCard(todayData.card, todayData.counts);
   } catch (e) {
-    _stopFakeProgress(); _stopStoryProgressPoll(); _hideLoadingBgButton();
+    await _startQuickFallback(e.message);
+  }
+}
+
+// Story generation failed (network hiccup or AI provider unreachable). Rather than
+// kicking the user back to the deck list with nothing to review, silently fall back
+// to words-only quick mode so they can keep going (issue #545). /api/today hits the
+// local DB, so it works even when only the AI provider is down. Only if that also
+// fails (server itself unreachable) do we surface the error and return to the decks.
+async function _startQuickFallback(reason) {
+  _stopFakeProgress(); _stopStoryProgressPoll(); _hideLoadingBgButton();
+  _bgLeaveRequested = false; _bgActiveResume = null;
+  quickMode = true;
+  story = null;
+  sentence = null;
+  // Shown on the banner above the review view. If the fallback itself fails below,
+  // showError() overwrites this same element, so no contradictory message lingers.
+  showNotice('Story unavailable — words-only mode.');
+  try {
+    if (rootDeckId) {
+      // Mixed (all-category) session — reuse its own words-only path.
+      await _doStartReviewMixed(null, 2, null, null, 50, 'story', true);
+      return;
+    }
+    setLoading('Loading words…', true);
+    const todayData = await api('GET', `/api/today/${deckId}/${category}${_langQP('?')}`);
+    if (!todayData.card) { showView('done'); return; }
+    try {
+      await fetch(`/api/preload-session/${deckId}/${category}?quick=true${_langQP('&')}`, { method: 'POST' });
+    } catch (_) {}
+    showView('review');
+    loadCard(todayData.card, todayData.counts);
+  } catch (e) {
     _showLoadingError('Failed to load session', e.message);
-    await new Promise(r => setTimeout(r, 2500));
+    await new Promise(r => setTimeout(r, 2000));
     showError('Failed to start session: ' + e.message);
     showView('decks');
   }
@@ -4034,9 +4072,7 @@ async function startReviewMixed(id, name, noStory = false, quick = false) {
       openStorySetup(total, { isMixed: true, learningCount: learning, estimatedTokens: estimated_tokens });
     }
   } catch (e) {
-    showError('Failed to start session: ' + e.message);
-    rootDeckId = null;
-    showView('decks');
+    await _startQuickFallback(e.message);
   }
 }
 
@@ -4064,12 +4100,7 @@ async function _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPc
           ? await api('POST', `/api/story/${rootDeckId}/unified/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeId), { articles })
           : await api('GET', `/api/story/${rootDeckId}/unified` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeId));
       } catch (e) {
-        _stopFakeProgress(); _stopStoryProgressPoll();
-        _showLoadingError('AI request failed', e.message);
-        await new Promise(r => setTimeout(r, 2500));
-        showError('Failed to generate story: ' + e.message);
-        rootDeckId = null;
-        showView('decks');
+        await _startQuickFallback(e.message);
         return;
       }
       _stopFakeProgress(); _stopStoryProgressPoll();

--- a/static/style.css
+++ b/static/style.css
@@ -178,6 +178,12 @@ main.browse-open {
   font-size: 14px;
   display: none;
 }
+/* Info variant (amber, non-alarming): e.g. fell back to words-only mode */
+#error-banner.notice {
+  background: #fffbeb;
+  color: #92400e;
+  border-color: #fde68a;
+}
 
 /* Clickable banner: a background story finished generating */
 #bg-story-banner {


### PR DESCRIPTION
## 背景

Daniel 反馈：故事因网络/AI 提供商不可达生成不出来时，系统会弹错误并把他踢回牌组列表，导致**什么都复习不了**。他希望至少能看到词汇继续复习。

关键洞察：AI（如 DeepSeek）挂了但服务器正常时，`/api/today` 走本地 DB 照常工作——所以词汇模式（`quickMode`）在"AI 不可达"场景下真的能用。

## 改动

- 新增 `_startQuickFallback()`：故事生成失败时清理生成态、置 `quickMode=true`，按有无 `rootDeckId` 走单类别（`/api/today`+`loadCard`）或混合（`_doStartReviewMixed(noStory=true)`）快速路径继续复习。仅当 `/api/today` 也失败（服务器不可达）才回退到原来的报错+牌组列表。
- 新增 `showNotice()` + `#error-banner.notice` 琥珀色非报警提示条（"Story unavailable — words-only mode."）；若兜底本身失败，`showError()` 复用同一元素覆盖，不留矛盾信息。
- 接入失败路径：`startReview` catch、`_doStartReview` 内外层 catch、`startReviewMixed` catch、`_doStartReviewMixed` 内层 AI catch。
- `_doStartReviewMixed` **外层** catch 保持真错误，避免 `_doStartReviewMixed(noStory=true)` 无限递归。

各类别显示沿用现有 `quickMode` 行为，未改动：Listening 只播音频不显示文字、Creating 显示德语释义+输入框、Reading 中文词翻牌。

## 测试

- `node --check static/app.js` 通过。
- 手动核对递归安全：兜底的单类别分支不调 `_doStartReview`；混合分支调 `_doStartReviewMixed(noStory=true)` 跳过 AI 块，外层 catch 为终端错误，无死循环。

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)