### PR TITLE
feat: 播客源「Load more」——按需拉取更旧的存量单集（#559）

### DIFF
--- a/podcast.py
+++ b/podcast.py
@@ -54,6 +54,11 @@ logger = logging.getLogger(__name__)
 # transcription work on a freshly-added source.
 FIRST_RUN_BACKFILL = 10
 
+# "Load more" (#559) pulls back-catalog older than the initial backfill in
+# on-demand pages of this size, metadata-only. Kept modest so one click on a
+# huge feed (声动早咖啡 ~1000 eps) adds a manageable chunk, not the whole backlog.
+LOAD_MORE_PAGE = 20
+
 # itunes:duration namespace, used to read episode duration straight from the
 # RSS feed (#497) — this is what lets duration-based guardrails/gates run
 # *before* any download.
@@ -144,6 +149,33 @@ def _parse_rss_pubdate(raw: str | None) -> str | None:
         return raw  # best-effort: keep the raw string rather than lose it
 
 
+def _parse_feed_item(item, feed_url: str) -> dict | None:
+    """Extract one RSS <item> into an episode dict, or None if it has no
+    stable id. Shared by fetch_new_videos() and load_more_episodes() so the
+    two stay in lockstep on how a feed item maps to an episode row."""
+    enclosure_el = item.find("enclosure")
+    audio_url = enclosure_el.get("url") if enclosure_el is not None else None
+    guid_el = item.find("guid")
+    guid = guid_el.text.strip() if guid_el is not None and guid_el.text else None
+    # Fall back to the enclosure URL as the unique id when a feed omits <guid>.
+    video_id = guid or audio_url
+    if not video_id:
+        return None
+    title_el = item.find("title")
+    link_el = item.find("link")
+    pubdate_el = item.find("pubDate")
+    duration_el = item.find("itunes:duration", _ITUNES_NS)
+    return {
+        "video_id": video_id,
+        "channel_id": feed_url,
+        "title": (title_el.text.strip() if title_el is not None and title_el.text else video_id),
+        "published_at": _parse_rss_pubdate(pubdate_el.text if pubdate_el is not None else None),
+        "youtube_url": (link_el.text.strip() if link_el is not None and link_el.text else feed_url),
+        "audio_url": audio_url,
+        "duration_seconds": _parse_itunes_duration(duration_el.text if duration_el is not None else None),
+    }
+
+
 def fetch_new_videos() -> list[dict]:
     """Return episodes from the configured podcast RSS feeds
     (podcast_feeds table, #502 — one row per source with its own
@@ -201,44 +233,57 @@ def fetch_new_videos() -> list[dict]:
         is_first_run = not database.has_any_episode_for_feed(feed_url)
         feed_videos: list[dict] = []
         for item in root.findall(".//item"):
-            enclosure_el = item.find("enclosure")
-            audio_url = enclosure_el.get("url") if enclosure_el is not None else None
-            guid_el = item.find("guid")
-            guid = guid_el.text.strip() if guid_el is not None and guid_el.text else None
-            # Fall back to the enclosure URL as the unique id when a feed
-            # omits <guid> (not expected for either of Daniel's feeds, but
-            # cheap insurance) — never fall back to nothing, we need a
-            # stable video_id for the UNIQUE constraint / dedup.
-            video_id = guid or audio_url
-            if not video_id:
+            video = _parse_feed_item(item, feed_url)
+            if video is None:
                 continue
-            if video_id in known:
+            if video["video_id"] in known:
                 if is_first_run:
                     continue  # shouldn't happen (nothing's known yet), but harmless
                 break  # newest-first feed: everything from here on is old backlog
 
-            title_el = item.find("title")
-            link_el = item.find("link")
-            pubdate_el = item.find("pubDate")
-            duration_el = item.find("itunes:duration", _ITUNES_NS)
-            feed_videos.append({
-                "video_id": video_id,
-                "channel_id": feed_url,
-                "title": (title_el.text.strip() if title_el is not None and title_el.text else video_id),
-                "published_at": _parse_rss_pubdate(pubdate_el.text if pubdate_el is not None else None),
-                "youtube_url": (link_el.text.strip() if link_el is not None and link_el.text else feed_url),
-                "audio_url": audio_url,
-                "duration_seconds": _parse_itunes_duration(
-                    duration_el.text if duration_el is not None else None),
-                "auto_process": auto_process,
-                "is_backfill": is_first_run,
-            })
+            video["auto_process"] = auto_process
+            video["is_backfill"] = is_first_run
+            feed_videos.append(video)
             if is_first_run and len(feed_videos) >= FIRST_RUN_BACKFILL:
                 break
 
         videos.extend(feed_videos)
 
     return videos
+
+
+def load_more_episodes(feed_id: int) -> dict:
+    """Ingest the next page of older back-catalog episodes for one feed,
+    metadata-only (never auto-processed). Regular check() only walks the
+    newest items and stops at the first already-known guid, so a feed's
+    back-catalog older than the initial backfill is otherwise unreachable;
+    this pulls it in on demand, LOAD_MORE_PAGE at a time, skipping anything
+    already stored. Returns {"added": N}. Raises ValueError (unknown feed) /
+    RuntimeError (fetch/parse failure) for the route to map to 404/500."""
+    feed = database.get_feed(feed_id)
+    if not feed:
+        raise ValueError("feed not found")
+    feed_url = feed["url"]
+    try:
+        root = ElementTree.fromstring(_http_get(feed_url, timeout=30))
+    except (urllib.error.URLError, ElementTree.ParseError) as e:
+        raise RuntimeError(f"failed to fetch/parse feed: {e}")
+
+    known = database.get_known_video_ids()
+    added = 0
+    for item in root.findall(".//item"):
+        video = _parse_feed_item(item, feed_url)
+        if video is None or video["video_id"] in known:
+            continue
+        database.create_pending_episode(
+            video["video_id"], video["channel_id"], video["title"],
+            video["published_at"], video["youtube_url"],
+            video.get("audio_url"), video.get("duration_seconds"),
+        )
+        added += 1
+        if added >= LOAD_MORE_PAGE:
+            break
+    return {"added": added}
 
 
 # ---------------------------------------------------------------------------

--- a/routes/podcast.py
+++ b/routes/podcast.py
@@ -217,6 +217,19 @@ def delete_feed(feed_id: int):
     return {"deleted": True}
 
 
+@router.post("/api/podcast/feeds/{feed_id}/load-more")
+def load_more_feed(feed_id: int):
+    """Pull in the next page of older back-catalog episodes for this feed,
+    metadata-only (transcribe on demand). See podcast.load_more_episodes."""
+    try:
+        return podcast.load_more_episodes(feed_id)
+    except ValueError:
+        raise HTTPException(404, "Feed not found")
+    except Exception as e:
+        logger.error("podcast load-more failed for feed %s: %s", feed_id, e)
+        raise HTTPException(500, str(e))
+
+
 class PodcastConfigUpdate(BaseModel):
     detail_level: str | None = None
     enabled: str | None = None

--- a/static/app.js
+++ b/static/app.js
@@ -2866,7 +2866,7 @@ async function openPodcastFeed(feedId) {
   _podcastCurrentFeedId = feedId;
   setLoading('Loading episodes…');
   try {
-    const episodes = await api('GET', `/api/podcast/episodes?feed_id=${feedId}`);
+    const episodes = await api('GET', `/api/podcast/episodes?feed_id=${feedId}&limit=1000`);
     _podcastEpisodes = episodes || [];
     showView('podcast');
     _renderPodcastEpisodeList();
@@ -2919,7 +2919,31 @@ function _renderPodcastEpisodeList() {
     <div class="keymap-panel">
       <h2 class="keymap-heading">${_escHtml(feed?.title || feed?.url || 'Feed')}</h2>
     </div>
-    <div class="podcast-list">${rows}</div>`;
+    <div class="podcast-list">${rows}</div>
+    <div class="podcast-load-more-row">
+      <button class="btn-secondary" id="podcast-load-more-btn" onclick="_loadMorePodcastEpisodes()">Load more</button>
+      <span id="podcast-load-more-msg" style="font-size:12px;color:var(--muted)"></span>
+    </div>`;
+}
+
+async function _loadMorePodcastEpisodes() {
+  if (_podcastCurrentFeedId == null) return;
+  const btn = document.getElementById('podcast-load-more-btn');
+  const msg = document.getElementById('podcast-load-more-msg');
+  if (btn) btn.disabled = true;
+  if (msg) msg.textContent = 'Loading…';
+  try {
+    const res = await api('POST', `/api/podcast/feeds/${_podcastCurrentFeedId}/load-more`);
+    const episodes = await api('GET', `/api/podcast/episodes?feed_id=${_podcastCurrentFeedId}&limit=1000`);
+    _podcastEpisodes = episodes || [];
+    _renderPodcastEpisodeList();
+    const added = res?.added || 0;
+    const laterMsg = document.getElementById('podcast-load-more-msg');
+    if (laterMsg) laterMsg.textContent = added ? `+${added} episode${added === 1 ? '' : 's'}` : 'No older episodes.';
+  } catch (e) {
+    if (msg) msg.textContent = 'Error: ' + e.message;
+    if (btn) btn.disabled = false;
+  }
 }
 
 async function _transcribePodcastEpisode(episodeId) {
@@ -2941,7 +2965,7 @@ function _schedulePodcastPollIfNeeded() {
   _podcastPollTimer = setTimeout(async () => {
     if (_podcastCurrentFeedId == null) return;  // left this view meanwhile
     try {
-      const episodes = await api('GET', `/api/podcast/episodes?feed_id=${_podcastCurrentFeedId}`);
+      const episodes = await api('GET', `/api/podcast/episodes?feed_id=${_podcastCurrentFeedId}&limit=1000`);
       _podcastEpisodes = episodes || [];
       _renderPodcastEpisodeList();
       _schedulePodcastPollIfNeeded();


### PR DESCRIPTION
Closes #559

## 问题
播客源详情页已有前端 "Load more" 按钮（`_loadMorePodcastEpisodes()`），但它调用的后端端点 `POST /api/podcast/feeds/{id}/load-more` **不存在**——点了直接报错。常规 `check` 只从最新处向下走、遇第一个已知 guid 即停（避免声动早咖啡那种上千集的源一次性倾倒积压），所以初始回填之外的更旧存量单集无法进库。

## 改动
**后端（`podcast.py` / `routes/podcast.py`）**
- 新增 `load_more_episodes(feed_id)`：抓取该源 RSS，跳过已入库 `video_id`，逐条 `create_pending_episode` 入库（仅元数据、不自动处理），凑够 `LOAD_MORE_PAGE`(20) 条即停，返回 `{added: N}`。
- 新增路由 `POST /api/podcast/feeds/{feed_id}/load-more`：`ValueError`→404，其余异常→500（记日志）。
- 抽出共享 `_parse_feed_item()`，`fetch_new_videos` 与新函数共用，消除 RSS `<item>` 解析重复（`fetch_new_videos` 行为不变）。

**前端（`static/app.js`）**
- "Load more" 按钮 + 结果提示；列表拉取改 `limit=1000`。

## 测试
- `py_compile` + `import podcast, routes.podcast` 通过；`node --check static/app.js` 通过。
- 离线单元测试（假 RSS + 临时库、monkeypatch `_http_get`、不联网）：`LOAD_MORE_PAGE=3` 下首次 `{added:3}`（3 条 `status=pending`、无转录）→ 再次 `{added:2}`（跳过已知，共 5 条）→ 第三次 `{added:0}`；未知 `feed_id` 抛 `ValueError`。全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)