### PR TITLE
新增「Words only」内容模式（单词复习，无故事，#547）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -6446,8 +6446,11 @@ function openStorySetup(sentenceCount, { isMixed = false, isUnfinished = false, 
   _setupIsMixed = isMixed;
   _setupIsUnfinished = isUnfinished;
   _setupIsDeckListRegen = false;
-  document.getElementById('setup-count-label').textContent =
+  const _countLabel = document.getElementById('setup-count-label');
+  _countLabel.textContent =
     `This story will have ${sentenceCount} sentence${sentenceCount !== 1 ? 's' : ''}.`;
+  // Remember this text so switching away from Words-only mode restores it (#547).
+  _countLabel.dataset.storyText = _countLabel.textContent;
   const warn = document.getElementById('setup-learning-warning');
   if (learningCount > 0) {
     warn.textContent = `⚠ ${learningCount} card${learningCount !== 1 ? 's' : ''} still in the Again queue. Generating now may cause a mismatch between story order and review order.`;
@@ -6533,6 +6536,24 @@ function updateSetupMode() {
   pasteSection.style.display = 'none';
   if (podcastSection) podcastSection.style.display = 'none';
   _autoSwitchModelForMode(mode);
+
+  // Words-only mode (issue #547): no story is generated, so the story-only
+  // controls (model, HSK-background level, grammar focus) don't apply — hide them.
+  // Non-vocab modes restore Model/HSK unconditionally; grammar follows the deck's
+  // language (Chinese-only, same rule as _applySetupLangRestrictions).
+  const isVocab = mode === 'vocab';
+  const modelLabel = document.getElementById('setup-model-label');
+  const hskLabel = document.getElementById('setup-hsk-label');
+  const grammarLabel = document.getElementById('setup-grammar-label');
+  if (modelLabel) modelLabel.style.display = isVocab ? 'none' : '';
+  if (hskLabel) hskLabel.style.display = isVocab ? 'none' : '';
+  if (grammarLabel) grammarLabel.style.display =
+    isVocab ? 'none' : ((_deckLangById[deckId] || 'zh') === 'zh' ? '' : 'none');
+  const countLabel = document.getElementById('setup-count-label');
+  // Restore the story-count text when switching back from Words-only mode.
+  if (!isVocab && countLabel && countLabel.dataset.storyText != null)
+    countLabel.textContent = countLabel.dataset.storyText;
+
   if (mode === 'qa') {
     topicLabel.childNodes[0].textContent = 'Question ';
     topicInput.placeholder = 'e.g. How was life in ancient China?';
@@ -6568,6 +6589,11 @@ function updateSetupMode() {
     if (podcastSection) podcastSection.style.display = 'block';
     btn.textContent = 'Generate podcast summary';
     _loadPodcastEpisodesForSetup();
+  } else if (mode === 'vocab') {
+    topicLabel.style.display = 'none';
+    kahnemanSection.style.display = 'none';
+    btn.textContent = 'Start (words only)';
+    if (countLabel) countLabel.textContent = 'Review the due words directly — no story is generated.';
   } else {
     topicLabel.childNodes[0].textContent = 'Topic ';
     topicInput.placeholder = 'e.g. a day at a coffee shop';
@@ -7022,6 +7048,24 @@ function confirmStorySetup() {
   }
   _currentStoryMode = mode;
   _closeSetupModal();
+  // Words-only mode (issue #547): no story to generate — start a quick words-only
+  // session directly, reusing the same path as the ⚡ speed button. Handled before
+  // the story-generation dispatch below so every entry point behaves consistently.
+  if (mode === 'vocab') {
+    quickMode = true;
+    story = null;
+    if (_setupIsDeckListRegen) {
+      // Deck-list ↺ targets a whole deck → words-only mixed (all-category) review.
+      rootDeckId = _deckListRegenId;
+      deckId = _deckListRegenId;
+      _doStartReviewMixed(null, 2, null, null, 50, 'story', true);
+    } else if (_setupIsMixed || rootDeckId) {
+      _doStartReviewMixed(null, 2, null, null, 50, 'story', true);
+    } else {
+      _doStartReview(null, 2);
+    }
+    return;
+  }
   if (_setupIsDeckListRegen) {
     _doRegenStoryForDeckList(_deckListRegenId, topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, articles, episodeId);
   } else if (_setupIsRegen) {
@@ -7530,8 +7574,11 @@ async function regenerateStoryFromList(deckId) {
     const data = await api('GET', `/api/story/${deckId}/unified/count${_langQP('?')}`);
     sentenceCount = data?.count ?? 0;
   } catch (_) {}
-  document.getElementById('setup-count-label').textContent =
+  const _countLabel = document.getElementById('setup-count-label');
+  _countLabel.textContent =
     `This story will have ${sentenceCount} sentence${sentenceCount !== 1 ? 's' : ''}.`;
+  // Remember this text so switching away from Words-only mode restores it (#547).
+  _countLabel.dataset.storyText = _countLabel.textContent;
   const warn = document.getElementById('setup-learning-warning');
   warn.style.display = 'none';
   const tokenWarn = document.getElementById('setup-token-warning');
@@ -7541,6 +7588,9 @@ async function regenerateStoryFromList(deckId) {
   document.getElementById('setup-grammar-pct').value = 50;
   document.getElementById('setup-hsk-slider').value = 3;
   updateHskLabel();
+  // Sync the per-mode control visibility to the current dropdown value (e.g. hide
+  // story-only controls when Words-only is selected, #547).
+  updateSetupMode();
   document.getElementById('setup-modal-overlay').style.display = 'block';
   document.getElementById('setup-modal').style.display = 'flex';
   document.getElementById('setup-topic').focus();

--- a/static/index.html
+++ b/static/index.html
@@ -706,6 +706,7 @@
         <option value="briefing" class="setup-mode-zh-only">🗞️ News flow — summary with German context</option>
         <option value="paste" class="setup-mode-zh-only">📋 Paste content — summarize anything</option>
         <option value="podcast" class="setup-mode-zh-only">🎙️ Podcast — summarize an episode</option>
+        <option value="vocab">🔤 Words only — no story, single vocab</option>
       </select>
     </label>
     <!-- Kahneman chapter selector (shown only in kahneman mode) -->
@@ -752,7 +753,7 @@
         <span style="font-size:13px;color:var(--muted,#888);white-space:nowrap">%</span>
       </div>
     </label>
-    <label class="edit-label">
+    <label class="edit-label" id="setup-model-label">
       <span style="display:flex;align-items:center;gap:6px">
         Model
         <button class="price-info-btn" onclick="togglePriceTable(event)" title="Pricing info">ℹ</button>
@@ -785,7 +786,7 @@
         <option value="gpt-5-mini">GPT-5 Mini — OpenAI, news mode</option>
       </select>
     </label>
-    <label class="edit-label">
+    <label class="edit-label" id="setup-hsk-label">
       Max HSK level for background vocabulary
       <div class="setup-slider-row">
         <span class="setup-slider-min">1</span>


### PR DESCRIPTION
## 背景

Daniel 想要一个**正式的内容模式**（不是隐藏的 ⚡ 快捷键），和 Story / News flow / Kahneman / Podcast 并列出现在生成弹窗里，选了之后不生成故事，每张卡只显示单个词汇。#545 的自动兜底是被动的；本 PR 是主动选择的模式。

## 改动（纯前端）

- **index.html**：内容模式下拉新增 `🔤 Words only — no story, single vocab`（所有语言可用，不限中文）；给 Model / HSK label 加 id 便于隐藏。
- **`updateSetupMode`**：vocab 时隐藏 topic / 语法 / 模型 / HSK 等只与故事生成有关的控件，按钮改 "Start (words only)"，计数提示改为"直接复习到期词汇，不生成故事"；切回非 vocab 时恢复模型/HSK/语法与故事计数文案。
- **`confirmStorySetup`**：在所有 regen/mixed 分发**之前**拦截 vocab，置 `quickMode=true`、`story=null`，按 单类别 / mixed / deck-list 决定路径，复用已有的 ⚡ 词汇会话逻辑（不调 AI）。
- **`regenerateStoryFromList`**：打开时补调 `updateSetupMode()`，让控件可见性与当前下拉值一致。

各类别显示沿用现有 `quickMode`：Listening 只播音频、Creating 显示德语释义+输入框、Reading 中文词翻牌。

## 关键点

- `openStorySetup` 的 `isUnfinished` 从不为 true，unfinished 不经此弹窗，无需处理。
- 无后端改动（vocab 无故事可存/预生成）。

## 测试

- `node --check static/app.js` 通过；index.html 可解析。
- 逐路径复核：vocab 拦截覆盖 fresh 单类别 / 单类别 regen / mixed / deck-list regen 四种上下文，分别落到 `_doStartReview`(quick) 或 `_doStartReviewMixed(noStory=true)`。

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)