### PR TITLE
fix: 埋藏同级卡后所有会话队列同步清除，取卡时兜底跳过已埋藏/暂停卡（#573）

### DIFF
--- a/routes/queue_manager.py
+++ b/routes/queue_manager.py
@@ -137,9 +137,13 @@ class QueueManager:
         - Otherwise pop it from the front of main (it was just answered) and
           remove it from intraday if it happened to be there.
         - buried_sibling_ids: card IDs that bury_siblings() just buried in the
-          DB.  They are removed from both queues so the DB and in-memory state
-          stay in sync.
+          DB.  Burying is global state, so they are removed from ALL cached
+          queues — not just this one — or a queue built earlier for another
+          category would still serve them (issue #573).
         """
+        if buried_sibling_ids:
+            self.discard_everywhere(buried_sibling_ids)
+
         if key not in self._queues:
             logger.debug("[QueueMgr] after_review key=%s — queue not found, skipping", key)
             return
@@ -172,25 +176,10 @@ class QueueManager:
             entries = list(q.intraday) + [{"id": card_id, "due": new_due}]
             q.intraday = deque(sorted(entries, key=lambda e: e["due"]))
 
-        # Remove siblings that bury_siblings() just buried in the DB
-        buried_removed_main     = []
-        buried_removed_intraday = []
-        if buried_sibling_ids:
-            remove_set = set(buried_sibling_ids)
-            new_main = deque(cid for cid in q.main if cid not in remove_set)
-            buried_removed_main = [cid for cid in q.main if cid in remove_set]
-            q.main = new_main
-            new_intraday = deque(e for e in q.intraday if e["id"] not in remove_set)
-            buried_removed_intraday = [e["id"] for e in q.intraday if e["id"] in remove_set]
-            q.intraday = new_intraday
-            q.requeued = deque(e for e in q.requeued if e["id"] not in remove_set)
-
         logger.debug(
             "[QueueMgr] after_review key=%s card=#%d → state=%s due=%s\n"
             "  removed_from: %s   becomes_intraday=%s\n"
-            "  buried_sibling_ids=%s\n"
-            "  buried_removed_from_main=%s\n"
-            "  buried_removed_from_intraday=%s\n"
+            "  buried_sibling_ids=%s (removed from ALL queues)\n"
             "  main before[0:10]=%s\n"
             "  main after [0:8] =%s\n"
             "  intraday before=%s\n"
@@ -198,13 +187,34 @@ class QueueManager:
             key, card_id, new_state, new_due,
             removed_from, becomes_intraday,
             buried_sibling_ids,
-            buried_removed_main,
-            buried_removed_intraday,
             main_before,
             list(q.main)[:8],
             intraday_before,
             [e["id"] for e in q.intraday],
         )
+
+    def discard_everywhere(self, card_ids) -> None:
+        """Remove the given card IDs from every cached queue.
+
+        Used for state changes that are global rather than per-session —
+        e.g. a card buried/suspended in the DB must stop being served by
+        every queue that was built before the change (issue #573).
+        """
+        remove_set = set(card_ids)
+        if not remove_set:
+            return
+        for key, q in self._queues.items():
+            removed = [cid for cid in q.main if cid in remove_set] + \
+                      [e["id"] for e in q.intraday if e["id"] in remove_set] + \
+                      [e["id"] for e in q.requeued if e["id"] in remove_set]
+            if not removed:
+                continue
+            q.main = deque(cid for cid in q.main if cid not in remove_set)
+            q.intraday = deque(e for e in q.intraday if e["id"] not in remove_set)
+            q.requeued = deque(e for e in q.requeued if e["id"] not in remove_set)
+            logger.debug(
+                "[QueueMgr] discard_everywhere key=%s removed=%s", key, removed,
+            )
 
     def soft_requeue(self, key: tuple, card_id: int, due: str) -> bool:
         """Re-show a card at `due` WITHOUT changing its DB scheduling state.

--- a/routes/review.py
+++ b/routes/review.py
@@ -158,18 +158,34 @@ def _key_and_build(
 
 
 def _next_card_from_queue(key, build_fn) -> dict | None:
-    """Ask the queue manager for the next card ID, then fetch the full card."""
+    """Ask the queue manager for the next card ID, then fetch the full card.
+
+    Queues are built once per Anki day, so a card can be buried/suspended/
+    deleted in the DB after the queue was built (e.g. bury_siblings from a
+    review in another category, issue #573).  Such stale entries are dropped
+    here instead of being served.
+    """
     today = database.anki_today().isoformat()
     now = datetime.now().isoformat(timespec="seconds")
-    card_id = _queue_mgr.get_next(key, build_fn, today, now)
-    if card_id is None:
-        return None
-    card = database.get_card(card_id)
-    if card:
+    while True:
+        card_id = _queue_mgr.get_next(key, build_fn, today, now)
+        if card_id is None:
+            return None
+        card = database.get_card(card_id)
+        if (card is None or card["state"] == "suspended"
+                or (card.get("buried_until") or "") >= today):
+            logger.debug(
+                "[review] skipping stale queue entry #%s (%s)",
+                card_id,
+                "deleted" if card is None else
+                f"state={card['state']} buried_until={card.get('buried_until')}",
+            )
+            _queue_mgr.discard_everywhere([card_id])
+            continue
         card["intervals"] = srs.preview_intervals(card)
         card["fsrs"] = srs.explain_card(card)
         _attach_again_sentence(card)
-    return card
+        return card
 
 
 # ---------------------------------------------------------------------------
@@ -498,8 +514,9 @@ def undo_review():
     for sib in entry.get("siblings_snapshot", []):
         database.set_card_buried_until(sib["id"], sib["buried_until"])
 
-    # Invalidate the queue so the restored card is picked up on next access
-    _queue_mgr.invalidate(entry.get("queue_key"))
+    # Invalidate ALL queues: the restored card belongs to this queue, but the
+    # un-buried siblings may sit in queues of other categories (issue #573).
+    _queue_mgr.invalidate()
 
     # Return the restored card so the frontend can show it
     restored = database.get_card(cb["id"])

--- a/tests/test_queue_manager.py
+++ b/tests/test_queue_manager.py
@@ -1,0 +1,200 @@
+"""
+Tests for the in-memory session queues in routes/queue_manager.py.
+
+Pure in-memory tests — no DB is touched.  Focus: cross-queue removal of
+buried sibling cards (issue #573): burying is global state, so a card buried
+after a review in one category must disappear from ALL cached queues, not
+just the queue the review happened in.
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from routes.queue_manager import QueueManager
+
+TODAY = "2026-07-17"
+NOW = "2026-07-17T10:00:00"
+
+KEY_LISTENING = ("multi", (1,), "listening")
+KEY_CREATING = ("multi", (1,), "creating")
+
+
+def build_fn_for(cards):
+    return lambda: [dict(c) for c in cards]
+
+
+def make_cards(*ids, state="review", due=TODAY):
+    return [{"id": i, "state": state, "due": due, "category": "x"} for i in ids]
+
+
+def fresh_manager():
+    """Manager with a listening queue (cards 10, 11, 12) and a creating
+    queue (cards 20, 21) already built."""
+    mgr = QueueManager()
+    mgr.get_next(KEY_LISTENING, build_fn_for(make_cards(10, 11, 12)), TODAY, NOW)
+    mgr.get_next(KEY_CREATING, build_fn_for(make_cards(20, 21)), TODAY, NOW)
+    return mgr
+
+
+# ---------------------------------------------------------------------------
+# discard_everywhere
+# ---------------------------------------------------------------------------
+
+def test_discard_everywhere_removes_from_all_queues():
+    mgr = fresh_manager()
+    mgr.discard_everywhere([11, 20])
+    assert list(mgr._queues[KEY_LISTENING].main) == [10, 12]
+    assert list(mgr._queues[KEY_CREATING].main) == [21]
+
+
+def test_discard_everywhere_removes_from_intraday_and_requeued():
+    mgr = QueueManager()
+    cards = [
+        {"id": 30, "state": "review", "due": TODAY, "category": "x"},
+        {"id": 31, "state": "learning", "due": "2026-07-17T11:00:00", "category": "x"},
+    ]
+    mgr.get_next(KEY_LISTENING, build_fn_for(cards), TODAY, NOW)
+    mgr.soft_requeue(KEY_LISTENING, 30, "2026-07-17T12:00:00")
+    q = mgr._queues[KEY_LISTENING]
+    assert [e["id"] for e in q.intraday] == [31]
+    assert [e["id"] for e in q.requeued] == [30]
+
+    mgr.discard_everywhere([30, 31])
+    assert list(q.main) == []
+    assert list(q.intraday) == []
+    assert list(q.requeued) == []
+
+
+def test_discard_everywhere_empty_is_noop():
+    mgr = fresh_manager()
+    mgr.discard_everywhere([])
+    assert list(mgr._queues[KEY_LISTENING].main) == [10, 11, 12]
+
+
+# ---------------------------------------------------------------------------
+# after_review with buried siblings (issue #573)
+# ---------------------------------------------------------------------------
+
+def test_after_review_purges_buried_siblings_from_other_queues():
+    """Reviewing card 20 in the creating queue buries sibling 11 — card 11
+    must also leave the listening queue that was built earlier."""
+    mgr = fresh_manager()
+    mgr.after_review(
+        KEY_CREATING, 20,
+        {"state": "review", "due": "2026-07-25"},
+        buried_sibling_ids=[11],
+    )
+    assert list(mgr._queues[KEY_CREATING].main) == [21]
+    assert list(mgr._queues[KEY_LISTENING].main) == [10, 12]
+
+
+def test_after_review_purges_buried_siblings_even_without_own_queue():
+    """The buried-sibling purge must run even when the reviewing context has
+    no cached queue (after_review used to return early in that case)."""
+    mgr = fresh_manager()
+    mgr.after_review(
+        ("single", 99, "creating"), 500,
+        {"state": "review", "due": "2026-07-25"},
+        buried_sibling_ids=[12],
+    )
+    assert list(mgr._queues[KEY_LISTENING].main) == [10, 11]
+
+
+def test_after_review_still_pops_reviewed_card():
+    mgr = fresh_manager()
+    mgr.after_review(KEY_LISTENING, 10, {"state": "review", "due": "2026-07-25"})
+    assert list(mgr._queues[KEY_LISTENING].main) == [11, 12]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end regression for issue #573 (through the real HTTP endpoints)
+# ---------------------------------------------------------------------------
+# Scenario observed in production 2026-07-17 (word 基本上): the listening
+# queue was built, then the creating sibling was reviewed — bury_siblings
+# marked the listening card buried in the DB, but the already-built listening
+# queue still served it 11 minutes later.
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+@pytest.fixture
+def e2e(tmp_path, monkeypatch):
+    """Fresh temp DB + empty queue manager + one imported word.
+
+    Returns (client, deck_id).  Uses the same DB_PATH monkeypatch pattern as
+    test_api.py; additionally clears the queue_mgr singleton, which persists
+    across tests inside one pytest process.
+    """
+    import database
+    import database.core
+    import importer
+    import yaml
+    import main
+    from routes.utils import queue_mgr
+
+    db_file = tmp_path / "test.db"
+    # Patch core.DB_PATH — get_db() reads this module global at call time.
+    # (Patching the `database` package attribute, as older tests do, silently
+    # leaves connections pointing at data/srs.db.)
+    monkeypatch.setattr(database.core, "DB_PATH", str(db_file))
+    database.init_db()
+    queue_mgr.invalidate()
+
+    d = tmp_path / "Kouyu"
+    d.mkdir()
+    entry = {"type": "vocabulary", "simplified": "你好", "pinyin": "nǐ hǎo",
+             "english": "hello", "pos": "intj", "hsk": "1"}
+    (d / "words.yaml").write_text(yaml.dump({"entries": [entry]}, allow_unicode=True))
+    importer.import_all(str(tmp_path))
+    deck_id = database.get_all_deck_id()
+
+    yield TestClient(main.app), deck_id
+    queue_mgr.invalidate()
+
+
+def _card_from(resp):
+    assert resp.status_code == 200
+    return resp.json()["card"]
+
+
+def test_buried_sibling_not_served_by_stale_queue(e2e):
+    client, deck_id = e2e
+
+    # 1. Build the listening queue — it now contains the listening card.
+    listening = _card_from(client.get(f"/api/today/{deck_id}/listening"))
+    assert listening is not None and listening["category"] == "listening"
+
+    # 2. Review the creating sibling (Good) → bury_siblings buries the
+    #    listening card in the DB.
+    creating = _card_from(client.get(f"/api/today/{deck_id}/creating"))
+    assert creating is not None and creating["category"] == "creating"
+    r = client.post("/api/review", params={"card_id": creating["id"], "rating": 3})
+    assert r.status_code == 200
+
+    # 3. The stale listening queue must NOT serve the buried card anymore.
+    after = _card_from(client.get(f"/api/today/{deck_id}/listening"))
+    assert after is None, (
+        f"buried listening card {listening['id']} was still served "
+        f"from the stale queue (issue #573)"
+    )
+
+
+def test_undo_brings_unburied_sibling_back(e2e):
+    client, deck_id = e2e
+
+    listening = _card_from(client.get(f"/api/today/{deck_id}/listening"))
+    creating = _card_from(client.get(f"/api/today/{deck_id}/creating"))
+    client.post("/api/review", params={"card_id": creating["id"], "rating": 3})
+    assert _card_from(client.get(f"/api/today/{deck_id}/listening")) is None
+
+    # Undo restores the sibling's buried_until and invalidates all queues,
+    # so the listening card must be served again.
+    r = client.post("/api/review/undo")
+    assert r.status_code == 200
+    restored = _card_from(client.get(f"/api/today/{deck_id}/listening"))
+    assert restored is not None and restored["id"] == listening["id"]


### PR DESCRIPTION
Closes #573

## 问题

复习一张卡后 `bury_siblings` 会把同词其他类别的卡标记为当天埋藏（数据库层面正常），但内存会话队列只清理当前复习上下文对应的那一个队列——其他类别此前已建好的队列仍会把已埋藏的卡发出来。

生产实测（2026-07-17，词条「基本上」，review_log #23842/#23894）：10:43 在 Creating 作答（Good）→ Listening 卡被正确埋藏 → 10:54 Listening 队列仍把它发给了用户。

## 修改

1. **`QueueManager.discard_everywhere()`**（新方法）：把卡片 ID 从**所有**缓存队列的 main/intraday/requeued 移除。埋藏是全局状态，与单个队列无关；`after_review` 的埋藏清理改用它，且即使当前上下文没有缓存队列也执行（原来会提前 return）。
2. **`_next_card_from_queue()` 兜底检查**：取到的卡若已埋藏（`buried_until ≥ 今天`）、已暂停或已删除，直接丢弃并继续取下一张。顺带覆盖了手动埋藏/暂停接口不失效队列的旧漏洞。
3. **`/api/review/undo` 失效全部队列**：恢复埋藏的兄弟卡后，它可能存在于其他类别的队列里，只失效当前队列不够。

## 测试

- 新增 `tests/test_queue_manager.py`：6 个纯内存单元测试 + 2 个端到端回归测试（TestClient 走真实 HTTP 接口，完整复现生产场景：建 Listening 队列 → Creating 作答 → Listening 不得再发出被埋藏的卡；撤销后恢复）。
- **反向验证**：两个端到端测试在未修复的 main 上失败，修复后通过。
- 顺带发现：现有 test_api/test_importer 的夹具给 `database.DB_PATH` 打补丁已失效（实际连接读的是 `database.core.DB_PATH`），导致这些测试静默连到本地 `data/srs.db`——这是 main 上 35 个既有测试失败的根因，与本 PR 无关，将另开议题。新测试使用正确的补丁方式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)