### PR TITLE
feat: 所有模式自定义每次 AI 调用生词数 + 埋藏兄弟卡队列同步修复（#574, #573）

### DIFF
--- a/routes/story.py
+++ b/routes/story.py
@@ -129,15 +129,20 @@ CHUNK_SIZE = 70
 
 
 def _generate_story_sentences(cards: list, *, topic, max_hsk, model, progress_key,
-                               grammar_focus, grammar_pct, mode, lang: str = "zh") -> tuple[list, str]:
-    """Generate story sentences, splitting into chunks of CHUNK_SIZE when cards > CHUNK_SIZE."""
-    if len(cards) <= CHUNK_SIZE:
+                               grammar_focus, grammar_pct, mode, lang: str = "zh",
+                               batch_size: int | None = None) -> tuple[list, str]:
+    """Generate story sentences, splitting into chunks of CHUNK_SIZE when cards > CHUNK_SIZE.
+
+    batch_size (issue #574): user-chosen words-per-AI-call from the setup modal;
+    overrides CHUNK_SIZE when set."""
+    chunk_limit = batch_size if batch_size and batch_size > 0 else CHUNK_SIZE
+    if len(cards) <= chunk_limit:
         return ai.generate_story(cards, topic=topic, max_hsk=max_hsk, model=model,
                                  progress_key=progress_key, grammar_focus=grammar_focus,
                                  grammar_pct=grammar_pct, mode=mode, lang=lang)
 
-    chunks = [cards[i:i + CHUNK_SIZE] for i in range(0, len(cards), CHUNK_SIZE)]
-    logger.info("story  CHUNKED %d cards → %d chunks of ≤%d", len(cards), len(chunks), CHUNK_SIZE)
+    chunks = [cards[i:i + chunk_limit] for i in range(0, len(cards), chunk_limit)]
+    logger.info("story  CHUNKED %d cards → %d chunks of ≤%d", len(cards), len(chunks), chunk_limit)
     all_sentences: list[dict] = []
     combined_prompt = ""
     for idx, chunk in enumerate(chunks):
@@ -246,7 +251,8 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
         if mode == "kahneman":
             parsed_chapter_ids = [int(x) for x in chapter_ids.split(",") if x.strip()] if chapter_ids else []
             sentences, prompt_text = _generate_kahneman_story_sentences(
-                cards, parsed_chapter_ids, model=model, progress_key=progress_key)
+                cards, parsed_chapter_ids, model=model, progress_key=progress_key,
+                batch_size=batch_size)
         elif mode in ("paste", "briefing"):
             # Briefing (issue #444) and paste (issue #481) share the briefing
             # pipeline and ignore the frontend's model selection — they always
@@ -277,7 +283,7 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
             sentences, prompt_text = _generate_briefing_story_sentences(
                 cards, articles, model=model, progress_key=progress_key,
                 max_hsk=max_hsk, generic=(mode == "paste"),
-                include_context=True)
+                include_context=True, batch_size=batch_size)
         elif mode == "podcast":
             # Podcast mode rework (issue #561): drops the briefing pipeline —
             # only the episode's German summary is sent (detailed enough since
