### PR TITLE
卡片释义：德语放到英语前面并加粗（#549）

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -264,9 +264,9 @@
               <div class="word-big" id="word-zh"></div>
               <div class="word-pin" id="word-pin"></div>
               <div class="word-pos-row"><span class="word-pos" id="word-pos"></span><span class="word-register" id="word-register" style="display:none"></span></div>
+              <div class="word-def-de" id="word-def-de" style="display:none"></div>
               <div class="word-def" id="word-def"></div>
               <div class="word-def-fr" id="word-def-fr" style="display:none"></div>
-              <div class="word-def-de" id="word-def-de" style="display:none"></div>
             </div>
 
           </div>
@@ -401,12 +401,12 @@
         <div class="wd-pos-def-row">
           <span class="word-pos" id="wd-pos" style="display:none"></span>
           <span class="word-register" id="wd-register" style="display:none"></span>
-          <span class="wd-def" id="wd-def"></span>
           <span id="wd-def-regen"></span>
         </div>
+        <div class="wd-def-de" id="wd-def-de" style="display:none"></div>
+        <div class="wd-def" id="wd-def"></div>
         <div class="wd-def-zh" id="wd-def-zh" style="display:none"></div>
         <div class="wd-def-fr" id="wd-def-fr" style="display:none"></div>
-        <div class="wd-def-de" id="wd-def-de" style="display:none"></div>
       </div>
       <button class="wd-edit-btn" id="wd-edit-btn">Edit</button>
       <button class="wd-edit-btn wd-regen-all-btn" id="wd-regen-all-btn" title="Regenerate all fields">↺ All</button>

--- a/static/style.css
+++ b/static/style.css
@@ -795,8 +795,8 @@ main.browse-open {
   letter-spacing: 0.5px;
 }
 .word-pos-row { text-align: center; margin: 2px 0; }
-.word-def  { font-size: 16px; color: var(--text); text-align: center; margin-bottom: 4px; }
-.word-def-de { font-size: 14px; color: var(--muted); text-align: center; margin-bottom: 4px; }
+.word-def  { font-size: 14px; color: var(--muted); text-align: center; margin-bottom: 4px; }
+.word-def-de { font-size: 16px; color: var(--text); font-weight: 700; text-align: center; margin-bottom: 4px; }
 .word-def-fr { font-size: 14px; color: var(--muted); text-align: center; margin-bottom: 4px; }
 
 /* ── Edit card ───────────────────────────────────────── */
@@ -2720,8 +2720,9 @@ a.news-source-line:hover {
   flex-wrap: wrap;
 }
 .wd-def    { font-size: 16px; color: var(--text); }
+#wd-def    { font-size: 14px; color: var(--muted); }
 .wd-def-zh { font-size: 14px; color: var(--muted); margin-top: 4px; }
-.wd-def-de { font-size: 14px; color: var(--muted); margin-top: 2px; }
+.wd-def-de { font-size: 16px; color: var(--text); font-weight: 700; margin-top: 4px; }
 .wd-def-fr { font-size: 14px; color: var(--muted); margin-top: 2px; }
 .word-register {
   display: inline-block;


### PR DESCRIPTION
## 改了什么
把德语释义提升为**主释义**（16px 深色加粗），放到英语前面；英语降为次要释义（14px 灰色）。改动覆盖两个视图：
- 复习卡片正面（vocab-detail）
- 单词详情弹窗（wd-def-block）

## 为什么
Daniel 学习以德语释义为准，德语应作为最显眼的主释义。

## 怎么测试
打开任意带德语释义的单词（复习卡片正面 / 浏览页点词弹窗），确认德语在英语上方且加粗、英语在下方变灰、🇩🇪 前缀保留。共用 .wd-def 类的繁体字显示（hd-trad）不受影响（英语降级用 #wd-def id 选择器）。

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)