### PR TITLE
feat: 服务启动时自动恢复被重启中断的孤儿播客单集（#598）

### DIFF
--- a/database/core.py
+++ b/database/core.py
@@ -642,6 +642,8 @@ def init_db() -> None:
             conn.execute("ALTER TABLE podcast_episodes ADD COLUMN duration_seconds INTEGER")
         if "transcript_de" not in pe_cols:
             conn.execute("ALTER TABLE podcast_episodes ADD COLUMN transcript_de TEXT")
+        if "processing_started_at" not in pe_cols:
+            conn.execute("ALTER TABLE podcast_episodes ADD COLUMN processing_started_at TEXT")
         conn.commit()
 
         # Purge stale legacy YouTube rows (#497): yt-dlp is retired, so any

--- a/database/podcast.py
+++ b/database/podcast.py
@@ -203,6 +203,32 @@ def update_episode(episode_id: int, **fields) -> None:
     conn.close()
 
 
+def recover_orphaned_podcast_episodes() -> int:
+    """Reset episodes orphaned mid-transcription back to 'error' so run_check's
+    auto-retry (#491) reprocesses them, reusing any stored transcript (#500).
+
+    _process_episode stamps processing_started_at while it works and clears it
+    (via finally) on every normal exit, so at process startup — when nothing is
+    running yet — any row with processing_started_at still set was left by a
+    restart/crash that killed the process mid-transcription (#598). Backfilled
+    episodes never reach _process_episode, so their stamp stays NULL and they
+    are untouched. 'summarized' rows are left alone defensively (a stray stamp
+    there should not clobber a finished episode). Returns the number recovered."""
+    conn = get_db()
+    cur = conn.execute(
+        """UPDATE podcast_episodes
+           SET status = 'error',
+               error = 'Interrupted by a restart — will auto-retry',
+               processing_started_at = NULL
+           WHERE processing_started_at IS NOT NULL
+             AND status != 'summarized'""",
+    )
+    conn.commit()
+    n = cur.rowcount
+    conn.close()
+    return n
+
+
 def _hydrate(row: dict) -> dict:
     d = dict(row)
     raw = d.get("hsk_words")

--- a/main.py
+++ b/main.py
@@ -197,7 +197,18 @@ try:
 
     @asynccontextmanager
     async def lifespan(app):
-        yield  # startup
+        # Recover podcast episodes orphaned by a mid-transcription restart/crash
+        # (#598): _process_episode marks an episode 'processing' while it works,
+        # so any 'processing' row at startup is a leftover (nothing runs yet) —
+        # flip it to 'error' so run_check's auto-retry reprocesses it, reusing
+        # any stored transcript. Best-effort: never block or crash startup.
+        try:
+            recovered = database.recover_orphaned_podcast_episodes()
+            if recovered:
+                logger.info("podcast: recovered %d episode(s) orphaned by a restart", recovered)
+        except Exception as e:
+            logger.warning("podcast: orphan recovery skipped at startup: %s", e)
+        yield  # startup done; below runs at shutdown
         if os.environ.get("DEV_CLEAR_DB"):
             import shutil
             import tts as _tts

