### PR TITLE
fix: 播客检查加网络超时防卡死，运行锁跳过不再误报为已禁用

### DIFF
--- a/podcast.py
+++ b/podcast.py
@@ -83,6 +83,12 @@ _WHISPER_SEGMENT_SECONDS = 20 * 60  # 20min segments stay well under OpenAI's 25
 # below is a generous safety net, not a known Google limit.
 NOTEBOOKLM_NOTEBOOK_TITLE = "AnkiAdvanced Transcripts"
 _NOTEBOOKLM_INDEX_TIMEOUT = 10 * 60  # 10min cap for source indexing to finish
+# Hard ceiling for a whole NotebookLM round (upload + indexing + fulltext/ask).
+# wait_until_ready only bounds the indexing wait — the other RPCs have no
+# timeout of their own, and one stalled call froze a check for 14h holding the
+# run lock (#565). On expiry asyncio.wait_for cancels the round and the caller
+# falls back down its chain (Tingwu/Whisper, API summarizers).
+_NOTEBOOKLM_RUN_TIMEOUT = _NOTEBOOKLM_INDEX_TIMEOUT + 15 * 60
 _NOTEBOOKLM_MAX_UPLOAD_BYTES = 190 * 1024 * 1024
 
 # Whisper (#485) is real money, so it only runs for short episodes (#495):
@@ -523,7 +529,10 @@ def _transcribe_via_notebooklm(audio_path: str, video_id: str) -> str | None:
         return None
 
     try:
-        transcript = asyncio.run(_run_notebooklm_transcription(audio_path, video_id))
+        transcript = asyncio.run(asyncio.wait_for(
+            _run_notebooklm_transcription(audio_path, video_id),
+            timeout=_NOTEBOOKLM_RUN_TIMEOUT,
+        ))
     except FileNotFoundError:
         # AuthTokens.from_storage() raises this when no credentials file
         # exists yet — i.e. `notebooklm login` was never run. Not an error.
@@ -594,7 +603,10 @@ def _summarize_via_notebooklm(transcript: str, title: str, detail_level: str) ->
         return None
 
     try:
-        answer = asyncio.run(_run_notebooklm_summary(transcript, title, detail_level))
+        answer = asyncio.run(asyncio.wait_for(
+            _run_notebooklm_summary(transcript, title, detail_level),
+            timeout=_NOTEBOOKLM_RUN_TIMEOUT,
+        ))
     except FileNotFoundError:
         logger.info("podcast: NotebookLM not authenticated (no credentials file), skipping summary for %r", title)
         return None
@@ -1435,24 +1447,48 @@ def run_check() -> dict:
     if cfg.get("enabled", "1") not in ("1", "true", "True"):
         logger.info("podcast: disabled via config, skipping check")
         return {"new": 0, "summarized": 0, "emailed": 0, "failed": 0,
-                "retried": 0, "skipped": True}
+                "retried": 0, "skipped": True, "reason": "disabled"}
 
     # Non-blocking cross-process lock (#495): if another run is still going
     # (transcribing a backlog can take over an hour), skip this cycle instead
-    # of processing the same episodes twice in parallel.
+    # of processing the same episodes twice in parallel. Opened "a+" (not
+    # "w") so a failed acquisition doesn't truncate the holder's start
+    # timestamp (#565); the holder writes its own start time below so the
+    # busy branch can report how long the other run has been going.
     os.makedirs(os.path.dirname(_RUN_LOCK_PATH), exist_ok=True)
-    lock_file = open(_RUN_LOCK_PATH, "w")
+    lock_file = open(_RUN_LOCK_PATH, "a+")
     try:
         fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except OSError:
+        held_minutes = _lock_age_minutes(lock_file)
         lock_file.close()
-        logger.info("podcast: another check is already running, skipping this cycle")
+        logger.info(
+            "podcast: another check is already running%s, skipping this cycle",
+            f" (started {held_minutes:.0f} min ago)" if held_minutes is not None else "",
+        )
         return {"new": 0, "summarized": 0, "emailed": 0, "failed": 0,
-                "retried": 0, "skipped": True}
+                "retried": 0, "skipped": True, "reason": "busy",
+                "held_minutes": held_minutes}
     try:
+        lock_file.seek(0)
+        lock_file.truncate()
+        lock_file.write(datetime.now().isoformat(timespec="seconds"))
+        lock_file.flush()
         return _run_check_locked(cfg)
     finally:
         lock_file.close()
+
+
+def _lock_age_minutes(lock_file) -> float | None:
+    """How long ago the current holder of the run lock started, in minutes,
+    read from the ISO timestamp it wrote into the lock file — None if the
+    file is empty/unparseable (e.g. a holder from before #565)."""
+    try:
+        lock_file.seek(0)
+        started = datetime.fromisoformat(lock_file.read().strip())
+        return max((datetime.now() - started).total_seconds() / 60, 0.0)
+    except (OSError, ValueError):
+        return None
 
 
 def _run_check_locked(cfg: dict) -> dict:

