### PR TITLE
离线模式：飞机上用 localhost 复习 + 服务器双向同步（#612）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,26 @@ Daniel 在中国需要 VPN 访问 GitHub。`gh` 命令报 `EOF` 错误时（`cur
 
 ---
 
+## 离线模式（2026-08-02，议题 #612）
+
+飞机上／没网时在笔记本上复习。**服务器永远是主库**，笔记本只是临时副本。
+
+```bash
+bash sync_offline.sh pull    # 起飞前（要有网）：拉数据库 + TTS 音频
+bash run.offline.sh          # 飞机上：http://localhost:8001
+bash sync_offline.sh push    # 落地后（要有网）：把复习结果合并回服务器
+```
+
+- **`OFFLINE_MODE=1`（`offline.py`）**：隐含 `DISABLE_AI`；TTS 只读 `data/tts/` 缓存，未命中抛 `tts.NotCachedOffline` → `/api/tts-file` 返回 404。**关键**：无网时 edge-tts 的 WebSocket 会挂到超时，拖死整个请求，所以缓存未命中必须立刻失败
+- 故事沿用同步下来的那一份（`DISABLE_AI` 分支本来就是"有缓存就返回、没有就返回 None"）；Again 单句重生成自动跳过
+- `GET /api/mode` → `{offline}`，前端据此显示顶部横幅并隐藏两个 Regenerate 按钮
+- `PORT` 环境变量（默认 8000）让离线实例跑 8001，不占用 Daniel 浏览器连的端口
+- **同步只合并 `cards` + `review_log` 两张表**（`scripts/offline_sync_server.py`，纯标准库，通过 ssh stdin 管道执行，不依赖服务器已部署该版本）。离线期间服务器 cron 仍在写入（播客单集、预生成故事、成本日志），整库对拷会毁掉这些数据——**绝不整库覆盖**
+- **同步令牌**（`app_settings.offline_sync_token`）：`pull` 时写入服务器并随快照带走，`push` 时两边必须一致，合并后轮换 → 同一份离线库无法重复 push；手工拷贝的库没有令牌，直接拒绝
+- 测试见 `tests/test_offline_sync.py`
+
+---
+
 ## 项目结构
 
 ```
@@ -139,7 +159,10 @@ Daniel 在中国需要 VPN 访问 GitHub。`gh` 命令报 `EOF` 错误时（`cur
 ├── ai.py                  # AI 提供商调用（每种提示词类型一个函数）
 ├── news_fetcher.py        # 新闻抓取（Tagesschau API + RSS；按天缓存 data/news_cache/）
 ├── podcast.py              # 播客爬虫（#479）：播客 RSS 直链发现新单集（#497，退役 YouTube/yt-dlp）、每源 auto_process 开关+非自动源只入库元数据（#502，podcast_feeds 表）、转录链 NotebookLM 免费主力+听悟+Whisper 保底、单步异常不中止整链（#510 重排，链式降级，原 #498/#485/#486）、摘要 NotebookLM chat.ask 免费优先+DeepSeek/gpt API 链回退（api 路径内部 DeepSeek 优先省钱，#532）、HSK生词、邮件通知+Signal 通知（signal-cli 关联设备，发 Note to Self，#521，二者独立可选、互不影响；消息抬头播客名·星期·日期、链接在末尾，单集日期按 Europe/Berlin 显示，#532）、摘要 table.media 风格（`<p>` 段落+每段首句 `<b>` 加粗总结，#567）+详情页 Regenerate summary 按钮
-├── tts.py                 # edge-tts 封装
+├── tts.py                 # edge-tts 封装（离线模式下只读缓存，#612）
+├── offline.py             # OFFLINE_MODE 全局开关（#612）
+├── sync_offline.sh        # 离线同步 pull/push（#612）
+├── run.offline.sh         # 离线启动（#612）
 ├── translator.py          # 翻译（Google Translate，deep-translator，可选）
 ├── yaml_fixer.py          # 修复 AI 生成的格式错误 YAML
 ├── schema.sql             # 数据库模式
@@ -151,7 +174,7 @@ Daniel 在中国需要 VPN 访问 GitHub。`gh` 命令报 `EOF` 错误时（`cur
 ├── requirements.txt       # Python 依赖清单
 ├── DEPLOY.md              # 服务器从零到上线的部署教程
 ├── deploy/                # systemd 单元、Caddyfile 示例、deploy.sh（自动部署）
-├── scripts/               # morning_pregen.py（早晨预生成故事+TTS）、podcast_check.py（播客爬虫定时脚本）+ README
+├── scripts/               # morning_pregen.py（早晨预生成故事+TTS）、podcast_check.py（播客爬虫定时脚本）、offline_sync_server.py（离线同步服务器端，#612）+ README
 ├── docs/yaml-format.md    # YAML 词条格式完整文档
 └── data/
     ├── srs.db             # SQLite 数据库（生产版在服务器上！）
@@ -281,6 +304,7 @@ POST   /api/decks ；PUT/DELETE /api/decks/{id}       → 创建 / 重命名 / �
 GET/PUT /api/decks/{id}/preset                       → 预设（yùshè - preset）设置
 GET/POST /api/presets ；DELETE /api/presets/{id}
 GET    /api/langs                                    → 当前使用的语言列表
+GET    /api/mode                                     → {offline}（#612，前端据此显示离线横幅）
 
 # 垃圾桶
 GET  /api/trash ；POST /api/trash/{deck_id}/restore
@@ -345,6 +369,7 @@ GET  /api/stats ；/api/retention ；/api/card-evolution（均支持 ?lang=）
 ```bash
 bash run.sh          # 生产启动（读取 .env，清理 8000 端口）——服务器上由 systemd 代替
 bash run.dev.sh      # 开发启动（DB_PATH=data/dev.db，DISABLE_AI=1）
