### PR TITLE
feat: Again 单句重生成有正式成本标签并按会话合并显示（#578）

### DIFF
--- a/database/stats.py
+++ b/database/stats.py
@@ -206,6 +206,13 @@ _LEGACY_CLUSTER_GAP_SECONDS = 90
 # the main action ("story"), not a 1:1 helper pass ("fix_commas").
 _AUX_PURPOSES = {"fix_commas", "briefing_fact_check", "briefing_repair"}
 
+# Single-word Again regenerations get a per-mode "… Again Sentences" action label
+# (issue #578). Each click is its own action (one call), so adjacent actions with
+# the same Again label within this gap are merged into one expandable row —
+# a review session's Again clicks read as one line instead of dozens.
+_AGAIN_MERGE_GAP_SECONDS = 1800
+_AGAIN_LABEL_SUFFIX = "Again Sentences"
+
 
 def log_api_call(model: str, input_tokens: int, output_tokens: int,
                  purpose: str = "story", cached_input_tokens: int = 0,
@@ -352,10 +359,34 @@ def get_api_costs(limit: int = 100) -> dict:
     # rows (and thus order) are already called_at DESC, and an action's
     # started_at is its earliest call — sort actions by that so the most
     # recently-started operation shows first, matching the flat log's order.
-    actions_list = sorted(
+    actions_sorted = sorted(
         (actions[k] for k in order),
         key=lambda a: a["started_at"], reverse=True,
-    )[:limit]
+    )
+
+    # Merge adjacent same-label "… Again Sentences" actions (issue #578): each
+    # Again click is its own one-call action, so without this a review session
+    # fills the list with dozens of single-call rows. Newest-first order means
+    # the previous merged row's earliest call vs this action's latest call is
+    # the true gap between them.
+    merged: list[dict] = []
+    for a in actions_sorted:
+        prev = merged[-1] if merged else None
+        if (prev is not None and a["label"] == prev["label"]
+                and (a["label"] or "").endswith(_AGAIN_LABEL_SUFFIX)):
+            prev_earliest = _parse_log_time(prev["started_at"])
+            a_latest = _parse_log_time(a["calls"][0]["called_at"]) if a["calls"] else None
+            if (prev_earliest is not None and a_latest is not None
+                    and (prev_earliest - a_latest).total_seconds() <= _AGAIN_MERGE_GAP_SECONDS):
+                prev["calls"].extend(a["calls"])
+                prev["call_count"] += a["call_count"]
+                if a["total_cost"] is not None:
+                    prev["total_cost"] = round((prev["total_cost"] or 0.0) + a["total_cost"], 6)
+                prev["started_at"] = a["started_at"]
+                prev["action_id"] = None  # spans several action_ids now
+                continue
+        merged.append(a)
+    actions_list = merged[:limit]
 
     return {
         "pricing_as_of": _PRICING_AS_OF,

--- a/routes/story.py
+++ b/routes/story.py
@@ -22,6 +22,16 @@ KAHNEMAN_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "kahneman_
 # 每次 Kahneman AI 调用最多处理的词数（词太多会漏词、句子质量下降）
 MAX_KAHNEMAN_BATCH = 10
 
+# Again 单句重生成的成本动作标签（issue #578）——按故事模式区分；
+# get_api_costs 会把相邻的同标签 "… Again Sentences" 动作合并成一行。
+_AGAIN_ACTION_LABELS = {
+    "podcast": "Podcast Again Sentences",
+    "kahneman": "Kahneman Again Sentences",
+    "news": "News Again Sentences",
+    "briefing": "News Again Sentences",
+    "paste": "Paste Again Sentences",
+}
+
 # 《思考，快与慢》原书的 5 个部分（Part）—— 按章节号区间划分。
 # 数据文件不存部分信息，统一在此按章节号计算，保证一致性。
 _KAHNEMAN_PARTS = [
@@ -203,9 +213,11 @@ def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
     if not cards:
         return None
     lang = lang or database.get_deck_lang(deck_id)
-    ai.fix_definition_commas(cards)
     ai._story_progress[progress_key] = {"phase": "starting", "msg": "Starting…", "percent": 5}
     with database.action_context(_action_label_for_story(mode, deck_id)):
+        # Inside the action context (issue #578): fix_commas calls previously ran
+        # before it and showed up as orphan "fix_commas · legacy" cost rows.
+        ai.fix_definition_commas(cards)
         return _generate_and_store_body(
             deck_id, category, today, cards,
             topic=topic, max_hsk=max_hsk, model=model, grammar_focus=grammar_focus,
@@ -455,47 +467,53 @@ def generate_sentence_for_word(card: dict, gen_params: dict | None) -> dict | No
     mode = gp.get("mode") or "story"
     model = _validated_model(gp.get("model"))
     lang = gp.get("lang") or database.get_deck_lang(card["deck_id"])
+    # Action label (issue #578): without this the calls logged NULL action_ids
+    # and the cost history showed them as cryptic "podcast · legacy" rows.
+    # get_api_costs merges adjacent same-label "… Again Sentences" actions into
+    # one expandable row, so each click doesn't clutter the list.
+    action_label = _AGAIN_ACTION_LABELS.get(mode, "Story Again Sentences")
     try:
-        if mode == "kahneman":
-            chapter = _pick_kahneman_chapter(gp.get("chapter_ids"))
-            if chapter is not None:
-                sentences = ai.generate_kahneman_sentences([card], chapter, model=model)
-            else:  # book data missing → fall back to a plain sentence
-                sentences, _ = ai.generate_story([card], model=model, lang=lang)
-        elif mode == "podcast":
-            # Podcast Again-regen (issue #561): same lean pipeline, one card +
-            # the episode summary, honoring the story's stored user-picked
-            # model (old stories stored gpt-5.1, which is not whitelisted, so
-            # _validated_model falls back). No summary → plain sentence.
-            ep = database.get_episode(gp["episode_id"]) if gp.get("episode_id") else None
-            summary = ((ep or {}).get("summary_de") or "").strip()
-            if summary:
-                sentences = ai.generate_podcast_sentences(
-                    [card], summary, ep.get("title") or "",
-                    model=_validated_model(gp.get("model"), default="gpt-5-mini"),
-                    max_hsk=gp.get("max_hsk", 3),
-                    source_url=ep.get("youtube_url") or f"/#podcast-{ep['id']}",
-                    source_title=ep.get("title"))
+        with database.action_context(action_label):
+            if mode == "kahneman":
+                chapter = _pick_kahneman_chapter(gp.get("chapter_ids"))
+                if chapter is not None:
+                    sentences = ai.generate_kahneman_sentences([card], chapter, model=model)
+                else:  # book data missing → fall back to a plain sentence
+                    sentences, _ = ai.generate_story([card], model=model, lang=lang)
+            elif mode == "podcast":
+                # Podcast Again-regen (issue #561): same lean pipeline, one card +
+                # the episode summary, honoring the story's stored user-picked
+                # model (old stories stored gpt-5.1, which is not whitelisted, so
+                # _validated_model falls back). No summary → plain sentence.
+                ep = database.get_episode(gp["episode_id"]) if gp.get("episode_id") else None
+                summary = ((ep or {}).get("summary_de") or "").strip()
+                if summary:
+                    sentences = ai.generate_podcast_sentences(
+                        [card], summary, ep.get("title") or "",
+                        model=_validated_model(gp.get("model"), default="gpt-5-mini"),
+                        max_hsk=gp.get("max_hsk", 3),
+                        source_url=ep.get("youtube_url") or f"/#podcast-{ep['id']}",
+                        source_title=ep.get("title"))
+                else:
+                    sentences, _ = ai.generate_story([card], model=model, lang=lang)
+            elif mode in ("news", "paste", "briefing"):
+                # Briefing/paste Again-regen reuses the single-sentence news path:
+                # one word gets one fresh sentence from the same articles (no
+                # context chain). Both always use BRIEFING_MODEL (issue #444/#481),
+                # ignoring the story's stored model — same resolution as the main
+                # generation.
+                news_model = ai.resolve_briefing_model() if mode in ("briefing", "paste") else model
+                articles = gp.get("articles") or []
+                if articles:
+                    sentences = ai.generate_news_sentences(
+                        [card], articles, model=news_model, generic=(mode == "paste"))
+                else:  # no articles context saved → fall back to a plain sentence
+                    sentences, _ = ai.generate_story([card], model=news_model, lang=lang)
             else:
-                sentences, _ = ai.generate_story([card], model=model, lang=lang)
-        elif mode in ("news", "paste", "briefing"):
-            # Briefing/paste Again-regen reuses the single-sentence news path:
-            # one word gets one fresh sentence from the same articles (no
-            # context chain). Both always use BRIEFING_MODEL (issue #444/#481),
-            # ignoring the story's stored model — same resolution as the main
-            # generation.
-            news_model = ai.resolve_briefing_model() if mode in ("briefing", "paste") else model
-            articles = gp.get("articles") or []
-            if articles:
-                sentences = ai.generate_news_sentences(
-                    [card], articles, model=news_model, generic=(mode == "paste"))
-            else:  # no articles context saved → fall back to a plain sentence
-                sentences, _ = ai.generate_story([card], model=news_model, lang=lang)
-        else:
-            sentences, _ = ai.generate_story(
-                [card], topic=gp.get("topic"), max_hsk=gp.get("max_hsk", 2),
-                model=model, grammar_focus=gp.get("grammar_focus"),
-                grammar_pct=gp.get("grammar_pct", 75), mode=mode, lang=lang)
+                sentences, _ = ai.generate_story(
+                    [card], topic=gp.get("topic"), max_hsk=gp.get("max_hsk", 2),
+                    model=model, grammar_focus=gp.get("grammar_focus"),
+                    grammar_pct=gp.get("grammar_pct", 75), mode=mode, lang=lang)
     except Exception as e:
         logger.warning("again-regen  generation error for word=%s: %s", card.get("word_zh"), e)
         return None

--- a/tests/test_cost_actions.py
+++ b/tests/test_cost_actions.py
@@ -1,0 +1,89 @@
+"""get_api_costs 的动作分组测试（issue #578）。
+
+重点：相邻的同标签 "… Again Sentences" 动作在显示时合并成一行；
+非 Again 标签、间隔过大或被其他动作隔开的不合并。
+"""
+import uuid
+
+import pytest
+
+import database
+import database.core
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    # 与 test_queue_manager 相同的 DB_PATH monkeypatch 模式。
+    monkeypatch.setattr(database.core, "DB_PATH", str(tmp_path / "test.db"))
+    database.init_db()
+
+
+def _insert(called_at: str, label: str | None, purpose: str = "story") -> None:
+    """直接插入一条 1 调用的动作行（每个动作独立 action_id，模拟一次 Again 点击）。"""
+    conn = database.core.get_db()
+    conn.execute(
+        """INSERT INTO api_call_log
+           (called_at, model, input_tokens, output_tokens, purpose,
+            action_id, action_label)
+           VALUES (?, 'deepseek-chat', 100, 50, ?, ?, ?)""",
+        (called_at, purpose, uuid.uuid4().hex if label else None, label),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _labels(limit: int = 100) -> list[tuple[str, int]]:
+    actions = database.get_api_costs(limit)["actions"]
+    return [(a["label"], a["call_count"]) for a in actions]
+
+
+def test_adjacent_again_actions_merge(db):
+    _insert("2026-07-17 18:50:00", "Podcast Again Sentences")
+    _insert("2026-07-17 18:53:00", "Podcast Again Sentences")
+    _insert("2026-07-17 19:00:00", "Podcast Again Sentences")
+    assert _labels() == [("Podcast Again Sentences", 3)]
+
+
+def test_different_again_labels_do_not_merge(db):
+    _insert("2026-07-17 18:34:00", "Story Again Sentences")
+    _insert("2026-07-17 18:50:00", "Podcast Again Sentences")
+    assert _labels() == [
+        ("Podcast Again Sentences", 1),
+        ("Story Again Sentences", 1),
+    ]
+
+
+def test_interleaved_other_action_breaks_merge(db):
+    _insert("2026-07-17 18:50:00", "Podcast Again Sentences")
+    _insert("2026-07-17 18:55:00", "Story Again Sentences")
+    _insert("2026-07-17 19:00:00", "Podcast Again Sentences")
+    assert _labels() == [
+        ("Podcast Again Sentences", 1),
+        ("Story Again Sentences", 1),
+        ("Podcast Again Sentences", 1),
+    ]
+
+
+def test_large_gap_does_not_merge(db):
+    _insert("2026-07-17 10:00:00", "Podcast Again Sentences")
+    _insert("2026-07-17 12:00:00", "Podcast Again Sentences")  # 2h > 30min gap
+    assert _labels() == [
+        ("Podcast Again Sentences", 1),
+        ("Podcast Again Sentences", 1),
+    ]
+
+
+def test_non_again_labels_never_merge(db):
+    _insert("2026-07-17 18:50:00", "Generate Story: All")
+    _insert("2026-07-17 18:51:00", "Generate Story: All")
+    assert _labels() == [
+        ("Generate Story: All", 1),
+        ("Generate Story: All", 1),
+    ]
+
+
+def test_legacy_null_rows_keep_time_clustering(db):
+    # NULL action_id 行仍走 #537 时间聚类：60 秒内归一簇，标签 "<purpose> · legacy"
+    _insert("2026-07-17 18:50:00", None, purpose="podcast")
+    _insert("2026-07-17 18:50:30", None, purpose="podcast")
+    assert _labels() == [("podcast · legacy", 2)]


### PR DESCRIPTION
## 改了什么

成本历史里的 "podcast · legacy ≈ grouped" 行其实是 Again 单句重生成——这条链没被 `action_context` 包住，落库 action_id 为 NULL，被当作旧数据显示。

- **routes/story.py**：`generate_sentence_for_word` 全程包在 `action_context` 里，标签按模式命名（Podcast/Story/Kahneman/News/Paste Again Sentences）；`fix_definition_commas` 也挪进全篇生成的 `action_context`，消除孤立的 "fix_commas · legacy" 行
- **database/stats.py**：`get_api_costs` 显示时把**相邻的同标签 Again 动作**（间隔 ≤30 分钟）合并成一行，▸ 展开可见每次调用；非 Again 标签、被其他动作隔开或间隔过大的不合并；旧 NULL 行保持 #537 时间聚类不变
- **tests/test_cost_actions.py**：6 个用例（合并/不同标签/被隔开/间隔过大/非 Again/legacy 聚类回归）

前端无需改动（复用现有展开行渲染；合并行没有 ≈ 标记，因为分组是精确的）。

## 怎么测试
- `pytest tests/test_cost_actions.py`（6 passed）
- 复习时点几次 Again → 成本弹窗出现一行 "Podcast Again Sentences (N calls)" 可展开

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)