--- a/scripts/podcast_check.py
+++ b/scripts/podcast_check.py
@@ -59,7 +59,14 @@ def main() -> int:
         return 1
 
     if summary.get("skipped"):
-        _log("播客爬虫已在设置里禁用，跳过。")
+        # 服务器用 reason 区分两种跳过（#565）；老服务器没有 reason 字段，
+        # 按原来的"已禁用"提示处理。
+        if summary.get("reason") == "busy":
+            held = summary.get("held_minutes")
+            extra = f"（已运行 {held:.0f} 分钟）" if isinstance(held, (int, float)) else ""
+            _log(f"上一轮播客检查仍在进行{extra}，本轮跳过。")
+        else:
+            _log("播客爬虫已在设置里禁用，跳过。")
         return 0
 
     new = summary.get("new", 0)

--- a/translator.py
+++ b/translator.py
@@ -7,11 +7,29 @@ can also translate other learner languages (e.g. French) into German.
 Requires internet access (VPN recommended in China).
 Install: pip install deep-translator
 """
+import concurrent.futures
 import logging
 
 logger = logging.getLogger(__name__)
 
 _translators: dict[tuple[str, str], object] = {}
+
+# deep-translator's underlying requests call sets no timeout, so one stalled
+# connection can hang the calling thread forever — a podcast check once froze
+# for 14h this way while holding its run lock (#565).
+_REQUEST_TIMEOUT_SECONDS = 90
+
+
+def _translate_with_timeout(t, text: str) -> str:
+    """Run t.translate(text) with a hard deadline on a throwaway thread. On
+    timeout the worker thread is abandoned (it dies whenever its socket does)
+    and concurrent.futures.TimeoutError propagates to the caller's existing
+    fallback handling."""
+    ex = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        return ex.submit(t.translate, text).result(timeout=_REQUEST_TIMEOUT_SECONDS)
+    finally:
+        ex.shutdown(wait=False)
 
 
 def _load(source: str, target: str) -> object | None:
@@ -36,7 +54,7 @@ def translate_zh(text: str, target: str = "en", source: str = "zh-CN") -> str:
     if t is None or not text.strip():
         return text
     try:
-        return t.translate(text) or text
+        return _translate_with_timeout(t, text) or text
     except Exception as e:
         logger.warning("translator: error (source=%s, target=%s) — %s", source, target, e)
         return text
@@ -53,7 +71,7 @@ def translate_batch(texts: list[str], target: str = "en", source: str = "zh-CN")
     sep = "\n"
     combined = sep.join(text.strip() or " " for text in texts)
     try:
-        translated = t.translate(combined) or combined
+        translated = _translate_with_timeout(t, combined) or combined
         parts = translated.split(sep)
         if len(parts) == len(texts):
             return [p.strip() or orig for p, orig in zip(parts, texts)]


### PR DESCRIPTION
Closes #565

## 改了什么

**1. 无超时的网络调用加硬上限（卡死根源）**
- `translator.py`：deep-translator 底层 requests 没有超时，一次挂住的请求可以永久悬挂调用线程。现在每次 `translate` 跑在一次性线程里，硬超时 90 秒；超时异常由调用方既有的 except 处理（返回原文/逐条回退）
- `podcast.py`：NotebookLM 转录与摘要的整轮 `asyncio.run(...)` 包一层 `asyncio.wait_for`（上限 = 索引超时 10 分钟 + 15 分钟 = 25 分钟）；超时由既有 except 捕获，落到回退链（听悟/Whisper、API 摘要链）

**2. 运行锁跳过不再误报为"已禁用"（排障误导）**
- `run_check` 返回值区分 `reason: disabled / busy`；busy 时从锁文件读持有者写入的开始时间戳，返回 `held_minutes`
- 锁文件从 `open(..., 'w')` 改为 `'a+'`——原来抢锁失败的一方会把持有者的内容截断
- `scripts/podcast_check.py`：busy 时日志为"上一轮播客检查仍在进行（已运行 X 分钟），本轮跳过"；老服务器无 reason 字段时保持原提示，向后兼容

## 为什么

2026-07-16 21:32 一轮检查在 NotebookLM 转录完成后卡在后续某个无超时网络调用里 14 小时，运行锁一直被占；之后所有 cron 轮次被挡，2026-07-17 早上的《声动早咖啡》新单集一直没被抓取。且 cron 日志把锁占用误报成"播客爬虫已在设置里禁用"，排障被带偏。

## 怎么测试的

- `py_compile` 语法检查三个文件通过
- 单元级：0.5 秒上限下 3 秒假 translate 正确抛 TimeoutError；`translate_zh` 超时回退为原文；`_lock_age_minutes` 解析 30 分钟前时间戳 ≈30、空文件 → None
- 端到端（临时 DB + 假 `_run_check_locked`）：无人持锁 → 正常执行且时间戳写入锁文件；他人持锁（10 分钟前）→ `{skipped: true, reason: busy, held_minutes: ≈10}`，且持有者的时间戳未被截断

🤖 Generated with [Claude Code](https://claude.com/claude-code)