### PR TITLE
提示词库：每个故事模式可保存多个命名提示词版本（#610）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,10 +318,15 @@ POST /api/podcast/episodes/{id}/regenerate-summary    → 仅重跑摘要步骤�
 GET/POST /api/podcast/feeds ；PUT/DELETE /api/podcast/feeds/{id} → RSS 源管理（#502；POST 抓取验证并提取节目标题；PUT 改 auto_process/title）
 GET/PUT /api/podcast/config                           → 读/改设置（email_to/detail_level/enabled/transcriber/whisper_max_minutes/summarizer[auto|api]（#510）；feeds 已迁到 podcast_feeds 表（#502），whisper_fallback、channel_url、channel_id、whisper_title_filter 已废弃但兼容，#497）
 
-# 提示词模板（#581；story/qa/expository/podcast，仅中文；无自定义行 = ai.DEFAULT_PROMPT_TEMPLATES 内置默认）
-GET    /api/prompt-template/{mode}                   → {template, default, is_custom, variables}
-PUT    /api/prompt-template/{mode}                   → 保存自定义（body {template}，必须含 {words} 记号；与默认相同时自动重置）
-DELETE /api/prompt-template/{mode}                   → 重置为内置默认
+# 提示词版本库（#581 单份自定义 → #610 每模式多个命名版本；story/qa/expository/podcast，仅中文）
+# prompt_presets 表：每 mode 可存多个命名版本，最多一行 is_active=1；无生效版本 = ai.DEFAULT_PROMPT_TEMPLATES 内置默认
+GET    /api/prompt-template/{mode}                   → {template, default, is_custom, variables, presets[], active_id}
+DELETE /api/prompt-template/{mode}                   → 取消生效（回内置默认；#610 起不再删除已保存版本）
+POST   /api/prompt-presets/{mode}                    → 新建命名版本并设为生效（body {name, template}，须含 {words}；重名 409）
+PUT    /api/prompt-presets/{id}                      → 改名/改内容（body {name?, template?}）
+POST   /api/prompt-presets/{id}/activate             → 设为该 mode 唯一生效版本
+DELETE /api/prompt-presets/{id}                      → 删除该版本
+# 旧的 PUT /api/prompt-template/{mode} 已由 POST/PUT /api/prompt-presets/* 取代（#610）
 
 # 成本
 GET  /api/costs                                      → 成本历史（动作分组；balances 列出各提供商余额，#580；Again 单句重生成有正式标签且相邻同标签 30 分钟内合并，#578）

--- a/database/core.py
+++ b/database/core.py
@@ -690,6 +690,27 @@ def init_db() -> None:
                          (cleaned, row["id"]))
     conn.commit()
 
+    # One-time migration (#610): the old prompt_templates table held at most one
+    # custom template per mode; the new prompt_presets table supports several
+    # named versions per mode. Migrate any existing prompt_templates rows into
+    # a preset named "Saved", marked active, but only if that mode doesn't
+    # already have presets — this keeps init_db() idempotent across restarts.
+    # The old table is left untouched (not dropped) so this is safe to roll back.
+    old_rows = conn.execute("SELECT mode, template FROM prompt_templates").fetchall()
+    for row in old_rows:
+        mode = row["mode"]
+        already = conn.execute(
+            "SELECT 1 FROM prompt_presets WHERE mode = ?", (mode,)
+        ).fetchone()
+        if already:
+            continue
+        conn.execute(
+            """INSERT INTO prompt_presets (mode, name, template, is_active, updated_at)
+               VALUES (?, 'Saved', ?, 1, datetime('now'))""",
+            (mode, row["template"]),
+        )
+    conn.commit()
+
     conn.close()
 
     # Seed the day-cutoff cache now that app_settings is guaranteed present

--- a/database/prompts.py
+++ b/database/prompts.py
@@ -1,35 +1,113 @@
-"""自定义提示词模板（issue #581）。
+"""提示词版本库（issue #610，原单份自定义模板见 #581）。
 
