### PR TITLE
难词阈值输入框仅在开关开启时显示（#604）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3642,6 +3642,12 @@ function applySchedulerVisibility() {
   document.querySelectorAll('.sched-fsrs').forEach(el => { el.style.display = fsrs ? '' : 'none'; });
 }
 
+// Learning-leech off → hide the threshold input (it only matters when on).
+function applyLearningLeechVisibility() {
+  const on = document.getElementById('opt-enable-learning-leech').checked;
+  document.querySelectorAll('.learning-leech-row').forEach(el => { el.style.display = on ? '' : 'none'; });
+}
+
 // Clickable ⓘ explanations for scheduling fields.
 const INFO_TEXT = {
   enable_fsrs: ['Enable FSRS',
@@ -3731,6 +3737,7 @@ function loadPresetFields(preset) {
   document.getElementById('opt-max-int').value         = preset.maximum_interval ?? 36500;
   document.getElementById('opt-reading-enabled').checked = !!preset.reading_enabled;
   applySchedulerVisibility();
+  applyLearningLeechVisibility();
 
   // Category order
   const order = (preset.category_order || 'listening,reading,creating').split(',').map(s => s.trim());

--- a/static/index.html
+++ b/static/index.html
@@ -513,11 +513,11 @@
       <div class="opt-group-label">Lapses</div>
       <div class="opt-row"><span class="opt-label">Relearning steps (minutes)</span><input class="opt-input wide" id="opt-relearn-steps" type="text"></div>
       <div class="opt-row"><span class="opt-label">Leech threshold (review lapses)</span>  <input class="opt-input" id="opt-leech"         type="number" min="1"></div>
-      <div class="opt-row"><span class="opt-label">Learning leech threshold (Again presses)</span>  <input class="opt-input" id="opt-learning-leech" type="number" min="1"></div>
       <div class="opt-row">
         <span class="opt-label">Count learning-phase leeches<br><span style="font-weight:400;font-size:11px;color:var(--muted)">off = only review-state lapses can flag a leech; on = Again presses in learning/relearn count too</span></span>
-        <input type="checkbox" id="opt-enable-learning-leech" style="width:18px;height:18px;cursor:pointer">
+        <input type="checkbox" id="opt-enable-learning-leech" style="width:18px;height:18px;cursor:pointer" onchange="applyLearningLeechVisibility()">
       </div>
+      <div class="opt-row learning-leech-row"><span class="opt-label">Learning leech threshold (Again presses)</span>  <input class="opt-input" id="opt-learning-leech" type="number" min="1"></div>
     </div>
 
     <div class="opt-group">


### PR DESCRIPTION
Closes #604

跟进 #602/#603 的小 UI 优化。

## 改动
- 设置弹窗 Lapses 组：把 **Count learning-phase leeches** 开关移到 **Learning leech threshold** 输入框**之上**。
- 阈值输入框加 `learning-leech-row` 类；新增 `applyLearningLeechVisibility()`：开关开 → 显示，开关关 → 隐藏。
- `onchange` 触发切换；加载预设时（`applySchedulerVisibility()` 旁）也调用一次初始化可见性。

纯前端，无构建步骤。