### PR TITLE
播客：中德对照转录 + 邮件附转录 + 更多生词 + 摘要生词中文括注（#553）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -1940,12 +1940,16 @@ Task:
    - Whenever you name a company, organization, brand or institution, add its common Chinese
      name in parentheses right after it, e.g. "Airbnb (爱彼迎)", "Lawn Tennis Association
      (英国草地网球协会)". If no established Chinese name exists, give a natural Chinese rendering.
+   - Whenever you use one of the HSK5+ vocabulary words you extract in Task 2 inside the
+     German summary, add its Chinese form in parentheses right after the German rendering,
+     e.g. "Rezession (经济衰退)", "Lieferkette (供应链)", so Daniel links the German meaning
+     to the Chinese word he is pre-learning.
    - If (and ONLY if) the transcript contains timestamps, add an approximate timestamp in
      parentheses when you introduce each major topic, e.g. "(ca. 12:30)", so the listener can
      jump to it. If the transcript contains no timestamps, do NOT invent any.
    Wrap the most important vocabulary/terms/names in <strong>...</strong> HTML tags (these
    become the highlighted words in the email).
-2. Extract the 10-20 most important Chinese words/phrases from the transcript that are HSK
+2. Extract the 20-35 most important Chinese words/phrases from the transcript that are HSK
    level 5 or above (i.e. non-basic vocabulary Daniel would benefit from pre-learning). For
    each, give pinyin and a German definition.
 

--- a/database/core.py
+++ b/database/core.py
@@ -595,6 +595,8 @@ def init_db() -> None:
             conn.execute("ALTER TABLE podcast_episodes ADD COLUMN audio_url TEXT")
         if "duration_seconds" not in pe_cols:
             conn.execute("ALTER TABLE podcast_episodes ADD COLUMN duration_seconds INTEGER")
+        if "transcript_de" not in pe_cols:
+            conn.execute("ALTER TABLE podcast_episodes ADD COLUMN transcript_de TEXT")
         conn.commit()
 
         # Purge stale legacy YouTube rows (#497): yt-dlp is retired, so any

