### PR TITLE
英语释义前加 🇬🇧 国旗（#551）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2157,7 +2157,7 @@ function renderWordDetail(word) {
   if (regenAllBtn) regenAllBtn.onclick = () => word.id && regenAllFields(word.id);
   document.getElementById('wd-hanzi').textContent = word.word_zh || '';
   document.getElementById('wd-pinyin').textContent = word.pinyin || '';
-  document.getElementById('wd-def').textContent = word.definition || '';
+  document.getElementById('wd-def').textContent = word.definition ? `🇬🇧 ${word.definition}` : '';
   const posEl = document.getElementById('wd-pos');
   posEl.textContent = word.pos || '—';
   posEl.style.display = 'inline-block';
@@ -4780,7 +4780,7 @@ function revealAnswer() {
   const wordPinEl = document.getElementById('word-pin');
   wordPinEl.textContent = isSentenceNote ? '' : (card.pinyin || '');
   wordPinEl.style.display = isSentenceNote ? 'none' : '';
-  document.getElementById('word-def').textContent = card.definition || '';
+  document.getElementById('word-def').textContent = card.definition ? `🇬🇧 ${card.definition}` : '';
   const wordDefDeEl = document.getElementById('word-def-de');
   wordDefDeEl.textContent = card.definition_de ? `🇩🇪 ${card.definition_de}` : '';
   wordDefDeEl.style.display = card.definition_de ? 'block' : 'none';
@@ -5238,7 +5238,7 @@ async function _applyRegenResult() {
           const posEl = document.getElementById('wd-pos');
           if (posEl) { posEl.textContent = updated.pos || '—'; posEl.style.display = 'inline-block'; }
           const defEl = document.getElementById('wd-def');
-          if (defEl) defEl.textContent = updated.definition || '';
+          if (defEl) defEl.textContent = updated.definition ? `🇬🇧 ${updated.definition}` : '';
           const defZhEl = document.getElementById('wd-def-zh');
           if (defZhEl) { defZhEl.textContent = updated.definition_zh || ''; defZhEl.style.display = updated.definition_zh ? 'block' : 'none'; }
           const defDeEl = document.getElementById('wd-def-de');
@@ -7433,7 +7433,7 @@ async function saveEditCard() {
       });
       document.getElementById('word-zh').textContent  = updated.word_zh || '';
       document.getElementById('word-pin').textContent = updated.pinyin  || '';
-      document.getElementById('word-def').textContent = updated.definition || '';
+      document.getElementById('word-def').textContent = updated.definition ? `🇬🇧 ${updated.definition}` : '';
       const wordDefDeEl2 = document.getElementById('word-def-de');
       wordDefDeEl2.textContent = updated.definition_de ? `🇩🇪 ${updated.definition_de}` : '';
       wordDefDeEl2.style.display = updated.definition_de ? 'block' : 'none';


### PR DESCRIPTION
## 改了什么
给英语释义加 🇬🇧 前缀，与德语 🇩🇪、法语 🇫🇷 保持一致。四处设置英语 textContent 的位置统一处理，释义为空时不加旗。

## 为什么
之前只有英语没有国旗，视觉不一致（见截图反馈）。

## 怎么测试
打开任意带英语释义的单词（复习卡片正面 / 浏览页点词弹窗 / 重新生成 / 编辑保存），确认英语前显示 🇬🇧，且与 🇩🇪/🇫🇷 格式一致。

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)