### PR TITLE
离线同步只传必要数据：快照瘦身 + 音频按需（#612）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,9 @@ bash sync_offline.sh push    # 落地后（要有网）：把复习结果合并�
 - `PORT` 环境变量（默认 8000）让离线实例跑 8001，不占用 Daniel 浏览器连的端口
 - **同步只合并 `cards` + `review_log` 两张表**（`scripts/offline_sync_server.py`，纯标准库，通过 ssh stdin 管道执行，不依赖服务器已部署该版本）。离线期间服务器 cron 仍在写入（播客单集、预生成故事、成本日志），整库对拷会毁掉这些数据——**绝不整库覆盖**
 - **同步令牌**（`app_settings.offline_sync_token`）：`pull` 时写入服务器并随快照带走，`push` 时两边必须一致，合并后轮换 → 同一份离线库无法重复 push；手工拷贝的库没有令牌，直接拒绝
+- **传输量优化（链路很慢，实测到服务器只有 ~8 KB/s）**：
+  - 快照**瘦身**：`prepare` 在快照上（不动生产库）清空 `api_call_log`、`podcast_episodes.transcript_*`、`stories.prompt_text` 再 VACUUM → 29.6 MB 降到 18.5 MB，`scp -C` 压缩后实际传 ~7 MB。`prepare … --full` 可保留全部
+  - 音频**按需**：`scripts/offline_tts_manifest.py` 从拉下来的库算出真正会用到的语音（故事句子 `sentence_zh` + 到期词 `word_zh`，前端只请求这两种），再与服务器实际存在的文件取交集 → ~250 个文件 / 6.3 MB，而不是整个 118 MB 的 `data/tts/`。**必须取交集**，否则 rsync 会为缺失文件返回非零码，`set -e` 会中断整个脚本
 - 测试见 `tests/test_offline_sync.py`
 
 ---
@@ -174,7 +177,7 @@ bash sync_offline.sh push    # 落地后（要有网）：把复习结果合并�
 ├── requirements.txt       # Python 依赖清单
 ├── DEPLOY.md              # 服务器从零到上线的部署教程
 ├── deploy/                # systemd 单元、Caddyfile 示例、deploy.sh（自动部署）
-├── scripts/               # morning_pregen.py（早晨预生成故事+TTS）、podcast_check.py（播客爬虫定时脚本）、offline_sync_server.py（离线同步服务器端，#612）+ README
+├── scripts/               # morning_pregen.py（早晨预生成故事+TTS）、podcast_check.py（播客爬虫定时脚本）、offline_sync_server.py + offline_tts_manifest.py（离线同步，#612）+ README
 ├── docs/yaml-format.md    # YAML 词条格式完整文档
 └── data/
     ├── srs.db             # SQLite 数据库（生产版在服务器上！）

--- a/scripts/offline_sync_server.py
+++ b/scripts/offline_sync_server.py
@@ -5,11 +5,13 @@ Runs ON the VPS, piped in over ssh stdin by sync_offline.sh, so it never
 depends on the server having deployed the current commit. Standard library
 only for the same reason — it must not need the app's virtualenv.
 
-    python3 - prepare <prod_db> <snapshot_out>
+    python3 - prepare <prod_db> <snapshot_out> [--full]
         Stamp a fresh sync token + review_log watermark into the production
         database, then snapshot it (WAL-safe) to <snapshot_out>. The snapshot
         carries the same token, which is what lets `merge` later prove that an
         incoming file really came from this server and hasn't been used yet.
+        The snapshot is slimmed by default (see _SLIM_STATEMENTS) because the
+        link to the laptop can be very slow; --full keeps every byte.
 
     python3 - merge <prod_db> <incoming_db>
         Merge the reviews done offline back into production, then rotate the
@@ -70,7 +72,7 @@ def _set_setting(conn: sqlite3.Connection, key: str, value: str) -> None:
         "ON CONFLICT(key) DO UPDATE SET value = excluded.value", (key, value))
 
 
