### PR TITLE
播客模式：默认一次性发送全部生词 + 界面每批词数控件

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -1923,8 +1923,11 @@ def generate_podcast_sentences(
         msg = (f"生成播客总结…{attempt_label}" if attempt == 0
                else f"补漏 {len(remaining)} 个词（第{attempt + 1}轮）…{attempt_label}")
         _set_progress(progress_key, phase="request", msg=msg, percent=20 + attempt * 25)
+        # 8192: all-at-once batching (issue #563) can mean 30+ sentences in one
+        # response, and the gpt-5 series shares this budget with internal
+        # reasoning tokens (same rationale as the briefing call).
         raw = _call_api(model, [{"role": "user", "content": _build_prompt(remaining)}],
-                         4096, purpose="podcast")
+                         8192, purpose="podcast")
 
         json_start = raw.find("[")
         json_end = raw.rfind("]") + 1

--- a/routes/story.py
+++ b/routes/story.py
@@ -182,7 +182,8 @@ def _validated_model(model: str | None, default: str | None = None) -> str:
 def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
                         topic, max_hsk, model, grammar_focus, grammar_pct, mode,
                         chapter_ids, articles=None, progress_key, lang: str | None = None,
-                        origin: str | None = None, episode_id: int | None = None) -> dict | None:
+                        origin: str | None = None, episode_id: int | None = None,
+                        batch_size: int | None = None) -> dict | None:
     """Generate a story for `cards`, persist it, and return the stored story
     (with sentences) — or an error dict on failure, or None if there is nothing
     to generate. Shared by the synchronous GET, the background thread, and regenerate.
@@ -205,7 +206,7 @@ def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
             topic=topic, max_hsk=max_hsk, model=model, grammar_focus=grammar_focus,
             grammar_pct=grammar_pct, mode=mode, chapter_ids=chapter_ids,
             articles=articles, progress_key=progress_key, lang=lang,
-            origin=origin, episode_id=episode_id,
+            origin=origin, episode_id=episode_id, batch_size=batch_size,
         )
 
 
@@ -229,7 +230,8 @@ def _action_label_for_story(mode: str, deck_id: int) -> str:
 def _generate_and_store_body(deck_id: int, category: str, today: str, cards: list, *,
                              topic, max_hsk, model, grammar_focus, grammar_pct, mode,
                              chapter_ids, articles, progress_key, lang: str,
-                             origin: str | None, episode_id: int | None) -> dict | None:
+                             origin: str | None, episode_id: int | None,
+                             batch_size: int | None = None) -> dict | None:
     try:
         if mode == "news":
             # Issue #512: the old auto-fetch-only "news" mode has been removed
@@ -293,8 +295,10 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
             if not summary:
                 raise ValueError("Selected podcast episode has no summary yet.")
             model = _validated_model(model, default="gpt-5-mini")
-            logger.info("story  podcast model in use: %s", model)
-            chunk_size = ai.MAX_NEWS_BATCH
+            logger.info("story  podcast model in use: %s batch_size=%s", model, batch_size)
+            # batch_size (issue #563): user-controlled words-per-call from the
+            # setup modal; empty/0 = everything in one call (the default).
+            chunk_size = batch_size if batch_size and batch_size > 0 else len(cards)
             chunks = [cards[i:i + chunk_size] for i in range(0, len(cards), chunk_size)]
             sentences = []
             for idx, chunk in enumerate(chunks):
@@ -317,7 +321,7 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
             topic=topic, max_hsk=max_hsk, model=model,
             grammar_focus=grammar_focus, grammar_pct=grammar_pct,
             mode=mode, chapter_ids=chapter_ids, articles=articles, lang=lang,
-            origin=origin, episode_id=episode_id)
+            origin=origin, episode_id=episode_id, batch_size=batch_size)
         database.create_story(today, category, deck_id, sentences, prompt_text, topic, gen_params, lang=lang)
         story = database.get_active_story(today, category, deck_id, lang=lang)
     except Exception as e:
@@ -339,7 +343,8 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
 def _start_background_generation(deck_id: int, category: str, today: str, cards: list, *,
                                  topic, max_hsk, model, grammar_focus, grammar_pct,
                                  mode, chapter_ids, articles=None, progress_key,
-                                 lang: str | None = None, episode_id: int | None = None) -> None:
+                                 lang: str | None = None, episode_id: int | None = None,
+                                 batch_size: int | None = None) -> None:
     """Spawn a daemon thread that generates+stores a story, recording a terminal
     progress state (done/error) the frontend can poll. De-duped by progress_key."""
     def _run() -> None:
@@ -350,7 +355,7 @@ def _start_background_generation(deck_id: int, category: str, today: str, cards:
                 topic=topic, max_hsk=max_hsk, model=model,
                 grammar_focus=grammar_focus, grammar_pct=grammar_pct,
                 mode=mode, chapter_ids=chapter_ids, articles=articles, progress_key=progress_key,
-                lang=lang, episode_id=episode_id)
+                lang=lang, episode_id=episode_id, batch_size=batch_size)
             if isinstance(result, dict) and result.get("error"):
                 ai._story_progress[progress_key] = {
                     "phase": "error", "percent": 0, "msg": result.get("reason", "Generation failed")}
@@ -372,7 +377,7 @@ def _start_background_generation(deck_id: int, category: str, today: str, cards:
 
 def _gen_params_dict(*, topic, max_hsk, model, grammar_focus, grammar_pct,
                      mode, chapter_ids, articles=None, lang="zh",
-                     origin=None, episode_id=None) -> dict:
+                     origin=None, episode_id=None, batch_size=None) -> dict:
     """Bundle the story generation settings persisted on each story row, so the
     Again regeneration can reproduce the same style (see generate_sentence_for_word).
 
