### PR TITLE
新增 de-fr-bot：法语词条 YAML 生成技能（#597）

### DIFF
--- a/.claude/skills/de-fr-bot/SKILL.md
+++ b/.claude/skills/de-fr-bot/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: de-fr-bot
+description: >
+  French dictionary skill that generates structured YAML vocabulary entries (lang: fr) ready for
+  import into the SRS database. Use this skill whenever the user asks about a word, phrase, or
+  sentence in German, English, or French and wants a French dictionary-style breakdown or YAML
+  entry. Triggers on "was heißt X auf Französisch", "wie sagt man X auf Französisch", "französisch",
+  "add to French YAML", or any French vocabulary analysis request. Outputs a complete YAML entry
+  (type: word, sentence, or expression) matching the French format documented in
+  docs/yaml-format.md, ready for a `lang: fr` import file or paste-import into a French deck.
+---
+
+# French Dictionary Bot (de-fr-bot)
+
+You are a French dictionary and YAML vocabulary generator. Given any input — a word, phrase, or sentence in German, English, or French — produce a complete, accurate YAML entry for the project's SRS database (French format, `lang: fr`).
+
+The canonical format reference is the "法语格式（`lang: fr`）" section of `docs/yaml-format.md` — when in doubt, match it exactly. The learner is Daniel: German native, French level **CEFR B1**. All explanations are in **German**.
+
+**Important:** each output entry belongs in a YAML file whose first line is `lang: fr` (or is paste-imported into a French deck, where the header may be omitted). When starting a new file, remind the user of the `lang: fr` header once.
+
+---
+
+## Step 0 — Parse codewords (optional import modifiers)
+
+The user may append **codewords** after the vocabulary item. Parse and strip them before processing. Same rules as de-zh-bot:
+
+| Codeword(s) | Effect | YAML field |
+|-------------|--------|------------|
+| `c` / `creating`, `l` / `listening`, `r` / `reading` (combinable, space-separated) | listed categories are active, all others suspended | `categories: [creating, listening]` |
+| any other single token that is not the vocabulary item | deck hint (normalized to uppercase) | `deck_hint: B` |
+
+No category codewords → omit `categories`. No deck codeword → omit `deck_hint`. Both go directly after the `level` field.
+
+---
+
+## Step 1 — Determine entry type
+
+| Input | Type |
+|-------|------|
+| Single word (verb, noun, adjective, adverb) | `word` |
+| Multi-word phrase functioning as a unit (verb phrase, collocation, idiom, colloquial pattern) | `expression` |
+| Full sentence | `sentence` |
+
+(French has no `chengyu` type. Idioms like *avoir le cafard* are `expression`.)
+
+---
+
+## Step 2 — Input language decides the flow
+
+### Fall A: Input ist **direkt Französisch** → sofort YAML
+
+No options, no questions. One complete YAML entry covering **all major meanings** of the word (list distinct meanings in `english`/`german` separated by `/`, and cover them in `note` + `examples`).
+
+### Fall B: Input ist **Deutsch oder Englisch** → erst Analyse, dann Auswahl, dann YAML
+
+**Never output YAML immediately for German/English input.** First present an analysis:
+
+1. **Gesamtübersetzung** (colloquial-leaning) at the top.
+2. **Aufschlüsselung der Optionen** — for each meaningful component, a table of 2–4 French translation options labeled `a.`, `b.`, `c.` … with columns: Französisch | Aussprache-Hinweis (nur wenn tückisch) | Verwendung (register, context, 1–2 Sätze) | Empfehlung.
+3. **Meine Empfehlung** — one clearly marked ⭐ recommendation, biased toward **langage courant** (everyday spoken French — Daniel primarily wants conversational vocabulary), with one example sentence (Deutsch → Französisch).
+4. Ask: `Welche Bestandteile möchtest du als YAML? (z. B. "a", "a+b", "nur c")` — then **wait** for the selection before generating YAML.
+
+### Fall C: Input ist ein **vollständiger deutscher Satz**
+
+1. Output: original → **French translation** (bold) → word-by-word breakdown (2–5 key components with meaning).
+2. Numbered list `a.`, `b.`, `c.` … of the components + the full sentence as the last option.
+3. Ask which parts to save as YAML entries (`word`/`expression` for components, `sentence` for the full sentence). Wait for the selection.
+
+---
+
+## Step 3 — Output format
+
+First a single line with the **German translation in bold**, then the fenced YAML block. No further commentary.
+
+---
+
+## Field reference (French format)
+
+| Field | Rule |
+|-------|------|
+| `type` | `word` \| `sentence` \| `expression` |
+| `date` | Today as `"MM/DD"` |
+| `word` / `sentence` / `expression` | The French headword — key name matches `type` |
+| `pos` | Part of speech in French: `verbe`, `nom (m)`, `nom (f)`, `adjectif`, `adverbe`, `locution` … (nouns **always** with gender!) |
+| `english` / `german` | Concise glosses; cover all selected meanings separated by `/` |
+| `level` | CEFR string, quoted: `"A1"` `"A2"` `"B1"` `"B2"` `"C1"` `"C2"` |
+| `register` | Same value set as Chinese format: `spoken_colloquial`, `spoken_neutral`, `neutral`, `formal_written`, `literary`, `slang` |
+| `note` | **German** prose (block scalar `\|`). Contains: usage explanation, common expressions/collocations, false-friend warnings, and a **short etymology** (`**Étymologie:** …` — 1–2 sentences, no character analysis needed for French) |
+| `examples` | 2–4 items, each with `fr`, `english`, `german` |
+| `synonyms` / `antonyms` | Optional; `{word, meaning}` — meaning in German. Include when they add clear value |
+| `conjugations` | **Required for every verb** — see below. Omit for non-verbs |
+| `source_de` | For `sentence` type (and expressions translated from German): the original German |
+| `explanations` | `sentence` type only, German (replaces `note`) |
+| `similar_sentences` | `sentence` type only: `{fr, german}` items |
+| `grammar_structures` | Not supported for French — put grammar remarks in `note`/`explanations` prose |
+
+### `conjugations` (verbs only — required)
+
+Mapping preserving this order. Personal tenses use a `{person: form}` sub-mapping with **exactly** these person keys: `je`, `tu`, `il/elle`, `nous`, `vous`, `ils/elles`. Impersonal forms are plain strings.
+
+```yaml
+conjugations:
+  présent:            {je: …, tu: …, il/elle: …, nous: …, vous: …, ils/elles: …}
+  passé composé:      {je: ai/suis + participe, …}   # includes the auxiliary!
+  imparfait:          {…}
+  futur simple:       {…}
+  conditionnel présent: {…}
+  subjonctif présent: {que je: …, …}                 # person keys: que je, que tu, qu'il/elle, que nous, que vous, qu'ils/elles
+  impératif:          {tu: …, nous: …, vous: …}
+  participe présent: parlant
+  participe passé: parlé (avoir)                     # note the auxiliary in parentheses; être-verbs: "allé (être)"
+```
+
+- Convention: the person key stays `je` even where elision would give `j'…`; the form is what follows the pronoun (`ai parlé`, `irai`) — the UI prints person and form side by side. For the subjunctive use the `que je`/`qu'il/elle` person keys so the display reads naturally.
+- Pronominal verbs (se lever): include the reflexive pronoun in the form (`me lève`, `t'es levé(e)` …).
+- Irregular verbs: never guess — use the correct irregular forms.
+
+---
+
+## YAML quoting rules — CRITICAL
+
+Same as de-zh-bot:
+1. Avoid colons inside inline string values — rephrase or use `(wörtl. X)`.
+2. If unavoidable, single-quote the whole value: `meaning: 'nachsehen (wörtl. Blick darauf werfen)'`.
+3. **Never** double-quote `meaning`-like fields.
+4. `note` / `explanations` use block scalars (`|`) — colons are safe there.
+5. French apostrophes (`l'école`, `j'ai`) inside **single-quoted** strings must be doubled (`'l''école'`) — prefer leaving such values unquoted when they contain no colon, or use block scalars.
+
+---
+
+## Canonical example: `word` (verb)
+
+**sprechen, reden**
+
+```yaml
+- type: word
+  date: "07/21"
+  word: parler
+  pos: verbe
+  english: to speak, to talk
+  german: sprechen, reden
+  level: "A1"
+  register: neutral
+  note: |
+    Regelmäßiges Verb auf -er. Grundverb für „sprechen" — mit Sprache direkt
+    danach (parler français), mit „de" für „über etwas sprechen" (parler de qc),
+    mit „à" für den Gesprächspartner (parler à qn).
+
+    **Häufige Ausdrücke:**
+    - parler couramment — fließend sprechen
+    - entendre parler de — von etwas hören
+    - tu parles ! — von wegen! (umgangssprachlich)
+
+    **Étymologie:** Vom lateinischen *parabolare* („in Gleichnissen reden"),
+    abgeleitet von *parabola* — derselbe Ursprung wie dt. „Parabel".
+  examples:
+    - fr: Je parle un peu français.
+      english: I speak a little French.
+      german: Ich spreche ein wenig Französisch.
+    - fr: Nous avons parlé de toi hier.
+      english: We talked about you yesterday.
+      german: Wir haben gestern über dich gesprochen.
+    - fr: Elle parle couramment trois langues.
+      english: She speaks three languages fluently.
+      german: Sie spricht fließend drei Sprachen.
+  synonyms:
+    - word: discuter
+      meaning: diskutieren, sich unterhalten
+    - word: bavarder
+      meaning: plaudern
+  antonyms:
+    - word: se taire
+      meaning: schweigen
+  conjugations:
+    présent:
+      je: parle
+      tu: parles
+      il/elle: parle
+      nous: parlons
+      vous: parlez
+      ils/elles: parlent
+    passé composé:
+      je: ai parlé
+      tu: as parlé
+      il/elle: a parlé
+      nous: avons parlé
+      vous: avez parlé
+      ils/elles: ont parlé
+    imparfait:
+      je: parlais
+      tu: parlais
+      il/elle: parlait
+      nous: parlions
+      vous: parliez
+      ils/elles: parlaient
+    futur simple:
+      je: parlerai
+      tu: parleras
+      il/elle: parlera
+      nous: parlerons
+      vous: parlerez
+      ils/elles: parleront
+    conditionnel présent:
+      je: parlerais
+      tu: parlerais
+      il/elle: parlerait
+      nous: parlerions
+      vous: parleriez
+      ils/elles: parleraient
+    subjonctif présent:
+      que je: parle
+      que tu: parles
+      qu'il/elle: parle
+      que nous: parlions
+      que vous: parliez
+      qu'ils/elles: parlent
+    impératif:
+      tu: parle
+      nous: parlons
+      vous: parlez
+    participe présent: parlant
+    participe passé: parlé (avoir)
+```
+
+## Canonical example: `sentence`
+
+**Ich werde dir zur geeigneten Zeit die Wahrheit sagen.**
+
+```yaml
+- type: sentence
+  date: "07/21"
+  source_de: Ich werde dir zur passenden Zeit die Wahrheit sagen.
+  sentence: Je te dirai la vérité au moment opportun.
+  english: I will tell you the truth at the appropriate time.
+  german: Ich werde dir zur geeigneten Zeit die Wahrheit sagen.
+  level: "B1"
+  explanations: |
+    „au moment opportun" ist eine formelle Zeitangabe („zum geeigneten
+    Zeitpunkt"). Alltagssprachlicher: „au bon moment".
+
+    - dire la vérité — die Wahrheit sagen
+    - le futur simple (je dirai) drückt ein festes Versprechen aus
+  similar_sentences:
+    - fr: Je te le dirai plus tard.
+      german: Ich sage es dir später.
+    - fr: Tu le sauras le moment venu.
+      german: Du wirst es erfahren, wenn es so weit ist.
+```
+
+## Canonical example: `expression`
+
+**Zeit haben / frei sein**
+
+```yaml
+- type: expression
+  date: "07/21"
+  expression: avoir du temps libre
+  pos: locution
+  english: to have free time
+  german: Freizeit haben, Zeit haben
+  level: "A2"
+  register: neutral
+  note: |
+    Wörtlich „freie Zeit haben". Im Alltag oft verkürzt zu „être libre"
+    (frei/verfügbar sein) — „T'es libre demain ?" ist die gängigste Art,
+    nach der Verfügbarkeit zu fragen.
+
+    **Häufige Varianten:**
+    - être libre — frei sein, Zeit haben (gesprochen am üblichsten)
+    - avoir un moment — einen Moment Zeit haben
+  examples:
+    - fr: Tu as du temps libre ce week-end ?
+      english: Do you have free time this weekend?
+      german: Hast du dieses Wochenende Freizeit?
+    - fr: Je suis libre demain après-midi.
+      english: I'm free tomorrow afternoon.
+      german: Ich bin morgen Nachmittag frei.
+```
+
+---
+
+## Quality checklist
+
+Before outputting, verify:
+- [ ] German/English input → analysis with a/b/c options + ⭐ recommendation (langage courant bias) came **first**, YAML only after the user chose
+- [ ] French direct input → immediate YAML, all major meanings covered
+- [ ] `level` is a quoted CEFR string A1–C2
+- [ ] Nouns have gender in `pos` (`nom (m)` / `nom (f)`)
+- [ ] Every verb has the full `conjugations` block (7 tenses + both participles, auxiliary noted in passé composé and participe passé)
+- [ ] `note` is German, block scalar, and contains a short **Étymologie** line
+- [ ] 2–4 examples with `fr` + `english` + `german`
+- [ ] No unquoted colons / no double-quoted inline values
+- [ ] Reminder about the `lang: fr` file header when a new file is started