-每个故事模式一行：mode → 用户编辑过的模板全文（含 {words} 等记号）。
-没有行 = 使用 ai.DEFAULT_PROMPT_TEMPLATES 里的内置模板。
+每个故事模式（story/qa/expository/podcast）可以保存多个命名的提示词版本
+（prompt_presets 表），其中最多一行 is_active=1 表示当前生效版本。没有
+生效行 = 使用 ai.DEFAULT_PROMPT_TEMPLATES 里的内置模板。
+
+旧的 prompt_templates 表（每模式一份自定义模板，无名字）仍保留在
+schema.sql 里但不再写入——数据已在 database/core.py 的 init_db() 迁移里
+搬到 prompt_presets（名为 "Saved" 的生效版本）。
 """
 from .core import get_db
 
 
 def get_prompt_template(mode: str) -> str | None:
+    """当前生效 preset 的模板全文；该 mode 没有生效版本时返回 None。"""
     conn = get_db()
     row = conn.execute(
-        "SELECT template FROM prompt_templates WHERE mode = ?", (mode,)
+        "SELECT template FROM prompt_presets WHERE mode = ? AND is_active = 1",
+        (mode,),
     ).fetchone()
     conn.close()
     return row["template"] if row else None
 
 
-def set_prompt_template(mode: str, template: str) -> None:
+def list_prompt_presets(mode: str) -> list[dict]:
+    """该 mode 下所有已保存版本的概要（不含模板全文），按名称排序。"""
     conn = get_db()
+    rows = conn.execute(
+        """SELECT id, name, is_active, updated_at FROM prompt_presets
+           WHERE mode = ? ORDER BY name COLLATE NOCASE""",
+        (mode,),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def get_prompt_preset(preset_id: int) -> dict | None:
+    conn = get_db()
+    row = conn.execute(
+        "SELECT * FROM prompt_presets WHERE id = ?", (preset_id,)
+    ).fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def create_prompt_preset(mode: str, name: str, template: str) -> int:
+    """新建一个版本并立即设为该 mode 的生效版本，返回新 id。
+
+    重名（同 mode+name）时 sqlite3.IntegrityError 会向上抛出，由路由层
+    捕获转成 409。
+    """
+    conn = get_db()
+    conn.execute("UPDATE prompt_presets SET is_active = 0 WHERE mode = ?", (mode,))
+    cur = conn.execute(
+        """INSERT INTO prompt_presets (mode, name, template, is_active, updated_at)
+           VALUES (?, ?, ?, 1, datetime('now'))""",
+        (mode, name, template),
+    )
+    conn.commit()
+    new_id = cur.lastrowid
+    conn.close()
+    return new_id
+
+
+def update_prompt_preset(preset_id: int, name: str | None = None,
+                          template: str | None = None) -> None:
+    """只更新传入的字段；重名（改名冲突）由 sqlite3.IntegrityError 向上抛出。"""
+    conn = get_db()
+    if name is not None:
+        conn.execute(
+            "UPDATE prompt_presets SET name = ?, updated_at = datetime('now') WHERE id = ?",
+            (name, preset_id),
+        )
+    if template is not None:
+        conn.execute(
+            "UPDATE prompt_presets SET template = ?, updated_at = datetime('now') WHERE id = ?",
+            (template, preset_id),
+        )
+    conn.commit()
+    conn.close()
+
+
+def activate_prompt_preset(preset_id: int) -> None:
+    """将 preset_id 设为其 mode 下唯一生效版本（同一事务内切换）。"""
+    conn = get_db()
+    row = conn.execute(
+        "SELECT mode FROM prompt_presets WHERE id = ?", (preset_id,)
+    ).fetchone()
+    if row is None:
+        conn.close()
+        return
+    conn.execute("UPDATE prompt_presets SET is_active = 0 WHERE mode = ?", (row["mode"],))
     conn.execute(
-        """INSERT INTO prompt_templates (mode, template, updated_at)
-           VALUES (?, ?, datetime('now'))
-           ON CONFLICT(mode) DO UPDATE SET
-             template = excluded.template, updated_at = excluded.updated_at""",
-        (mode, template),
+        "UPDATE prompt_presets SET is_active = 1, updated_at = datetime('now') WHERE id = ?",
+        (preset_id,),
     )
     conn.commit()
     conn.close()
 
 
-def delete_prompt_template(mode: str) -> None:
+def delete_prompt_preset(preset_id: int) -> None:
     conn = get_db()
-    conn.execute("DELETE FROM prompt_templates WHERE mode = ?", (mode,))
+    conn.execute("DELETE FROM prompt_presets WHERE id = ?", (preset_id,))
+    conn.commit()
+    conn.close()
+
+
+def deactivate_prompt_presets(mode: str) -> None:
+    """该 mode 下全部版本设为非生效——故事生成回落内置默认模板。"""
+    conn = get_db()
+    conn.execute("UPDATE prompt_presets SET is_active = 0 WHERE mode = ?", (mode,))
     conn.commit()
     conn.close()

--- a/routes/story.py
+++ b/routes/story.py
@@ -5,6 +5,7 @@ import math
 import os
 import random
 import re
+import sqlite3
 import threading
 
 import jieba
@@ -678,7 +679,7 @@ def regenerate_story(deck_id: int, category: str,
     return result
 
 
-# ── 自定义提示词模板（issue #581）──────────────────────────────────────────────
+# ── 提示词版本库（issue #610；原单份自定义模板见 #581）──────────────────────────
 
 def _require_editable_mode(mode: str) -> None:
     if mode not in ai.DEFAULT_PROMPT_TEMPLATES:
@@ -686,37 +687,98 @@ def _require_editable_mode(mode: str) -> None:
                             detail=f"Mode '{mode}' has no editable prompt template")
 
 
+def _validate_template(template: str) -> None:
+    if "{words}" not in (template or ""):
+        raise HTTPException(status_code=400,
+                            detail="Template must contain the {words} placeholder")
+
+
 @router.get("/api/prompt-template/{mode}")
 def get_prompt_template(mode: str):
-    """当前生效模板（自定义优先）+ 内置默认 + 可用记号列表。"""
+    """当前生效模板（生效 preset 优先）+ 内置默认 + 可用记号列表 + 版本列表。
+
+    字段 template/default/is_custom/variables 与 #581 时保持一致（向后兼容）；
+    presets/active_id 是 #610 新增的版本库信息。
+    """
     _require_editable_mode(mode)
     custom = database.get_prompt_template(mode)
     default = ai.DEFAULT_PROMPT_TEMPLATES[mode]
+    presets = database.list_prompt_presets(mode)
+    active = next((p for p in presets if p["is_active"]), None)
     return {"mode": mode, "template": custom or default, "default": default,
             "is_custom": custom is not None,
-            "variables": ai.PROMPT_TEMPLATE_VARIABLES[mode]}
+            "variables": ai.PROMPT_TEMPLATE_VARIABLES[mode],
+            "presets": presets,
+            "active_id": active["id"] if active else None}
 
 
-@router.put("/api/prompt-template/{mode}")
-def put_prompt_template(mode: str, body: dict):
+@router.post("/api/prompt-presets/{mode}")
+def create_prompt_preset(mode: str, body: dict):
+    """新建一个命名版本并立即设为生效版本。"""
     _require_editable_mode(mode)
+    name = ((body or {}).get("name") or "").strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="Name must not be empty")
     template = (body or {}).get("template") or ""
-    if "{words}" not in template:
-        raise HTTPException(status_code=400,
-                            detail="Template must contain the {words} placeholder")
-    # 存回未改动的默认模板 = 视为重置，避免默认将来更新时被旧快照锁死
-    if template.strip() == ai.DEFAULT_PROMPT_TEMPLATES[mode].strip():
-        database.delete_prompt_template(mode)
-        return {"mode": mode, "is_custom": False}
-    database.set_prompt_template(mode, template)
-    return {"mode": mode, "is_custom": True}
+    _validate_template(template)
+    try:
+        new_id = database.create_prompt_preset(mode, name, template)
+    except sqlite3.IntegrityError:
+        raise HTTPException(status_code=409,
+                            detail="A preset with that name already exists")
+    return {"id": new_id, "mode": mode, "name": name, "is_active": True}
+
+
+@router.put("/api/prompt-presets/{preset_id}")
+def update_prompt_preset(preset_id: int, body: dict):
+    """改名和/或改内容；两者都是可选的。"""
+    preset = database.get_prompt_preset(preset_id)
+    if preset is None:
+        raise HTTPException(status_code=404, detail="Preset not found")
+    body = body or {}
+    name = body.get("name")
+    if name is not None:
+        name = name.strip()
+        if not name:
+            raise HTTPException(status_code=400, detail="Name must not be empty")
+    template = body.get("template")
+    if template is not None:
+        _validate_template(template)
+    try:
+        database.update_prompt_preset(preset_id, name=name, template=template)
+    except sqlite3.IntegrityError:
+        raise HTTPException(status_code=409,
+                            detail="A preset with that name already exists")
+    updated = database.get_prompt_preset(preset_id)
+    return {"id": preset_id, "name": updated["name"]}
+
+
+@router.post("/api/prompt-presets/{preset_id}/activate")
+def activate_prompt_preset(preset_id: int):
+    preset = database.get_prompt_preset(preset_id)
+    if preset is None:
+        raise HTTPException(status_code=404, detail="Preset not found")
+    database.activate_prompt_preset(preset_id)
+    return {"id": preset_id, "mode": preset["mode"], "is_active": True}
+
+
+@router.delete("/api/prompt-presets/{preset_id}")
+def delete_prompt_preset(preset_id: int):
+    preset = database.get_prompt_preset(preset_id)
+    if preset is None:
+        raise HTTPException(status_code=404, detail="Preset not found")
+    database.delete_prompt_preset(preset_id)
+    return {"deleted": True}
 
 
 @router.delete("/api/prompt-template/{mode}")
 def reset_prompt_template(mode: str):
+    """取消该 mode 的生效版本（issue #610 起语义变化：不再删除已保存版本，
+    只是回落到内置默认模板；原来的 #581 行为是彻底删除唯一的自定义模板，
+    效果相同但现在版本本身继续保留，可随时重新 activate）。"""
     _require_editable_mode(mode)
-    database.delete_prompt_template(mode)
-    return {"mode": mode, "is_custom": False}
+    database.deactivate_prompt_presets(mode)
+    return {"mode": mode, "is_active": False}
 
 
 @router.get("/api/story/{deck_id}/{category}/history")

--- a/schema.sql
+++ b/schema.sql
@@ -447,6 +447,21 @@ CREATE TABLE IF NOT EXISTS prompt_templates (
 );
 
 -- ---------------------------------------------------------------------------
+-- prompt_presets — 每个故事模式可保存多个命名提示词版本（issue #610）；
+-- 每个 mode 最多一行 is_active=1；无生效行 = 用 ai.DEFAULT_PROMPT_TEMPLATES
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS prompt_presets (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    mode        TEXT NOT NULL,
+    name        TEXT NOT NULL,
+    template    TEXT NOT NULL,
+    is_active   INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(mode, name)
+);
+
+-- ---------------------------------------------------------------------------
 -- entry_components  (formerly note_components — links sentences/chengyu to their component vocabulary)
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS entry_components (

--- a/static/app.js
+++ b/static/app.js
@@ -3535,8 +3535,12 @@ async function loadPromptEditor() {
       'Placeholders (replaced at generation time): ' + data.variables.map(v => `{${v}}`).join('  ');
     ta.value = data.template;
 
-    select.innerHTML = '<option value="">Built-in default</option>' +
-      data.presets.map(p => `<option value="${p.id}">${p.name}</option>`).join('');
+    // Build options via the DOM, not an HTML string — preset names are free
+    // text and would break the markup on a quote or angle bracket.
+    select.innerHTML = '';
+    const defaultOpt = new Option('Built-in default', '');
+    select.appendChild(defaultOpt);
+    data.presets.forEach(p => select.appendChild(new Option(p.name, String(p.id))));
     select.value = data.active_id != null ? String(data.active_id) : '';
 
     const active = data.presets.find(p => p.is_active);

--- a/static/app.js
+++ b/static/app.js
@@ -3473,12 +3473,15 @@ function closeCostPrompt() {
   if (overlay) overlay.style.display = 'none';
 }
 
-// ── Prompt template editor (issue #581) ──────────────────────────────────────
+// ── Prompt template editor (issue #581, versioned presets since #610) ───────
 // Edit the full prompt of the currently selected story mode; dynamic content
 // ({words}, {topic}, …) stays as placeholders so the word list never clutters
-// the editor. Stored server-side (prompt_templates table), applies everywhere
-// the mode generates — full stories and Again single-sentence regens alike.
+// the editor. Each mode can hold several named versions (prompt_presets
+// table); at most one is "active" and applies everywhere the mode
+// generates — full stories and Again single-sentence regens alike. No
+// active version = built-in default.
 let _promptEditorMode = null;
+let _promptEditorData = null;  // last GET /api/prompt-template/{mode} response
 
 async function openPromptEditor() {
   const mode = document.getElementById('setup-mode').value;
@@ -3493,11 +3496,17 @@ async function openPromptEditor() {
           <span id="prompt-editor-title">Prompt template</span>
           <button class="cost-prompt-close" onclick="closePromptEditor()">&times;</button>
         </div>
+        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+          <select id="prompt-preset-select" class="edit-input" style="flex:1;min-width:140px" onchange="onPromptPresetChange()"></select>
+          <input id="prompt-preset-name" class="edit-input" style="flex:1;min-width:140px" placeholder="Name for new version">
+        </div>
         <div id="prompt-editor-vars" style="font-size:12px;color:var(--muted,#888)"></div>
         <textarea id="prompt-editor-text" spellcheck="false"
           style="width:100%;min-height:50vh;font-family:monospace;font-size:12px;line-height:1.45;resize:vertical"></textarea>
-        <div style="display:flex;gap:8px;justify-content:flex-end">
+        <div style="display:flex;gap:8px;justify-content:flex-end;flex-wrap:wrap">
           <button class="edit-cancel-btn" onclick="resetPromptTemplate()">Reset to default</button>
+          <button class="edit-cancel-btn" onclick="deletePromptPreset()">Delete</button>
+          <button class="edit-save-btn" onclick="savePromptPresetAsNew()">Save as new</button>
           <button class="edit-save-btn" onclick="savePromptTemplate()">Save</button>
         </div>
       </div>`;
@@ -3506,32 +3515,101 @@ async function openPromptEditor() {
   }
   overlay.style.display = 'flex';
   _promptEditorMode = mode;
+  await loadPromptEditor();
+}
+
+// (Re)loads the mode's template metadata + presets from the server and
+// refreshes the title, placeholder hint, preset dropdown and textarea.
+async function loadPromptEditor() {
+  const mode = _promptEditorMode;
   const title = document.getElementById('prompt-editor-title');
   const ta = document.getElementById('prompt-editor-text');
+  const select = document.getElementById('prompt-preset-select');
+  document.getElementById('prompt-preset-name').value = '';
   title.textContent = 'Loading…';
   ta.value = '';
   try {
     const data = await api('GET', `/api/prompt-template/${mode}`);
-    title.textContent = `Prompt template — ${mode}${data.is_custom ? ' (custom)' : ''}`;
+    _promptEditorData = data;
     document.getElementById('prompt-editor-vars').textContent =
       'Placeholders (replaced at generation time): ' + data.variables.map(v => `{${v}}`).join('  ');
     ta.value = data.template;
+
+    select.innerHTML = '<option value="">Built-in default</option>' +
+      data.presets.map(p => `<option value="${p.id}">${p.name}</option>`).join('');
+    select.value = data.active_id != null ? String(data.active_id) : '';
+
+    const active = data.presets.find(p => p.is_active);
+    title.textContent = `Prompt template — ${mode}` + (active ? ` · ${active.name}` : '');
   } catch (e) {
     title.textContent = 'Failed to load template';
     ta.value = e.message;
   }
 }
 
+// Switching the dropdown activates the chosen preset (or deactivates all
+// presets for "Built-in default") and reloads the editor with its content.
+async function onPromptPresetChange() {
+  const select = document.getElementById('prompt-preset-select');
+  const value = select.value;
+  try {
+    if (value) {
+      await api('POST', `/api/prompt-presets/${value}/activate`);
+    } else {
+      await api('DELETE', `/api/prompt-template/${_promptEditorMode}`);
+    }
+    await loadPromptEditor();
+  } catch (e) {
+    showError('Failed to switch version: ' + e.message);
+  }
+}
+
 async function savePromptTemplate() {
   if (!_promptEditorMode) return;
+  const template = document.getElementById('prompt-editor-text').value;
+  const activeId = _promptEditorData && _promptEditorData.active_id;
   try {
-    const r = await api('PUT', `/api/prompt-template/${_promptEditorMode}`,
-                        { template: document.getElementById('prompt-editor-text').value });
-    document.getElementById('prompt-editor-title').textContent =
-      `Prompt template — ${_promptEditorMode}${r.is_custom ? ' (custom)' : ''}`;
+    if (activeId != null) {
+      await api('PUT', `/api/prompt-presets/${activeId}`, { template });
+    } else {
+      const name = document.getElementById('prompt-preset-name').value.trim() || 'Custom';
+      await api('POST', `/api/prompt-presets/${_promptEditorMode}`, { name, template });
+    }
+    await loadPromptEditor();
     closePromptEditor();
   } catch (e) {
-    showError('Save failed — the template must keep the {words} placeholder.');
+    showError('Save failed: ' + e.message);
+  }
+}
+
+async function savePromptPresetAsNew() {
+  if (!_promptEditorMode) return;
+  const name = document.getElementById('prompt-preset-name').value.trim();
+  if (!name) {
+    showError('Enter a name for the new version.');
+    return;
+  }
+  const template = document.getElementById('prompt-editor-text').value;
+  try {
+    await api('POST', `/api/prompt-presets/${_promptEditorMode}`, { name, template });
+    await loadPromptEditor();
+  } catch (e) {
+    showError('Save failed: ' + e.message);
+  }
+}
+
+async function deletePromptPreset() {
+  const activeId = _promptEditorData && _promptEditorData.active_id;
+  if (activeId == null) {
+    showError('Select a saved version to delete.');
+    return;
+  }
+  if (!confirm('Delete this prompt version? This cannot be undone.')) return;
+  try {
+    await api('DELETE', `/api/prompt-presets/${activeId}`);
+    await loadPromptEditor();
+  } catch (e) {
+    showError('Delete failed: ' + e.message);
   }
 }
 
@@ -3539,10 +3617,7 @@ async function resetPromptTemplate() {
   if (!_promptEditorMode) return;
   try {
     await api('DELETE', `/api/prompt-template/${_promptEditorMode}`);
-    const data = await api('GET', `/api/prompt-template/${_promptEditorMode}`);
-    document.getElementById('prompt-editor-text').value = data.template;
-    document.getElementById('prompt-editor-title').textContent =
-      `Prompt template — ${_promptEditorMode}`;
+    await loadPromptEditor();
   } catch (e) {
     showError('Reset failed: ' + e.message);
   }

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -1,9 +1,11 @@
-"""自定义提示词模板测试（issue #581）。
+"""提示词模板/版本库测试（issue #581 引入模板，#610 升级为多命名版本）。
 
 核心保证：默认模板经 _render_prompt 渲染后与重构前的内联 f-string 逐字一致
-（提示词质量不因重构漂移），以及 DB 覆盖/重置往返正确。
+（提示词质量不因重构漂移）；prompt_presets 的增删改查、生效切换往返正确；
+旧 prompt_templates 数据能幂等迁移为名为 "Saved" 的生效版本。
 """
 import os
