### PR TITLE
播客摘要：难词括号内同时显示拼音和汉字（#608）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -2194,9 +2194,11 @@ Task:
      name in parentheses right after it, e.g. "Airbnb (爱彼迎)", "Lawn Tennis Association
      (英国草地网球协会)". If no established Chinese name exists, give a natural Chinese rendering.
    - Whenever you use one of the HSK5+ vocabulary words you extract in Task 2 inside the
-     German summary, add its Chinese form in parentheses right after the German rendering,
-     e.g. "Rezession (经济衰退)", "Lieferkette (供应链)", so Daniel links the German meaning
-     to the Chinese word he is pre-learning.
+     German summary, add its pinyin AND Chinese form in parentheses right after the German
+     rendering, in the format "pinyin/汉字",
+     e.g. "Rezession (jīngjì shuāituì/经济衰退)", "Lieferkette (gōngyìng liàn/供应链)", so
+     Daniel links the German meaning to the Chinese word — and its pronunciation — he is
+     pre-learning. Use the same pinyin (with tone marks) you give for that word in Task 2.
    - If (and ONLY if) the transcript contains timestamps, add an approximate timestamp in
      parentheses when you introduce each major topic, e.g. "(ca. 12:30)", so the listener can
      jump to it. If the transcript contains no timestamps, do NOT invent any.


### PR DESCRIPTION
## 改了什么

播客德语摘要正文里，HSK5+ 生词的括号标注从 `Wort（汉字）` 改为 `Wort（拼音/汉字）`。

例如：`Rezession (经济衰退)` → `Rezession (jīngjì shuāituì/经济衰退)`

## 为什么

Daniel 想在读摘要时直接读出生词发音，不必再去查生词表格里的拼音列。

## 怎么做的

只改 `ai.py` 中 `summarize_podcast_transcript` 的提示词：要求 AI 在括号内先写拼音、斜杠、再写汉字，并复用 Task 2 里同一个词已生成的带声调拼音。摘要与生词表在同一次 AI 调用里生成，AI 手里已有拼音，无需额外数据或逻辑改动。

## 怎么测试

下一集播客摘要生成后，检查正文里生词括号是否为「拼音/汉字」格式；也可对已有单集点「Regenerate summary」按钮重新生成验证。公司名标注、HSK 生词表格均不受影响。

Closes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)