### PR TITLE
fix: 手机上故事设置弹窗内容超屏可滚动（#590）

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1160,6 +1160,8 @@ main.browse-open {
   border-radius: var(--radius);
   box-shadow: 0 8px 40px rgba(0,0,0,0.18);
   width: min(420px, 92vw);
+  max-height: 92vh;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   padding: 20px 24px 24px;
@@ -1197,6 +1199,8 @@ main.browse-open {
   border-radius: var(--radius);
   box-shadow: 0 8px 40px rgba(0,0,0,0.18);
   width: min(440px, 92vw);
+  max-height: 92vh;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   padding: 20px 24px 24px;


### PR DESCRIPTION
## 背景

Daniel 在手机上复习时，播客模式下的故事设置弹窗（Story setup modal）内容很多（单集选择器 + 语法 + 模型 + HSK 滑块等），超出屏幕的部分被裁掉且无法滚动，底部的「Generate」按钮够不到。

## 改动

`#setup-modal` 与 `#unfinished-modal` 为 `position: fixed` 居中定位，但没有设 `max-height` / `overflow-y`。加上 `max-height: 92vh` + `overflow-y: auto`，内容超屏时弹窗内部可滚动，底部按钮可达。

## 测试

- 手机上打开播客模式的故事设置弹窗，确认可上下滚动、底部「Generate」按钮可点。
- 桌面端弹窗内容不超屏时行为不变。

## 说明

Issue #590 同时包含听力音频修复。**音频部分（`playSentence` 改为在用户手势内新建 `Audio` 元素，解决 iOS 上点播不响）已随 #591 的 PR #592 合并进 main**（两个会话共用工作目录导致提交交叉，音频改动搭车进了 #592）。本 PR 只补齐弹窗滚动这一半。

Closes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)