### PR TITLE
feat: 模型下拉框加 GPT-5/GPT-5.1，所有选项标注价格（#584）

### DIFF
--- a/routes/story.py
+++ b/routes/story.py
@@ -180,6 +180,8 @@ ALLOWED_MODELS = {
     "claude-sonnet-4-6",
     "claude-opus-4-6",
     "gpt-5-mini",
+    "gpt-5",
+    "gpt-5.1",
     "glm-5",
     "glm-4.7",
     "glm-4.7-flashx",

--- a/static/index.html
+++ b/static/index.html
@@ -772,22 +772,27 @@
             <tr><td>Haiku 4.5</td><td>Anthropic</td><td>$0.80</td><td>$4.00</td></tr>
             <tr><td>Sonnet 4.6</td><td>Anthropic</td><td>$3.00</td><td>$15.00</td></tr>
             <tr><td>GPT-5 Mini</td><td>OpenAI</td><td>$0.25</td><td>$2.00</td></tr>
+            <tr><td>GPT-5</td><td>OpenAI</td><td>$1.25</td><td>$10.00</td></tr>
             <tr><td>GPT-5.1</td><td>OpenAI</td><td>$1.25</td><td>$10.00</td></tr>
           </tbody>
         </table>
         <p class="price-table-note">Prices per 1M tokens (USD)</p>
       </div>
+      <!-- Prices: $input/$output per 1M tokens (issue #584); keep in sync with
+           database/stats.py _MODEL_PRICING and the ℹ price table above -->
       <select class="edit-input" id="setup-model">
-        <option value="glm-4.7">GLM-4.7 — Zhipu, best Chinese value</option>
-        <option value="glm-5">GLM-5 — Zhipu flagship</option>
-        <option value="glm-4.7-flashx">GLM-4.7-FlashX — Zhipu, very cheap</option>
+        <option value="glm-4.7">GLM-4.7 — Zhipu, $0.60/$2.20</option>
+        <option value="glm-5">GLM-5 — Zhipu flagship, $1.00/$3.20</option>
+        <option value="glm-4.7-flashx">GLM-4.7-FlashX — Zhipu, $0.07/$0.40</option>
         <option value="glm-4.7-flash">GLM-4.7-Flash — Zhipu, free</option>
-        <option value="deepseek-v4-flash" selected>DeepSeek V4 Flash — cheap, reliable</option>
-        <option value="deepseek-v4-pro">DeepSeek V4 Pro — higher quality</option>
-        <option value="qwen-turbo">Qwen Turbo — Alibaba, cheap</option>
-        <option value="claude-haiku-4-5-20251001">Haiku — Anthropic fast</option>
-        <option value="claude-sonnet-4-6">Sonnet — Anthropic balanced</option>
-        <option value="gpt-5-mini">GPT-5 Mini — OpenAI, news mode</option>
+        <option value="deepseek-v4-flash" selected>DeepSeek V4 Flash — $0.14/$0.28</option>
+        <option value="deepseek-v4-pro">DeepSeek V4 Pro — $0.44/$0.87</option>
+        <option value="qwen-turbo">Qwen Turbo — Alibaba, $0.07/$0.26</option>
+        <option value="claude-haiku-4-5-20251001">Haiku — Anthropic, $0.80/$4.00</option>
+        <option value="claude-sonnet-4-6">Sonnet — Anthropic, $3.00/$15.00</option>
+        <option value="gpt-5-mini">GPT-5 Mini — OpenAI, $0.25/$2.00</option>
+        <option value="gpt-5">GPT-5 — OpenAI, $1.25/$10.00</option>
+        <option value="gpt-5.1">GPT-5.1 — OpenAI, $1.25/$10.00</option>
       </select>
     </label>
     <!-- Words per AI call (issue #563 podcast-only, #574 all modes):


### PR DESCRIPTION
## 改了什么

- `routes/story.py` `ALLOWED_MODELS` 白名单加 `gpt-5`、`gpt-5.1`（`_MODEL_PRICING` 里两者价格早已存在，成本核算直接生效）
- 设置弹窗模型下拉框：新增 GPT-5 / GPT-5.1 选项；**所有**选项直接标注 $输入/$输出（每百万 token），不用再点 ℹ
- ℹ 价格表补 GPT-5 行

## 怎么测试
- 下拉框能选 GPT-5 / GPT-5.1 并正常生成
- 价格与 `_MODEL_PRICING` 一致

Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)