### PR TITLE
feat: 成本弹窗显示所有已配置提供商的余额（#580）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -2232,3 +2232,108 @@ def get_deepseek_balance() -> dict | None:
     except Exception as e:
         logger.debug("get_deepseek_balance failed: %s", e)
         return None
+
+
+def _get_alibaba_balance() -> dict | None:
+    """Fetch the Alibaba Cloud account balance via the BSS OpenAPI
+    QueryAccountBalance action (issue #580), signed with the classic RPC
+    HMAC-SHA1 scheme — stdlib only, no alibabacloud_bssopenapi dependency.
+
+    Reuses the Tingwu AccessKey pair (ALIBABA_CLOUD_ACCESS_KEY_ID/SECRET).
+    Tries the international endpoint first (Daniel's account uses
+    dashscope-intl), then the mainland one. Returns {"balance", "currency"}
+    or None — never raises (nice-to-have, same contract as DeepSeek)."""
+    ak = os.environ.get("ALIBABA_CLOUD_ACCESS_KEY_ID")
+    sk = os.environ.get("ALIBABA_CLOUD_ACCESS_KEY_SECRET")
+    if not (ak and sk):
+        return None
+    import base64
+    import hashlib
+    import hmac
+    import urllib.parse
+    import urllib.request
+    import uuid
+    from datetime import datetime, timezone
+
+    params = {
+        "Action": "QueryAccountBalance",
+        "Version": "2017-12-14",
+        "Format": "JSON",
+        "AccessKeyId": ak,
+        "SignatureMethod": "HMAC-SHA1",
+        "SignatureVersion": "1.0",
+        "SignatureNonce": uuid.uuid4().hex,
+        "Timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+    def _pct(s: str) -> str:
+        return urllib.parse.quote(str(s), safe="-_.~")
+
+    canonical = "&".join(f"{_pct(k)}={_pct(v)}" for k, v in sorted(params.items()))
+    string_to_sign = "GET&%2F&" + _pct(canonical)
+    params["Signature"] = base64.b64encode(
+        hmac.new((sk + "&").encode(), string_to_sign.encode(), hashlib.sha1).digest()
+    ).decode()
+    query = urllib.parse.urlencode(params)
+    # The signature covers only the query string, not the host — one signature
+    # works for both endpoints.
+    for host in ("business.ap-southeast-1.aliyuncs.com", "business.aliyuncs.com"):
+        try:
+            with urllib.request.urlopen(f"https://{host}/?{query}", timeout=5) as resp:
+                data = json.loads(resp.read())
+            d = data.get("Data") or {}
+            if d.get("AvailableAmount") is not None:
+                return {"balance": d["AvailableAmount"], "currency": d.get("Currency") or "CNY"}
+        except Exception as e:
+            logger.debug("alibaba balance via %s failed: %s", host, e)
+    return None
+
+
+# Provider-balance cache (issue #580): the fetches block the cost modal, so a
+# 5-minute cache keeps repeat opens instant. Balances only change when Daniel
+# tops up or generates something — staleness is harmless.
+_balance_cache: dict = {"at": 0.0, "data": None}
+_BALANCE_CACHE_TTL_SECONDS = 300
+
+
+def get_provider_balances() -> list[dict]:
+    """Balance rows for every configured AI provider (issue #580).
+
+    Row shape: {"provider": str, "balance": str|None, "currency": str|None,
+    "unsupported": bool, "note": str|None}. Providers whose key isn't
+    configured are omitted; providers with no balance API (OpenAI, Anthropic,
+    Zhipu) get unsupported=True with a pointer to their console. Fetch
+    failures show balance=None so the frontend can say "unavailable"."""
+    import time as _time
+    now = _time.time()
+    if _balance_cache["data"] is not None and now - _balance_cache["at"] < _BALANCE_CACHE_TTL_SECONDS:
+        return _balance_cache["data"]
+
+    from concurrent.futures import ThreadPoolExecutor
+    with ThreadPoolExecutor(max_workers=2) as ex:
+        f_ds = ex.submit(get_deepseek_balance)
+        f_ali = ex.submit(_get_alibaba_balance)
+        ds, ali = f_ds.result(), f_ali.result()
+
+    rows: list[dict] = []
+
+    def _row(provider: str, balance: dict | None = None, note: str | None = None,
+             unsupported: bool = False) -> dict:
+        return {"provider": provider,
+                "balance": (balance or {}).get("balance"),
+                "currency": (balance or {}).get("currency"),
+                "unsupported": unsupported, "note": note}
+
+    if os.environ.get("DEEPSEEK_API_KEY"):
+        rows.append(_row("DeepSeek", ds))
+    if os.environ.get("ALIBABA_CLOUD_ACCESS_KEY_ID"):
+        rows.append(_row("Alibaba", ali))
+    if os.environ.get("ZHIPU_API_KEY"):
+        rows.append(_row("Zhipu", unsupported=True, note="no balance API — bigmodel.cn console"))
+    if os.environ.get("OPENAI_API_KEY"):
+        rows.append(_row("OpenAI", unsupported=True, note="no balance API — platform.openai.com"))
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        rows.append(_row("Anthropic", unsupported=True, note="no balance API — console.anthropic.com"))
+
+    _balance_cache.update(at=now, data=rows)
+    return rows

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -503,7 +503,7 @@ def get_card_evolution(days: int = 365, deck_id: int | None = None, lang: str | 
 
 @router.get("/api/costs")
 def get_api_costs(limit: int = 100):
-    return {**database.get_api_costs(limit=limit), "deepseek_balance": ai.get_deepseek_balance()}
+    return {**database.get_api_costs(limit=limit), "balances": ai.get_provider_balances()}
 
 
 @router.get("/api/costs/call/{call_id}")

--- a/static/app.js
+++ b/static/app.js
@@ -3308,10 +3308,17 @@ function renderCostModal(data) {
     <span>Last 30 days <b>${fmt(data.total_cost_30d)}</b></span>
   </div>`;
 
-  if (data.deepseek_balance) {
-    const b = data.deepseek_balance;
-    const symbol = b.currency === 'CNY' ? '¥' : (b.currency === 'USD' ? '$' : (b.currency + ' '));
-    html += `<div class="cost-balance">DeepSeek balance: ${symbol}${b.balance}</div>`;
+  for (const b of data.balances || []) {
+    let value;
+    if (b.unsupported) {
+      value = `<span style="color:var(--muted)">${_escHtml(b.note || 'no balance API')}</span>`;
+    } else if (b.balance == null) {
+      value = `<span style="color:var(--muted)">unavailable</span>`;
+    } else {
+      const symbol = b.currency === 'CNY' ? '¥' : (b.currency === 'USD' ? '$' : (b.currency + ' '));
+      value = `${symbol}${b.balance}`;
+    }
+    html += `<div class="cost-balance">${_escHtml(b.provider)} balance: ${value}</div>`;
   }
 
   if (data.unknown_calls > 0) {


### PR DESCRIPTION
## 改了什么

- **ai.py**：新增 `_get_alibaba_balance()`——BSS OpenAPI `QueryAccountBalance`，经典 RPC HMAC-SHA1 签名（纯标准库，不新增依赖），复用听悟的 `ALIBABA_CLOUD_ACCESS_KEY_ID/SECRET`；先试国际端点（账户用 dashscope-intl）再试大陆端点。`get_provider_balances()` 并行请求 DeepSeek + 阿里云，缓存 5 分钟（弹窗重复打开秒开）
- 调查确认（见议题）：OpenAI、Anthropic、智谱**都没有**余额查询接口——已配置密钥时显示 "no balance API — <控制台地址>"，未配置的提供商不显示
- **/api/costs**：`deepseek_balance` → `balances` 列表；前端逐行渲染，查询失败显示 "unavailable"，单个提供商失败不影响其他行

## 怎么测试
- 本地无密钥环境：balances 为空列表，弹窗不显示余额区（正常）
- 部署后打开成本弹窗：应看到 DeepSeek/Alibaba 的实际余额与三行说明——**阿里云签名逻辑需要服务器上的真实密钥验证，若显示 unavailable 请把 journalctl 里的 debug 日志发我**

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)