### PR TITLE
可配置的每日分界时间（默认早上 5 点）（#588）

### DIFF
--- a/database/core.py
+++ b/database/core.py
@@ -7,17 +7,52 @@ from datetime import date, datetime, timedelta
 DB_PATH = os.environ.get("DB_PATH", "data/srs.db")
 SCHEMA_PATH = os.path.join(os.path.dirname(__file__), "..", "schema.sql")
 
-DAY_CUTOFF_HOUR = 4  # New day starts at 4am, like Anki
+DEFAULT_DAY_CUTOFF_HOUR = 5  # New day starts at 5am by default (issue #588)
+
+# Cached day-cutoff hour. anki_today() runs dozens of times per request, so we
+# must not open a DB connection each call. This module-level cache is refreshed
+# by refresh_day_cutoff_hour() at the end of init_db() and whenever the setting
+# is changed via the API. (issue #588)
+_day_cutoff_hour = DEFAULT_DAY_CUTOFF_HOUR
+
+
+def get_day_cutoff_hour() -> int:
+    """Hour (0-23) at which a new Anki day begins. Reads the cached value; the
+    cache is seeded/refreshed by refresh_day_cutoff_hour(). (issue #588)"""
+    return _day_cutoff_hour
+
+
+def refresh_day_cutoff_hour() -> int:
+    """Reload the day-cutoff hour from app_settings into the module cache and
+    return it. Called at init and after the setting is updated. Falls back to
+    the default on any error or invalid value. (issue #588)"""
+    global _day_cutoff_hour
+    try:
+        conn = get_db()
+        try:
+            row = conn.execute(
+                "SELECT value FROM app_settings WHERE key = 'day_cutoff_hour'"
+            ).fetchone()
+        finally:
+            conn.close()
+        if row is not None:
+            h = int(row["value"])
+            if 0 <= h <= 23:
+                _day_cutoff_hour = h
+    except Exception:
+        pass
+    return _day_cutoff_hour
 
 
 def anki_today() -> date:
-    """Return today's date using 4am as the day boundary (like Anki).
+    """Return today's date using the configurable day boundary (default 5am,
+    like Anki's 4am; issue #588).
 