+import sqlite3
 
 import pytest
 
@@ -82,15 +84,103 @@ def test_podcast_template_keeps_json_example_braces():
 
 
 def test_custom_template_roundtrip(db):
+    """创建一个 preset 就地生效；重命名/改内容不改变生效状态；删除后回落默认。"""
     assert database.get_prompt_template("story") is None
-    database.set_prompt_template("story", "MY TEMPLATE {words}")
+    preset_id = database.create_prompt_preset("story", "V1", "MY TEMPLATE {words}")
     assert database.get_prompt_template("story") == "MY TEMPLATE {words}"
     assert ai._story_prompt_template("story") == "MY TEMPLATE {words}"
-    database.set_prompt_template("story", "V2 {words}")  # upsert
+
+    database.update_prompt_preset(preset_id, template="V2 {words}")
     assert database.get_prompt_template("story") == "V2 {words}"
-    database.delete_prompt_template("story")
+
+    database.delete_prompt_preset(preset_id)
     assert database.get_prompt_template("story") is None
     assert ai._story_prompt_template("story") == ai.DEFAULT_PROMPT_TEMPLATES["story"]
+
+
+def test_create_preset_sets_active_and_deactivates_others(db):
+    p1 = database.create_prompt_preset("story", "Detective", "D {words}")
+    assert database.get_prompt_template("story") == "D {words}"
+    p2 = database.create_prompt_preset("story", "Everyday", "E {words}")
+    # Creating a second preset activates it and deactivates the first.
+    assert database.get_prompt_template("story") == "E {words}"
+    presets = {p["id"]: p for p in database.list_prompt_presets("story")}
+    assert presets[p1]["is_active"] == 0
+    assert presets[p2]["is_active"] == 1
+
+
+def test_activate_preset_switches_which_is_active(db):
+    p1 = database.create_prompt_preset("story", "Detective", "D {words}")
+    p2 = database.create_prompt_preset("story", "Everyday", "E {words}")
+    database.activate_prompt_preset(p1)
+    assert database.get_prompt_template("story") == "D {words}"
+    presets = {p["id"]: p for p in database.list_prompt_presets("story")}
+    assert presets[p1]["is_active"] == 1
+    assert presets[p2]["is_active"] == 0
+
+
+def test_rename_preset(db):
+    p1 = database.create_prompt_preset("story", "Detective", "D {words}")
+    database.update_prompt_preset(p1, name="Renamed")
+    preset = database.get_prompt_preset(p1)
+    assert preset["name"] == "Renamed"
+    assert preset["template"] == "D {words}"  # untouched
+
+
+def test_duplicate_preset_name_raises(db):
+    database.create_prompt_preset("story", "Detective", "D {words}")
+    with pytest.raises(sqlite3.IntegrityError):
+        database.create_prompt_preset("story", "Detective", "Other {words}")
+
+
+def test_presets_scoped_per_mode(db):
+    database.create_prompt_preset("story", "Same Name", "S {words}")
+    # Same name in a different mode is fine — UNIQUE is (mode, name).
+    database.create_prompt_preset("qa", "Same Name", "Q {words}")
+    assert database.get_prompt_template("story") == "S {words}"
+    assert database.get_prompt_template("qa") == "Q {words}"
+
+
+def test_delete_active_preset_falls_back_to_default(db):
+    p1 = database.create_prompt_preset("story", "Detective", "D {words}")
+    database.delete_prompt_preset(p1)
+    assert database.get_prompt_template("story") is None
+    assert ai._story_prompt_template("story") == ai.DEFAULT_PROMPT_TEMPLATES["story"]
+
+
+def test_deactivate_prompt_presets_keeps_saved_versions(db):
+    """DELETE /api/prompt-template/{mode} 语义（#610）：取消生效但不删除版本。"""
+    p1 = database.create_prompt_preset("story", "Detective", "D {words}")
+    database.deactivate_prompt_presets("story")
+    assert database.get_prompt_template("story") is None
+    # Preset still exists and can be re-activated.
+    assert database.get_prompt_preset(p1) is not None
+    database.activate_prompt_preset(p1)
+    assert database.get_prompt_template("story") == "D {words}"
+
+
+def test_migration_from_old_prompt_templates_table(db):
+    """旧 prompt_templates 行迁移为名为 Saved 的生效 preset；再次 init_db 不重复插入。"""
+    conn = database.core.get_db()
+    conn.execute(
+        "INSERT INTO prompt_templates (mode, template) VALUES (?, ?)",
+        ("expository", "OLD CUSTOM {words}"),
+    )
+    conn.commit()
+    conn.close()
+
+    database.init_db()
+    assert database.get_prompt_template("expository") == "OLD CUSTOM {words}"
+    presets = database.list_prompt_presets("expository")
+    assert len(presets) == 1
+    assert presets[0]["name"] == "Saved"
+    assert presets[0]["is_active"] == 1
+
+    # Running init_db() again must not duplicate the migrated preset, even
+    # though the old prompt_templates row is still there (never deleted).
+    database.init_db()
+    presets_again = database.list_prompt_presets("expository")
+    assert len(presets_again) == 1
 
 
 def test_every_template_declares_words_variable():


