### PR TITLE
fix: 混合复习 today-mixed 500——遍历 word_ids 取代 s["word_id"]（#569）

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -923,14 +923,18 @@ def get_due_cards_any_cat(root_deck_id: int, lang: str | None = None) -> list[di
         story = get_active_story(today, cat, deck_id)
         if story:
             for s in get_story_sentences(story["id"]):
-                story_pos[s["word_id"]] = s["position"]
+                # One sentence can map to several words (token-segmentation):
+                # get_story_sentences() exposes word_ids (list), not word_id.
+                for wid in s["word_ids"]:
+                    story_pos[wid] = s["position"]
     # Unified story is stored as category="unified" on the root deck —
     # the per-category loop above never finds it, so check explicitly.
     if not story_pos:
         unified_story = get_active_story(today, "unified", root_deck_id)
         if unified_story:
             for s in get_story_sentences(unified_story["id"]):
-                story_pos[s["word_id"]] = s["position"]
+                for wid in s["word_ids"]:
+                    story_pos[wid] = s["position"]
 
     NO_POS = 9999
     if story_pos:


### PR DESCRIPTION
## 问题
主页混合复习报 `GET /api/today-mixed/24?lang=zh → 500`。

## 根因
`database/cards.py` 的 `get_due_cards_any_cat` 按故事顺序排序时用了 `s["word_id"]`，但 `get_story_sentences()` 在「一句多词」改造后只返回 `word_ids`（list），`story_sentences` 表也无 `word_id` 列 → `KeyError: 'word_id'`。仅在「各分类无当日故事、但存在 unified 混合故事」时触发（走 unified 分支）。

## 修复
两处改为遍历 `s["word_ids"]`，把每个 word_id 映射到句子 position，语义与已在用的 `get_story_position_map` 一对多写法一致。

## 验证
临时库单元验证：`get_story_sentences` 返回含 `word_ids` 不含 `word_id`；旧写法复现 `KeyError`；修复后一句多词（首句两词）正确生成 `story_pos={1:0,2:1}`。语法/导入检查通过。

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)