### PR TITLE
法语管线完善：动词变位 + CEFR 等级贯通（#596）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,9 @@ Daniel 在中国需要 VPN 访问 GitHub。`gh` 命令报 `EOF` 错误时（`cur
 
 - **`languages.py` 是语言注册表**：每种语言定义 TTS 语音、翻译源、分词方式（jieba/空格）、AI 提示词参数、功能开关（拼音/汉字/量词仅中文）。加新语言 = 加一个条目
 - **`decks.lang` / `entries.lang`**（默认 `'zh'`）：目标语言；子牌组创建时继承父牌组的 lang
-- `word_zh` 对所有语言存"目标语言词形"（`_zh` 后缀是历史遗留）；法语词条的 pinyin/hsk_level/characters 留空
+- `word_zh` 对所有语言存"目标语言词形"（`_zh` 后缀是历史遗留）；法语词条的 pinyin/characters 留空
+- **等级共用 1–6 整数**（#596）：`entries.hsk_level` 对中文存 HSK 1–6，对法语存 CEFR（A1=1 … C2=6，YAML 里写 `level: "B1"`）；故事设置弹窗的背景词汇难度滑块两种语言通用（1–6），前端按 `languages.py` 的 `level_system` 显示 "HSK 3" 或 "B1"，法语故事提示词用滑块值生成 "CEFR A1-X" 上限（原来写死 A1-A2）
+- **动词变位**（#596）：`entry_conjugations` 表按"时态 × 人称"通用存储（person='' 表示分词等无人称形式，position 保留 YAML 顺序）；法语 YAML 用 `conjugations:` 映射导入；`/api/word/{id}` 返回 `conjugations`，词条详情页和复习卡背面渲染 Conjugation 折叠区（每时态一张小卡片）；同义反义词/相似句处理对法语也启用
 - **已知限制：** `UNIQUE(word_zh)` 是全局约束——文字系统不同（中文 vs 法语）不冲突；将来加第二种拉丁字母语言需改为 `UNIQUE(word_zh, lang)`（要重建表）
 - **中文专属：** 汉字分解、量词、拼音、kahneman/paste/briefing 故事模式
 - **主页语言标签页**（#436）：`GET /api/langs` 返回使用中的语言；前端多于一种语言才显示标签栏，选择存 `localStorage`。所有主页/复习/故事/统计接口支持可选 `?lang=`（默认不过滤，向后兼容）；解析规则统一为 `lang 参数 或 get_deck_lang(deck_id)`
