### PR TITLE
重做播客故事模式：精简摘要式管线、自选模型、按源筛选单集

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -117,6 +117,11 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str,
         if model.startswith("deepseek-"):
             extra["extra_body"] = {"thinking": {"type": "enabled" if thinking else "disabled"}}
             logger.debug("[%s] thinking=%s", model, thinking)
+        elif model.startswith(("glm-4.5", "glm-4.6", "glm-4.7", "glm-5")):
+            # GLM-4.5 起支持 thinking 模式且默认开启 —— 生成句子不需要思维链，
+            # 显式关闭以省时省钱（旧 glm-4-flash/air 不认识该参数，故不加）。
+            extra["extra_body"] = {"thinking": {"type": "enabled" if thinking else "disabled"}}
+            logger.debug("[%s] thinking=%s", model, thinking)
         try:
             if model.startswith("gpt-"):
                 # gpt-5 series (Chat Completions): max_completion_tokens replaces max_tokens
@@ -1843,6 +1848,137 @@ def generate_briefing_sentences(
         except Exception as e:
             logger.warning("briefing: context translation failed — %s", e)
 
+    return sentences
+
+
+def generate_podcast_sentences(
+    cards: list[dict],
+    summary: str,            # the episode's German summary_de (caller ensures non-empty)
+    episode_title: str,
+    model: str = "gpt-5-mini",
+    max_hsk: int = 3,
+    progress_key: str | None = None,
+    attempt_label: str = "",
+    source_url: str | None = None,
+    source_title: str | None = None,
+) -> list[dict]:
+    """Podcast mode rework (issue #561) — a lean single-purpose pipeline that
+    replaces reuse of the briefing machinery (originally #482).
+
+    One main call + up to 2 missing-word retry rounds + fallback sentences.
+    Deliberately has NO fact-check and NO whole-summary validation retry —
+    those are what make briefing slow and expensive, and podcast summaries
+    (unlike news) are AI-authored to begin with, so there's no external source
+    to fact-check against. The only input is the German episode summary
+    (detailed enough since #541) — the full transcript is never sent.
+
+    attempt_label: chunk marker like " (2/3)" appended to every progress
+    message — the route batches cards by MAX_NEWS_BATCH and calls this once
+    per chunk (same convention as generate_briefing_sentences).
+    """
+    if not cards or not summary.strip():
+        return []
+
+    def _build_prompt(batch: list[dict], extra_hint: str = "") -> str:
+        word_list = "\n".join(
+            f"{i + 1}. {c['word_zh']}（{c.get('pinyin', '')}）— {c.get('definition', '')}"
+            for i, c in enumerate(batch)
+        )
+        return f"""任务：下面是一期播客单集的内容摘要（德语）。请用简体中文写一篇该单集内容的连贯总结，
+帮助 HSK 4-5 学习者复习词汇。
+
+单集标题：{episode_title}
+
+内容摘要（德语）：
+{summary}
+
+目标词汇（每个词必须在总结中恰好出现一次，以原文形式出现）：
+{word_list}
+
+规则：
+- 总结按句子输出为 JSON 数组，数组顺序就是阅读顺序
+- 【重要】每一句话都必须恰好包含一个目标词汇——不允许出现任何不含目标词的句子，
+  因此句子总数必须恰好等于目标词数量
+- 【词序自由】任意安排目标词出现的先后顺序，选择能写出最自然、最连贯总结的顺序
+- 【难度控制，严格遵守】每句 8 到 20 个字，其中除目标词外只允许 HSK 1-{max_hsk} 的词汇；
+  如果某个事实需要更难的词才能表达，就换一种更简单的说法，或省略这个细节
+- 【重要】每句都必须传达摘要中的一个具体事实（是什么、涉及谁、有多少），
+  严禁没有信息量的空洞句子，例如"内容很有趣。""他说了很多。"这类句子绝对不可以出现
+- 【重要】只允许使用摘要中明确陈述的事实——禁止编造摘要没有的细节或主观评论
+- 所有输出只用简体中文，绝对不要出现繁体字；不要使用markdown格式
+- target_word 是该句包含的目标词汇原文
+{extra_hint}
+
+仅返回如下JSON数组，不加任何其他文字：
+[
+  {{"sentence_zh": "含目标词的句子", "target_word": "词汇"}}
+]"""
+
+    sentences: list[dict] = []
+    remaining = list(cards)
+
+    for attempt in range(3):
+        if not remaining:
+            break
+        msg = (f"生成播客总结…{attempt_label}" if attempt == 0
+               else f"补漏 {len(remaining)} 个词（第{attempt + 1}轮）…{attempt_label}")
+        _set_progress(progress_key, phase="request", msg=msg, percent=20 + attempt * 25)
+        raw = _call_api(model, [{"role": "user", "content": _build_prompt(remaining)}],
+                         4096, purpose="podcast")
+
+        json_start = raw.find("[")
+        json_end = raw.rfind("]") + 1
+        if json_start == -1 or json_end == 0:
+            logger.warning("podcast attempt %d: no JSON array found", attempt + 1)
+            continue
+        try:
+            items = json.loads(raw[json_start:json_end])
+        except json.JSONDecodeError as e:
+            logger.warning("podcast attempt %d: JSON parse error: %s", attempt + 1, e)
+            continue
+
+        # Scan in order: not trusting the AI's target_word tag, only the actual
+        # sentence content counts (same approach as briefing).
+        for item in items:
+            s_zh = (item.get("sentence_zh") or "").strip()
+            if not s_zh:
+                continue
+            matched = next((c for c in remaining if _briefing_word_match(c["word_zh"], s_zh)), None)
+            if matched is None:
+                continue          # no target word → drop (this mode allows no context sentences)
+            remaining.remove(matched)
+            sentences.append({
+                "word_ids": [matched["word_id"]],
+                "sentence_zh": s_zh,
+                "sentence_en": "",
+                "concept_en": "",
+                "concept_zh": "",
+                "reasoning_zh": "",
+                "source_url": source_url,
+                "source_title": source_title,
+                "tokens": [],
+            })
+
+        if remaining:
+            logger.warning("podcast attempt %d: missing words (will re-request): %s",
+                           attempt + 1, [c["word_zh"] for c in remaining])
+
+    # Per-word fallback so every card ends up with a sentence.
+    for card in remaining:
+        logger.warning("podcast: using fallback sentence for %s", card["word_zh"])
+        sentences.append({
+            "word_ids": [card["word_id"]],
+            "sentence_zh": card.get("source_sentence") or f"我学了{card['word_zh']}这个词。",
+            "sentence_en": "",
+            "concept_en": "",
+            "concept_zh": "",
+            "reasoning_zh": "",
+            "source_url": source_url,
+            "source_title": source_title,
+            "tokens": [],
+        })
+
+    _fill_translations(sentences, progress_key=progress_key)
     return sentences
 
 

--- a/database/stats.py
+++ b/database/stats.py
@@ -89,7 +89,7 @@ def get_stats(deck_id: int | None = None, lang: str | None = None) -> dict:
 # this table is hand-maintained — update it (and the static price table in
 # static/index.html's story-setup modal) whenever a provider changes pricing
 # or a new model is adopted. See CLAUDE.md "规范与约束".
-_PRICING_AS_OF = "2026-07-12"
+_PRICING_AS_OF = "2026-07-16"
 _MODEL_PRICING: dict[str, dict[str, float]] = {
     # OpenAI (news/briefing/podcast summaries)
     "gpt-5.1":      {"input": 1.25, "cached": 0.125, "output": 10.00},
@@ -106,6 +106,11 @@ _MODEL_PRICING: dict[str, dict[str, float]] = {
     "deepseek-reasoner": {"input": 0.50, "output": 2.18},
     "glm-4-flash":       {"input": 0.00, "output": 0.00},
     "glm-4-air":         {"input": 0.06, "output": 0.06},
+    # GLM-4.7/5 (podcast mode rework, issue #561)
+    "glm-5":           {"input": 1.00, "output": 3.20},
+    "glm-4.7":         {"input": 0.60, "output": 2.20},
+    "glm-4.7-flashx":  {"input": 0.07, "output": 0.40},
+    "glm-4.7-flash":   {"input": 0.00, "output": 0.00},
     "qwen-turbo":        {"input": 0.065, "output": 0.26},
     "qwen-plus":         {"input": 0.40, "output": 1.20},
     "claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.00},

--- a/routes/story.py
+++ b/routes/story.py
@@ -165,14 +165,18 @@ ALLOWED_MODELS = {
     "claude-sonnet-4-6",
     "claude-opus-4-6",
     "gpt-5-mini",
+    "glm-5",
+    "glm-4.7",
+    "glm-4.7-flashx",
+    "glm-4.7-flash",
 }
 DEFAULT_MODEL = ai.DEFAULT_MODEL
 
 
-def _validated_model(model: str | None) -> str:
+def _validated_model(model: str | None, default: str | None = None) -> str:
     if model and model in ALLOWED_MODELS:
         return model
-    return DEFAULT_MODEL
+    return default or DEFAULT_MODEL
 
 
 def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
@@ -241,14 +245,13 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
             parsed_chapter_ids = [int(x) for x in chapter_ids.split(",") if x.strip()] if chapter_ids else []
             sentences, prompt_text = _generate_kahneman_story_sentences(
                 cards, parsed_chapter_ids, model=model, progress_key=progress_key)
-        elif mode in ("paste", "briefing", "podcast"):
-            # Briefing (issue #444), paste (issue #481) and podcast (issue
-            # #482) all share the briefing pipeline and ignore the frontend's
-            # model selection — they always use BRIEFING_MODEL (env, default
-            # gpt-5.1, verified/cached via ai.resolve_briefing_model()),
-            # OpenAI only. Resolved before the article-selection call so
-            # summarize_news_items uses the same model as the sentence
-            # generation (issue #448).
+        elif mode in ("paste", "briefing"):
+            # Briefing (issue #444) and paste (issue #481) share the briefing
+            # pipeline and ignore the frontend's model selection — they always
+            # use BRIEFING_MODEL (env, default gpt-5.1, verified/cached via
+            # ai.resolve_briefing_model()), OpenAI only. Resolved before the
+            # article-selection call so summarize_news_items uses the same
+            # model as the sentence generation (issue #448).
             model = ai.resolve_briefing_model()
             logger.info("story  %s model in use: %s", mode, model)
             if mode == "briefing" and not articles:
@@ -264,35 +267,45 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
                     today, lang, exclude_deck_id=deck_id, exclude_category=category)
                 articles = _auto_news_articles(model=model, progress_key=progress_key,
                                                exclude_urls=used)
-            if mode == "podcast" and not articles:
-                # Podcast mode (issue #482): the single article is the selected
-                # episode's Chinese transcript — no auto-fetch, no pasted text.
-                # Truncated to a safe length (transcripts can be very long).
-                if not episode_id:
-                    raise ValueError("Podcast mode requires selecting an episode.")
-                episode = database.get_episode(episode_id)
-                if not episode:
-                    raise ValueError(f"Podcast episode {episode_id} not found.")
-                transcript = (episode.get("transcript_zh") or "").strip()
-                if not transcript:
-                    raise ValueError("Selected podcast episode has no transcript.")
-                articles = [{
-                    "url": episode.get("youtube_url"),
-                    "title": episode.get("title"),
-                    "text": transcript[:15000],
-                }]
-            # Paste (issue #481) and podcast (issue #482) reuse the briefing
-            # pipeline (Python validation, dedup, fact-check) with generic=True
-            # swapping the news-briefing prompt wording for plain content
-            # framing. Podcast additionally sets include_context=False — every
-            # sentence must carry a target word, no context sentences at all.
-            # Neither mode auto-fetches, so missing articles surface as a
-            # clear error inside _generate_briefing_story_sentences (podcast's
-            # own no-episode error above fires first).
+            # Paste (issue #481) reuses the briefing pipeline (Python
+            # validation, dedup, fact-check) with generic=True swapping the
+            # news-briefing prompt wording for plain content framing. It
+            # never auto-fetches, so a missing pasted article surfaces as a
+            # clear error inside _generate_briefing_story_sentences.
             sentences, prompt_text = _generate_briefing_story_sentences(
                 cards, articles, model=model, progress_key=progress_key,
-                max_hsk=max_hsk, generic=(mode in ("paste", "podcast")),
-                include_context=(mode != "podcast"))
+                max_hsk=max_hsk, generic=(mode == "paste"),
+                include_context=True)
+        elif mode == "podcast":
+            # Podcast mode rework (issue #561): drops the briefing pipeline —
+            # only the episode's German summary is sent (detailed enough since
+            # #541, never the full transcript), one lean call per batch of
+            # MAX_NEWS_BATCH words plus missing-word top-ups, no fact-check.
+            # The model is the user's dropdown pick, no longer locked to
+            # BRIEFING_MODEL; default gpt-5-mini (glm-4.7 once Daniel's Zhipu
+            # registration clears — a dropdown click, no code change).
+            if not episode_id:
+                raise ValueError("Podcast mode requires selecting an episode.")
+            episode = database.get_episode(episode_id)
+            if not episode:
+                raise ValueError(f"Podcast episode {episode_id} not found.")
+            summary = (episode.get("summary_de") or "").strip()
+            if not summary:
+                raise ValueError("Selected podcast episode has no summary yet.")
+            model = _validated_model(model, default="gpt-5-mini")
+            logger.info("story  podcast model in use: %s", model)
+            chunk_size = ai.MAX_NEWS_BATCH
+            chunks = [cards[i:i + chunk_size] for i in range(0, len(cards), chunk_size)]
+            sentences = []
+            for idx, chunk in enumerate(chunks):
+                label = f" ({idx + 1}/{len(chunks)})" if len(chunks) > 1 else ""
+                sentences.extend(ai.generate_podcast_sentences(
+                    chunk, summary, episode.get("title") or "",
+                    model=model, max_hsk=max_hsk, progress_key=progress_key,
+                    attempt_label=label,
+                    source_url=episode.get("youtube_url") or f"/#podcast-{episode_id}",
+                    source_title=episode.get("title")))
+            prompt_text = f"podcast mode — episode {episode_id}"
         else:
             sentences, prompt_text = _generate_story_sentences(
                 cards, topic=topic, max_hsk=max_hsk, model=model,
@@ -368,8 +381,9 @@ def _gen_params_dict(*, topic, max_hsk, model, grammar_focus, grammar_pct,
     origin: "pregen" when the story was created by the morning pregen —
     get_recent_story_keys skips those rows so pregen only ever reproduces
     user-initiated generations instead of feeding on its own output (issue #468).
-    episode_id: podcast mode's selected episode (issue #482) — kept alongside
-    articles purely for display/debugging; Again-regen reuses `articles`.
+    episode_id: podcast mode's selected episode (issue #482, summary-only
+    pipeline since #561) — Again-regen re-fetches the episode's summary_de by
+    this id rather than reusing `articles` (podcast stories don't store any).
     """
     return {
         "mode": mode,
@@ -430,19 +444,33 @@ def generate_sentence_for_word(card: dict, gen_params: dict | None) -> dict | No
                 sentences = ai.generate_kahneman_sentences([card], chapter, model=model)
             else:  # book data missing → fall back to a plain sentence
                 sentences, _ = ai.generate_story([card], model=model, lang=lang)
-        elif mode in ("news", "paste", "briefing", "podcast"):
-            # Briefing/paste/podcast Again-regen reuses the single-sentence news
-            # path: one word gets one fresh sentence from the same articles (no
-            # context chain). All three always use BRIEFING_MODEL (issue
-            # #444/#481/#482), ignoring the story's stored model — same
-            # resolution as the main generation (paste/podcast's stored
-            # gen_params.model is already the resolved server model, but this
-            # stays consistent regardless).
-            news_model = ai.resolve_briefing_model() if mode in ("briefing", "paste", "podcast") else model
+        elif mode == "podcast":
+            # Podcast Again-regen (issue #561): same lean pipeline, one card +
+            # the episode summary, honoring the story's stored user-picked
+            # model (old stories stored gpt-5.1, which is not whitelisted, so
+            # _validated_model falls back). No summary → plain sentence.
+            ep = database.get_episode(gp["episode_id"]) if gp.get("episode_id") else None
+            summary = ((ep or {}).get("summary_de") or "").strip()
+            if summary:
+                sentences = ai.generate_podcast_sentences(
+                    [card], summary, ep.get("title") or "",
+                    model=_validated_model(gp.get("model"), default="gpt-5-mini"),
+                    max_hsk=gp.get("max_hsk", 3),
+                    source_url=ep.get("youtube_url") or f"/#podcast-{ep['id']}",
+                    source_title=ep.get("title"))
+            else:
+                sentences, _ = ai.generate_story([card], model=model, lang=lang)
+        elif mode in ("news", "paste", "briefing"):
+            # Briefing/paste Again-regen reuses the single-sentence news path:
+            # one word gets one fresh sentence from the same articles (no
+            # context chain). Both always use BRIEFING_MODEL (issue #444/#481),
+            # ignoring the story's stored model — same resolution as the main
+            # generation.
+            news_model = ai.resolve_briefing_model() if mode in ("briefing", "paste") else model
             articles = gp.get("articles") or []
             if articles:
                 sentences = ai.generate_news_sentences(
-                    [card], articles, model=news_model, generic=(mode in ("paste", "podcast")))
+                    [card], articles, model=news_model, generic=(mode == "paste"))
             else:  # no articles context saved → fall back to a plain sentence
                 sentences, _ = ai.generate_story([card], model=news_model, lang=lang)
         else:
@@ -578,9 +606,10 @@ def regenerate_story(deck_id: int, category: str,
     """Regenerate today's story. body (optional JSON): {"articles": [{"url", "title", "text"}]}
     — pasted texts for mode="paste" (too long to fit in a query string).
     mode="briefing" ignores pasted articles and auto-fetches today's news (issue #387);
-    mode="paste" with no articles is an error (issue #396); mode="podcast" builds
-    its single article from the episode_id's transcript (issue #482). mode="news"
-    (the old auto-fetch-only mode) has been removed (issue #512) and is rejected."""
+    mode="paste" with no articles is an error (issue #396); mode="podcast" uses the
+    episode_id's German summary directly, no articles involved (reworked #561).
+    mode="news" (the old auto-fetch-only mode) has been removed (issue #512) and
+    is rejected."""
     if DISABLE_AI:
         return None
     chosen_model = _validated_model(model)
@@ -744,8 +773,9 @@ def _generate_briefing_story_sentences(
     sentences, validation, dedup, fact-check) identical. Paste never auto-fetches,
     so the no-articles error below is the only guard against an empty run.
 
-    include_context=False (issue #482): podcast mode — no context sentences,
-    every sentence carries a target word."""
+    include_context: kept as a parameter (default True) for callers, but only
+    briefing/paste call this function now — podcast moved to its own lean
+    pipeline (ai.generate_podcast_sentences, issue #561) and never calls it."""
     if not articles:
         raise RuntimeError(
             "Paste mode requires at least one pasted text. "

--- a/static/app.js
+++ b/static/app.js
@@ -6613,23 +6613,35 @@ function updateSetupMode() {
   }
 }
 
-// ── News-family modes (briefing/paste/podcast) lock the model select ────────
-// briefing/paste/podcast share the server-side briefing pipeline and always
-// use BRIEFING_MODEL (DeepSeek censors news content, so it's OpenAI-only).
+// ── News-family modes (briefing/paste) lock the model select ────────────────
+// briefing/paste share the server-side briefing pipeline and always use
+// BRIEFING_MODEL (DeepSeek censors news content, so it's OpenAI-only).
 // Switching to one of them locks the dropdown to a "Server: BRIEFING_MODEL"
 // placeholder and remembers the previous model; switching back restores it.
+// podcast (issue #561 rework) is no longer part of this lock — it picks its
+// own model, remembered per-mode via localStorage (see MODE_MODEL_DEFAULTS
+// below) instead of sharing BRIEFING_MODEL.
 let _modelBeforeNewsMode = null;
+
+// Per-mode remembered model (issue #561): podcast defaults to gpt-5-mini the
+// first time it's opened, then remembers whatever the user picked last.
+const MODE_MODEL_DEFAULTS = { podcast: 'gpt-5-mini' };
+let _modelSelMode = 'story';   // mode the model dropdown's current value belongs to
 
 function _autoSwitchModelForMode(mode) {
   const modelSel = document.getElementById('setup-model');
   if (!modelSel) return;
 
-  // Briefing, paste (issue #481) and podcast (issue #482) all share the
-  // briefing pipeline and ignore this dropdown server-side — the server always
-  // resolves BRIEFING_MODEL (env, default gpt-5.1). Lock the control and show
-  // that honestly instead of a stale gpt-5-mini selection (issue #448).
+  // Briefing and paste (issues #481/#444) share the briefing pipeline and
+  // ignore this dropdown server-side — the server always resolves
+  // BRIEFING_MODEL (env, default gpt-5.1). Lock the control and show that
+  // honestly instead of a stale gpt-5-mini selection (issue #448).
   const serverOpt = document.getElementById('setup-model-server-opt');
-  if (mode === 'briefing' || mode === 'paste' || mode === 'podcast') {
+  if (mode === 'briefing' || mode === 'paste') {
+    // Remember the outgoing mode's selection before overwriting it — but
+    // never persist the server placeholder itself as a "model".
+    if (_modelSelMode && modelSel.value !== 'briefing-server')
+      localStorage.setItem('setupModel:' + _modelSelMode, modelSel.value);
     if (!serverOpt) {
       const opt = document.createElement('option');
       opt.id = 'setup-model-server-opt';
@@ -6643,6 +6655,7 @@ function _autoSwitchModelForMode(mode) {
     }
     modelSel.disabled = true;
     modelSel.title = 'News flow always uses BRIEFING_MODEL on the server (default gpt-5.1)';
+    _modelSelMode = null;   // dropdown shows the server placeholder, not a real mode's model
     return;
   }
   modelSel.disabled = false;
@@ -6653,6 +6666,15 @@ function _autoSwitchModelForMode(mode) {
     }
     serverOpt.remove();
   }
+  // Every other mode remembers its own model selection (issue #561) — save
+  // the outgoing mode's value, then restore the incoming mode's last pick
+  // (or its hardcoded default, or just leave the current value untouched).
+  if (_modelSelMode && modelSel.value !== 'briefing-server')
+    localStorage.setItem('setupModel:' + _modelSelMode, modelSel.value);
+  const remembered = localStorage.getItem('setupModel:' + mode);
+  modelSel.value = remembered || MODE_MODEL_DEFAULTS[mode] || modelSel.value;
+  if (!modelSel.value) modelSel.selectedIndex = 0;   // remembered value no longer in the list
+  _modelSelMode = mode;
 }
 
 // ── Paste mode: repeatable pasted-content blocks ────────────────────────────
@@ -6982,43 +7004,77 @@ function randomKahnemanChapters() {
   _updateKahnemanCount();
 }
 
-// ── Podcast episode picker (issue #482) — single-select, template copied from
-// the kahneman chapter selector above but radio-style (one episode per story).
-let _setupPodcastEpisodes = null; // null = not loaded yet, [] = loaded but empty
+// ── Podcast episode picker (issue #482, feed filter added in #561) —
+// single-select, template copied from the kahneman chapter selector above
+// but radio-style (one episode per story).
+let _setupPodcastFeeds = null;              // null = not loaded yet
+let _setupPodcastEpisodesByFeed = {};       // key '' (all) or feed_id → episodes array
 
 async function _loadPodcastEpisodesForSetup() {
   const container = document.getElementById('setup-podcast-episodes');
   const loading = document.getElementById('setup-podcast-loading');
+  const feedSel = document.getElementById('setup-podcast-feed');
   if (!container) return;
-  if (_setupPodcastEpisodes) { _renderPodcastEpisodes(); return; }
+  if (_setupPodcastFeeds === null) {
+    try {
+      const feeds = await api('GET', '/api/podcast/feeds');
+      _setupPodcastFeeds = feeds || [];
+      if (feedSel) {
+        const esc = s => String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        feedSel.innerHTML = '<option value="">All podcasts</option>' +
+          _setupPodcastFeeds.map(f => `<option value="${f.id}">${esc(f.title || f.url)}</option>`).join('');
+        feedSel.onchange = _onPodcastFeedFilterChange;
+      }
+    } catch (e) {
+      _setupPodcastFeeds = [];
+    }
+  }
+  await _loadPodcastEpisodesForCurrentFeed();
+}
+
+function _onPodcastFeedFilterChange() {
+  _loadPodcastEpisodesForCurrentFeed();
+}
+
+async function _loadPodcastEpisodesForCurrentFeed() {
+  const container = document.getElementById('setup-podcast-episodes');
+  const loading = document.getElementById('setup-podcast-loading');
+  const feedSel = document.getElementById('setup-podcast-feed');
+  if (!container) return;
+  const feedId = feedSel ? feedSel.value : '';
+  if (_setupPodcastEpisodesByFeed[feedId]) { _renderPodcastEpisodes(feedId); return; }
   container.style.display = 'none';
   if (loading) loading.style.display = 'block';
   try {
-    const data = await api('GET', '/api/podcast/episodes');
+    const url = '/api/podcast/episodes?limit=1000' + (feedId ? `&feed_id=${feedId}` : '');
+    const data = await api('GET', url);
     // Only episodes with a finished summary can seed a story (issue #482).
-    _setupPodcastEpisodes = (data || []).filter(ep => ep.status === 'summarized');
+    _setupPodcastEpisodesByFeed[feedId] = (data || []).filter(ep => ep.status === 'summarized');
     if (loading) loading.style.display = 'none';
     container.style.display = 'block';
-    _renderPodcastEpisodes();
+    _renderPodcastEpisodes(feedId);
   } catch (e) {
     if (loading) loading.textContent = 'Failed to load episodes.';
   }
 }
 
-function _renderPodcastEpisodes() {
+function _renderPodcastEpisodes(feedId) {
   const container = document.getElementById('setup-podcast-episodes');
-  if (!container || !_setupPodcastEpisodes) return;
-  if (!_setupPodcastEpisodes.length) {
+  const episodes = _setupPodcastEpisodesByFeed[feedId];
+  if (!container || !episodes) return;
+  if (!episodes.length) {
     container.innerHTML = '<div style="padding:12px;text-align:center;color:var(--muted,#888);font-size:13px">No summarized episodes yet.</div>';
     return;
   }
   const esc = s => String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  container.innerHTML = _setupPodcastEpisodes.map(ep => `
+  // Rows show just title + date (issue #561) — the summary preview was
+  // dropped, it made the list too tall to scan with many episodes.
+  container.innerHTML = episodes.map(ep => `
     <label class="kahneman-chapter-row">
       <input type="radio" class="podcast-episode-radio" name="podcast-episode" value="${ep.id}">
       <div class="kahneman-chapter-info">
         <span class="kahneman-chapter-title">${esc(ep.title || '(untitled)')}</span>
-        <span class="kahneman-chapter-concept">${esc(_localDate(ep.published_at || ''))} · ${esc(ep.summary_de || '')}</span>
+        <span class="kahneman-chapter-concept">${esc(_localDate(ep.published_at || ''))}</span>
       </div>
     </label>`).join('');
 }
@@ -7042,6 +7098,9 @@ function confirmStorySetup() {
   const grammarFocus = document.getElementById('setup-grammar').value.trim() || null;
   const grammarPct  = parseInt(document.getElementById('setup-grammar-pct').value, 10) || 75;
   const mode        = document.getElementById('setup-mode').value;
+  // Remember this mode's model choice (issue #561) — never the briefing/paste
+  // server placeholder, which isn't a real model selection.
+  if (model && model !== 'briefing-server') localStorage.setItem('setupModel:' + mode, model);
   const chapterIds  = mode === 'kahneman' ? _getSelectedChapterIds() : null;
   const articles    = mode === 'paste' ? _collectPastedContents() : null;
   const episodeId   = mode === 'podcast' ? _getSelectedEpisodeId() : null;

--- a/static/index.html
+++ b/static/index.html
@@ -739,6 +739,7 @@
       <div style="font-size:12px;color:var(--muted,#888);margin:2px 0 6px">
         Pick one summarized episode — the sentences will summarize its content (no context sentences).
       </div>
+      <select class="edit-input" id="setup-podcast-feed" style="margin-bottom:6px"></select>
       <div id="setup-podcast-episodes" style="max-height:220px;overflow-y:auto;border:1px solid var(--border,#ddd);border-radius:6px;padding:4px 0"></div>
       <div id="setup-podcast-loading" style="display:none;padding:12px;text-align:center;color:var(--muted,#888);font-size:13px">Loading episodes…</div>
     </div>
@@ -761,8 +762,10 @@
         <table class="price-table">
           <thead><tr><th>Model</th><th>Provider</th><th>Input</th><th>Output</th></tr></thead>
           <tbody>
-            <tr><td>GLM-4-Flash</td><td>Zhipu</td><td class="price-free">FREE</td><td class="price-free">FREE</td></tr>
-            <tr><td>GLM-4-Air</td><td>Zhipu</td><td>$0.06</td><td>$0.06</td></tr>
+            <tr><td>GLM-4.7-Flash</td><td>Zhipu</td><td class="price-free">FREE</td><td class="price-free">FREE</td></tr>
+            <tr><td>GLM-4.7-FlashX</td><td>Zhipu</td><td>$0.07</td><td>$0.40</td></tr>
+            <tr><td>GLM-4.7</td><td>Zhipu</td><td>$0.60</td><td>$2.20</td></tr>
+            <tr><td>GLM-5</td><td>Zhipu</td><td>$1.00</td><td>$3.20</td></tr>
             <tr><td>DeepSeek V4 Flash</td><td>DeepSeek</td><td>$0.14</td><td>$0.28</td></tr>
             <tr><td>DeepSeek V4 Pro</td><td>DeepSeek</td><td>$0.44</td><td>$0.87</td></tr>
             <tr><td>Qwen Turbo</td><td>Alibaba</td><td>$0.07</td><td>$0.26</td></tr>
@@ -775,8 +778,10 @@
         <p class="price-table-note">Prices per 1M tokens (USD)</p>
       </div>
       <select class="edit-input" id="setup-model">
-        <option value="glm-4-flash">GLM-4-Flash — free, great Chinese</option>
-        <option value="glm-4-air">GLM-4-Air — paid, higher quality</option>
+        <option value="glm-4.7">GLM-4.7 — Zhipu, best Chinese value</option>
+        <option value="glm-5">GLM-5 — Zhipu flagship</option>
+        <option value="glm-4.7-flashx">GLM-4.7-FlashX — Zhipu, very cheap</option>
+        <option value="glm-4.7-flash">GLM-4.7-Flash — Zhipu, free</option>
         <option value="deepseek-v4-flash" selected>DeepSeek V4 Flash — cheap, reliable</option>
         <option value="deepseek-v4-pro">DeepSeek V4 Pro — higher quality</option>
         <option value="qwen-turbo">Qwen Turbo — Alibaba, cheap</option>
@@ -1110,8 +1115,10 @@
     <p id="story-error-history-note" style="font-size:11px;color:var(--clr-muted,#888);margin:0 0 8px;display:none"></p>
     <label class="edit-label">Try a different model
       <select class="edit-input" id="story-error-model">
-        <option value="glm-4-flash">GLM-4-Flash — free, great Chinese</option>
-        <option value="glm-4-air">GLM-4-Air — paid, higher quality</option>
+        <option value="glm-4.7">GLM-4.7 — Zhipu, best Chinese value</option>
+        <option value="glm-5">GLM-5 — Zhipu flagship</option>
+        <option value="glm-4.7-flashx">GLM-4.7-FlashX — Zhipu, very cheap</option>
+        <option value="glm-4.7-flash">GLM-4.7-Flash — Zhipu, free</option>
         <option value="deepseek-v4-flash">DeepSeek V4 Flash — cheap, reliable</option>
         <option value="deepseek-v4-pro">DeepSeek V4 Pro — higher quality</option>
         <option value="qwen-turbo">Qwen Turbo — Alibaba, cheap</option>


### PR DESCRIPTION
Closes #561

## 改了什么

**后端**
- `ai.py` 新增 `generate_podcast_sentences`：全新精简管线取代对 briefing 管线的复用——输入只有单集的德语摘要（#541 起足够详细，不再发 15000 字转录全文），一次主调用 + 最多 2 轮漏词补齐 + 兜底句；**没有**事实核查、没有整篇校验重试（那是旧管线又慢又贵的根源）。每句恰好含一个目标词，8–20 个字，无上下文句；德译沿用 Google Translate（非 AI）
- `ai.py` `_call_api`：GLM-4.5/4.6/4.7/GLM-5 系列显式关闭 thinking 模式（这些型号默认开启，生成句子不需要思维链，白白花钱花时间）
- `routes/story.py`：podcast 拆成独立分支，生词按 `MAX_NEWS_BATCH`（10 个）分批，每批一次调用；模型由用户下拉框选择，不再锁死 BRIEFING_MODEL，默认 gpt-5-mini（Daniel 的智谱账号还在审核，通过后在界面选一次 GLM 即可，无需改代码）；Again 单句重生成走同一新管线，用故事里存的用户所选模型；gen_params 不再存转录全文
- `ALLOWED_MODELS` 白名单与 `database/stats.py` 价格表加入智谱新阵容：glm-5（$1.0/$3.2）、glm-4.7（$0.6/$2.2）、glm-4.7-flashx（$0.07/$0.4）、glm-4.7-flash（免费）

**前端**
- 模型下拉框（两处）：旧 glm-4-flash/glm-4-air 换成上述 4 个新 GLM 选项；设置弹窗价格表同步更新
- 每模式记住各自的模型（localStorage `setupModel:<mode>`），播客模式初始默认 gpt-5-mini；briefing/paste 的服务器模型锁死行为不变
- 播客单集选择器：新增播客源筛选下拉框（`GET /api/podcast/feeds` + `?feed_id=` 过滤），单集行只显示标题+日期，不再塞整段 summary_de

## 怎么测试的

- `python3 -m py_compile ai.py routes/story.py database/stats.py` + `node --check static/app.js` 全过
- 端到端实测（隔离临时数据库，未动 8000 端口）：用 gpt-5-mini + 德语测试摘要 + 3 个词卡直接调用新函数——3 句全部含目标词、长度 11–19 字、事实来自摘要、sentence_de 已填，全程 28 秒

🤖 Generated with [Claude Code](https://claude.com/claude-code)