### PR TITLE
fix: 翻卡时预取音频，消除播放延迟（#554）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -4285,6 +4285,10 @@ function loadCard(c, counts) {
     || story?.sentences?.find(s => s.word_ids?.includes(card.word_id))
     || null;
 
+  // Warm the browser cache for the flip audio right away (#554); the async story
+  // path below re-prefetches once the real sentence arrives.
+  _prefetchSentenceAudio();
+
   // In unfinished mode or mixed mode: story may be from a different deck/category.
   // Async-load the correct story and update the display when it arrives.
   if (!sentence && (unfinishedMode || rootDeckId) && !quickMode) {
@@ -4318,6 +4322,8 @@ function loadCard(c, counts) {
         inp.textContent = sentence.sentence_de || sentence.sentence_fr || '';
         _syncFrontTransToggle();
       }
+      // Real sentence now known — prefetch its audio so the flip plays instantly (#554).
+      _prefetchSentenceAudio();
     };
     // In unfinished "existing story" mode, only fetch a cached story (never generate).
     const unfNoGen = unfinishedMode && _unfinishedStoryMode === 'existing';
@@ -7490,13 +7496,45 @@ function _updateListenCounters() {
   });
 }
 
-function playSentence() {
+// TTS URL for the current card's sentence (falls back to the bare word).
+function _sentenceAudioUrl() {
   const text = sentence?.sentence_zh || card?.word_zh;
-  if (!text) return;
+  if (!text) return null;
+  return `/api/tts-file?text=${encodeURIComponent(text)}&lang=${currentCardLang()}`;
+}
+
+// Warm the browser cache for the back-side audio while the front is showing, so
+// flipping plays instantly instead of waiting for a network round trip (#554).
+// /api/tts-file sends Cache-Control: immutable, so once buffered here the audio
+// element playSentence() creates on flip replays from cache with no delay.
+let _prefetchedAudio = null;
+let _prefetchedUrl   = null;
+function _prefetchSentenceAudio() {
+  const url = _sentenceAudioUrl();
+  if (!url || url === _prefetchedUrl) return;
+  const a = new Audio();
+  a.preload = 'auto';
+  a.src = url;
+  a.load();
+  _prefetchedAudio = a;
+  _prefetchedUrl   = url;
+}
+
+function playSentence() {
+  const url = _sentenceAudioUrl();
+  if (!url) return;
   _listenCount++;
   _updateListenCounters();
   if (_currentAudio) { _currentAudio.onended = null; _currentAudio.pause(); _currentAudio = null; }
-  const audio = new Audio(`/api/tts-file?text=${encodeURIComponent(text)}&lang=${currentCardLang()}`);
+  // Reuse the pre-buffered element when it matches (#554) — plays with no wait.
+  let audio;
+  if (_prefetchedAudio && _prefetchedUrl === url) {
+    audio = _prefetchedAudio;
+    try { audio.currentTime = 0; } catch (_) {}
+    _prefetchedAudio = null;
+  } else {
+    audio = new Audio(url);
+  }
   _currentAudio = audio;
   audio.play().catch(() => {});
 }


### PR DESCRIPTION
Closes #554

## 问题
复习翻到卡片背面时，音频有可感知的延迟才响起。`playSentence()` 在翻卡瞬间才第一次 `new Audio('/api/tts-file?...')` 并发起 HTTP 请求——即使服务器已缓存音频文件，浏览器仍要一次网络往返才能开始播放。阅读/写作类别正面不自动播放，延迟最明显。

## 改动（`static/app.js`）
1. 抽出 `_sentenceAudioUrl()` 统一计算 TTS URL。
2. 新增 `_prefetchSentenceAudio()`：正面显示、句子文本已知时，用 `preload="auto"` 的隐藏 `Audio` 提前把背面音频缓冲到浏览器（`/api/tts-file` 已带 `Cache-Control: immutable`）。
3. `playSentence()`：若预取 URL 与当前一致，直接复用已缓冲的 `Audio` 播放，否则回退到新建。
4. 在同步路径（`loadCard`）和异步故事加载路径（`applySentenceToUI`）都触发预取。

## 测试
- `node --check static/app.js` 语法通过。
- 逻辑：URL 不匹配时安全回退新建 `Audio`；换卡后旧预取因 URL 不同不会被误播。listening 正面自动播放不受影响（同一 URL，命中浏览器缓存）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)