@@ -194,6 +196,7 @@ Daniel 在中国需要 VPN 访问 GitHub。`gh` 命令报 `EOF` 错误时（`cur
 deck_presets → decks（自引用 parent_id，支持嵌套）→ entries
                                                       ├── entry_examples
                                                       ├── entry_measure_words（量词）
+                                                      ├── entry_conjugations（动词变位，时态×人称，#596）
                                                       ├── entry_relations（同义词等关系）
                                                       ├── entry_components（sentence 类型的组成词）
                                                       ├── entry_characters → characters → character_compounds

--- a/ai.py
+++ b/ai.py
@@ -242,6 +242,10 @@ def resolve_briefing_model() -> str:
 # Public API
 # ---------------------------------------------------------------------------
 
+# Shared 1-6 difficulty value → CEFR label, for non-zh story prompts (issue
+# #596). Mirrors importer._CEFR_TO_INT (A1=1 … C2=6).
+_CEFR_LEVELS = {1: "A1", 2: "A2", 3: "B1", 4: "B2", 5: "C1", 6: "C2"}
+
 # ── 自定义提示词模板（issue #581）──────────────────────────────────────────────
 # 每个可自定义模式一份内置模板；database.get_prompt_template(mode) 有自定义行时
 # 覆盖内置。渲染用 _render_prompt 做逐记号字符串替换（不是 str.format——模板里
@@ -458,6 +462,10 @@ def generate_story(cards: list[dict], topic: str | None = None, max_hsk: int = 2
         cfg = languages.get_lang_config(lang)
         lang_name = cfg["name_en"]
         learner = cfg["learner_level"]
+        # Background-vocabulary cap follows the setup-modal slider (issue #596):
+        # the shared 1-6 value maps to CEFR A1…C2 instead of HSK levels.
+        cefr_cap = _CEFR_LEVELS.get(max_hsk, "B1")
+        background_vocab = f"CEFR A1-{cefr_cap}"
 
         if mode == "qa":
             task_line = f"Answer the following question in {lang_name}, one sentence at a time, to help a {learner} learner review vocabulary.\nQuestion: {topic or 'Describe something interesting.'}"
@@ -480,7 +488,7 @@ Rules:
 - Write the sentences in the same order as the target word list above
 - For items marked [SENTENCE]: use that exact text as the sentence, unchanged
 - Use natural {lang_name} punctuation
-- Use only simple {cfg["background_vocab"]} level vocabulary for non-target words; each sentence must contain exactly ONE target word from the list — do not use other target words from the list in that sentence
+- Use only simple {background_vocab} level vocabulary for non-target words; each sentence must contain exactly ONE target word from the list — do not use other target words from the list in that sentence
 - Keep each sentence short and simple (max {cfg["sentence_limit"]})
 {style_rule}
 - Each target word must appear in exactly the given form; you may adapt or drop its leading article (le/la/les/un/une) to fit the sentence

--- a/database/entries.py
+++ b/database/entries.py
@@ -96,6 +96,7 @@ def get_word_full(word_id: int) -> dict | None:
     word["measure_words"] = get_word_measure_words(word_id)
     word["relations"] = get_word_relations(word_id)
     word["components"] = get_note_components(word_id)
+    word["conjugations"] = get_word_conjugations(word_id)
     return word
 
 
@@ -199,6 +200,30 @@ def insert_word_relation(word_id: int, related_zh: str,
     )
     conn.commit()
     conn.close()
+
+
+def insert_word_conjugation(word_id: int, tense: str, person: str,
+                            form: str, position: int) -> None:
+    """person is '' for impersonal forms (participles, infinitive)."""
+    conn = get_db()
+    conn.execute(
+        """INSERT OR IGNORE INTO entry_conjugations
+           (word_id, tense, person, form, position)
+           VALUES (?, ?, ?, ?, ?)""",
+        (word_id, tense, person, form, position),
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_word_conjugations(word_id: int) -> list[dict]:
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT * FROM entry_conjugations WHERE word_id = ? ORDER BY position, id",
+        (word_id,),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
 
 
 def delete_word_examples(word_id: int) -> None:

--- a/docs/yaml-format.md
+++ b/docs/yaml-format.md
@@ -14,6 +14,7 @@
 5. [类型：`grammar`（语法点）](#类型-grammar语法点-仅展示不导入)
 6. [嵌套结构：`word_analyses`](#嵌套结构-word_analyses)
 7. [向后兼容性](#向后兼容性)
+8. [法语格式（`lang: fr`）](#法语格式lang-fr)
 
 ---
 
@@ -316,3 +317,96 @@ word_analyses:
 | `grammar_structures` | `entry_grammar_structures` |
 | `characters` | `entry_characters` → `characters` → `character_compounds`（旧格式，仍支持） |
 | `word_analyses` | `entry_components` + 递归导入子词语（所有类型的统一格式） |
+
+---
+
+## 法语格式（`lang: fr`）
+
+文件顶层必须声明 `lang: fr`（或粘贴导入到法语牌组——此时可省略）。法语条目经
+`importer._normalize_fr_entry` 归一化后复用全部下游逻辑；中文专属模块（汉字分解、
+量词、拼音、`word_analyses`）不适用。
+
+### 与中文格式的字段差异
+
+| 字段 | 说明 |
+|------|------|
+| `word` / `sentence` / `expression` | 词形字段（代替 `simplified`），按 `type` 取名 |
+| `level` | CEFR 等级字符串 `"A1"`–`"C2"`（代替 `hsk`），映射为 1–6 存入 `entries.hsk_level` |
+| `english` / `german` | 英/德释义（同中文格式） |
+| `note` | 德语使用说明，**建议在其中包含简短词源（Étymologie）**——法语没有独立词源列 |
+| `examples[]` | 每项 `{fr, german, english}`（`fr` 代替 `zh`，`german` 代替 `de`） |
+| `similar_sentences[]` | 同上，`{fr, german}`，仅 sentence 类型 |
+| `synonyms` / `antonyms` | 同中文格式：`{word, meaning}`（meaning 用德语） |
+| `conjugations` | 动词专用，见下——存入 `entry_conjugations` 表（议题 #596） |
+| `register` | 同中文格式的取值集合 |
+
+### `conjugations` 结构（仅动词）
+
+映射的两种形态：**有人称的时态**用 `{人称: 形式}` 子映射；**无人称形式**
+（分词、不定式）直接写字符串。时态与人称的书写顺序会按原样保留并展示。
+
+```yaml
+lang: fr
+entries:
+  - type: word
+    date: "07/21"
+    word: parler
+    pos: verbe
+    english: to speak, to talk
+    german: sprechen, reden
+    level: "A1"
+    register: neutral
+    note: |
+      Regelmäßiges Verb auf -er.
+
+      **Étymologie:** Vom lateinischen *parabolare* („in Gleichnissen reden").
+    examples:
+      - fr: Je parle un peu français.
+        english: I speak a little French.
+        german: Ich spreche ein wenig Französisch.
+    synonyms:
+      - word: discuter
+        meaning: diskutieren, sich unterhalten
+    conjugations:
+      présent:
+        je: parle
+        tu: parles
+        il/elle: parle
+        nous: parlons
+        vous: parlez
+        ils/elles: parlent
+      passé composé:
+        je: ai parlé
+        tu: as parlé
+        il/elle: a parlé
+        nous: avons parlé
+        vous: avez parlé
+        ils/elles: ont parlé
+      participe présent: parlant
+      participe passé: parlé (avoir)
+```
+
+### sentence 类型（法语）
+
+```yaml
+  - type: sentence
+    date: "07/21"
+    source_de: Ich werde dir zur passenden Zeit die Wahrheit sagen.
+    sentence: Je te dirai la vérité au moment opportun.
+    english: I will tell you the truth at the appropriate time.
+    german: Ich werde dir zur geeigneten Zeit die Wahrheit sagen.
+    level: "B1"
+    explanations: |
+      „au moment opportun" ist eine formelle Zeitangabe.
+    similar_sentences:
+      - fr: Je te le dirai plus tard.
+        german: Ich sage es dir später.
+```
+
+### 法语专属数据库映射
+
+| YAML 字段 | 数据库表 / 列 |
+|-----------|--------------|
+| `word` / `sentence` / `expression` | `entries.word_zh`（列名是历史遗留，存目标语言词形） |
+| `level`（CEFR） | `entries.hsk_level`（A1=1 … C2=6） |
+| `conjugations` | `entry_conjugations`（word_id, tense, person, form, position；无人称形式 person=''） |

--- a/importer.py
+++ b/importer.py
@@ -333,11 +333,20 @@ def _strip_ellipsis(word_zh: str) -> str:
     return word_zh.strip('.')
 
 
+# CEFR level string → the shared 1-6 integer scale stored in entries.hsk_level
+# (A1=1 … C2=6; languages.py `level_system` tells the frontend how to label it).
+_CEFR_TO_INT = {"A1": 1, "A2": 2, "B1": 3, "B2": 4, "C1": 5, "C2": 6}
+
+
+def _cefr_to_int(level) -> int | None:
+    return _CEFR_TO_INT.get(str(level or "").strip().upper())
+
+
 def _normalize_fr_entry(entry: dict) -> dict:
     """Reshape a French-format YAML entry into the internal (Chinese-era) key
     layout so all downstream processing (_build_word_dict, examples, etc.)
-    stays untouched. Non-French language modules (characters, measure words,
-    word_analyses) are simply absent from the French format for now.
+    stays untouched. Chinese-only modules (characters, measure words,
+    word_analyses) are simply absent from the French format.
     """
     normalized = dict(entry)
     normalized["simplified"] = (
@@ -353,9 +362,21 @@ def _normalize_fr_entry(entry: dict) -> dict:
         }
         for ex in (entry.get("examples") or [])
     ]
-    # French format doesn't define these Chinese-only fields yet
+    # `level: B1` (CEFR string) → shared 1-6 integer level (issue #596)
+    normalized["cefr_level"] = _cefr_to_int(entry.get("level"))
+    # similar_sentences {fr, german} → internal {zh, de} keys (sentence entries)
+    normalized["similar_sentences"] = [
+        {
+            "zh":      ss.get("fr", ""),
+            "english": ss.get("english"),
+            "de":      ss.get("german") or ss.get("de"),
+            "pinyin":  None,
+        }
+        for ss in (entry.get("similar_sentences") or [])
+    ]
+    # French format doesn't define these Chinese-only fields
     for key in ("hsk", "traditional", "pinyin", "word_analyses",
-                "characters", "measure_words", "similar_sentences"):
+                "characters", "measure_words"):
         normalized.pop(key, None)
     return normalized
 
@@ -377,7 +398,9 @@ def _build_word_dict(entry: dict, source: str, note_type: str = "vocabulary",
         "definition_de":   entry.get("german"),
         "definition_fr":   entry.get("french"),
         "pos":             entry.get("pos"),
-        "hsk_level":       _hsk_to_int(str(entry.get("hsk", ""))),
+        # non-zh: CEFR level mapped to the same 1-6 scale (see _cefr_to_int)
+        "hsk_level":       entry.get("cefr_level") if lang != "zh"
+                           else _hsk_to_int(str(entry.get("hsk", ""))),
         "traditional":     entry.get("traditional"),
         "definition_zh":   entry.get("definition_zh"),
         "source":          source,
@@ -465,6 +488,36 @@ def _process_word_relations(entry: dict, word_id: int) -> None:
                 related_de=item.get("de") or item.get("meaning"),
                 relation_type=rel_type,
             )
+
+
+def _process_conjugations(entry: dict, word_id: int) -> None:
+    """Insert verb conjugations (issue #596) from an entry's `conjugations` mapping.
+
+    YAML shape: {tense: {person: form, …}} for personal tenses, or
+    {tense: "form"} for impersonal forms (participles, infinitive) — the person
+    is stored as '' for those. Insertion order of the mapping is preserved via
+    position so the UI shows tenses in the order the YAML defined them.
+    """
+    conjugations = entry.get("conjugations")
+    if not isinstance(conjugations, dict):
+        return
+    position = 0
+    for tense, forms in conjugations.items():
+        tense = str(tense).strip()
+        if not tense:
+            continue
+        if isinstance(forms, dict):
+            pairs = [(str(p).strip(), str(f).strip()) for p, f in forms.items()]
+        else:
+            pairs = [("", str(forms).strip())]
+        for person, form in pairs:
+            if not form:
+                continue
+            database.insert_word_conjugation(
+                word_id=word_id, tense=tense, person=person,
+                form=form, position=position,
+            )
+            position += 1
 
 
 def _import_grammar_entry(entry: dict, label: str) -> bool:
@@ -744,9 +797,15 @@ def _import_entries(entries: list, deck_ids: dict, source: str, label: str,
                     example_type="similar",
                 )
 
+        # Synonyms / antonyms — language-neutral (fr synonyms use the same
+        # word/meaning keys, issue #596)
+        _process_word_relations(entry, word_id)
+
+        # Verb conjugations (fr and future conjugating languages, issue #596)
+        _process_conjugations(entry, word_id)
+
         # The following processors handle Chinese-only YAML fields (characters,
-        # measure words, synonyms/antonyms, grammar structures, word_analyses
-        # components) — French format doesn't define them yet.
+        # measure words, grammar structures, word_analyses components).
         if lang == "zh":
             # Legacy: top-level `characters:` on vocabulary entries.
             # New format uses `word_analyses:` for all entry types (handled below).
@@ -755,9 +814,6 @@ def _import_entries(entries: list, deck_ids: dict, source: str, label: str,
 
             # Measure words (量词)
             _process_measure_words(entry, word_id)
-
-            # Synonyms / antonyms
-            _process_word_relations(entry, word_id)
 
             # Grammar structures (sentence entries)
             if note_type == "sentence":

--- a/schema.sql
+++ b/schema.sql
@@ -212,6 +212,21 @@ CREATE TABLE IF NOT EXISTS entry_relations (
 );
 
 -- ---------------------------------------------------------------------------
+-- entry_conjugations  (verb conjugation forms — generic tense × person grid,
+-- used by French (issue #596) and any future conjugating language; person is
+-- '' for impersonal forms like participles/infinitives)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS entry_conjugations (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    word_id     INTEGER NOT NULL REFERENCES entries(id) ON DELETE CASCADE,
+    tense       TEXT NOT NULL,      -- e.g. 'présent', 'passé composé', 'participe passé'
+    person      TEXT NOT NULL DEFAULT '',  -- e.g. 'je', 'tu', 'il/elle', '' for impersonal
+    form        TEXT NOT NULL,      -- the conjugated form, e.g. 'parle'
+    position    INTEGER NOT NULL DEFAULT 0, -- preserves the YAML tense/person order
+    UNIQUE(word_id, tense, person)
+);
+
+-- ---------------------------------------------------------------------------
 -- entry_examples
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS entry_examples (

--- a/static/app.js
+++ b/static/app.js
@@ -102,6 +102,13 @@ function currentCardLang() {
   return _deckLangById[id] || 'zh';
 }
 
+// Shared 1-6 difficulty value → per-language label (issue #596):
+// zh uses HSK levels, every other language the CEFR scale (A1=1 … C2=6).
+const CEFR_LABELS = { 1: 'A1', 2: 'A2', 3: 'B1', 4: 'B2', 5: 'C1', 6: 'C2' };
+function levelLabel(lang, lvl) {
+  return lang === 'zh' ? `HSK ${lvl}` : (CEFR_LABELS[lvl] || `${lvl}`);
+}
+
 // — Customizable review shortcuts —
 // Each action maps to one key. Defaults below are the active bindings.
 // User overrides persist in localStorage('reviewKeymap'). Rating keys 1-4 stay fixed.
@@ -2202,7 +2209,8 @@ function renderWordDetail(word) {
     relEl.innerHTML = '';
   }
 
-  // Shared sections (notes, word analysis, examples)
+  // Shared sections (notes, conjugation, word analysis, examples)
+  renderConjugationSection(document.getElementById('wd-conjugation-section'), word);
   renderNotesSection(document.getElementById('wd-notes-section'), word.notes, word.id);
   renderWordAnalysis(document.getElementById('wd-word-analysis-section'), word, word.id);
   renderVocabDetail(document.getElementById('wd-examples-section'), word.examples, word.id);
@@ -4570,11 +4578,20 @@ function loadCard(c, counts) {
     deckPath.style.display = 'none';
   }
 
-  // HSK badge — Chinese-only concept; hidden entirely for non-zh decks.
-  // Otherwise always visible; "HSK -" when unknown (click to AI-fill)
+  // Level badge — zh shows "HSK n" ("HSK -" when unknown, click to AI-fill);
+  // CEFR languages show "B1" etc. when the entry has a level, otherwise the
+  // badge is hidden (AI-enrich is a Chinese-only feature) — issue #596.
   const hskBadge = document.getElementById('card-hsk-badge');
-  if (currentCardLang() !== 'zh') {
-    hskBadge.style.display = 'none';
+  const _cardLang = currentCardLang();
+  if (_cardLang !== 'zh') {
+    if (card.hsk_level) {
+      hskBadge.textContent = levelLabel(_cardLang, card.hsk_level);
+      hskBadge.classList.remove('hsk-unknown');
+      hskBadge.disabled = true;
+      hskBadge.style.display = 'inline';
+    } else {
+      hskBadge.style.display = 'none';
+    }
   } else {
     hskBadge.textContent = card.hsk_level ? `HSK ${card.hsk_level}` : 'HSK -';
     hskBadge.classList.toggle('hsk-unknown', !card.hsk_level);
@@ -4612,6 +4629,7 @@ function loadCard(c, counts) {
         }
         renderVocabDetail();
         renderNotesSection();
+        renderConjugationSection();
         _callRenderWordAnalysis();
         // MOST IMPORTANT: Re-render category row with actual card data
         renderReviewCatRow();
@@ -5001,8 +5019,9 @@ function revealAnswer() {
   // Show multi-word rating UI when the sentence contains multiple vocab words
   _renderMultiRatingIfNeeded();
 
-  // Populate character breakdown, examples, notes, grammar, and word analysis
+  // Populate character breakdown, examples, notes, conjugation, and word analysis
   renderNotesSection();
+  renderConjugationSection();
   _callRenderWordAnalysis();
   renderVocabDetail();
   renderReviewCatRow();
@@ -5503,6 +5522,35 @@ function renderNotesSection(container, notes, wordId) {
       `<span><span id="${bodyId}-arrow">▷</span> Notes</span>${regenBtn}</div>` +
     `<div id="${bodyId}" class="section-peek" data-peek="1" data-state="peek">${bodyContent}</div>`;
   el.style.display = '';
+}
+
+// Verb conjugation section (issue #596) — French & future conjugating
+// languages. wordData.conjugations rows come pre-ordered by position; group
+// them back into per-tense cards (person '' = impersonal form, e.g. participle).
+function renderConjugationSection(container, wordData) {
+  const el = container ?? document.getElementById('conjugation-section');
+  if (!el) return;
+  const conj = (wordData ?? wordDetails)?.conjugations || [];
+  if (!conj.length) { el.innerHTML = ''; return; }
+  const tenses = [];
+  const byTense = new Map();
+  conj.forEach(c => {
+    if (!byTense.has(c.tense)) { byTense.set(c.tense, []); tenses.push(c.tense); }
+    byTense.get(c.tense).push(c);
+  });
+  const bodyId = el.id + '-body';
+  const cards = tenses.map(t => {
+    const rows = byTense.get(t).map(c =>
+      c.person
+        ? `<div class="conj-row"><span class="conj-person">${c.person}</span><span class="conj-form">${c.form}</span></div>`
+        : `<div class="conj-row"><span class="conj-form">${c.form}</span></div>`
+    ).join('');
+    return `<div class="conj-tense-card"><div class="conj-tense-name">${t}</div>${rows}</div>`;
+  }).join('');
+  el.innerHTML =
+    `<div class="section-label section-toggle" onclick="toggleSection('${bodyId}')">` +
+      `<span id="${bodyId}-arrow">▶</span> Conjugation</div>` +
+    `<div id="${bodyId}" style="display:none"><div class="conj-grid">${cards}</div></div>`;
 }
 
 function renderWordAnalysis(container, wordData, wordId) {
@@ -6667,7 +6715,10 @@ function openStorySetup(sentenceCount, { isMixed = false, isUnfinished = false, 
       _prefillGp = raw ? (typeof raw === 'string' ? JSON.parse(raw) : raw) : null;
     } catch { _prefillGp = null; }
   }
-  document.getElementById('setup-hsk-slider').value = _prefillGp?.max_hsk ?? 3;
+  // Default background level: HSK 3 for zh, A2 (=2) for CEFR languages (#596)
+  const _setupLang = _deckLangById[deckId] || 'zh';
+  document.getElementById('setup-hsk-slider').value =
+    _prefillGp?.max_hsk ?? (_setupLang === 'zh' ? 3 : 2);
   const _modeSel = document.getElementById('setup-mode');
   _modeSel.value = _prefillGp?.mode || 'story';
   if (_modeSel.selectedIndex < 0) _modeSel.value = 'story'; // unknown mode in gen_params
@@ -6694,6 +6745,11 @@ function _applySetupLangRestrictions() {
   }
   const grammarLabel = document.getElementById('setup-grammar-label');
   if (grammarLabel) grammarLabel.style.display = lang === 'zh' ? '' : 'none';
+  // Difficulty slider label follows the deck's level system (#596)
+  const hskLabelText = document.getElementById('setup-hsk-label-text');
+  if (hskLabelText) hskLabelText.textContent = lang === 'zh'
+    ? 'Max HSK level for background vocabulary'
+    : 'Max CEFR level for background vocabulary';
 }
 
 function togglePriceTable(e) {
@@ -6704,8 +6760,9 @@ function togglePriceTable(e) {
 }
 
 function updateHskLabel() {
-  const v = document.getElementById('setup-hsk-slider').value;
-  document.getElementById('setup-hsk-badge').textContent = `HSK ${v}`;
+  const v = parseInt(document.getElementById('setup-hsk-slider').value, 10);
+  const lang = _deckLangById[deckId] || 'zh';
+  document.getElementById('setup-hsk-badge').textContent = levelLabel(lang, v);
 }
 
 function updateSetupMode() {

--- a/static/index.html
+++ b/static/index.html
@@ -289,6 +289,7 @@
         </div>
         <div id="vocab-content" style="display:none">
           <div id="notes-section"></div>
+          <div id="conjugation-section"></div>
           <div id="word-analysis-section"></div>
           <div id="examples-section"></div>
           <div style="display:flex;gap:8px;justify-content:center">
@@ -414,6 +415,7 @@
     </div>
     <div class="wd-body">
       <div id="wd-relations-section"></div>
+      <div id="wd-conjugation-section"></div>
       <div id="wd-notes-section"></div>
       <div id="wd-word-analysis-section"></div>
       <div id="wd-examples-section"></div>
@@ -805,7 +807,7 @@
       <input class="edit-input" id="setup-batch-size" type="number" min="1" step="1" placeholder="default">
     </label>
     <label class="edit-label" id="setup-hsk-label">
-      Max HSK level for background vocabulary
+      <span id="setup-hsk-label-text">Max HSK level for background vocabulary</span>
       <div class="setup-slider-row">
         <span class="setup-slider-min">1</span>
         <input type="range" id="setup-hsk-slider" min="1" max="6" value="3" oninput="updateHskLabel()">

--- a/static/style.css
+++ b/static/style.css
@@ -4961,3 +4961,39 @@ table.fsrs-table td.ivl { font-weight: 700; }
   line-height: 1.4;
   margin-top: 2px;
 }
+
+/* ── Verb conjugation section (issue #596) ─────────────────────────────── */
+.conj-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 8px 0;
+}
+.conj-tense-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 12px;
+  min-width: 150px;
+  flex: 0 1 auto;
+}
+.conj-tense-name {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+.conj-row {
+  display: flex;
+  gap: 8px;
+  font-size: 14px;
+  line-height: 1.6;
+}
+.conj-person {
+  color: var(--muted);
+  min-width: 58px;
+  flex-shrink: 0;
+}
+.conj-form { color: var(--text); }


### PR DESCRIPTION
Closes #596

## 改了什么
- **数据库**：新表 `entry_conjugations`（word_id, tense, person, form, position，UNIQUE(word_id,tense,person)）——按"时态 × 人称"通用存储，person='' 表示分词等无人称形式；`schema.sql` 的 CREATE TABLE IF NOT EXISTS 即是迁移；`get_word_full` 返回 `conjugations`
- **导入器**：法语 YAML 新增 `level: "B1"`（CEFR → 1–6 存 hsk_level）与 `conjugations:` 映射；`similar_sentences` 不再丢弃（{fr,german}→{zh,de}）；同义反义词处理对所有语言启用（原来仅中文）
- **AI 提示词**：`generate_story` 非中文分支的背景词汇难度从写死 "CEFR A1-A2" 改为滑块值映射（1→A1 … 6→C2）；Again 单句重生成走同一函数自动生效；中文提示词不变
- **前端**：
  - 设置弹窗难度滑块按牌组语言显示标签（"HSK 3" / "B1"），法语默认 A2；标题文本同步切换
  - 词条详情页 + 复习卡背面新增 Conjugation 折叠区（每时态一张小卡片，flex 换行，暗色模式用现有 CSS 变量）
  - 复习卡等级徽章：法语有等级时显示 "B1" 等（不可点击，AI 补全仍仅中文），无等级隐藏
- **文档**：`docs/yaml-format.md` 新增完整法语格式章节（此前完全缺失）；CLAUDE.md 同步架构决定

## 怎么测试的
- 临时数据库端到端导入含 26 个变位形式、同反义词、相似句、CEFR 等级的法语 YAML——全部字段落库正确（见 issue #596 完成标准）
- monkeypatch `_call_api` 验证法语提示词：max_hsk=4 → "CEFR A1-B2"，max_hsk=2 → "CEFR A1-A2"，目标词匹配正常
- `node --check app.js`、py_compile 全部文件、`init_db()` + 主模块导入通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)