-    Between midnight and 3:59am, returns yesterday's date so that late-night
-    review sessions still count as the previous calendar day.
+    Between midnight and the cutoff hour, returns yesterday's date so that
+    late-night review sessions still count as the previous calendar day.
     """
     now = datetime.now()
-    if now.hour < DAY_CUTOFF_HOUR:
+    if now.hour < _day_cutoff_hour:
         return (now - timedelta(days=1)).date()
     return now.date()
 
@@ -547,6 +582,14 @@ def init_db() -> None:
         "INSERT OR IGNORE INTO app_settings (key, value) VALUES ('pregen_enabled', '1')")
     conn.commit()
 
+    # day_cutoff_hour seeding (issue #588): the hour a new Anki day begins.
+    # Default 5 (Daniel reviews past midnight and doesn't want the next day's
+    # cards appearing before 5am). Same unconditional INSERT OR IGNORE pattern;
+    # existing installs pick up the default on next startup without a migration.
+    conn.execute(
+        "INSERT OR IGNORE INTO app_settings (key, value) VALUES ('day_cutoff_hour', '5')")
+    conn.commit()
+
     # feeds (#497) seeding: RSS direct-link sources replacing the dead
     # YouTube channel_url (YouTube started bot-verifying the server's IP with
     # no Cookie fix that stuck, #491/#497). Same unconditional INSERT OR
@@ -644,6 +687,10 @@ def init_db() -> None:
     conn.commit()
 
     conn.close()
+
+    # Seed the day-cutoff cache now that app_settings is guaranteed present
+    # (issue #588). Every anki_today() thereafter reads the cache, not the DB.
+    refresh_day_cutoff_hour()
 
 
 def _migrate_story_sentences_multi_word(conn: sqlite3.Connection) -> None:

--- a/routes/story.py
+++ b/routes/story.py
@@ -1165,6 +1165,30 @@ def put_pregen_enabled(body: dict):
     return {"ok": True, "enabled": enabled}
 
 
+@router.get("/api/day-cutoff-hour")
+def get_day_cutoff_hour_endpoint():
+    """The hour (0-23) at which a new Anki day begins (issue #588). Before this
+    hour, late-night reviews still count as the previous day and the next day's
+    cards stay out of the stack."""
+    return {"hour": database.get_day_cutoff_hour()}
+
+
+@router.put("/api/day-cutoff-hour")
+def put_day_cutoff_hour(body: dict):
+    """Set the day-boundary hour (issue #588). body: {"hour": int 0-23}.
+    Refreshes the in-memory cache so anki_today() picks it up immediately."""
+    try:
+        hour = int(body.get("hour"))
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail="hour must be an integer")
+    if not 0 <= hour <= 23:
+        raise HTTPException(status_code=400, detail="hour must be between 0 and 23")
+    database.set_app_setting("day_cutoff_hour", str(hour))
+    database.refresh_day_cutoff_hour()
+    logger.info("day-cutoff-hour  set to %s", hour)
+    return {"ok": True, "hour": hour}
+
+
 @router.put("/api/pregen-config")
 def put_pregen_config(body: dict):
     """Replace the config rows for one deck. body: {"deck_id": int,

--- a/srs.py
+++ b/srs.py
@@ -288,13 +288,14 @@ def _smart_due(due_dt: datetime) -> str:
     same-day datetime in SQL comparisons, so the card is correctly included
     in story generation and review queries from the start of that day.
     """
-    next_4am = datetime.combine(
+    cutoff_hour = database.get_day_cutoff_hour()
+    next_cutoff = datetime.combine(
         database.anki_today() + timedelta(days=1),
-        dtime(database.DAY_CUTOFF_HOUR, 0, 0),
+        dtime(cutoff_hour, 0, 0),
     )
-    if due_dt >= next_4am:
+    if due_dt >= next_cutoff:
         # Determine the Anki day the card will be shown on
-        due_date = (due_dt.date() if due_dt.hour >= database.DAY_CUTOFF_HOUR
+        due_date = (due_dt.date() if due_dt.hour >= cutoff_hour
                     else (due_dt - timedelta(days=1)).date())
         return due_date.isoformat()
     return due_dt.isoformat(timespec="seconds")

--- a/static/app.js
+++ b/static/app.js
@@ -2545,10 +2545,39 @@ async function openStats() {
 // ── Settings (customize review shortcuts) ────────────────────────────────────
 let _capturingAction = null;
 let _settingsMsg = '';
+let _dayCutoffHour = 5;
 function openSettings() {
   _capturingAction = null; _settingsMsg = '';
   showView('settings');
   renderSettings();
+  _loadDayCutoffHour();
+}
+
+async function _loadDayCutoffHour() {
+  try {
+    const res = await api('GET', '/api/day-cutoff-hour');
+    if (res && Number.isInteger(res.hour)) {
+      _dayCutoffHour = res.hour;
+      renderSettings();
+    }
+  } catch (e) { /* keep default */ }
+}
+
+async function saveDayCutoffHour() {
+  const input = document.getElementById('day-cutoff-hour-input');
+  const msg = document.getElementById('day-cutoff-msg');
+  const hour = parseInt(input.value, 10);
+  if (!Number.isInteger(hour) || hour < 0 || hour > 23) {
+    if (msg) msg.textContent = 'Enter 0–23';
+    return;
+  }
+  try {
+    const res = await api('PUT', '/api/day-cutoff-hour', { hour });
+    _dayCutoffHour = res.hour;
+    if (msg) msg.textContent = 'Saved ✓';
+  } catch (e) {
+    if (msg) msg.textContent = 'Failed: ' + e.message;
+  }
 }
 function renderSettings() {
   const rows = KEYMAP_ACTIONS.map(a => {
@@ -2583,6 +2612,18 @@ function renderSettings() {
                  onchange="setNewsflowLangFromSwitch(this.checked)" style="width:18px;height:18px;cursor:pointer">
           <span id="newsflow-lang-value">${nfZh ? '中文' : 'Original (DE)'}</span>
         </label>
+      </div>
+    </div>
+    <div class="keymap-panel">
+      <h2 class="keymap-heading">Day boundary</h2>
+      <p class="keymap-hint">Hour a new day starts. Cards due the next day stay out of the stack until this time, so late-night reviews still count as the previous day. Default 5.</p>
+      <div class="keymap-row">
+        <span class="keymap-label">New day starts at</span>
+        <input class="opt-input" id="day-cutoff-hour-input" type="number" min="0" max="23"
+               value="${_dayCutoffHour}" style="width:64px">
+        <span class="keymap-label">:00</span>
+        <button class="keymap-reset-all" onclick="saveDayCutoffHour()">Save</button>
+        <span id="day-cutoff-msg" class="keymap-label"></span>
       </div>
     </div>
     <div class="keymap-panel">


### PR DESCRIPTION
## 改了什么

把硬编码的凌晨 4 点"Anki 日"分界改为**可配置的全局设置**，默认改为**早上 5 点**。

## 为什么

Daniel 有时在午夜之后还在复习，希望第二天到期的卡片在设定的分界时间之前**不要进入卡堆**——这样深夜复习仍算作前一天。

## 怎么做

- **`database/core.py`**：`app_settings` 新增 `day_cutoff_hour`（默认 `5`）。`anki_today()` 读模块级缓存，避免每次调用（每请求几十次）都开数据库连接；`init_db()` 末尾与设置更新时通过 `refresh_day_cutoff_hour()` 刷新缓存
- **`srs.py`**：唯一直接引用 `DAY_CUTOFF_HOUR` 常量的地方改用 `get_day_cutoff_hour()`
- **`routes/story.py`**：新增 `GET/PUT /api/day-cutoff-hour`（PUT 校验 0–23，成功后刷新缓存）
- **`static/app.js`**：设置弹窗新增"Day boundary"面板，小时数输入框

队列按 Anki 日缓存，分界一变 `anki_today()` 返回值就变，队列自动重建——无需额外失效逻辑。

## 怎么测试

- Python/JS 语法检查、`import main` 均通过
- 临时数据库验证：默认为 5；改为 3 后，模拟凌晨 2 点 `anki_today()` 返回前一天、凌晨 4 点返回当天——断言全部通过

Closes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)