@@ -314,7 +320,8 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
             sentences, prompt_text = _generate_story_sentences(
                 cards, topic=topic, max_hsk=max_hsk, model=model,
                 progress_key=progress_key, grammar_focus=grammar_focus,
-                grammar_pct=grammar_pct, mode=mode, lang=lang)
+                grammar_pct=grammar_pct, mode=mode, lang=lang,
+                batch_size=batch_size)
         for i, s in enumerate(sentences):
             s["position"] = i
         gen_params = _gen_params_dict(
@@ -389,8 +396,11 @@ def _gen_params_dict(*, topic, max_hsk, model, grammar_focus, grammar_pct,
     episode_id: podcast mode's selected episode (issue #482, summary-only
     pipeline since #561) — Again-regen re-fetches the episode's summary_de by
     this id rather than reusing `articles` (podcast stories don't store any).
-    batch_size: podcast mode's words-per-AI-call (issue #563); None/0 = all at
-    once. Stored for handoff/reproducibility only — Again-regen is single-card.
+    batch_size: user-chosen words-per-AI-call (issue #563 podcast-only, #574 all
+    modes); None/0 = each mode's default chunking (podcast: all at once; story
+    family: CHUNK_SIZE; kahneman: per-chapter split capped at MAX_KAHNEMAN_BATCH;
+    briefing/paste: MAX_NEWS_BATCH). Stored for handoff/reproducibility only —
+    Again-regen is single-card.
     """
     return {
         "mode": mode,
@@ -712,6 +722,7 @@ def _load_kahneman_chapter(chapter_id: int) -> dict | None:
 def _generate_kahneman_story_sentences(
     cards: list, chapter_ids: list[int] | None,
     model: str, progress_key: str | None,
+    batch_size: int | None = None,
 ) -> tuple[list, str]:
     """Distribute cards across selected chapters, call AI once per chapter, merge results."""
     if not os.path.exists(KAHNEMAN_PATH):
@@ -735,7 +746,11 @@ def _generate_kahneman_story_sentences(
     n = len(selected)
     # Cap words per AI call: large batches make the model skip words and dilute
     # sentence quality. Extra batches cycle through the selected chapters.
-    chunk_size = min(math.ceil(len(cards) / n), MAX_KAHNEMAN_BATCH)
+    # batch_size (issue #574): user-chosen override from the setup modal.
+    if batch_size and batch_size > 0:
+        chunk_size = batch_size
+    else:
+        chunk_size = min(math.ceil(len(cards) / n), MAX_KAHNEMAN_BATCH)
     chunks = [cards[i:i + chunk_size] for i in range(0, len(cards), chunk_size)]
 
     all_sentences: list[dict] = []
@@ -772,6 +787,7 @@ def _group_sentences_by_article(sentences: list[dict], articles: list[dict]) -> 
 def _generate_briefing_story_sentences(
     cards: list, articles: list[dict], model: str, progress_key: str | None,
     max_hsk: int = 3, generic: bool = False, include_context: bool = True,
+    batch_size: int | None = None,
 ) -> tuple[list, str]:
     """News flow mode (issue #399): split cards into batches of ai.MAX_NEWS_BATCH,
     each batch produces its own flowing mini-summary (target-word sentences +
@@ -794,7 +810,9 @@ def _generate_briefing_story_sentences(
             "News flow mode found no articles. "
             "Today's news fetch may have failed — please try again.")
 
-    chunk_size = ai.MAX_NEWS_BATCH
+    # batch_size (issue #574): user-chosen words-per-AI-call from the setup modal;
+    # empty = the long-standing MAX_NEWS_BATCH default.
+    chunk_size = batch_size if batch_size and batch_size > 0 else ai.MAX_NEWS_BATCH
     chunks = [cards[i:i + chunk_size] for i in range(0, len(cards), chunk_size)]
 
     # Detailed loading-screen progress (issue #407): overall word counter and the

--- a/static/app.js
+++ b/static/app.js
@@ -4074,10 +4074,11 @@ function _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chap
   if (mode && mode !== 'story')           p.set('mode', mode);
   if (chapterIds && chapterIds.length)    p.set('chapter_ids', chapterIds.join(','));
   if (episodeId)                          p.set('episode_id', episodeId);
-  // Podcast words-per-call (issue #563) — a module global (set in
-  // confirmStorySetup, persisted in localStorage) rather than yet another
-  // positional parameter through every call chain. Unset = all at once.
-  if (mode === 'podcast' && _podcastBatchSize) p.set('batch_size', _podcastBatchSize);
+  // Words per AI call (issue #563 podcast-only, #574 all modes) — persisted
+  // per mode in localStorage (like setupModel) rather than yet another
+  // positional parameter through every call chain. Unset = mode default.
+  const _bs = _savedBatchSize(mode);
+  if (_bs)                                p.set('batch_size', _bs);
   // Active language tab (issue #436) — only sent once more than one language is
   // in use, so a pure-Chinese install's requests stay byte-identical.
   if (_langQ())                           p.set('lang', activeLang());
@@ -6599,6 +6600,12 @@ function updateSetupMode() {
   const grammarLabel = document.getElementById('setup-grammar-label');
   if (modelLabel) modelLabel.style.display = isVocab ? 'none' : '';
   if (hskLabel) hskLabel.style.display = isVocab ? 'none' : '';
+  // Words per AI call (issue #574): per-mode persisted value, hidden in
+  // words-only mode (nothing is generated there).
+  const batchLabel = document.getElementById('setup-batch-label');
+  const batchInp = document.getElementById('setup-batch-size');
+  if (batchLabel) batchLabel.style.display = isVocab ? 'none' : '';
+  if (batchInp) batchInp.value = _savedBatchSize(mode) || '';
   if (grammarLabel) grammarLabel.style.display =
     isVocab ? 'none' : ((_deckLangById[deckId] || 'zh') === 'zh' ? '' : 'none');
   const countLabel = document.getElementById('setup-count-label');
@@ -6641,8 +6648,6 @@ function updateSetupMode() {
     if (podcastSection) podcastSection.style.display = 'block';
     btn.textContent = 'Generate podcast summary';
     _loadPodcastEpisodesForSetup();
-    const batchInp = document.getElementById('setup-podcast-batch');
-    if (batchInp) batchInp.value = _podcastBatchSize || '';
   } else if (mode === 'vocab') {
     topicLabel.style.display = 'none';
     kahnemanSection.style.display = 'none';
@@ -7053,9 +7058,20 @@ function randomKahnemanChapters() {
 // but radio-style (one episode per story).
 let _setupPodcastFeeds = null;              // null = not loaded yet
 let _setupPodcastEpisodesByFeed = {};       // key '' (all) or feed_id → episodes array
-// Podcast words-per-AI-call (issue #563): null = all due words in one call
-// (the default). Read by _storyParams for every podcast generation URL.
-let _podcastBatchSize = parseInt(localStorage.getItem('podcastBatchSize'), 10) || null;
+// Words per AI call (issue #563 podcast-only, #574 all modes): persisted per
+// mode like setupModel. null = the mode's default chunking. Read by
+// _storyParams for every generation URL.
+function _savedBatchSize(mode) {
+  return parseInt(localStorage.getItem('setupBatch:' + mode), 10) || null;
+}
+// One-time migration from the podcast-only #563 key.
+(() => {
+  const old = localStorage.getItem('podcastBatchSize');
+  if (old) {
+    localStorage.setItem('setupBatch:podcast', old);
+    localStorage.removeItem('podcastBatchSize');
+  }
+})();
 
 async function _loadPodcastEpisodesForSetup() {
   const container = document.getElementById('setup-podcast-episodes');
@@ -7162,13 +7178,13 @@ function confirmStorySetup() {
     showError('Podcast mode needs an episode — select one first.');
     return;
   }
-  // Podcast words-per-call (issue #563): empty input = all at once (null).
-  if (mode === 'podcast') {
-    const batchInp = document.getElementById('setup-podcast-batch');
+  // Words per AI call (issue #563 podcast-only, #574 all modes): empty input
+  // = the mode's default chunking; persisted per mode like setupModel.
+  {
+    const batchInp = document.getElementById('setup-batch-size');
     const v = parseInt((batchInp && batchInp.value) || '', 10);
-    _podcastBatchSize = v > 0 ? v : null;
-    if (_podcastBatchSize) localStorage.setItem('podcastBatchSize', _podcastBatchSize);
-    else localStorage.removeItem('podcastBatchSize');
+    if (v > 0) localStorage.setItem('setupBatch:' + mode, v);
+    else localStorage.removeItem('setupBatch:' + mode);
   }
   _currentStoryMode = mode;
   _closeSetupModal();

--- a/static/index.html
+++ b/static/index.html
@@ -742,10 +742,6 @@
       <select class="edit-input" id="setup-podcast-feed" style="margin-bottom:6px"></select>
       <div id="setup-podcast-episodes" style="max-height:220px;overflow-y:auto;border:1px solid var(--border,#ddd);border-radius:6px;padding:4px 0"></div>
       <div id="setup-podcast-loading" style="display:none;padding:12px;text-align:center;color:var(--muted,#888);font-size:13px">Loading episodes…</div>
-      <!-- Words per AI call (issue #563): empty = all due words in one call -->
-      <label class="edit-label" style="margin-top:8px">Words per AI call <span style="font-weight:400;text-transform:none">(empty = all at once)</span>
-        <input class="edit-input" id="setup-podcast-batch" type="number" min="1" step="1" placeholder="all">
-      </label>
     </div>
     <label class="edit-label" id="setup-topic-label">Topic <span style="font-weight:400;text-transform:none">(optional)</span>
       <input class="edit-input" id="setup-topic" type="text" placeholder="e.g. a day at a coffee shop" onkeydown="if(event.key==='Enter')confirmStorySetup()">
@@ -793,6 +789,11 @@
         <option value="claude-sonnet-4-6">Sonnet — Anthropic balanced</option>
         <option value="gpt-5-mini">GPT-5 Mini — OpenAI, news mode</option>
       </select>
+    </label>
+    <!-- Words per AI call (issue #563 podcast-only, #574 all modes):
+         empty = each mode's default chunking -->
+    <label class="edit-label" id="setup-batch-label">Words per AI call <span style="font-weight:400;text-transform:none">(empty = default)</span>
+      <input class="edit-input" id="setup-batch-size" type="number" min="1" step="1" placeholder="default">
     </label>
     <label class="edit-label" id="setup-hsk-label">
       Max HSK level for background vocabulary


### PR DESCRIPTION
## 说明

本 PR 包含两个独立提交（因本地共享工作区的两个会话相互交错，#573 的修复提交落在了本分支上，为避免强推重写历史，一并在此合并）：

### fc71453 — fix: 埋藏兄弟卡后其他类别队列仍发出该卡（Closes #573）
- `QueueManager.discard_everywhere()`：把卡片 ID 从**所有**缓存队列（main/intraday/requeued）移除；`after_review` 的埋藏清理改用它
- `_next_card_from_queue()`：取卡时兜底跳过已埋藏/已暂停/已删除的卡
- 新增 `tests/test_queue_manager.py`，8 个测试全部通过（本地已验证）

### bf74f8d — feat: 所有故事模式支持自定义每次 AI 调用的生词数（Closes #574）
- 后端：`batch_size` 传入所有模式的分批逻辑——story/qa/expository 覆盖 `CHUNK_SIZE=70`；kahneman 覆盖章节均分上限 10；briefing/paste 覆盖 `MAX_NEWS_BATCH=10`；podcast 保持 #563 现状；留空时行为完全不变
- 前端："Words per AI call" 输入框移到设置弹窗通用区，按模式持久化（`setupBatch:<mode>`，迁移旧 `podcastBatchSize` 键），words-only 模式隐藏

## 怎么测试
- 任意模式填批次大小 → 日志显示对应分块数（如 `story CHUNKED 20 cards → 4 chunks of ≤5`）
- 复习一张卡后切到其他类别 → 不再出现已埋藏的兄弟卡
- `node --check app.js` / `py_compile` / `pytest tests/test_queue_manager.py`（8 passed）均通过

Closes #573
Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)