--- a/database/podcast.py
+++ b/database/podcast.py
@@ -186,12 +186,13 @@ def create_pending_episode(video_id: str, channel_id: str | None, title: str,
 
 
 def update_episode(episode_id: int, **fields) -> None:
-    """Generic column update for an episode. hsk_words (if present) is
-    serialized to JSON automatically."""
+    """Generic column update for an episode. hsk_words and transcript_de (if
+    present) are serialized to JSON automatically."""
     if not fields:
         return
-    if "hsk_words" in fields and not isinstance(fields["hsk_words"], str):
-        fields["hsk_words"] = json.dumps(fields["hsk_words"], ensure_ascii=False)
+    for _jcol in ("hsk_words", "transcript_de"):
+        if _jcol in fields and not isinstance(fields[_jcol], str):
+            fields[_jcol] = json.dumps(fields[_jcol], ensure_ascii=False)
     conn = get_db()
     set_clause = ", ".join(f"{k} = ?" for k in fields)
     conn.execute(
@@ -209,6 +210,11 @@ def _hydrate(row: dict) -> dict:
         d["hsk_words"] = json.loads(raw) if raw else []
     except (ValueError, TypeError):
         d["hsk_words"] = []
+    raw_de = d.get("transcript_de")
+    try:
+        d["transcript_de"] = json.loads(raw_de) if raw_de else []
+    except (ValueError, TypeError):
+        d["transcript_de"] = []
     return d
 
 

--- a/podcast.py
+++ b/podcast.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import html
 import json
 import logging
 import os
@@ -39,6 +40,7 @@ from zoneinfo import ZoneInfo
 
 import ai
 import database
+import translator
 
 logger = logging.getLogger(__name__)
 
@@ -936,6 +938,56 @@ def filter_new_words(words: list[dict]) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
+# Bilingual transcript (#553)
+# ---------------------------------------------------------------------------
+
+def _split_transcript_segments(text: str) -> list[str]:
+    """Split a Chinese transcript into roughly sentence-sized segments for the
+    parallel zh/de view (#553). Splits after each sentence-ending punctuation
+    (。！？…), keeping any leading Tingwu timestamp attached to the sentence
+    that follows. Blank pieces are dropped."""
+    if not text:
+        return []
+    parts = re.split(r"(?<=[。！？…])\s*", text)
+    return [p.strip() for p in parts if p.strip()]
+
+
+def _translate_segments_de(zh_segments: list[str]) -> list[str]:
+    """Translate each Chinese segment to German via Google Translate, batching
+    under the free endpoint's ~5000-char request limit (translate_batch joins
+    a batch with newlines into one request). Returns a list aligned 1:1 with
+    zh_segments (translate_batch already falls back to the source text for any
+    segment it can't translate)."""
+    out: list[str] = []
+    batch: list[str] = []
+    size = 0
+    for seg in zh_segments:
+        if batch and size + len(seg) > 4500:
+            out.extend(translator.translate_batch(batch, target="de", source="zh-CN"))
+            batch, size = [], 0
+        batch.append(seg)
+        size += len(seg) + 1
+    if batch:
+        out.extend(translator.translate_batch(batch, target="de", source="zh-CN"))
+    return out
+
+
+def build_transcript_de(transcript_zh: str) -> list[dict]:
+    """Build the bilingual segment-pair list [{"zh","de"}] for a transcript
+    (#553). Best-effort: returns [] if the transcript is empty or translation
+    is unavailable/fails."""
+    segs = _split_transcript_segments(transcript_zh)
+    if not segs:
+        return []
+    try:
+        de = _translate_segments_de(segs)
+    except Exception as e:
+        logger.warning("podcast: transcript translation failed: %s", e)
+        return []
+    return [{"zh": z, "de": (d or "")} for z, d in zip(segs, de)]
+
+
+# ---------------------------------------------------------------------------
 # Spotify link
 # ---------------------------------------------------------------------------
 
@@ -1002,6 +1054,20 @@ def _words_table_html(words: list[dict]) -> str:
     )
 
 
+def _bilingual_transcript_html(pairs: list[dict]) -> str:
+    """Render the bilingual (zh/de) transcript block appended to the end of
+    the notification email (#553). Plain-text segments are HTML-escaped."""
+    if not pairs:
+        return ""
+    rows = "".join(
+        "<div style='margin:0 0 8px'>"
+        f"<div>{html.escape(p.get('zh', ''))}</div>"
+        f"<div style='color:#666'>{html.escape(p.get('de', ''))}</div></div>"
+        for p in pairs
+    )
+    return f"<h3>Transkript (中德对照)</h3><div style='font-size:14px'>{rows}</div>"
+
+
 def send_email(episode: dict) -> bool:
     """Send the HTML notification email for a freshly-summarized episode.
     Returns True if sent, False if skipped (SMTP not configured) — skipping
@@ -1021,8 +1087,9 @@ def send_email(episode: dict) -> bool:
 
     transcript_link = f"{public_base}/#podcast-{episode['id']}"
     words_html = _words_table_html(episode.get("hsk_words") or [])
+    transcript_html = _bilingual_transcript_html(episode.get("transcript_de") or [])
 
-    html = f"""
+    body_html = f"""
     <html><body style="font-family:sans-serif;max-width:640px">
       <h2>{episode['title']}</h2>
       <div>{episode.get('summary_de') or ''}</div>
@@ -1033,6 +1100,7 @@ def send_email(episode: dict) -> bool:
         <a href="{episode.get('spotify_url') or ''}">Spotify</a> ·
         <a href="{episode['youtube_url']}">Folge</a>
       </p>
+      {transcript_html}
     </body></html>
     """
 
@@ -1040,7 +1108,7 @@ def send_email(episode: dict) -> bool:
     msg["Subject"] = f"Neue Podcast-Folge: {episode['title']}"
     msg["From"] = from_addr
     msg["To"] = to_addr
-    msg.attach(MIMEText(html, "html", "utf-8"))
+    msg.attach(MIMEText(body_html, "html", "utf-8"))
 
     with smtplib.SMTP(host, port, timeout=30) as server:
         server.starttls()
@@ -1212,6 +1280,18 @@ def _process_episode(episode_id: int, video: dict, detail_level: str, summary: d
                 # Dev mode: stop at pending with the transcript stored, no AI
                 # call, no email — matches DISABLE_AI's behavior for stories.
                 return
+
+            # Bilingual transcript (#553): translate the Chinese transcript to
+            # German segment-by-segment for the parallel view + email. Skip if
+            # already built (retry path). Best-effort — must not fail the episode.
+            if not (database.get_episode(episode_id) or {}).get("transcript_de"):
+                try:
+                    pairs = build_transcript_de(transcript)
+                    if pairs:
+                        database.update_episode(episode_id, transcript_de=pairs)
+                except Exception as e:
+                    logger.warning("podcast: transcript_de build failed for %s: %s",
+                                   video["video_id"], e)
 
             result = summarize(transcript, video["title"], detail_level)
             if not result.get("summary_de"):

--- a/routes/podcast.py
+++ b/routes/podcast.py
@@ -60,6 +60,18 @@ def get_episode(episode_id: int):
     episode = database.get_episode(episode_id)
     if not episode:
         raise HTTPException(404, "Episode not found")
+    # Lazy bilingual-transcript backfill (#553): episodes summarized before this
+    # feature have transcript_zh but no transcript_de — build it on first detail
+    # view so old episodes also get the parallel view. Best-effort, one-time.
+    if episode.get("transcript_zh") and not episode.get("transcript_de"):
+        try:
+            pairs = podcast.build_transcript_de(episode["transcript_zh"])
+            if pairs:
+                database.update_episode(episode_id, transcript_de=pairs)
+                episode["transcript_de"] = pairs
+        except Exception:
+            logger.warning("podcast: lazy transcript_de backfill failed for episode %s",
+                           episode_id, exc_info=True)
     return _overlay_processing_status(episode)
 
 

--- a/schema.sql
+++ b/schema.sql
@@ -583,6 +583,7 @@ CREATE TABLE IF NOT EXISTS podcast_episodes (
     duration_seconds INTEGER, -- parsed itunes:duration, #497 — used as a pre-download guardrail/gate
     spotify_url      TEXT,
     transcript_zh    TEXT,
+    transcript_de    TEXT,   -- JSON array of {"zh","de"} bilingual segment pairs (#553)
     summary_de       TEXT,
     hsk_words        TEXT,   -- JSON array of {word, pinyin, definition_de, hsk}
     detail_level     TEXT,   -- detail_level used for the summary (short|medium|detailed)

--- a/static/app.js
+++ b/static/app.js
@@ -3014,10 +3014,17 @@ function _renderPodcastDetail(ep) {
     ep.status === 'summarized' ? `<button id="podcast-notify-signal" class="btn-secondary" onclick="doPodcastNotify('signal')">Send to Signal</button>` : '',
     ep.status === 'summarized' ? `<button id="podcast-notify-email" class="btn-secondary" onclick="doPodcastNotify('email')">Send Email</button>` : '',
   ].filter(Boolean).join(' ');
-  const transcript = ep.transcript_zh
+  const trPairs = Array.isArray(ep.transcript_de) ? ep.transcript_de : [];
+  const trBody = trPairs.length
+    ? trPairs.map(p => `<div class="podcast-tr-pair">
+         <div class="podcast-tr-zh">${_escHtml(p.zh || '')}</div>
+         <div class="podcast-tr-de">${_escHtml(p.de || '')}</div>
+       </div>`).join('')
+    : (ep.transcript_zh ? _escHtml(ep.transcript_zh).replace(/\n/g, '<br>') : '');
+  const transcript = (trPairs.length || ep.transcript_zh)
     ? `<div class="podcast-transcript-wrap">
          <button class="keymap-reset-all" onclick="_togglePodcastTranscript()">Show/hide transcript</button>
-         <div id="podcast-transcript-body" class="podcast-transcript" style="display:none">${_escHtml(ep.transcript_zh).replace(/\n/g, '<br>')}</div>
+         <div id="podcast-transcript-body" class="podcast-transcript" style="display:none">${trBody}</div>
        </div>`
     : '';
 

--- a/static/style.css
+++ b/static/style.css
@@ -4944,3 +4944,16 @@ table.fsrs-table td.ivl { font-weight: 700; }
     border-color: #6b5700;
   }
 }
+
+.podcast-tr-pair {
+  margin: 0 0 10px;
+  padding: 0 0 8px;
+  border-bottom: 1px solid var(--border, #eee);
+}
+.podcast-tr-zh { line-height: 1.5; }
+.podcast-tr-de {
+  color: var(--muted, #888);
+  font-size: 0.92em;
+  line-height: 1.4;
+  margin-top: 2px;
+}


### PR DESCRIPTION
## 改了什么

四项播客学习辅助改进（Issue #553）：

1. **中德对照转录**：新增 `transcript_de` 列（JSON 段对 `[{zh,de}]`）。处理单集时把中文转录按句（。！？…）切段，分块（每块 <4500 字符）经 Google Translate 译成德语。详情页转录区改为**逐行中德对照**（一行中文、一行德语）。旧单集打开详情页时**懒回填**并回存。
2. **邮件末尾附对照转录**：通知邮件（`send_email`）末尾加完整中德对照块（HTML 转义）。Signal 不动（纯文本、太长）。
3. **更多生词**：摘要提示词抽词目标 `10-20` → `20-35`。
4. **摘要生词中文括注**：提示词新增指令——摘要正文里出现抽取的 HSK5+ 生词时，德语后加中文括号（沿用公司名括注的做法）。

## 为什么

Daniel 想在播客页/邮件里看到德语对照转录辅助理解，并让难生词在摘要里也带上中文，便于预学。

## 怎么测试

- 语法检查（ast.parse 5 个 Python 文件）+ `node --check static/app.js` 通过。
- 迁移冒烟测试：全新 DB `init_db()` 建出 `transcript_de` 列；`build_transcript_de('你好。今天天气很好。我们去公园吧！')` 切成 3 段并实译为德语。
- CI 同款导入检查通过。

## 说明

- 用 Google Translate（免费，与 briefing 模式 context_de 一致），不花 AI 钱。
- `transcript_de` 存中德段对 JSON，对齐永不错位，也不受 `_normalize_transcript` 二次规范化影响。

Closes #553