@@ -384,6 +389,8 @@ def _gen_params_dict(*, topic, max_hsk, model, grammar_focus, grammar_pct,
     episode_id: podcast mode's selected episode (issue #482, summary-only
     pipeline since #561) — Again-regen re-fetches the episode's summary_de by
     this id rather than reusing `articles` (podcast stories don't store any).
+    batch_size: podcast mode's words-per-AI-call (issue #563); None/0 = all at
+    once. Stored for handoff/reproducibility only — Again-regen is single-card.
     """
     return {
         "mode": mode,
@@ -397,6 +404,7 @@ def _gen_params_dict(*, topic, max_hsk, model, grammar_focus, grammar_pct,
         "lang": lang,
         "origin": origin,
         "episode_id": episode_id,
+        "batch_size": batch_size,
     }
 
 
@@ -495,6 +503,7 @@ def get_story(deck_id: int, category: str,
               mode: str = "story",
               chapter_ids: str | None = None,
               episode_id: int | None = None,
+              batch_size: int | None = None,
               no_generate: bool = False,
               background: bool = False,
               lang: str | None = None):
@@ -574,7 +583,7 @@ def get_story(deck_id: int, category: str,
             topic=topic, max_hsk=max_hsk, model=chosen_model,
             grammar_focus=grammar_focus, grammar_pct=grammar_pct,
             mode=mode, chapter_ids=chapter_ids, progress_key=progress_key, lang=lang,
-            episode_id=episode_id)
+            episode_id=episode_id, batch_size=batch_size)
         return {"generating": True}
 
     # ── Synchronous mode (default): generate now and return the story ─────────
@@ -588,7 +597,7 @@ def get_story(deck_id: int, category: str,
         topic=topic, max_hsk=max_hsk, model=chosen_model,
         grammar_focus=grammar_focus, grammar_pct=grammar_pct,
         mode=mode, chapter_ids=chapter_ids, progress_key=progress_key, lang=lang,
-        episode_id=episode_id)
+        episode_id=episode_id, batch_size=batch_size)
     ai._story_progress.pop(progress_key, None)
     return result
 
@@ -601,6 +610,7 @@ def regenerate_story(deck_id: int, category: str,
                      mode: str = "story",
                      chapter_ids: str | None = None,
                      episode_id: int | None = None,
+                     batch_size: int | None = None,
                      body: dict | None = None,
                      lang: str | None = None):
     """Regenerate today's story. body (optional JSON): {"articles": [{"url", "title", "text"}]}
@@ -627,7 +637,7 @@ def regenerate_story(deck_id: int, category: str,
         topic=topic, max_hsk=max_hsk, model=chosen_model,
         grammar_focus=grammar_focus, grammar_pct=grammar_pct,
         mode=mode, chapter_ids=chapter_ids, articles=articles, progress_key=progress_key, lang=lang,
-        episode_id=episode_id)
+        episode_id=episode_id, batch_size=batch_size)
     ai._story_progress.pop(progress_key, None)
     if result:
         # A new story means word→position mapping changed — invalidate every

--- a/static/app.js
+++ b/static/app.js
@@ -4038,6 +4038,10 @@ function _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chap
   if (mode && mode !== 'story')           p.set('mode', mode);
   if (chapterIds && chapterIds.length)    p.set('chapter_ids', chapterIds.join(','));
   if (episodeId)                          p.set('episode_id', episodeId);
+  // Podcast words-per-call (issue #563) — a module global (set in
+  // confirmStorySetup, persisted in localStorage) rather than yet another
+  // positional parameter through every call chain. Unset = all at once.
+  if (mode === 'podcast' && _podcastBatchSize) p.set('batch_size', _podcastBatchSize);
   // Active language tab (issue #436) — only sent once more than one language is
   // in use, so a pure-Chinese install's requests stay byte-identical.
   if (_langQ())                           p.set('lang', activeLang());
@@ -6599,6 +6603,8 @@ function updateSetupMode() {
     if (podcastSection) podcastSection.style.display = 'block';
     btn.textContent = 'Generate podcast summary';
     _loadPodcastEpisodesForSetup();
+    const batchInp = document.getElementById('setup-podcast-batch');
+    if (batchInp) batchInp.value = _podcastBatchSize || '';
   } else if (mode === 'vocab') {
     topicLabel.style.display = 'none';
     kahnemanSection.style.display = 'none';
@@ -7009,6 +7015,9 @@ function randomKahnemanChapters() {
 // but radio-style (one episode per story).
 let _setupPodcastFeeds = null;              // null = not loaded yet
 let _setupPodcastEpisodesByFeed = {};       // key '' (all) or feed_id → episodes array
+// Podcast words-per-AI-call (issue #563): null = all due words in one call
+// (the default). Read by _storyParams for every podcast generation URL.
+let _podcastBatchSize = parseInt(localStorage.getItem('podcastBatchSize'), 10) || null;
 
 async function _loadPodcastEpisodesForSetup() {
   const container = document.getElementById('setup-podcast-episodes');
@@ -7114,6 +7123,14 @@ function confirmStorySetup() {
   if (mode === 'podcast' && !episodeId) {
     showError('Podcast mode needs an episode — select one first.');
     return;
+  }
+  // Podcast words-per-call (issue #563): empty input = all at once (null).
+  if (mode === 'podcast') {
+    const batchInp = document.getElementById('setup-podcast-batch');
+    const v = parseInt((batchInp && batchInp.value) || '', 10);
+    _podcastBatchSize = v > 0 ? v : null;
+    if (_podcastBatchSize) localStorage.setItem('podcastBatchSize', _podcastBatchSize);
+    else localStorage.removeItem('podcastBatchSize');
   }
   _currentStoryMode = mode;
   _closeSetupModal();

--- a/static/index.html
+++ b/static/index.html
@@ -742,6 +742,10 @@
       <select class="edit-input" id="setup-podcast-feed" style="margin-bottom:6px"></select>
       <div id="setup-podcast-episodes" style="max-height:220px;overflow-y:auto;border:1px solid var(--border,#ddd);border-radius:6px;padding:4px 0"></div>
       <div id="setup-podcast-loading" style="display:none;padding:12px;text-align:center;color:var(--muted,#888);font-size:13px">Loading episodes…</div>
+      <!-- Words per AI call (issue #563): empty = all due words in one call -->
+      <label class="edit-label" style="margin-top:8px">Words per AI call <span style="font-weight:400;text-transform:none">(empty = all at once)</span>
+        <input class="edit-input" id="setup-podcast-batch" type="number" min="1" step="1" placeholder="all">
+      </label>
     </div>
     <label class="edit-label" id="setup-topic-label">Topic <span style="font-weight:400;text-transform:none">(optional)</span>
       <input class="edit-input" id="setup-topic" type="text" placeholder="e.g. a day at a coffee shop" onkeydown="if(event.key==='Enter')confirmStorySetup()">


### PR DESCRIPTION
Closes #563

## 改了什么

- **默认行为反转**：#561 的固定 10 词分批改为**默认一次性把全部到期生词发给 AI**（batch_size 为空/0 时单批全发）
- **界面控件**：设置弹窗播客区块新增「Words per AI call」数字输入框，留空 = 全发（默认），填 N = 按 N 个词分批实验；上次的值记在 localStorage
- **参数贯通**：`batch_size` 查询参数从前端 `_storyParams`（模块级全局，普通生成/重生成/混合复习三条链路全覆盖）→ `get_story`/`regenerate_story` → 后台线程 → podcast 分支，并存入 `gen_params`
- **输出预算**：播客调用 max_tokens 4096→8192——一次全发可能 30+ 句，且 gpt-5 系列的内部推理 token 与输出共享预算（与 briefing 调用同理）

## 怎么测试的

- `py_compile` + `node --check` 全过
- 分批逻辑穷举验证：batch_size ∈ {None, 0, 5, 12, 99} × 12 词 → 分别得到 1/1/3(5+5+2)/1/1 批，符合预期

🤖 Generated with [Claude Code](https://claude.com/claude-code)