--- a/podcast.py
+++ b/podcast.py
@@ -1330,6 +1330,15 @@ def _process_episode(episode_id: int, video: dict, detail_level: str, summary: d
 
     label = f"Transcribe & Summarize: {video['title'][:30]}"
     with database.action_context(label):
+        # Stamp the episode as actively processing (#598): the finally below
+        # clears this on every normal exit (success/error/no_transcript/dev),
+        # so a still-set timestamp means the process was killed mid-transcription
+        # (restart/crash) and recover_orphaned_podcast_episodes() will flip the
+        # episode to 'error' at next startup for auto-retry. Backfilled episodes
+        # never reach here (they rest at 'pending' until manually processed), so
+        # this reliably marks "actively working" without a 'processing' status
+        # (the DB CHECK constraint forbids one).
+        database.update_episode(episode_id, processing_started_at=datetime.now().isoformat())
         try:
             # Reuse an already-stored transcript (#500): after e.g. an OpenAI-quota
             # failure in the summary step, the retry must not re-run the whole
@@ -1401,7 +1410,6 @@ def _process_episode(episode_id: int, video: dict, detail_level: str, summary: d
                 logger.warning("podcast: email failed for %s: %s", video["video_id"], e)
                 sent = False
             if sent:
-                from datetime import datetime
                 database.update_episode(episode_id, email_sent_at=datetime.now().isoformat())
                 summary["emailed"] += 1
 
@@ -1416,6 +1424,11 @@ def _process_episode(episode_id: int, video: dict, detail_level: str, summary: d
             logger.error("podcast: episode %s failed: %s", video["video_id"], e)
             database.update_episode(episode_id, status="error", error=str(e))
             summary["failed"] += 1
+        finally:
+            # Clear the "actively processing" stamp on every normal exit (#598).
+            # Only a hard kill (SIGKILL) skips this, leaving the timestamp set so
+            # startup recovery can spot the orphan.
+            database.update_episode(episode_id, processing_started_at=None)
 
 
 def regenerate_summary(episode_id: int) -> dict:

--- a/schema.sql
+++ b/schema.sql
@@ -603,6 +603,7 @@ CREATE TABLE IF NOT EXISTS podcast_episodes (
     transcript_source TEXT,  -- 'tingwu' | 'whisper' | 'notebooklm' | NULL (#498/#486); legacy rows may say 'captions'
     error            TEXT,
     email_sent_at    TEXT,
+    processing_started_at TEXT,  -- set while _process_episode runs, cleared on exit; a leftover value = killed mid-transcription, recovered at startup (#598)
     created_at       TEXT NOT NULL DEFAULT (datetime('now'))
 );
 


### PR DESCRIPTION
## 背景

播客转录跑在 web 服务进程内部（cron 脚本只发 `POST /api/podcast/check` 触发）。`deploy/deploy.sh` 每次部署都 `systemctl restart ankiadvanced` 硬重启，不检查是否正在转录。若部署/崩溃发生在转录途中，进程被 SIGKILL 杀掉，单集被留在 `pending`：自动重试只捞 `error`、`fetch_new_videos` 不会再把它当新视频 → **孤儿式卡死，只能手动 Retry**。

不能一刀切恢复所有 `pending`：新订阅源的 backfill 单集**故意**存成 `pending`（元数据 only、按需转录），blanket 恢复会误转录整个目录（很贵）。

## 方案

`_process_episode` 开始时给单集盖 `processing_started_at` 时间戳，用 `try/finally` 在**任何正常退出路径**（成功/error/no_transcript/DISABLE_AI）清空它；只有被 SIGKILL 杀掉（finally 不执行）才会残留。启动时（`main.py` lifespan）把残留时间戳的单集翻成 `error`（附"重启中断"说明），复用现有自动重试机制（#491）下一轮重跑、并复用已存转录（#500 不重复付费）。

backfill 单集从不进 `_process_episode`，永不盖时间戳，天然安全。数据库 `status` 有 CHECK 约束不含 `processing`，故用独立时间戳列而非新状态。

## 改动

- `podcast._process_episode`：起始盖时间戳，`finally` 清空；顺手修掉一处多余的局部 `datetime` 导入（它会遮蔽模块级导入，导致 `UnboundLocalError`）
- `database.recover_orphaned_podcast_episodes()`：时间戳残留且非 `summarized` 的翻成 `error`、清空时间戳，返回数量
- `main.py` lifespan：启动时 best-effort 调用（try/except，绝不让启动崩溃）
- 迁移：`schema.sql` + `core.py` 的 `ALTER TABLE ADD COLUMN processing_started_at`

## 测试

本地已验证：
- DISABLE_AI 早返回路径 + 异常路径都正确清空时间戳
- 恢复函数：两种孤儿（摘要途中有转录 / 转录途中无转录）→ `error`，转录保留；backfill（无时间戳）不动；summarized 防御性跳过；幂等（二次恢复 0）
- 前端已支持 `processing` 徽章，无需改动

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)