### PR TITLE
feat: 添加播客源时自动加载最近 10 集元数据（#593）

### DIFF
--- a/podcast.py
+++ b/podcast.py
@@ -258,22 +258,26 @@ def fetch_new_videos() -> list[dict]:
     return videos
 
 
-def load_more_episodes(feed_id: int) -> dict:
-    """Ingest the next page of older back-catalog episodes for one feed,
-    metadata-only (never auto-processed). Regular check() only walks the
-    newest items and stops at the first already-known guid, so a feed's
-    back-catalog older than the initial backfill is otherwise unreachable;
-    this pulls it in on demand, LOAD_MORE_PAGE at a time, skipping anything
-    already stored. Returns {"added": N}. Raises ValueError (unknown feed) /
-    RuntimeError (fetch/parse failure) for the route to map to 404/500."""
+def ingest_feed_episodes(feed_id: int, limit: int, root=None) -> int:
+    """Store up to `limit` not-yet-known episodes of one feed as pending
+    (metadata-only, never auto-processed), newest first. Shared by
+    load_more_episodes (back-catalog paging) and create_feed (immediate
+    backfill of the latest episodes right when a feed is added, #593).
+
+    `root` may be a pre-parsed RSS ElementTree to avoid a redundant fetch
+    (create_feed already fetched it to validate the URL); when None the feed
+    is fetched here. Skips episodes already in the DB. Returns the count
+    added. Raises ValueError (unknown feed) / RuntimeError (fetch/parse
+    failure) for callers/routes to map to 404/500."""
     feed = database.get_feed(feed_id)
     if not feed:
         raise ValueError("feed not found")
     feed_url = feed["url"]
-    try:
-        root = ElementTree.fromstring(_http_get(feed_url, timeout=30))
-    except (urllib.error.URLError, ElementTree.ParseError) as e:
-        raise RuntimeError(f"failed to fetch/parse feed: {e}")
+    if root is None:
+        try:
+            root = ElementTree.fromstring(_http_get(feed_url, timeout=30))
+        except (urllib.error.URLError, ElementTree.ParseError) as e:
+            raise RuntimeError(f"failed to fetch/parse feed: {e}")
 
     known = database.get_known_video_ids()
     added = 0
@@ -287,9 +291,20 @@ def load_more_episodes(feed_id: int) -> dict:
             video.get("audio_url"), video.get("duration_seconds"),
         )
         added += 1
-        if added >= LOAD_MORE_PAGE:
+        if added >= limit:
             break
-    return {"added": added}
+    return added
+
+
+def load_more_episodes(feed_id: int) -> dict:
+    """Ingest the next page of older back-catalog episodes for one feed,
+    metadata-only (never auto-processed). Regular check() only walks the
+    newest items and stops at the first already-known guid, so a feed's
+    back-catalog older than the initial backfill is otherwise unreachable;
+    this pulls it in on demand, LOAD_MORE_PAGE at a time, skipping anything
+    already stored. Returns {"added": N}. Raises ValueError (unknown feed) /
+    RuntimeError (fetch/parse failure) for the route to map to 404/500."""
+    return {"added": ingest_feed_episodes(feed_id, LOAD_MORE_PAGE)}
 
 
 # ---------------------------------------------------------------------------

--- a/routes/podcast.py
+++ b/routes/podcast.py
@@ -209,7 +209,12 @@ def create_feed(body: FeedCreate):
     """Add a new RSS feed subscription. Validates the URL is a parseable RSS
     feed (fetches it once, synchronously) and pulls the channel <title> for
     display before storing — new feeds default to auto_process=0 (manual),
-    matching #502's "opt in to automation per-source" design."""
+    matching #502's "opt in to automation per-source" design.
+
+    Immediately backfills the feed's latest FIRST_RUN_BACKFILL episodes as
+    metadata-only pending rows (#593), reusing the RSS root already fetched
+    for validation — so the newest episodes show up in the list right away
+    instead of waiting for the next crawl cycle. Nothing is transcribed."""
     url = body.url.strip()
     if not url:
         raise HTTPException(400, "url is required")
@@ -226,6 +231,12 @@ def create_feed(body: FeedCreate):
         # else here would be unexpected, but still just a 400 (bad input),
         # not a 500 (server bug).
         raise HTTPException(400, "Feed already exists")
+    # Backfill the latest episodes (metadata-only). A failure here must not
+    # undo the successful subscription — the next crawl cycle backfills too.
+    try:
+        podcast.ingest_feed_episodes(feed_id, podcast.FIRST_RUN_BACKFILL, root=root)
+    except Exception as e:
+        logger.warning("podcast: initial backfill failed for feed %s: %s", feed_id, e)
     return database.get_feed(feed_id)
 
 


### PR DESCRIPTION
## 改了什么

添加新播客源（`POST /api/podcast/feeds`）时，存下源之后立即回填该源**最近 10 集**（`FIRST_RUN_BACKFILL`）为 `status=pending` 的单集，**仅元数据、不转录**。这样添加完马上就能在列表里看到最近的单集，而不用等下一次定时爬虫（cron）。

## 为什么

之前 `create_feed` 只验证 URL、存标题，单集要等最长几分钟的定时任务首次爬取才出现。Daniel 希望添加时就立刻加载最近 10 集（但不转录）。

## 怎么实现

- 把 `load_more_episodes` 的分页逻辑抽成共用函数 `ingest_feed_episodes(feed_id, limit, root=None)`，支持传入已解析的 RSS `root`（复用 `create_feed` 验证时已抓取的那次，避免二次网络请求）和自定义数量。
- `load_more_episodes` 现在是它的薄封装（`limit=LOAD_MORE_PAGE`）。
- `create_feed` 存源后调用 `ingest_feed_episodes(feed_id, FIRST_RUN_BACKFILL, root=root)`；回填失败只记日志、**不影响订阅成功**（下次爬虫仍会回填）。
- 行为与 `auto_process=0` 一致：绝不触发转录/摘要。

## 怎么测试

本地临时数据库 + 模拟含 15 集的 RSS：
- `create_feed` → 恰好入库最近 10 集，全部 `pending`，无转录。
- 随后 `load_more_episodes` → 补上剩余 5 集，共 15，无重复。
- `py_compile` + 导入检查通过。

Closes #593