-def cmd_prepare(prod_db: str, snapshot_out: str) -> None:
+def cmd_prepare(prod_db: str, snapshot_out: str, slim: bool = True) -> None:
     conn = _connect(prod_db)
     token = uuid.uuid4().hex
     watermark = conn.execute("SELECT COALESCE(MAX(id), 0) AS m FROM review_log").fetchone()["m"]
@@ -86,11 +88,44 @@ def cmd_prepare(prod_db: str, snapshot_out: str) -> None:
     conn.backup(dest)
     dest.close()
     conn.close()
+
+    raw_kb = os.path.getsize(snapshot_out) // 1024
+    if slim:
+        _slim(snapshot_out)
     os.chmod(snapshot_out, 0o600)
 
     print(f"token={token}")
     print(f"review_log_watermark={watermark}")
-    print(f"snapshot={snapshot_out} ({os.path.getsize(snapshot_out) // 1024} KB)")
+    size_kb = os.path.getsize(snapshot_out) // 1024
+    note = f" (slimmed from {raw_kb} KB)" if slim else ""
+    print(f"snapshot={snapshot_out} ({size_kb} KB){note}")
+
+
+# Bulk that costs megabytes and is worthless on a plane. Dropping it from the
+# SNAPSHOT only — production is untouched — is safe because `merge` copies back
+# nothing but cards and review_log.
+_SLIM_STATEMENTS = [
+    # full AI prompts + responses, only ever read by the cost page
+    "DELETE FROM api_call_log",
+    # podcast transcripts are the single biggest table; the German summaries and
+    # HSK word lists are small, so they stay readable offline
+    "UPDATE podcast_episodes SET transcript_zh = NULL, transcript_de = NULL",
+    # the prompt that produced each story, shown only in a debug view
+    "UPDATE stories SET prompt_text = NULL",
+]
+
+
+def _slim(path: str) -> None:
+    conn = sqlite3.connect(path)
+    for statement in _SLIM_STATEMENTS:
+        try:
+            conn.execute(statement)
+        except sqlite3.OperationalError as e:
+            # A table missing on an older schema is not worth failing a sync over.
+            print(f"  slim: skipped ({e})", file=sys.stderr)
+    conn.commit()
+    conn.execute("VACUUM")   # actually reclaim the freed pages
+    conn.close()
 
 
 def cmd_merge(prod_db: str, incoming_db: str) -> None:
@@ -148,11 +183,13 @@ def cmd_merge(prod_db: str, incoming_db: str) -> None:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 4:
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    flags = {a for a in sys.argv[1:] if a.startswith("--")}
+    if len(args) != 3:
         sys.exit(__doc__)
-    command, db, other = sys.argv[1], sys.argv[2], sys.argv[3]
+    command, db, other = args
     if command == "prepare":
-        cmd_prepare(db, other)
+        cmd_prepare(db, other, slim="--full" not in flags)
     elif command == "merge":
         cmd_merge(db, other)
     else:

