### PR TITLE
feat: 成本弹窗可查看 AI 回答与完整提示词（#579）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -72,14 +72,20 @@ def _openai_client(model: str) -> openai.OpenAI:
 
 
 def _extract_prompt(messages: list) -> str:
-    """Join the content of all user-role messages (for cost-modal display).
+    """Join the content of ALL messages (for cost-modal display).
 
-    Truncation to a display-safe length happens in database.log_api_call, not
-    here — never trust the caller to have already truncated.
+    System messages carry the format guides, so they must show too (issue #579)
+    — non-user roles are prefixed with a [role] marker so the reader can tell
+    them apart. Truncation to a display-safe length happens in
+    database.log_api_call, not here — never trust the caller to have already
+    truncated.
     """
-    return "\n\n".join(
-        m.get("content", "") for m in messages if m.get("role") == "user"
-    )
+    parts = []
+    for m in messages:
+        content = m.get("content", "")
+        role = m.get("role", "user")
+        parts.append(content if role == "user" else f"[{role}]\n{content}")
+    return "\n\n".join(parts)
 
 
 def _call_api(model: str, messages: list, max_tokens: int, purpose: str,
@@ -99,6 +105,7 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str,
         cached_tokens = getattr(msg.usage, "cache_read_input_tokens", 0) or 0
         logger.info("[%s] API call done in %.1fs — in=%d out=%d cached=%d purpose=%s",
                     model, elapsed, msg.usage.input_tokens, msg.usage.output_tokens, cached_tokens, purpose)
+        text = msg.content[0].text.strip()
         database.log_api_call(
             # Log the requested model id, not msg.model (the API returns a dated
             # snapshot name like "claude-sonnet-4-6-20260115" that the pricing
@@ -109,8 +116,9 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str,
             purpose=purpose,
             cached_input_tokens=cached_tokens,
             prompt=prompt_text,
+            response=text,
         )
-        return msg.content[0].text.strip()
+        return text
     else:
         client = _openai_client(model)
         extra: dict = {}
@@ -172,6 +180,7 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str,
             purpose=purpose,
             cached_input_tokens=cached_tokens,
             prompt=prompt_text,
+            response=content,
         )
 
         if choice.finish_reason == "length":

--- a/database/core.py
+++ b/database/core.py
@@ -173,6 +173,8 @@ def init_db() -> None:
         conn.execute("ALTER TABLE api_call_log ADD COLUMN action_label TEXT")
     if "prompt" not in api_call_log_cols:
         conn.execute("ALTER TABLE api_call_log ADD COLUMN prompt TEXT")
+    if "response" not in api_call_log_cols:
+        conn.execute("ALTER TABLE api_call_log ADD COLUMN response TEXT")
 
     story_cols = {r["name"] for r in conn.execute("PRAGMA table_info(stories)").fetchall()}
     if "prompt_text" not in story_cols:

--- a/database/stats.py
+++ b/database/stats.py
@@ -187,11 +187,12 @@ def action_context(label: str):
         _ACTION_CTX.reset(token)
 
 
-# Prompts are stored for the cost-modal "show prompt" button but must not
-# bloat api_call_log or the /api/costs payload indefinitely — truncate here,
-# in the single place every log_api_call() caller funnels through, rather
-# than trusting each call site to have already truncated.
-_PROMPT_MAX_CHARS = 10000
+# Prompts/responses are stored for the cost-modal Prompt/Response buttons but
+# must not bloat api_call_log indefinitely — truncate here, in the single place
+# every log_api_call() caller funnels through, rather than trusting each call
+# site to have already truncated. 30000 chars fits every current prompt whole
+# (issue #579: 10000 cut off the format guides of long briefing prompts).
+_PROMPT_MAX_CHARS = 30000
 
 # Rows predating the action_context() grouping (#525) have a NULL action_id.
 # Rather than list each on its own line, get_api_costs clusters NULL-action rows
@@ -216,34 +217,38 @@ _AGAIN_LABEL_SUFFIX = "Again Sentences"
 
 def log_api_call(model: str, input_tokens: int, output_tokens: int,
                  purpose: str = "story", cached_input_tokens: int = 0,
-                 prompt: str | None = None) -> None:
+                 prompt: str | None = None, response: str | None = None) -> None:
     action = _ACTION_CTX.get()
     action_id, action_label = action if action else (None, None)
     if prompt is not None and len(prompt) > _PROMPT_MAX_CHARS:
         prompt = prompt[:_PROMPT_MAX_CHARS]
+    if response is not None and len(response) > _PROMPT_MAX_CHARS:
+        response = response[:_PROMPT_MAX_CHARS]
 
     conn = get_db()
     conn.execute(
         """INSERT INTO api_call_log
            (model, input_tokens, output_tokens, purpose, cached_input_tokens,
-            action_id, action_label, prompt)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            action_id, action_label, prompt, response)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (model, input_tokens, output_tokens, purpose, cached_input_tokens,
-         action_id, action_label, prompt),
+         action_id, action_label, prompt, response),
     )
     conn.commit()
     conn.close()
 
 