+bash run.offline.sh  # 离线启动（OFFLINE_MODE=1，DB_PATH=data/offline.db，端口 8001）——见"离线模式"
 python main.py import                # 导入 imports/ 下的 YAML（目录需存在）
 python main.py status [--deck X]     # 显示每个牌组/类别的到期数量
 ```
@@ -356,6 +381,8 @@ python main.py status [--deck X]     # 显示每个牌组/类别的到期数量
 | `OPENAI_API_KEY` | 可选 | 新闻模式默认模型 `gpt-5-mini`（DeepSeek 会审查新闻，故用 OpenAI） |
 | `DB_PATH` | `data/srs.db` | 数据库路径（开发用 `data/dev.db`） |
 | `DISABLE_AI` | `0` | 设为 `1` 跳过 AI 故事生成 |
+| `OFFLINE_MODE` | `0` | 设为 `1` 进入离线模式（#612）：隐含 `DISABLE_AI`，TTS 只读缓存，零网络请求 |
+| `PORT` | `8000` | 服务监听端口（`run.offline.sh` 用 8001） |
 | `LOG_LEVEL` | `INFO` | 日志级别（`DEBUG` 输出详细日志） |
 | `DEV_CLEAR_DB` | `` | 设为任意值启动时清空数据库——生产环境绝不要设置 |
 | `AUTH_USERNAME` / `AUTH_PASSWORD` | 可选 | 两者都设置时启用 HTTP Basic Auth（保护所有路径） |

--- a/main.py
+++ b/main.py
@@ -417,7 +417,10 @@ if __name__ == "__main__":
         import uvicorn
         database.init_db()
         database.purge_old_trash()
-        uvicorn.run(app, host="0.0.0.0", port=8000, access_log=False)
+        # PORT lets the offline instance (run.offline.sh) run alongside
+        # anything already on 8000 — issue #612.
+        uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8000")),
+                    access_log=False)
     else:
         print("Install fastapi and uvicorn to run the web server.")
         print("Usage: python main.py import | status [--deck NAME]")

--- a/offline.py
+++ b/offline.py
@@ -1,0 +1,23 @@
+"""Offline mode flag (issue #612).
+
+Set OFFLINE_MODE=1 (see run.offline.sh) to run the app on a laptop with no
+network at all — on a flight, for example. In this mode the app must never
+open an outbound connection, because a hanging socket blocks the whole
+request for as long as its timeout lasts.
+
+What it turns off:
+  - AI calls of every kind (implies DISABLE_AI — see routes/utils.py)
+  - edge-tts generation: data/tts/ is served read-only, a cache miss is a
+    fast 404 instead of a WebSocket attempt (see tts.py)
+  - news fetching, translation, podcast processing (all AI/HTTP paths)
+
+Everything already stored in the local database still works: reviews,
+scheduling, browsing, stats, and any story + audio synced down beforehand.
+
+This module deliberately has no imports beyond os so that anything can
+import it without creating a cycle.
+"""
+
+import os
+
+OFFLINE_MODE = os.getenv("OFFLINE_MODE", "").lower() in ("1", "true", "yes")

--- a/routes/decks.py
+++ b/routes/decks.py
@@ -4,6 +4,7 @@ import database
 import languages
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
+from offline import OFFLINE_MODE
 from .utils import queue_mgr
 
 logger = logging.getLogger(__name__)
@@ -90,6 +91,16 @@ def _attach_counts(flat_decks: list) -> None:
 # ---------------------------------------------------------------------------
 # Deck routes
 # ---------------------------------------------------------------------------
+
+@router.get("/api/mode")
+def get_mode():
+    """Runtime flags the frontend needs to know about (issue #612).
+
+    offline=True means this instance has no network: the UI hides everything
+    that would trigger an AI call and shows the offline banner instead.
+    """
+    return {"offline": OFFLINE_MODE}
+
 
 @router.get("/api/langs")
 def get_langs():

--- a/routes/story.py
+++ b/routes/story.py
@@ -1014,7 +1014,12 @@ def story_count(deck_id: int, category: str, lang: str | None = None):
 @router.get("/api/tts-file")
 async def tts_file(text: str, lang: str = "zh"):
     """Return the cached mp3 for text (generating it if needed). Used by the browser Audio API."""
-    path = await tts.get_cached_path(text, lang=lang)
+    try:
+        path = await tts.get_cached_path(text, lang=lang)
+    except tts.NotCachedOffline:
+        # Offline with no cached audio — a plain 404 lets the frontend skip
+        # this sentence silently instead of showing an error (issue #612).
+        raise HTTPException(404, "No cached audio for this text (offline mode)")
     # Content-addressed by (text, lang) — the file at this path never changes,
     # so it's safe to cache aggressively (issue #513).
     return FileResponse(path, media_type="audio/mpeg",

--- a/routes/utils.py
+++ b/routes/utils.py
@@ -1,10 +1,12 @@
 import os
 
 import database
+from offline import OFFLINE_MODE
 from .queue_manager import QueueManager
 
-# Set DISABLE_AI=1 in run.dev.sh to skip story generation during development
-DISABLE_AI = os.getenv("DISABLE_AI", "").lower() in ("1", "true", "yes")
+# Set DISABLE_AI=1 in run.dev.sh to skip story generation during development.
+# Offline mode (issue #612) implies it — no network, so no AI either.
+DISABLE_AI = OFFLINE_MODE or os.getenv("DISABLE_AI", "").lower() in ("1", "true", "yes")
 
 # Shared singleton — imported by review.py and browse.py
 queue_mgr = QueueManager()

--- a/run.offline.sh
+++ b/run.offline.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# 离线模式启动（议题 #612）——飞机上用，全程不联网。
+#
+# 前提：起飞前已经跑过 `bash sync_offline.sh pull`。
+# 落地后跑 `bash sync_offline.sh push` 把复习结果同步回服务器。
+set -e
+cd "$(dirname "$0")"
+
+if [ ! -f data/offline.db ]; then
+    echo "❌ 找不到 data/offline.db"
+    echo "   有网的时候先运行： bash sync_offline.sh pull"
+    exit 1
+fi
+
+# .env 只为读取 DB 无关的配置；离线模式下所有 API 密钥都用不上。
+# 不加载 AUTH_* —— 本机 localhost 不需要 Basic Auth。
+PY=.venv/bin/python
+[ -x "$PY" ] || PY=python3
+
+echo "✈️  离线模式启动中…"
+echo "    数据库： data/offline.db"
+echo "    地址：   http://localhost:8001"
+echo "    （AI、新闻抓取、TTS 生成全部关闭；音频只读 data/tts/ 缓存）"
+echo
+
+OFFLINE_MODE=1 DB_PATH=data/offline.db PORT=8001 "$PY" main.py

--- a/scripts/offline_sync_server.py
+++ b/scripts/offline_sync_server.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Server side of the offline sync (issue #612).
+
+Runs ON the VPS, piped in over ssh stdin by sync_offline.sh, so it never
+depends on the server having deployed the current commit. Standard library
+only for the same reason — it must not need the app's virtualenv.
+
+    python3 - prepare <prod_db> <snapshot_out>
+        Stamp a fresh sync token + review_log watermark into the production
+        database, then snapshot it (WAL-safe) to <snapshot_out>. The snapshot
+        carries the same token, which is what lets `merge` later prove that an
+        incoming file really came from this server and hasn't been used yet.
+
+    python3 - merge <prod_db> <incoming_db>
+        Merge the reviews done offline back into production, then rotate the
+        token so the same file can't be merged twice.
+
+Merge scope — deliberately narrow. The server keeps running cron jobs while
+Daniel is away (podcast episodes, morning pregen, cost logs), so copying the
+whole database back would destroy that work. Offline reviewing can only touch
+two tables, and only those two are merged:
+
+    review_log  — rows newer than the watermark are appended (fresh ids)
+    cards       — rows whose scheduling state differs are updated in place
+
+Cards that exist offline but not on the server are ignored: the offline
+instance cannot create entries or cards.
+"""
+
+import os
+import sqlite3
+import sys
+import uuid
+
+TOKEN_KEY = "offline_sync_token"
+WATERMARK_KEY = "offline_sync_review_log_max"
+
+# Every card column the review flow can change. `id`, `word_id`, `deck_id` and
+# `category` identify the card and are never written.
+CARD_FIELDS = [
+    "state", "due", "step_index", "interval", "ease", "repetitions", "lapses",
+    "stability", "difficulty", "last_review", "learning_again_count",
+    "is_leech", "buried_until", "pre_suspend_state", "next_note", "probation",
+]
+
+REVIEW_FIELDS = [
+    "card_id", "reviewed_at", "rating", "user_response", "ai_score",
+    "duration_ms", "state", "last_interval",
+]
+
+
+def _connect(path: str) -> sqlite3.Connection:
+    if not os.path.exists(path):
+        sys.exit(f"ERROR: database not found: {path}")
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _get_setting(conn: sqlite3.Connection, key: str, schema: str = "main") -> str | None:
+    row = conn.execute(
+        f"SELECT value FROM {schema}.app_settings WHERE key = ?", (key,)
+    ).fetchone()
+    return row["value"] if row else None
+
+
+def _set_setting(conn: sqlite3.Connection, key: str, value: str) -> None:
+    conn.execute(
+        "INSERT INTO app_settings (key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value", (key, value))
+
+
+def cmd_prepare(prod_db: str, snapshot_out: str) -> None:
+    conn = _connect(prod_db)
+    token = uuid.uuid4().hex
+    watermark = conn.execute("SELECT COALESCE(MAX(id), 0) AS m FROM review_log").fetchone()["m"]
+    _set_setting(conn, TOKEN_KEY, token)
+    _set_setting(conn, WATERMARK_KEY, str(watermark))
+    conn.commit()
+
+    # sqlite3's backup API is safe against concurrent writers (the live app is
+    # still serving requests), unlike copying the file.
+    if os.path.exists(snapshot_out):
+        os.unlink(snapshot_out)
+    dest = sqlite3.connect(snapshot_out)
+    conn.backup(dest)
+    dest.close()
+    conn.close()
+    os.chmod(snapshot_out, 0o600)
+
+    print(f"token={token}")
+    print(f"review_log_watermark={watermark}")
+    print(f"snapshot={snapshot_out} ({os.path.getsize(snapshot_out) // 1024} KB)")
+
+
+def cmd_merge(prod_db: str, incoming_db: str) -> None:
+    conn = _connect(prod_db)
+    if not os.path.exists(incoming_db):
+        sys.exit(f"ERROR: incoming database not found: {incoming_db}")
+    conn.execute("ATTACH ? AS off", (incoming_db,))
+
+    server_token = _get_setting(conn, TOKEN_KEY)
+    offline_token = _get_setting(conn, TOKEN_KEY, schema="off")
+    if not server_token or not offline_token:
+        sys.exit("ERROR: no sync token — this database was never prepared by `pull`.")
+    if server_token != offline_token:
+        sys.exit("ERROR: sync token mismatch. This offline database was already "
+                 "pushed, or it came from a different pull. Refusing to merge.")
+
+    watermark = int(_get_setting(conn, WATERMARK_KEY, schema="off") or 0)
+
+    # ── review_log: append everything recorded offline ────────────────────────
+    cols = ", ".join(REVIEW_FIELDS)
+    placeholders = ", ".join("?" for _ in REVIEW_FIELDS)
+    new_reviews = conn.execute(
+        f"SELECT {cols} FROM off.review_log WHERE id > ? ORDER BY id", (watermark,)
+    ).fetchall()
+    # Skip reviews for cards the server no longer has (deleted while away).
+    known = {r["id"] for r in conn.execute("SELECT id FROM main.cards")}
+    kept = [tuple(r) for r in new_reviews if r["card_id"] in known]
+    conn.executemany(
+        f"INSERT INTO main.review_log ({cols}) VALUES ({placeholders})", kept)
+    skipped_reviews = len(new_reviews) - len(kept)
+
+    # ── cards: update rows whose scheduling state changed ─────────────────────
+    field_list = ", ".join(CARD_FIELDS)
+    server_cards = {
+        r["id"]: tuple(r)[1:]
+        for r in conn.execute(f"SELECT id, {field_list} FROM main.cards")
+    }
+    changed = []
+    for row in conn.execute(f"SELECT id, {field_list} FROM off.cards"):
+        before = server_cards.get(row["id"])
+        if before is not None and before != tuple(row)[1:]:
+            changed.append(tuple(row)[1:] + (row["id"],))
+    assignments = ", ".join(f"{f} = ?" for f in CARD_FIELDS)
+    conn.executemany(f"UPDATE main.cards SET {assignments} WHERE id = ?", changed)
+
+    # Rotate the token so this same file can never be merged a second time.
+    _set_setting(conn, TOKEN_KEY, uuid.uuid4().hex)
+    conn.commit()
+    conn.execute("DETACH off")
+    conn.close()
+
+    print(f"reviews_merged={len(kept)}")
+    print(f"reviews_skipped_deleted_card={skipped_reviews}")
+    print(f"cards_updated={len(changed)}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        sys.exit(__doc__)
+    command, db, other = sys.argv[1], sys.argv[2], sys.argv[3]
+    if command == "prepare":
+        cmd_prepare(db, other)
+    elif command == "merge":
+        cmd_merge(db, other)
+    else:
+        sys.exit(f"ERROR: unknown command {command!r}")

--- a/static/app.js
+++ b/static/app.js
@@ -68,6 +68,7 @@ let _retentionData = null;  // cached result from GET /api/retention
 let _cachedDecks = null;       // last fetched deck tree (for toggle re-renders)
 let _deckLangById = {};        // deckId → 'zh'|'fr', rebuilt whenever decks load (flatten(decks))
 let _availableLangs = ['zh'];  // distinct langs in use, from GET /api/langs — tab bar shows only when > 1
+let _offlineMode = false;      // GET /api/mode — true for the run.offline.sh instance (#612)
 
 // The main-page language tab bar (issue #436) is the single source of truth for
 // "what language am I studying right now" on the home page: deck list, All-deck
@@ -839,10 +840,12 @@ function showView(name) {
     name === 'podcast'      ? 'Podcasts' : 'AnkiAdvanced';
   if (name === 'decks') quickMode = false;
   const headerRegenBtn = document.getElementById('header-regen-btn');
-  if (headerRegenBtn) headerRegenBtn.style.display = (name === 'review' && !unfinishedMode && !quickMode) ? '' : 'none';
+  // Offline mode hides both regenerate affordances — they can only fail (#612).
+  if (headerRegenBtn) headerRegenBtn.style.display =
+    (name === 'review' && !unfinishedMode && !quickMode && !_offlineMode) ? '' : 'none';
   if (name === 'review') {
     const regenBtn = document.querySelector('.regen-btn');
-    if (regenBtn) regenBtn.style.display = (unfinishedMode || quickMode) ? 'none' : '';
+    if (regenBtn) regenBtn.style.display = (unfinishedMode || quickMode || _offlineMode) ? 'none' : '';
   }
 }
 
@@ -1024,14 +1027,30 @@ function showNotice(msg) {
   setTimeout(() => { el.style.display = 'none'; el.classList.remove('notice'); }, 6000);
 }
 
+// Persistent reminder that this instance can't reach the network, so an empty
+// story or a silent sentence is expected rather than a bug (issue #612).
+function _renderOfflineBanner() {
+  const existing = document.getElementById('offline-banner');
+  if (!_offlineMode) { if (existing) existing.remove(); return; }
+  if (existing) return;
+  const el = document.createElement('div');
+  el.id = 'offline-banner';
+  el.textContent = '✈️ Offline mode — stories and audio are read-only from the last sync';
+  document.body.prepend(el);
+}
+
+
 // ── Deck list ───────────────────────────────────────────────────────────────
 async function loadDecks() {
   setLoading('Loading decks…');
   try {
-    const [langs] = await Promise.all([
+    const [langs, mode] = await Promise.all([
       api('GET', '/api/langs').catch(() => ['zh']),
+      api('GET', '/api/mode').catch(() => ({ offline: false })),
     ]);
     _availableLangs = langs && langs.length ? langs : ['zh'];
+    _offlineMode = !!(mode && mode.offline);
+    _renderOfflineBanner();
     // Only scope requests to the active tab once there's more than one language
     // in use — keeps a pure-Chinese install byte-identical to pre-#436 behavior.
     const langParam = _availableLangs.length > 1 ? `&lang=${activeLang()}` : '';

--- a/static/style.css
+++ b/static/style.css
@@ -4997,3 +4997,17 @@ table.fsrs-table td.ivl { font-weight: 700; }
   flex-shrink: 0;
 }
 .conj-form { color: var(--text); }
+
+/* ── Offline mode banner (#612) ───────────────────────────────────────────── */
+#offline-banner {
+  position: sticky;
+  top: 0;
+  z-index: 200;
+  padding: 6px 12px;
+  background: #7a5c00;
+  color: #fff5d6;
+  font-size: 13px;
+  font-weight: 600;
+  text-align: center;
+  letter-spacing: 0.3px;
+}

--- a/sync_offline.sh
+++ b/sync_offline.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# 离线模式同步脚本（议题 #612）
+#
+#   bash sync_offline.sh pull    上飞机前：把服务器的数据库和音频拉到笔记本
+#   bash sync_offline.sh push    落地后：把飞机上的复习结果合并回服务器
+#
+# 服务器永远是主库。push 只合并 cards + review_log 两张表，
+# 离线期间服务器 cron 新增的播客单集、预生成故事都不会被覆盖。
+set -euo pipefail
+
+SERVER="${ANKI_SERVER:-anki@207.180.204.135}"
+REMOTE_DIR="${ANKI_REMOTE_DIR:-/home/anki/AnkiAdvanced}"
+REMOTE_DB="$REMOTE_DIR/data/srs.db"
+REMOTE_SNAPSHOT="/tmp/anki_offline_snapshot.db"
+REMOTE_INCOMING="/tmp/anki_offline_incoming.db"
+
+cd "$(dirname "$0")"
+LOCAL_DB="data/offline.db"
+SERVER_SCRIPT="scripts/offline_sync_server.py"
+
+ACTION="${1:-}"
+
+# 服务器端脚本通过 stdin 管道执行——不依赖服务器上是否已经部署了这个版本的代码
+run_remote() {
+    ssh "$SERVER" "python3 - $*" < "$SERVER_SCRIPT"
+}
+
+case "$ACTION" in
+pull)
+    echo "== 步骤 1/5：检查 SSH 连接 =="
+    echo "   连接 $SERVER …"
+    ssh -o ConnectTimeout=10 "$SERVER" "test -f '$REMOTE_DB'" \
+        || { echo "❌ 连不上服务器，或找不到 $REMOTE_DB。你现在有网／VPN 吗？"; exit 1; }
+    echo "   ✅ 连接正常，生产数据库存在"
+
+    echo
+    echo "== 步骤 2/5：在服务器上生成同步令牌并做数据库快照 =="
+    echo "   （令牌保证这份离线库只能被推回一次；快照对正在运行的服务是安全的）"
+    run_remote "prepare '$REMOTE_DB' '$REMOTE_SNAPSHOT'"
+    echo "   ✅ 快照完成"
+
+    echo
+    echo "== 步骤 3/5：下载数据库到 $LOCAL_DB（约 30 MB，几秒钟）=="
+    mkdir -p data
+    if [ -f "$LOCAL_DB" ]; then
+        mv "$LOCAL_DB" "$LOCAL_DB.replaced-$(date +%Y%m%d-%H%M%S)"
+        echo "   （上一份离线库已改名备份，没有覆盖）"
+    fi
+    scp "$SERVER:$REMOTE_SNAPSHOT" "$LOCAL_DB"
+    ssh "$SERVER" "rm -f '$REMOTE_SNAPSHOT'"
+    echo "   ✅ 数据库已下载"
+
+    echo
+    echo "== 步骤 4/5：同步 TTS 音频缓存（首次约 120 MB，Wi-Fi 下 1–3 分钟；以后只传新增文件）=="
+    mkdir -p data/tts
+    rsync -a --info=progress2 "$SERVER:$REMOTE_DIR/data/tts/" data/tts/
+    echo "   ✅ 音频同步完成"
+
+    echo
+    echo "== 步骤 5/5：完成 =="
+    echo "   现在可以断网了。飞机上运行："
+    echo "       bash run.offline.sh"
+    echo "   然后浏览器打开 http://localhost:8001"
+    echo
+    echo "   落地有网后运行： bash sync_offline.sh push"
+    echo
+    echo "把以上全部输出发给 Claude。"
+    ;;
+
+push)
+    echo "== 步骤 1/4：检查本地离线数据库 =="
+    [ -f "$LOCAL_DB" ] || { echo "❌ 找不到 $LOCAL_DB——是不是还没 pull，或者已经 push 过了？"; exit 1; }
+    echo "   ✅ 找到 $LOCAL_DB（$(du -h "$LOCAL_DB" | cut -f1)）"
+    echo "   提示：如果离线服务还开着，先按 Ctrl+C 停掉，确保数据全部写盘"
+
+    echo
+    echo "== 步骤 2/4：上传到服务器（约 30 MB，几秒钟）=="
+    scp "$LOCAL_DB" "$SERVER:$REMOTE_INCOMING"
+    echo "   ✅ 上传完成"
+
+    echo
+    echo "== 步骤 3/4：在服务器上合并复习结果 =="
+    echo "   （只合并 cards + review_log；令牌不匹配会直接拒绝，防止重复合并）"
+    run_remote "merge '$REMOTE_DB' '$REMOTE_INCOMING'"
+    ssh "$SERVER" "rm -f '$REMOTE_INCOMING'"
+    echo "   ✅ 合并完成"
+
+    echo
+    echo "== 步骤 4/4：归档本地离线库 =="
+    mv "$LOCAL_DB" "$LOCAL_DB.pushed-$(date +%Y%m%d-%H%M%S)"
+    echo "   ✅ 已改名归档——下次要离线复习，重新跑一次 pull"
+    echo
+    echo "把以上全部输出发给 Claude。"
+    ;;
+
+*)
+    echo "用法： bash sync_offline.sh pull   （上飞机前，需要网络）"
+    echo "       bash sync_offline.sh push   （落地后，需要网络）"
+    exit 1
+    ;;
+esac

--- a/tests/test_offline_sync.py
+++ b/tests/test_offline_sync.py
@@ -1,0 +1,152 @@
+"""离线模式同步测试（issue #612）。
+
+核心保证：`push` 只把 cards + review_log 合并回生产库，离线期间服务器上
+新增的数据（播客单集、预生成故事、成本日志）一行都不能丢；同一份离线库
+不能被合并第二次。
+"""
+import importlib.util
+import os
+import sqlite3
+
+import pytest
+
+os.environ.setdefault("DISABLE_AI", "1")
+
+import database
+import database.core
+
+_SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "offline_sync_server.py")
+_spec = importlib.util.spec_from_file_location("offline_sync_server", _SCRIPT)
+sync_server = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sync_server)
+
+
+def _make_db(path, monkeypatch):
+    monkeypatch.setattr(database.core, "DB_PATH", str(path))
+    database.init_db()
+
+
+@pytest.fixture()
+def server_db(tmp_path, monkeypatch):
+    """A production-like database with one leaf deck, one entry and one card."""
+    path = tmp_path / "srs.db"
+    _make_db(path, monkeypatch)
+    conn = sqlite3.connect(path)
+    # deck 1 ("All") and preset 1 are seeded by init_db()
+    conn.execute("INSERT INTO decks (id, name, category, preset_id, parent_id) "
+                 "VALUES (2, 'Test', 'reading', 1, 1)")
+    conn.execute("INSERT INTO entries (id, word_zh, definition) VALUES (1, '测试', 'test')")
+    conn.execute("INSERT INTO cards (id, word_id, deck_id, category, state, due) "
+                 "VALUES (1, 1, 2, 'reading', 'new', '2026-08-01')")
+    conn.commit()
+    conn.close()
+    return str(path)
+
+
+def _prepare(server_db, tmp_path):
+    snapshot = str(tmp_path / "offline.db")
+    sync_server.cmd_prepare(server_db, snapshot)
+    return snapshot
+
+
+def _review_offline(offline_db, card_id=1, rating=3, due='2026-08-05'):
+    """Simulate one review done on the plane: log it and advance the card."""
+    conn = sqlite3.connect(offline_db)
+    conn.execute("INSERT INTO review_log (card_id, reviewed_at, rating) VALUES (?, ?, ?)",
+                 (card_id, '2026-08-03T10:00:00', rating))
+    conn.execute("UPDATE cards SET state = 'review', due = ?, interval = 4 WHERE id = ?",
+                 (due, card_id))
+    conn.commit()
+    conn.close()
+
+
+def test_prepare_snapshot_carries_token(server_db, tmp_path):
+    snapshot = _prepare(server_db, tmp_path)
+    assert os.path.exists(snapshot)
+    server_token = sqlite3.connect(server_db).execute(
+        "SELECT value FROM app_settings WHERE key = 'offline_sync_token'").fetchone()[0]
+    offline_token = sqlite3.connect(snapshot).execute(
+        "SELECT value FROM app_settings WHERE key = 'offline_sync_token'").fetchone()[0]
+    assert server_token == offline_token
+
+
+def test_merge_applies_reviews_and_card_state(server_db, tmp_path):
+    snapshot = _prepare(server_db, tmp_path)
+    _review_offline(snapshot)
+
+    sync_server.cmd_merge(server_db, snapshot)
+
+    conn = sqlite3.connect(server_db)
+    logs = conn.execute("SELECT card_id, rating FROM review_log").fetchall()
+    assert logs == [(1, 3)]
+    state, due, interval = conn.execute(
+        "SELECT state, due, interval FROM cards WHERE id = 1").fetchone()
+    assert (state, due, interval) == ('review', '2026-08-05', 4)
+
+
+def test_merge_keeps_data_the_server_created_while_offline(server_db, tmp_path):
+    """The cron jobs keep running while Daniel is on the plane — a story added
+    after the snapshot must survive the merge."""
+    snapshot = _prepare(server_db, tmp_path)
+    _review_offline(snapshot)
+
+    conn = sqlite3.connect(server_db)
+    conn.execute("INSERT INTO stories (deck_id, date, category, topic) "
+                 "VALUES (2, '2026-08-03', 'reading', '服务器上新生成的故事')")
+    conn.commit()
+    conn.close()
+
+    sync_server.cmd_merge(server_db, snapshot)
+
+    conn = sqlite3.connect(server_db)
+    assert conn.execute("SELECT COUNT(*) FROM stories").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM review_log").fetchone()[0] == 1
+
+
+def test_second_merge_of_same_file_is_refused(server_db, tmp_path):
+    snapshot = _prepare(server_db, tmp_path)
+    _review_offline(snapshot)
+    sync_server.cmd_merge(server_db, snapshot)
+
+    with pytest.raises(SystemExit) as exc:
+        sync_server.cmd_merge(server_db, snapshot)
+    assert "token mismatch" in str(exc.value)
+    # the first merge's rows are still there, not duplicated
+    assert sqlite3.connect(server_db).execute(
+        "SELECT COUNT(*) FROM review_log").fetchone()[0] == 1
+
+
+def test_merge_skips_reviews_for_cards_deleted_on_the_server(server_db, tmp_path):
+    snapshot = _prepare(server_db, tmp_path)
+    _review_offline(snapshot)
+
+    conn = sqlite3.connect(server_db)
+    conn.execute("DELETE FROM cards WHERE id = 1")
+    conn.commit()
+    conn.close()
+
+    sync_server.cmd_merge(server_db, snapshot)  # must not raise a foreign-key error
+    assert sqlite3.connect(server_db).execute(
+        "SELECT COUNT(*) FROM review_log").fetchone()[0] == 0
+
+
+def test_merge_without_prepare_is_refused(server_db, tmp_path):
+    """A hand-copied database has no token — refuse rather than guess."""
+    stray = str(tmp_path / "stray.db")
+    _make_db(tmp_path / "stray.db", pytest.MonkeyPatch())
+    with pytest.raises(SystemExit) as exc:
+        sync_server.cmd_merge(server_db, stray)
+    assert "never prepared" in str(exc.value)
+
+
+def test_untouched_cards_are_not_rewritten(server_db, tmp_path):
+    """Only rows that actually differ get an UPDATE — a no-op sync changes nothing."""
+    snapshot = _prepare(server_db, tmp_path)
+    before = sqlite3.connect(server_db).execute(
+        "SELECT state, due FROM cards WHERE id = 1").fetchone()
+
+    sync_server.cmd_merge(server_db, snapshot)
+
+    after = sqlite3.connect(server_db).execute(
+        "SELECT state, due FROM cards WHERE id = 1").fetchone()
+    assert before == after

--- a/tts.py
+++ b/tts.py
@@ -25,6 +25,7 @@ import threading
 import edge_tts
 
 import languages
+from offline import OFFLINE_MODE
 
 # Bypass system proxy (e.g. Shadowrocket in China) for edge-tts WebSocket connections.
 # The VPN tunnel routes traffic at the network level, so direct connections work fine.
@@ -53,12 +54,25 @@ def _cache_path(text: str, voice: str = VOICE) -> str:
     return os.path.join(TTS_CACHE_DIR, f"{key}.mp3")
 
 
+class NotCachedOffline(Exception):
+    """Offline mode + cache miss — the audio simply doesn't exist here (#612)."""
+
+
 async def _ensure_cached(text: str, voice: str = VOICE) -> str:
-    """Return path to mp3 for text, generating via edge-tts if not on disk."""
+    """Return path to mp3 for text, generating via edge-tts if not on disk.
+
+    In offline mode a cache miss raises NotCachedOffline instead: opening an
+    edge-tts WebSocket with no network would hang until its timeout and stall
+    the request, so a miss has to fail immediately.
+    """
     path = _cache_path(text, voice)
     if path in _hot or os.path.exists(path):
         _hot.add(path)
         return path
+
+    if OFFLINE_MODE:
+        logger.info("tts  offline cache MISS %r — no audio available", text[:30])
+        raise NotCachedOffline(text)
 
     os.makedirs(TTS_CACHE_DIR, exist_ok=True)
     tmp = path + ".tmp"
@@ -106,6 +120,16 @@ async def preload_all_async(texts: list[str], progress_key: str | None = None,
             _preload_progress[progress_key]["done"] = total
         return
 
+    if OFFLINE_MODE:
+        # Nothing to generate without a network. Report the batch as finished
+        # so the frontend's progress poll doesn't spin — the uncached
+        # sentences just play silently (issue #612).
+        logger.info("tts  offline — %d/%d sentences have no cached audio, skipping",
+                    len(missing), total)
+        if progress_key is not None:
+            _preload_progress[progress_key]["done"] = total
+        return
+
     logger.info("tts  generating %d/%d sentences (rest cached), concurrency=%d",
                 len(missing), total, _TTS_CONCURRENCY)
     done_count = already_cached
@@ -144,6 +168,8 @@ async def preload_all_async(texts: list[str], progress_key: str | None = None,
 
 def preload(text: str, lang: str = "zh") -> None:
     """Fire-and-forget single-item preload (background thread)."""
+    if OFFLINE_MODE:
+        return
     voice = languages.get_lang_config(lang)["tts_voice"]
     threading.Thread(target=lambda: asyncio.run(_ensure_cached(text, voice)),
                      daemon=True).start()


### PR DESCRIPTION
## 改了什么

飞机上／没网时能在笔记本上完整复习，落地后把复习结果合并回服务器。

```bash
bash sync_offline.sh pull    # 起飞前（要有网）：拉数据库 + TTS 音频
bash run.offline.sh          # 飞机上：http://localhost:8001
bash sync_offline.sh push    # 落地后（要有网）：合并回服务器
```

**运行模式**
- `offline.py`：`OFFLINE_MODE` 全局开关，隐含 `DISABLE_AI`
- `tts.py`：缓存未命中抛 `NotCachedOffline`，`/api/tts-file` 返回 404。**这是最关键的一处**——无网时 edge-tts 的 WebSocket 会挂到超时，会拖死整个请求；实测未命中 4 毫秒返回，命中正常返回 mp3
- 批量 preload 离线时直接跳过并把进度标记为完成，前端不会一直转圈
- `GET /api/mode` → 前端显示顶部横幅、隐藏两个 Regenerate 按钮
- `main.py` 支持 `PORT`，离线实例跑 8001，不占用 Daniel 浏览器连的 8000

故事本身不需要改：`DISABLE_AI` 分支本来就是"有缓存故事就返回、没有就返回 None"，正是"生成不了就用已有的"。Again 单句重生成也自动跳过。

**同步的安全模型**

服务器永远是主库，**绝不整库对拷**。离线期间服务器 cron 仍在写入（播客新单集、早晨预生成故事、成本日志），整库覆盖会毁掉这些数据。

`scripts/offline_sync_server.py` 只合并两张表：
- `review_log`：插入 id 大于 pull 水位线的新行（重新分配 id，不会主键冲突）
- `cards`：逐行对比，只 UPDATE 内容真正不同的行（这样 bury/难词标记/next_note 也一并带回）

同步令牌（`app_settings.offline_sync_token`）在 pull 时写入服务器并随快照带走，push 时两边必须一致，合并后立刻轮换——同一份离线库无法重复 push，手工拷贝的库没有令牌直接拒绝。

服务器端脚本通过 ssh stdin 管道执行，不依赖服务器是否已经部署该版本的代码。

## 怎么测试的

- `tests/test_offline_sync.py` 7 个测试全过：令牌随快照下发、复习结果正确合并、离线期间服务器新增的故事不丢、重复 push 被拒、卡片已删时跳过日志、无令牌的库拒绝合并、无改动不写库
- 实机在 8011 端口起了离线实例（dev.db 副本）：`/api/mode` 返回 `{"offline":true}`、`/api/decks` 200、TTS 未命中 404（4ms）、命中返回 6.3 KB mp3、`/api/story` 13ms 返回 null、`/api/preload-session` 3ms 返回

**已知的既有问题（与本 PR 无关）**：`tests/test_importer.py` 有一批 fixture 报错（`UNIQUE constraint failed: decks.name, decks.parent_id`），在 main 的 worktree 上复现结果完全一致。

Closes #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)