--- a/scripts/offline_tts_manifest.py
+++ b/scripts/offline_tts_manifest.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""List the TTS files an offline session actually needs (issue #612).
+
+Run on the laptop against the freshly pulled data/offline.db; prints one
+`<sha256>.mp3` filename per line for rsync --files-from.
+
+Syncing all of data/tts/ means moving ~120 MB of audio accumulated over
+months, most of it for words that aren't due. Over a slow link before a
+flight that's the difference between a minute and an hour. The frontend only
+ever asks for two kinds of text (see _ttsUrl / _storyAudioUrl in app.js):
+
+    story_sentences.sentence_zh   — listening fronts and "play full story"
+    entries.word_zh               — the fallback when a card has no sentence
+
+so the manifest is exactly those two, scoped to what's reachable in the next
+few days.
+
+    python scripts/offline_tts_manifest.py data/offline.db [--days-ahead 14]
+"""
+
+import argparse
+import datetime
+import os
+import sqlite3
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import languages  # noqa: E402
+import tts  # noqa: E402
+
+# Stories older than this are not reachable in a review session, but a couple
+# of days of slack costs almost nothing and covers a pull made after midnight.
+STORY_LOOKBACK_DAYS = 3
+
+
+def _filename(text: str, lang: str) -> str | None:
+    if not text or not text.strip():
+        return None
+    voice = languages.get_lang_config(lang)["tts_voice"]
+    return os.path.basename(tts._cache_path(text, voice))
+
+
+def collect(db_path: str, days_ahead: int) -> list[str]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    today = datetime.date.today()
+    since = (today - datetime.timedelta(days=STORY_LOOKBACK_DAYS)).isoformat()
+    until = (today + datetime.timedelta(days=days_ahead)).isoformat()
+
+    names: set[str] = set()
+
+    # Story sentences — stories carry their own lang ('zh' for legacy NULL rows).
+    for row in conn.execute(
+        "SELECT ss.sentence_zh AS text, COALESCE(s.lang, 'zh') AS lang "
+        "FROM story_sentences ss JOIN stories s ON s.id = ss.story_id "
+        "WHERE s.date >= ?", (since,)
+    ):
+        name = _filename(row["text"], row["lang"])
+        if name:
+            names.add(name)
+
+    # Words on cards that can come up in the session. Suspended cards are
+    # excluded; buried ones are not, since burial lifts the next day.
+    for row in conn.execute(
+        "SELECT e.word_zh AS text, COALESCE(e.lang, 'zh') AS lang "
+        "FROM cards c JOIN entries e ON e.id = c.word_id "
+        "WHERE c.deleted_at IS NULL AND c.state != 'suspended' AND c.due <= ?",
+        (until,)
+    ):
+        name = _filename(row["text"], row["lang"])
+        if name:
+            names.add(name)
+
+    conn.close()
+    return sorted(names)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("db", help="path to the pulled offline database")
+    parser.add_argument("--days-ahead", type=int, default=14,
+                        help="include words due within this many days (default 14)")
+    args = parser.parse_args()
+
+    if not os.path.exists(args.db):
+        sys.exit(f"ERROR: database not found: {args.db}")
+    for name in collect(args.db, args.days_ahead):
+        print(name)
+
+
+if __name__ == "__main__":
+    main()

--- a/sync_offline.sh
+++ b/sync_offline.sh
@@ -17,6 +17,9 @@ REMOTE_INCOMING="/tmp/anki_offline_incoming.db"
 cd "$(dirname "$0")"
 LOCAL_DB="data/offline.db"
 SERVER_SCRIPT="scripts/offline_sync_server.py"
+MANIFEST="data/.offline_tts_manifest"
+# 提前多少天的到期词也一起同步音频——离线期间可以往前学
+DAYS_AHEAD="${ANKI_OFFLINE_DAYS_AHEAD:-14}"
 
 ACTION="${1:-}"
 
@@ -34,26 +37,44 @@ pull)
     echo "   ✅ 连接正常，生产数据库存在"
 
     echo
-    echo "== 步骤 2/5：在服务器上生成同步令牌并做数据库快照 =="
+    echo "== 步骤 2/5：在服务器上生成同步令牌并做数据库快照（约 20 秒）=="
     echo "   （令牌保证这份离线库只能被推回一次；快照对正在运行的服务是安全的）"
+    echo "   快照会剔除飞机上用不到的大块数据：API 调用日志、播客转录全文、故事提示词"
     run_remote "prepare '$REMOTE_DB' '$REMOTE_SNAPSHOT'"
     echo "   ✅ 快照完成"
 
     echo
-    echo "== 步骤 3/5：下载数据库到 $LOCAL_DB（约 30 MB，几秒钟）=="
+    echo "== 步骤 3/5：下载数据库到 $LOCAL_DB =="
+    echo "   压缩后约 7 MB。链路慢的话（实测过 ~8 KB/s）这一步可能要十几分钟。"
     mkdir -p data
     if [ -f "$LOCAL_DB" ]; then
         mv "$LOCAL_DB" "$LOCAL_DB.replaced-$(date +%Y%m%d-%H%M%S)"
         echo "   （上一份离线库已改名备份，没有覆盖）"
     fi
-    scp "$SERVER:$REMOTE_SNAPSHOT" "$LOCAL_DB"
+    scp -C "$SERVER:$REMOTE_SNAPSHOT" "$LOCAL_DB"
     ssh "$SERVER" "rm -f '$REMOTE_SNAPSHOT'"
     echo "   ✅ 数据库已下载"
 
     echo
-    echo "== 步骤 4/5：同步 TTS 音频缓存（首次约 120 MB，Wi-Fi 下 1–3 分钟；以后只传新增文件）=="
+    echo "== 步骤 4/5：同步会用到的 TTS 音频 =="
+    echo "   服务器上攒了 ~120 MB 音频，绝大部分是不到期的旧词。"
+    echo "   这里只算出接下来真正会听到的那些文件（故事句子 + 到期词），通常几 MB。"
     mkdir -p data/tts
-    rsync -a --info=progress2 "$SERVER:$REMOTE_DIR/data/tts/" data/tts/
+    PY=.venv/bin/python
+    [ -x "$PY" ] || PY=python3
+    "$PY" scripts/offline_tts_manifest.py "$LOCAL_DB" --days-ahead "$DAYS_AHEAD" \
+        | sort > "$MANIFEST.want"
+    echo "   会用到 $(wc -l < "$MANIFEST.want" | tr -d ' ') 段语音"
+    # 清单里有不少词服务器上还没生成过音频。先取交集，
+    # 否则 rsync 会为每个缺失文件报错并以非零码退出，让整个脚本中断。
+    ssh "$SERVER" "ls '$REMOTE_DIR/data/tts'" | sort > "$MANIFEST.have"
+    comm -12 "$MANIFEST.want" "$MANIFEST.have" > "$MANIFEST"
+    echo "   服务器上实际存在 $(wc -l < "$MANIFEST" | tr -d ' ') 个（其余的词服务器也还没生成过音频）"
+    if [ -s "$MANIFEST" ]; then
+        rsync -a --info=progress2 --files-from="$MANIFEST" \
+            "$SERVER:$REMOTE_DIR/data/tts/" data/tts/
+    fi
+    rm -f "$MANIFEST" "$MANIFEST.want" "$MANIFEST.have"
     echo "   ✅ 音频同步完成"
 
     echo
@@ -74,8 +95,8 @@ push)
     echo "   提示：如果离线服务还开着，先按 Ctrl+C 停掉，确保数据全部写盘"
 
     echo
-    echo "== 步骤 2/4：上传到服务器（约 30 MB，几秒钟）=="
-    scp "$LOCAL_DB" "$SERVER:$REMOTE_INCOMING"
+    echo "== 步骤 2/4：上传到服务器（压缩后约 7 MB）=="
+    scp -C "$LOCAL_DB" "$SERVER:$REMOTE_INCOMING"
     echo "   ✅ 上传完成"
 
     echo

--- a/tests/test_offline_sync.py
+++ b/tests/test_offline_sync.py
@@ -139,6 +139,41 @@ def test_merge_without_prepare_is_refused(server_db, tmp_path):
     assert "never prepared" in str(exc.value)
 
 
+def test_slim_strips_bulk_from_the_snapshot_only(server_db, tmp_path):
+    """The snapshot loses the megabyte-heavy columns; production keeps them."""
+    conn = sqlite3.connect(server_db)
+    conn.execute("INSERT INTO api_call_log (model, input_tokens, output_tokens, prompt) "
+                 "VALUES ('m', 1, 1, '很长的提示词')")
+    conn.execute("INSERT INTO podcast_episodes (video_id, title, youtube_url, "
+                 "transcript_zh, summary_de) VALUES ('v', 't', 'u', '长转录', '摘要')")
+    conn.execute("INSERT INTO stories (deck_id, date, category, prompt_text) "
+                 "VALUES (2, '2026-08-02', 'reading', '很长的提示词')")
+    conn.commit()
+    conn.close()
+
+    snapshot = _prepare(server_db, tmp_path)
+
+    snap = sqlite3.connect(snapshot)
+    assert snap.execute("SELECT COUNT(*) FROM api_call_log").fetchone()[0] == 0
+    assert snap.execute("SELECT transcript_zh FROM podcast_episodes").fetchone()[0] is None
+    assert snap.execute("SELECT prompt_text FROM stories").fetchone()[0] is None
+    # the small, still-useful podcast fields survive
+    assert snap.execute("SELECT summary_de FROM podcast_episodes").fetchone()[0] == '摘要'
+
+    prod = sqlite3.connect(server_db)
+    assert prod.execute("SELECT COUNT(*) FROM api_call_log").fetchone()[0] == 1
+    assert prod.execute("SELECT transcript_zh FROM podcast_episodes").fetchone()[0] == '长转录'
+    assert prod.execute("SELECT prompt_text FROM stories").fetchone()[0] == '很长的提示词'
+
+
+def test_slimmed_snapshot_still_merges(server_db, tmp_path):
+    snapshot = _prepare(server_db, tmp_path)   # slimming runs by default
+    _review_offline(snapshot)
+    sync_server.cmd_merge(server_db, snapshot)
+    assert sqlite3.connect(server_db).execute(
+        "SELECT due FROM cards WHERE id = 1").fetchone()[0] == '2026-08-05'
+
+
 def test_untouched_cards_are_not_rewritten(server_db, tmp_path):
     """Only rows that actually differ get an UPDATE — a no-op sync changes nothing."""
     snapshot = _prepare(server_db, tmp_path)


### PR DESCRIPTION
## 为什么

#613 合并后我实测了到服务器的链路：**约 8.5 KB/s**（20 个音频文件 492 KB 用了 58 秒）。按原方案要传 29 MB 数据库 + 118 MB 音频，起飞前根本准备不完。

## 改了什么

**快照瘦身**（`offline_sync_server.py`）——只在快照上操作，生产库一个字节都不动：
- 清空 `api_call_log`（3.4 MB，全是提示词和回答，只有成本页读）
- `podcast_episodes.transcript_zh/_de` 置空（5.4 MB，飞机上没法听播客；德语摘要和 HSK 词表保留，还能读）
- `stories.prompt_text` 置空（1.8 MB，只在调试视图显示）
- 然后 VACUUM 真正回收空间

在生产库副本上实测：**29.6 MB → 18.5 MB，`scp -C` 压缩后实际传 6.8 MB**。`prepare … --full` 可保留全部。

**音频按需**（新增 `scripts/offline_tts_manifest.py`）：
前端只请求两种文本（`_ttsUrl` / `_storyAudioUrl`）——故事句子 `sentence_zh` 和词本身 `word_zh`。脚本从拉下来的库算出这两类里近几天可达的部分，再和服务器上实际存在的文件取交集。

生产库上实测：**254 个文件 / 6.3 MB**，而不是整个 118 MB。

**取交集是必须的**：清单里 1130 条中有 876 条服务器还没生成过音频。直接把清单喂给 rsync，它会为每个缺失文件报错并以 23 退出，`set -e` 会中断整个 pull。

## 怎么测试的

`tests/test_offline_sync.py` 加到 9 个测试，全过——新增两个覆盖瘦身：快照被剥离而生产库完好（含"小而有用的德语摘要要保留"）、瘦身后的快照仍能正常合并。

在生产库的**副本**上跑了完整往返（生产库未被触碰）：
```
snapshot=/tmp/slim_snap.db (18540 KB) (slimmed from 29640 KB)
gzip 后 6.8 MB
reviews_merged=1  cards_updated=1
合并后卡片 1: (review, 2099-01-01)
播客单集数 123（不变）  api_call_log 3505 行（不变）  转录 42 条仍在
重复 merge → ERROR: sync token mismatch（退出码 1）
```
清理了所有服务器临时文件。

预计现在 pull 全程约 25 分钟（数据库 ~13 分钟 + 音频 ~12 分钟），取决于当时网速。

Closes #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)