-def get_api_call_prompt(call_id: int) -> str | None:
+def get_api_call_details(call_id: int) -> dict | None:
+    """Prompt + response of one logged call (fetched on demand, issue #579) —
+    or None if the call id doesn't exist."""
     conn = get_db()
     row = conn.execute(
-        "SELECT prompt FROM api_call_log WHERE id = ?", (call_id,)
+        "SELECT prompt, response FROM api_call_log WHERE id = ?", (call_id,)
     ).fetchone()
     conn.close()
     if row is None:
         return None
-    return row["prompt"]
+    return {"prompt": row["prompt"], "response": row["response"]}
 
 
 def _parse_log_time(called_at: str) -> _dt.datetime | None:
@@ -259,11 +264,12 @@ def _parse_log_time(called_at: str) -> _dt.datetime | None:
 def get_api_costs(limit: int = 100) -> dict:
     conn = get_db()
     # Never SELECT prompt here — actions/calls feed the /api/costs payload and
-    # prompts are fetched on demand via get_api_call_prompt() instead.
+    # prompts/responses are fetched on demand via get_api_call_details() instead.
     rows = [dict(r) for r in conn.execute(
         """SELECT id, called_at, model, input_tokens, output_tokens, purpose,
                   cached_input_tokens, action_id, action_label,
-                  (prompt IS NOT NULL) AS has_prompt
+                  (prompt IS NOT NULL) AS has_prompt,
+                  (response IS NOT NULL) AS has_response
            FROM api_call_log ORDER BY called_at DESC"""
     ).fetchall()]
     conn.close()
@@ -338,6 +344,7 @@ def get_api_costs(limit: int = 100) -> dict:
             "cached_input_tokens": r["cached_input_tokens"] or 0,
             "cost": round(cost, 6) if cost is not None else None,
             "has_prompt": bool(r["has_prompt"]),
+            "has_response": bool(r["has_response"]),
         })
         a["call_count"] += 1
         if cost is not None:

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -507,11 +507,11 @@ def get_api_costs(limit: int = 100):
 
 
 @router.get("/api/costs/call/{call_id}")
-def get_api_cost_call_prompt(call_id: int):
-    prompt = database.get_api_call_prompt(call_id)
-    if prompt is None:
-        raise HTTPException(status_code=404, detail="Call not found or has no stored prompt")
-    return {"id": call_id, "prompt": prompt}
+def get_api_cost_call_details(call_id: int):
+    details = database.get_api_call_details(call_id)
+    if details is None:
+        raise HTTPException(status_code=404, detail="Call not found")
+    return {"id": call_id, **details}
 
 
 @router.get("/api/pinyin")

--- a/schema.sql
+++ b/schema.sql
@@ -415,7 +415,8 @@ CREATE TABLE IF NOT EXISTS api_call_log (
     cached_input_tokens  INTEGER NOT NULL DEFAULT 0,
     action_id            TEXT,
     action_label         TEXT,
-    prompt               TEXT
+    prompt               TEXT,
+    response             TEXT
 );
 
 -- ---------------------------------------------------------------------------

