### PR TITLE
feat: 快捷键 Option+L 打开日志查看器（#591）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2633,7 +2633,7 @@ function renderSettings() {
     </div>
     <div class="keymap-panel">
       <h2 class="keymap-heading">Server logs</h2>
-      <p class="keymap-hint">View the last lines of the server log (helpful for debugging story generation, TTS, etc).</p>
+      <p class="keymap-hint">View the last lines of the server log (helpful for debugging story generation, TTS, etc). Shortcut: Option+L (Alt+L).</p>
       <button class="keymap-reset-all" onclick="openLogsViewer()">Open logs</button>
     </div>`;
   _loadPregenSettings();
@@ -7819,16 +7819,13 @@ function playSentence() {
   _listenCount++;
   _updateListenCounters();
   if (_currentAudio) { _currentAudio.onended = null; _currentAudio.pause(); _currentAudio = null; }
-  // Reuse the pre-buffered element when warmed (#554/#557) — gapless, no wait;
-  // otherwise a fresh element still replays instantly from the immutable HTTP cache.
-  const warm = _warmed.get(url);
-  let audio;
-  if (warm) {
-    audio = warm;
-    try { audio.currentTime = 0; } catch (_) {}
-  } else {
-    audio = _warmAudio(url);
-  }
+  // Always create a fresh element inside this (user-gesture) call — iOS Safari
+  // refuses to play an Audio element that was created in the background (e.g. by
+  // _warmAudio's prefetch), so reusing a warmed element left listening cards
+  // silent on mobile (#590). The URL is immutable-cached, so a fresh element
+  // still replays instantly once the mp3 exists on disk; the warmed cache is
+  // kept only for gapless full-story playback in _playStoryAtIdx.
+  const audio = new Audio(url);
   _currentAudio = audio;
   audio.play().catch(() => {});
 }
@@ -9226,6 +9223,18 @@ document.addEventListener('keydown', async e => {
   // Shift+S toggles the FSRS scheduler inspector
   if (e.key === 'S' && e.shiftKey && !e.ctrlKey && !e.metaKey) {
     if (!inInput) { e.preventDefault(); toggleFsrsInspector(); }
+    return;
+  }
+
+  // Alt+L (Option+L) toggles the logs viewer. Use e.code, not e.key: on macOS
+  // Option+L produces the character '¬', so e.key wouldn't be 'L'.
+  if (e.code === 'KeyL' && e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
+    if (!inInput) {
+      e.preventDefault();
+      const overlay = document.getElementById('logs-modal-overlay');
+      if (overlay && overlay.style.display !== 'none') closeLogsViewer();
+      else openLogsViewer();
+    }
     return;
   }
 


### PR DESCRIPTION
## 改了什么
新增全局快捷键 **Option+L（Alt+L）**，开关式打开/关闭已有的日志查看器弹窗。

## 为什么
日志查看器（`openLogsViewer()`）和后端 `GET /api/logs` 都已存在，之前只能从设置里的 "Open logs" 按钮打开。加个快捷键方便随手查看当前日志。

## 实现细节
- 键位选 Option+L：`Shift+L` / 纯 `L` 已被复习标记难词占用（`KEYMAP_RESERVED`）。
- 与 `Shift+R`（重启）、`Shift+S`（FSRS 检查器）同类，固定绑定。
- 用 `e.code === 'KeyL'` 判断而非 `e.key`——macOS 上 Option+L 会输入字符 ¬。
- 输入框聚焦时不触发；Esc 关闭走已有逻辑。
- 设置里 "Open logs" 按钮提示补上快捷键说明。

## 怎么测试
任意视图下（非输入框）按 Option+L → 日志弹窗打开；再按 → 关闭。

Closes #591