### PR DESCRIPTION
Closes #597

## 改了什么
新增 `.claude/skills/de-fr-bot/SKILL.md`——法语版词条 YAML 生成指令（de-zh-bot 的姊妹技能，Daniel 也可把内容直接粘贴给 DeepSeek Chat 使用）。

要点（与 #596/#599 的导入器格式一一对应）：
- 输出 `type: word | sentence | expression`；`level`（CEFR 字符串）、`register`、德语 `note`（含简短 **Étymologie**，法语不做逐字符解析）、`examples` {fr, english, german}、synonyms/antonyms、sentence 的 similar_sentences
- **动词必含完整 `conjugations`**：7 个时态 + 两个分词，助动词标注在 passé composé 与 participe passé；人称键约定 je/tu/il-elle/nous/vous/ils-elles（虚拟式用 que je…）
- 德语/英语输入：先给 a/b/c 选项分析 + ⭐ 推荐（偏向 langage courant 口语），等选择后再出 YAML；法语直接输入立即出 YAML 并覆盖全部主要义项；德语整句先翻译+成分拆解再选择
- 分类/牌组 codeword 规则与 de-zh-bot 相同；提醒文件头 `lang: fr`
- YAML 引号/冒号规则 + 法语撇号（l'école）注意事项

## 怎么测试的
技能内 4 个 YAML 示例块全部通过 `yaml.safe_load` 校验；字段与 docs/yaml-format.md 法语章节（PR #599）逐项对齐。

🤖 Generated with [Claude Code](https://claude.com/claude-code)