--- a/static/app.js
+++ b/static/app.js
@@ -3349,9 +3349,11 @@ function renderCostModal(data) {
         const model = _prettyModel(c.model);
         const cachedTitle = c.cached_input_tokens > 0
           ? ` title="(${c.cached_input_tokens.toLocaleString()} cached)"` : '';
-        const promptBtn = c.has_prompt
-          ? `<button class="cost-prompt-btn" onclick="event.stopPropagation(); showCostPrompt(${c.id})">Prompt</button>`
-          : '';
+        const promptBtn = (c.has_prompt
+          ? `<button class="cost-prompt-btn" onclick="event.stopPropagation(); showCostPrompt(${c.id}, 'prompt')">Prompt</button>`
+          : '') + (c.has_response
+          ? ` <button class="cost-prompt-btn" onclick="event.stopPropagation(); showCostPrompt(${c.id}, 'response')">Response</button>`
+          : '');
         html += `<tr>
           <td>${_fmtCostTime(c.called_at)}</td>
           <td><span class="cost-model">${model}</span></td>
@@ -3380,7 +3382,7 @@ function toggleCostAction(idx) {
   arrow.innerHTML = open ? '&#9656;' : '&#9662;';
 }
 
-async function showCostPrompt(callId) {
+async function showCostPrompt(callId, kind = 'prompt') {
   let overlay = document.getElementById('cost-prompt-overlay');
   if (!overlay) {
     overlay = document.createElement('div');
@@ -3389,7 +3391,7 @@ async function showCostPrompt(callId) {
     overlay.innerHTML = `
       <div class="cost-prompt-box">
         <div class="cost-prompt-header">
-          <span>Prompt</span>
+          <span id="cost-prompt-title">Prompt</span>
           <button class="cost-prompt-close" onclick="closeCostPrompt()">&times;</button>
         </div>
         <pre class="cost-prompt-body" id="cost-prompt-body">Loading…</pre>
@@ -3398,13 +3400,15 @@ async function showCostPrompt(callId) {
     document.body.appendChild(overlay);
   }
   overlay.style.display = 'flex';
+  const title = kind === 'response' ? 'Response' : 'Prompt';
+  document.getElementById('cost-prompt-title').textContent = title;
   const body = document.getElementById('cost-prompt-body');
   body.textContent = 'Loading…';
   try {
     const data = await api('GET', `/api/costs/call/${callId}`);
-    body.textContent = data.prompt || '(no prompt stored)';
+    body.textContent = data[kind] || `(no ${kind} stored)`;
   } catch (e) {
-    body.textContent = 'Failed to load prompt: ' + e.message;
+    body.textContent = `Failed to load ${kind}: ` + e.message;
   }
 }
 


### PR DESCRIPTION
## 改了什么

- **ai.py**：`_extract_prompt` 此前只拼接 user 消息——system 消息里的格式指南全部丢失（Daniel 的观察属实）。现在包含所有消息，非 user 角色加 `[role]` 前缀；`_call_api` 两条分支（Anthropic/OpenAI 兼容）都把回答文本传给 `log_api_call`
- **database**：`api_call_log` 新增 `response` 列（core.py 迁移 + schema.sql）；prompt/response 截断上限 10000 → 30000 字符（旧上限会切掉长简报提示词的格式指南）；`get_api_call_prompt` → `get_api_call_details`（返回 prompt+response）
- **routes/browse.py**：`/api/costs/call/{id}` 返回 `{prompt, response}`
- **前端**：调用行在 Prompt 旁新增 Response 按钮（仅当有存储时显示），复用同一弹层，标题随内容切换

## 怎么测试

- 本地临时库验证：写入 40000 字符 prompt/response → 截断到 30000；`has_prompt`/`has_response` 正确；不存在的 id 返回 None（404）
- `py_compile` / `node --check` 通过
- 部署后任意生成一次故事 → 成本弹窗展开调用行，Prompt 里能看到 [system] 段，Response 显示 AI 原始回答

旧调用没有 response，不显示按钮，不受影响。

Closes #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)