### PR DESCRIPTION
## 改了什么

把 #581 的"每模式一份自定义提示词"升级为**每模式一个命名版本库**：可保存任意多个带名字的提示词版本，随时下拉切换、重命名、删除、回落内置默认。

- **数据库**：新表 `prompt_presets`（mode/name/template/is_active，`UNIQUE(mode,name)`），每个 mode 最多一行 `is_active=1`；无生效行 = 用 `ai.DEFAULT_PROMPT_TEMPLATES`
- **迁移**（`init_db` 阶段 3，幂等）：旧 `prompt_templates` 的行迁为名叫 `Saved` 的生效版本；旧表保留不删（回滚安全）
- **API**：`POST /api/prompt-presets/{mode}`（新建并生效，重名 409）、`PUT /api/prompt-presets/{id}`（改名/改内容）、`POST .../{id}/activate`、`DELETE .../{id}`；`GET /api/prompt-template/{mode}` 保留原字段并新增 `presets[]`/`active_id`；`DELETE /api/prompt-template/{mode}` 语义改为"取消生效"而非删除
- **前端**：编辑弹窗加版本下拉 + 名称框，按钮为 `Save` / `Save as new` / `Delete` / `Reset to default`；下拉构造用 DOM 而非 HTML 字符串（名字含引号不会破坏标记）
- `ai._story_prompt_template` 无需改动——`database.get_prompt_template(mode)` 签名不变，只是改为返回生效版本，故事生成与 Again 单句重生成自动跟随

## 为什么

Daniel 想为同一个模式保留多套提示词风格（如 story 的"侦探风格"/"日常对话"），以前只能存一份、改了就覆盖。

## 怎么测试

`python -m pytest tests/test_prompt_templates.py -q` → **13 passed**。覆盖：preset 增删改查、同 mode 单一生效版本、删除生效版本后回落内置默认、旧模板迁移为 `Saved` 且重复 `init_db()` 不重复插入。另做了 `node --check static/app.js` 与 Python 语法检查。

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)