### PR TITLE
测试不再写真实数据库，全套 158 项通过（#615）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,6 +400,16 @@ python main.py status [--deck X]     # 显示每个牌组/类别的到期数量
 
 ---
 
+## 测试（`tests/`，`pytest tests/` 全套约 11 秒）
+
+- **隔离数据库只能打 `database.core.DB_PATH` 这个补丁**：`database/__init__.py` 是 `from .core import *`，`database.DB_PATH` 只是一份名字副本，`get_db()` 读的是 core 的模块全局。打错位置不会报错，测试会**静默写进真实的 `data/srs.db`**（#615，`test_importer`/`test_api` 曾这样跑了很久）。`tests/conftest.py` 还额外把 `DB_PATH` 指向临时目录兜底
+- `conftest.py` 有个 autouse 夹具把 `tts._ensure_cached` 打桩——否则故事相关的测试会真的去连 edge-tts（曾让 `test_api` 从 2 秒变成 85 秒，且断网必挂）
+- **AI 要打桩在 `ai._call_api` 上**，不要打在某个提供商的客户端上：默认模型换过（Claude → DeepSeek），打在 `anthropic.Anthropic` 上的补丁会静默失效（#615）
+- 导入器建的牌组嵌套在 `All` 下面。用 `get_or_create_deck("Kouyu")` 查找会因为默认 `parent_id=None` **新建一个空牌组**，查什么都是空——按名字查已存在的牌组（见 `test_importer.deck_id_by_name`）
+- 测试替身的签名/返回格式会随生产代码漂移而悄悄作废。桩函数尽量吃 `**kwargs`，断言写在稳定的契约上
+
+---
+
 ## 规范与约束
 
 - 所有数据库访问通过 `database/` 包——其他文件不写原始 SQL（`import database` 仍然有效）

--- a/importer.py
+++ b/importer.py
@@ -908,7 +908,15 @@ def _hsk_to_int(hsk_str: str) -> int | None:
     try:
         return int(s)
     except ValueError:
-        return None
+        pass
+    # Some older Kouyu entries grade a word across two levels ("4/5"). The
+    # documented format is a single digit, but falling through to None would
+    # silently import the word with no HSK level at all, so take the higher one.
+    if "/" in s:
+        levels = [int(part) for part in s.split("/") if part.strip().isdigit()]
+        if levels:
+            return max(levels)
+    return None
 
 
 # Keep old name as alias

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,53 @@
+"""Shared pytest setup (issue #615).
+
+The safety net here exists because a wrong monkeypatch is invisible: for a long
+time two test modules patched `database.DB_PATH` instead of
+`database.core.DB_PATH`. `database/__init__.py` does `from .core import *`, so
+the package-level name is only a copy — get_db() kept connecting to the real
+data/srs.db, and the tests quietly wrote to it. The symptom was a confusing
+`UNIQUE constraint failed: decks.name` from leftover rows, not an obvious
+"you are writing to production" error.
+
+Pointing DB_PATH at a throwaway file before any test imports a database module
+means a missing patch can, at worst, produce a stray file in a temp directory.
+"""
+
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# Must be set before database.core is imported: it reads DB_PATH at import time.
+_FALLBACK_DB = os.path.join(tempfile.mkdtemp(prefix="ankiadvanced-tests-"), "fallback.db")
+os.environ["DB_PATH"] = _FALLBACK_DB
+
+# DISABLE_AI is deliberately NOT set here: routes.utils reads it at import time,
+# and tests like test_api's story suite mock the AI layer and assert it was
+# called. Modules that want it (test_offline_sync, test_prompt_templates) set it
+# themselves before importing.
+
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_real_tts(monkeypatch, tmp_path_factory):
+    """Never let a test open an edge-tts connection.
+
+    Once the DB isolation above was fixed, the story endpoint tests started
+    actually reaching the TTS preload step — one test file went from instant to
+    85 seconds of real network calls, and it would fail outright on a machine
+    with no internet. Audio generation is not what any of these tests are
+    checking, so stub it at the single choke point every path goes through.
+    """
+    import tts
+
+    cache = tmp_path_factory.mktemp("tts")
+
+    async def _fake_ensure_cached(text, voice=tts.VOICE):
+        path = cache / f"{abs(hash((text, voice)))}.mp3"
+        path.write_bytes(b"")
+        return str(path)
+
+    monkeypatch.setattr(tts, "_ensure_cached", _fake_ensure_cached)

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -30,24 +30,37 @@ SAMPLE_CARDS = [
     {"word_id": 3, "word_zh": "进步", "pinyin": "jìn bù",  "definition": "progress",       "pos": "n"},
 ]
 
-VALID_AI_RESPONSE = [
-    {"word_id": 1, "sentence_zh": "她很担心考试。",     "sentence_en": "She is worried about the exam."},
-    {"word_id": 2, "sentence_zh": "他每天努力学习。",   "sentence_en": "He studies hard every day."},
-    {"word_id": 3, "sentence_zh": "她看到了他的进步。", "sentence_en": "She saw his progress."},
+# What the model is asked to return: a numbered list of Chinese sentences,
+# each containing exactly one target word verbatim. No JSON, no translations.
+VALID_AI_RESPONSE = """1. 她很担心考试。
+2. 他每天努力学习。
+3. 她看到了他的进步。"""
+
+# 21 words so that one missing word is under the 5%-patch threshold.
+_MANY_WORDS = [
+    "担心", "努力", "进步", "学习", "老师", "学生", "朋友", "工作", "问题", "办法",
+    "时间", "机会", "结果", "经验", "习惯", "态度", "计划", "目标", "方向", "选择",
+    "决定",
 ]
 
 
-def _mock_anthropic(response_text: str):
+def _mock_api(response_text: str):
     """
-    Patches anthropic.Anthropic so that messages.create() returns a fake
-    response containing response_text as its first content block.
-    Returns a context manager — use with `with _mock_anthropic(...):`.
+    Patch ai._call_api so the provider layer returns response_text verbatim.
+    Returns a context manager — use with `with _mock_api(...):`.
+
+    This used to patch anthropic.Anthropic. That stopped working the day the
+    default model moved to DeepSeek: generate_story went through the
+    OpenAI-compatible client instead, the mock never applied, and the tests
+    died on a missing DEEPSEEK_API_KEY (issue #615). _call_api is the one
+    choke point every provider goes through, so patching it here survives
+    future changes of default model.
     """
-    mock_client = MagicMock()
-    mock_msg = MagicMock()
-    mock_msg.content = [MagicMock(text=response_text)]
-    mock_client.messages.create.return_value = mock_msg
-    return patch("anthropic.Anthropic", return_value=mock_client)
+    return patch("ai._call_api", return_value=response_text)
+
+
+# Kept under the old name so the live-API tests below read unchanged.
+_mock_anthropic = _mock_api
 
 
 # ---------------------------------------------------------------------------
@@ -55,88 +68,99 @@ def _mock_anthropic(response_text: str):
 # ---------------------------------------------------------------------------
 
 class TestGenerateStory:
+    """The AI contract changed twice since these tests were written (issue #615).
+
+    It no longer returns JSON: the prompt asks for a numbered list of Chinese
+    sentences, and generate_story matches each target word into a sentence by
+    string search. English/German translations are added afterwards by
+    _fill_translations (a translator call, stubbed here), not by the model.
+    Each result item is {word_ids: [...], sentence_zh, tokens}, and the return
+    value is a (sentences, prompt) tuple.
+
+    There is also no "placeholder fallback" anymore: an unusable response is
+    retried three times and then raises, because silently reviewing invented
+    sentences was worse than failing loudly.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_translation_calls(self, monkeypatch):
+        """_fill_translations hits the translation service — stub it out."""
+        def _fake(parsed, progress_key=None, lang="zh"):
+            for s in parsed:
+                s["sentence_en"] = f"[en] {s['sentence_zh']}"
+        monkeypatch.setattr(ai, "_fill_translations", _fake)
 
     def test_returns_one_sentence_per_card(self):
-        """
-        generate_story must return exactly N sentences for N input cards.
-        If this breaks, the frontend can't match sentences to cards.
-        """
-        with _mock_anthropic(json.dumps(VALID_AI_RESPONSE)):
-            result = ai.generate_story(SAMPLE_CARDS)
-        assert len(result) == len(SAMPLE_CARDS)
+        """N input cards → N sentences, so the frontend can map 1:1."""
+        with _mock_api(VALID_AI_RESPONSE):
+            sentences, _prompt = ai.generate_story(SAMPLE_CARDS)
+        assert len(sentences) == len(SAMPLE_CARDS)
 
     def test_word_ids_match_input_cards(self):
-        """
-        Each returned sentence must carry the word_id of its corresponding
-        input card (in order). The frontend uses word_id to find the right
-        sentence for each card.
-        """
-        with _mock_anthropic(json.dumps(VALID_AI_RESPONSE)):
-            result = ai.generate_story(SAMPLE_CARDS)
-        for sentence, card in zip(result, SAMPLE_CARDS):
-            assert sentence["word_id"] == card["word_id"], (
-                f"Expected word_id={card['word_id']}, got {sentence['word_id']}"
-            )
+        """Each card's word_id must land in exactly one sentence."""
+        with _mock_api(VALID_AI_RESPONSE):
+            sentences, _prompt = ai.generate_story(SAMPLE_CARDS)
+
+        found = [wid for s in sentences for wid in s["word_ids"]]
+        assert sorted(found) == sorted(c["word_id"] for c in SAMPLE_CARDS)
+        assert len(found) == len(set(found)), "a word_id was assigned twice"
+
+    def test_returns_the_prompt_it_sent(self):
+        """The caller stores the prompt with the story for later inspection."""
+        with _mock_api(VALID_AI_RESPONSE):
+            _sentences, prompt = ai.generate_story(SAMPLE_CARDS)
+        assert "担心" in prompt, "the target words must appear in the prompt"
 
     def test_each_sentence_has_zh_and_en(self):
-        """
-        Every sentence must have both a Chinese text and an English
-        translation — the frontend displays both.
-        """
-        with _mock_anthropic(json.dumps(VALID_AI_RESPONSE)):
-            result = ai.generate_story(SAMPLE_CARDS)
-        for s in result:
-            assert s.get("sentence_zh"), f"Missing sentence_zh in {s}"
-            assert s.get("sentence_en"), f"Missing sentence_en in {s}"
+        """zh comes from the model, en from _fill_translations afterwards."""
+        with _mock_api(VALID_AI_RESPONSE):
+            sentences, _prompt = ai.generate_story(SAMPLE_CARDS)
+        for s in sentences:
+            assert s.get("sentence_zh")
+            assert s.get("sentence_en")
 
-    def test_empty_cards_returns_empty_list_without_api_call(self):
-        """
-        generate_story([]) must return [] immediately without ever calling
-        the Anthropic API (no point generating a story for zero words, and
-        it would waste tokens).
-        """
-        with patch("anthropic.Anthropic") as mock_cls:
-            result = ai.generate_story([])
-        assert result == []
-        mock_cls.assert_not_called()
+    def test_empty_cards_returns_empty_without_api_call(self):
+        """No cards → no tokens spent."""
+        with patch("ai._call_api") as mock_api:
+            sentences, prompt = ai.generate_story([])
+        assert sentences == []
+        assert prompt == ""
+        mock_api.assert_not_called()
 
-    def test_malformed_json_falls_back_to_placeholder_sentences(self):
-        """
-        The AI sometimes returns prose, markdown, or broken JSON instead of
-        valid JSON. generate_story must catch this and return one fallback
-        sentence per card so the session can still continue.
-        """
-        with _mock_anthropic("Here is your story: she worried a lot. Very nice."):
-            result = ai.generate_story(SAMPLE_CARDS)
-        # Must still return one sentence per card
-        assert len(result) == len(SAMPLE_CARDS)
-        for sentence, card in zip(result, SAMPLE_CARDS):
-            assert sentence["word_id"] == card["word_id"]
-            assert sentence["sentence_zh"]
-            assert sentence["sentence_en"]
+    def test_response_without_numbered_lines_is_retried_then_raises(self):
+        """Prose instead of a numbered list is unusable — fail loudly.
 
-    def test_wrong_sentence_count_falls_back(self):
+        Returning invented placeholder sentences (the old behaviour) meant
+        reviewing sentences that never contained the target word.
         """
-        If the AI returns fewer sentences than cards (e.g. it skipped a word),
-        generate_story must detect the mismatch and fall back rather than
-        silently misaligning sentences with cards.
-        """
-        too_few = json.dumps(VALID_AI_RESPONSE[:1])  # 1 sentence for 3 cards
-        with _mock_anthropic(too_few):
-            result = ai.generate_story(SAMPLE_CARDS)
-        assert len(result) == len(SAMPLE_CARDS)
+        with _mock_api("Here is your story: she worried a lot. Very nice.") as mock_api:
+            with pytest.raises(RuntimeError, match="failed after 3 attempts"):
+                ai.generate_story(SAMPLE_CARDS)
+        assert mock_api.call_count == 3, "should retry twice before giving up"
 
-    def test_markdown_code_fence_stripped(self):
-        """
-        The AI frequently wraps JSON in ```json ... ``` code fences.
-        generate_story must strip them before parsing.
-        """
-        fenced = f"```json\n{json.dumps(VALID_AI_RESPONSE)}\n```"
-        with _mock_anthropic(fenced):
-            result = ai.generate_story(SAMPLE_CARDS)
-        assert len(result) == len(SAMPLE_CARDS)
-        for sentence, card in zip(result, SAMPLE_CARDS):
-            assert sentence["word_id"] == card["word_id"]
+    def test_missing_words_are_retried(self):
+        """A response covering only some target words triggers a retry."""
+        too_few = "1. 她很担心考试。"
+        with _mock_api(too_few) as mock_api:
+            with pytest.raises(RuntimeError, match="2 word"):
+                ai.generate_story(SAMPLE_CARDS)
+        assert mock_api.call_count == 3
+
+    def test_a_single_missing_word_is_patched_instead_of_failing(self):
+        """Below the 5% threshold the missing word gets a patched sentence,
+        so one stubborn word can't sink a whole 40-word story."""
+        cards = [
+            {"word_id": i, "word_zh": w, "pinyin": "", "definition": "x", "pos": "n"}
+            for i, w in enumerate(_MANY_WORDS, start=1)
+        ]
+        # Every word but the last one appears in the response.
+        response = "\n".join(f"{i}. 这里有{w}。" for i, w in enumerate(_MANY_WORDS[:-1], start=1))
+
+        with _mock_api(response):
+            sentences, _prompt = ai.generate_story(cards)
+
+        covered = {wid for s in sentences for wid in s["word_ids"]}
+        assert covered == {c["word_id"] for c in cards}, "every word must be covered"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,13 +42,17 @@ ENTRY_谢谢 = {"type": "vocabulary", "simplified": "谢谢", "pinyin": "xiè xi
                "english": "thank you", "pos": "v",    "hsk": "1"}
 
 
-def fake_generate_story(cards):
+def fake_generate_story(cards, **kwargs):
     """
     Drop-in replacement for ai.generate_story used in tests.
     Returns one sentence per card with the correct word_id so the
     endpoint can save them to the DB and return them to the client.
+
+    **kwargs swallows topic/max_hsk/model/mode/lang/… — the real signature has
+    grown repeatedly, and a stub that has to be edited every time is a stub that
+    silently rots (issue #615). Returns (sentences, prompt) like the real one.
     """
-    return [
+    sentences = [
         {
             "word_id": c["word_id"],
             "sentence_zh": f"他说{c['word_zh']}。",
@@ -56,6 +60,7 @@ def fake_generate_story(cards):
         }
         for c in cards
     ]
+    return sentences, "fake prompt"
 
 
 # ---------------------------------------------------------------------------
@@ -66,10 +71,13 @@ def fake_generate_story(cards):
 def tmp_db(tmp_path, monkeypatch):
     """
     Redirect all DB access to a fresh temp file for this test.
-    Same pattern as test_importer.py — keeps tests fully isolated.
+
+    Patch database.core.DB_PATH, not database.DB_PATH: the latter is a copy of
+    the name made by `from .core import *`, and get_db() reads core's module
+    global at call time (issue #615).
     """
     db_file = tmp_path / "test.db"
-    monkeypatch.setattr(database, "DB_PATH", str(db_file))
+    monkeypatch.setattr(database.core, "DB_PATH", str(db_file))
     database.init_db()
     return db_file
 
@@ -79,7 +87,10 @@ def populated_db(tmp_db, tmp_path):
     """tmp_db with 2 words already imported. Returns the Kouyu deck_id."""
     write_yaml(tmp_path, "words.yaml", [ENTRY_你好, ENTRY_谢谢])
     importer.import_all(str(tmp_path))
-    return database.get_or_create_deck("Kouyu")
+    # Look the deck up rather than get_or_create_deck("Kouyu"): the importer
+    # nests it under "All", so the default parent_id=None would create a
+    # second, empty top-level deck (issue #615).
+    return next(d["id"] for d in database.get_all_decks() if d["name"] == "Kouyu")
 
 
 # ---------------------------------------------------------------------------
@@ -219,14 +230,15 @@ class TestSpeak:
 
     def test_speak_calls_tts_with_correct_text(self, tmp_db):
         """
-        POST /api/speak?text=你好 must pass exactly "你好" to tts.speak.
+        POST /api/speak?text=你好 must pass exactly "你好" to tts.speak_sync.
         The endpoint is a thin wrapper — we just verify the routing.
+        (lang is passed too since the multi-language work, issue #436.)
         """
-        with patch("tts.speak") as mock_tts:
+        with patch("tts.speak_sync") as mock_tts:
             r = client.post("/api/speak", params={"text": "你好"})
 
         assert r.status_code == 200
-        mock_tts.assert_called_once_with("你好")
+        mock_tts.assert_called_once_with("你好", lang="zh")
 
     def test_speak_returns_ok(self, tmp_db):
         """Response must be {"ok": true} so the frontend can detect success."""

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,8 +1,8 @@
 """
 Integration tests for the Kouyu importer and card queue logic.
 
-Each test gets its own isolated in-memory-backed temp DB by monkeypatching
-database.DB_PATH before calling any database functions.
+Each test gets its own isolated temp DB by monkeypatching database.core.DB_PATH
+before calling any database functions.
 """
 import os
 import sys
@@ -25,9 +25,14 @@ import importer
 
 @pytest.fixture
 def tmp_db(tmp_path, monkeypatch):
-    """Point database.DB_PATH at a temp file and initialise the schema."""
+    """Point database.core.DB_PATH at a temp file and initialise the schema.
+
+    It has to be core's global: database.DB_PATH is only a copy of the name
+    made by `from .core import *`, so patching it leaves get_db() connecting
+    to the real data/srs.db (issue #615).
+    """
     db_file = str(tmp_path / "test_srs.db")
-    monkeypatch.setattr(database, "DB_PATH", db_file)
+    monkeypatch.setattr(database.core, "DB_PATH", db_file)
     # init_db also creates the data/ dir and default preset+deck
     database.init_db()
     return db_file
@@ -152,7 +157,7 @@ class TestCardQueue:
 
     def test_new_card_appears_in_due_list(self, tmp_db, tmp_path):
         self._import_word(tmp_path, ENTRY_你好)
-        deck_id = database.get_or_create_deck("Kouyu · Listening")
+        deck_id = deck_id_by_name("Kouyu · Listening")
         cards = database.get_due_cards(deck_id, "listening")
         assert len(cards) == 1
         assert cards[0]["word_zh"] == "你好"
@@ -160,7 +165,7 @@ class TestCardQueue:
 
     def test_count_due_shows_new_card(self, tmp_db, tmp_path):
         self._import_word(tmp_path, ENTRY_你好)
-        deck_id = database.get_or_create_deck("Kouyu · Listening")
+        deck_id = deck_id_by_name("Kouyu · Listening")
         counts = database.count_due(deck_id, "listening")
         assert counts["new"] == 1
         assert counts["learning"] == 0
@@ -168,7 +173,7 @@ class TestCardQueue:
 
     def test_get_next_card_returns_top_priority(self, tmp_db, tmp_path):
         self._import_word(tmp_path, ENTRY_你好)
-        deck_id = database.get_or_create_deck("Kouyu · Listening")
+        deck_id = deck_id_by_name("Kouyu · Listening")
         card = database.get_next_card(deck_id, "listening")
         assert card is not None
         assert card["word_zh"] == "你好"
@@ -209,6 +214,19 @@ def _force_card_state(card_id, state, due, step_index=0, interval=1,
     )
 
 
+def deck_id_by_name(name):
+    """Find an existing deck by name.
+
+    Not get_or_create_deck(name): the importer nests its decks under "All"
+    (All → Kouyu → Kouyu · Listening), and get_or_create_deck defaults to
+    parent_id=None, so it would silently create a second, empty top-level deck
+    and every query against it would come back empty (issue #615).
+    """
+    match = next((d for d in database.get_all_decks() if d["name"] == name), None)
+    assert match is not None, f"deck {name!r} not found — did the import run?"
+    return match["id"]
+
+
 def _get_listening_card_id(word_zh):
     cards = database.get_all_cards_for_browse({"category": "listening"})
     return next(c["id"] for c in cards if c["word_zh"] == word_zh)
@@ -225,7 +243,7 @@ class TestQueuePriority:
         """Import 你好, 再见, 老师 and return the Kouyu · Listening deck_id."""
         write_yaml(tmp_path, "p.yaml", [ENTRY_你好, ENTRY_再见, ENTRY_老师])
         importer.import_all(str(tmp_path))
-        return database.get_or_create_deck("Kouyu · Listening")
+        return deck_id_by_name("Kouyu · Listening")
 
     def test_learning_card_beats_new_card(self, tmp_db, tmp_path):
         """A learning card that is now overdue should come before a new card."""
@@ -255,42 +273,59 @@ class TestQueuePriority:
             "Review card due today should come before new cards"
         assert next_card["state"] == "review"
 
-    def test_learning_card_beats_review_card(self, tmp_db, tmp_path):
-        """An overdue learning card should come before a review card due today."""
+    def test_learning_first_preset_puts_learning_before_review(self, tmp_db, tmp_path):
+        """With interday_learning_review_order='learning_first', an overdue
+        learning card comes before a mature review card due today.
+
+        This used to assert an unconditional "learning beats review" rule. That
+        rule is now a preset knob (issue #615): the default is 'mixed', which
+        merges both groups by due time — and a review card's date-only due
+        ("2026-08-03") sorts before a learning card's datetime due on the same
+        day, so under 'mixed' the review card legitimately comes first.
+        """
         deck_id = self._setup_three_words(tmp_path)
+        preset_id = database.get_preset_for_deck(deck_id, "listening")["id"]
+        database.update_preset(preset_id, {"interday_learning_review_order": "learning_first"})
 
         # 你好 → overdue learning
         learning_id = _get_listening_card_id("你好")
         past = (datetime.now() - timedelta(seconds=1)).isoformat(timespec="seconds")
         _force_card_state(learning_id, state="learning", due=past)
 
-        # 再见 → review due today
+        # 再见 → review due today. The interval must clear learned_interval (4),
+        # otherwise the card counts as still-learning and never reaches the
+        # review group at all.
         review_id = _get_listening_card_id("再见")
         today = date.today().isoformat()
-        _force_card_state(review_id, state="review", due=today, interval=1)
+        _force_card_state(review_id, state="review", due=today, interval=10)
 
         # 老师 stays new
         next_card = database.get_next_card(deck_id, "listening")
         assert next_card["id"] == learning_id, \
-            "Overdue learning card should beat review card"
+            "learning_first preset should put the learning card first"
 
-    def test_future_learning_card_does_not_appear(self, tmp_db, tmp_path):
-        """
-        A card rated Again gets due=now+1min (future).
-        It must NOT appear in the queue yet — the user should see other cards first.
+    def test_learning_card_due_later_today_is_still_gathered(self, tmp_db, tmp_path):
+        """A learning card whose minute-timer hasn't expired is still gathered.
+
+        This test used to assert the opposite. get_due_cards' WHERE clause is
+        `state IN ('learning','relearn') AND due < tomorrow` on purpose: the
+        deck list's "learning_future" badge counts exactly this set. Withholding
+        the card until its timer expires is the session queue's job, and that
+        guarantee is tested where it lives, in test_queue_manager.py
+        (test_learning_card_due_later_today_is_not_served_yet, issue #615).
         """
         deck_id = self._setup_three_words(tmp_path)
 
-        # Put 你好 in learning but due 2 minutes in the FUTURE
         card_id = _get_listening_card_id("你好")
         future = (datetime.now() + timedelta(minutes=2)).isoformat(timespec="seconds")
         _force_card_state(card_id, state="learning", due=future)
 
-        # Queue should only contain 再见 and 老师 (new), not 你好
-        due_cards = database.get_due_cards(deck_id, "listening")
-        due_ids = [c["id"] for c in due_cards]
-        assert card_id not in due_ids, \
-            "Future-due learning card must not appear in queue yet"
+        due_ids = [c["id"] for c in database.get_due_cards(deck_id, "listening")]
+        assert card_id in due_ids
+
+        counts = database.count_due(deck_id, "listening")
+        assert counts["learning_future"] == 1
+        assert counts["learning"] == 0, "not due yet, so not in the actionable count"
 
     def test_again_card_reappears_at_top_after_delay(self, tmp_db, tmp_path):
         """
@@ -303,14 +338,12 @@ class TestQueuePriority:
 
         card_a_id = _get_listening_card_id("你好")
 
-        # Step 1: simulate rating Again — card goes to learning, due is in the future
+        # Step 1: simulate rating Again — card goes to learning, due is in the future.
+        # It is gathered but not yet serveable; the session queue is what holds it
+        # back (see test_queue_manager.py, issue #615).
         future = (datetime.now() + timedelta(minutes=1)).isoformat(timespec="seconds")
         _force_card_state(card_a_id, state="learning", due=future, step_index=0)
-
-        # At this point card A should NOT be in the queue
-        due_now = database.get_due_cards(deck_id, "listening")
-        assert card_a_id not in [c["id"] for c in due_now], \
-            "Card should not appear while its due time is still in the future"
+        assert database.count_due(deck_id, "listening")["learning"] == 0
 
         # Step 2: simulate 1 minute passing — set due to 1 second ago
         past = (datetime.now() - timedelta(seconds=1)).isoformat(timespec="seconds")
@@ -369,7 +402,7 @@ class TestMultipleAgainCards:
     def _setup_three_words(self, tmp_path):
         write_yaml(tmp_path, "m.yaml", [ENTRY_你好, ENTRY_再见, ENTRY_老师])
         importer.import_all(str(tmp_path))
-        return database.get_or_create_deck("Kouyu · Listening")
+        return deck_id_by_name("Kouyu · Listening")
 
     def test_two_again_cards_returned_in_due_order(self, tmp_db, tmp_path):
         """
@@ -457,9 +490,9 @@ class TestMultipleAgainCards:
 
     def test_only_expired_again_cards_are_visible(self, tmp_db, tmp_path):
         """
-        You click Again on two cards at different times.
-        Only the card whose timer has already expired is visible;
-        the other is still hidden (due in the future).
+        You click Again on two cards at different times. Both belong to today,
+        so both are gathered; only the one whose timer already expired counts
+        as actionable ("learning"), the other sits in "learning_future".
         """
         deck_id = self._setup_three_words(tmp_path)
 
@@ -471,8 +504,13 @@ class TestMultipleAgainCards:
         _force_card_state(id_expired, state="learning", due=past)
         _force_card_state(id_waiting,  state="learning", due=future)
 
-        due_cards = database.get_due_cards(deck_id, "listening")
-        due_ids = [c["id"] for c in due_cards]
+        # Both are gathered — get_due_cards returns everything due *today*.
+        # The counts are what tell them apart, and the session queue only serves
+        # the expired one (test_queue_manager.py, issue #615).
+        due_ids = [c["id"] for c in database.get_due_cards(deck_id, "listening")]
+        assert id_expired in due_ids
+        assert id_waiting in due_ids
 
-        assert id_expired in due_ids,  "Expired Again card should be visible"
-        assert id_waiting  not in due_ids, "Not-yet-due Again card should be hidden"
+        counts = database.count_due(deck_id, "listening")
+        assert counts["learning"] == 1, "only the expired timer is actionable now"
+        assert counts["learning_future"] == 1, "the other one is still waiting"

--- a/tests/test_queue_manager.py
+++ b/tests/test_queue_manager.py
@@ -198,3 +198,59 @@ def test_undo_brings_unburied_sibling_back(e2e):
     assert r.status_code == 200
     restored = _card_from(client.get(f"/api/today/{deck_id}/listening"))
     assert restored is not None and restored["id"] == listening["id"]
+
+
+# ---------------------------------------------------------------------------
+# Intraday learning gating (issue #615)
+# ---------------------------------------------------------------------------
+# get_due_cards() deliberately gathers EVERY learning card due today, including
+# ones whose minute-timer hasn't expired yet — that set is what the deck list's
+# "learning_future" badge counts. Not serving them early is the queue's job: it
+# keeps same-day learning cards (an ISO datetime, i.e. a "T" in due) in a
+# separate intraday deque and only hands one over once due <= now.
+#
+# test_importer.py used to assert this against get_due_cards(), which stopped
+# being the right layer once learning_future existed. It belongs here.
+
+def test_learning_card_due_later_today_is_not_served_yet(e2e):
+    import database
+
+    client, deck_id = e2e
+    from datetime import datetime, timedelta
+
+    card = _card_from(client.get(f"/api/today/{deck_id}/listening"))
+    assert card is not None
+
+    # Push it into learning with its timer expiring two minutes from now.
+    future = (datetime.now() + timedelta(minutes=2)).isoformat(timespec="seconds")
+    database.update_card(card["id"], state="learning", due=future, step_index=0,
+                     interval=0, ease=2.5, repetitions=0, lapses=0)
+
+    from routes.utils import queue_mgr
+    queue_mgr.invalidate()
+
+    # It is due *today*, so the leaf deck still gathers it …
+    # (deck_id here is the aggregate "All" deck; get_due_cards works on leaves)
+    due_ids = [c["id"] for c in database.get_due_cards(card["deck_id"], "listening")]
+    assert card["id"] in due_ids, "today's learning card should still be gathered"
+
+    # … but the session must not serve it before its timer expires.
+    assert _card_from(client.get(f"/api/today/{deck_id}/listening")) is None
+
+
+def test_learning_card_is_served_once_its_timer_expired(e2e):
+    import database
+
+    client, deck_id = e2e
+    from datetime import datetime, timedelta
+
+    card = _card_from(client.get(f"/api/today/{deck_id}/listening"))
+    past = (datetime.now() - timedelta(seconds=30)).isoformat(timespec="seconds")
+    database.update_card(card["id"], state="learning", due=past, step_index=0,
+                     interval=0, ease=2.5, repetitions=0, lapses=0)
+
+    from routes.utils import queue_mgr
+    queue_mgr.invalidate()
+
+    served = _card_from(client.get(f"/api/today/{deck_id}/listening"))
+    assert served is not None and served["id"] == card["id"]


### PR DESCRIPTION
## 根因

`test_importer.py` 和 `test_api.py` 这样打补丁：

```python
monkeypatch.setattr(database, "DB_PATH", db_file)      # ❌ 无效
```

但 `database/__init__.py` 是 `from .core import *`，`database.DB_PATH` 只是一份**名字副本**，`get_db()` 读的是 `database/core.py` 的模块全局。补丁静默失效，**这些测试一直在写真实的 `data/srs.db`**——报 `UNIQUE constraint failed: decks.name` 就是因为那个库里早有同名牌组。

生产数据库在服务器上，从未被触碰；被写的是本地那份早已过时的副本。但在干净环境上跑测试会凭空建出一个 `data/srs.db`。

`test_importer_fr.py`、`test_queue_manager.py` 等较新的文件都已用正确写法，`test_importer_fr.py` 的文档字符串甚至写明了这个坑——只有最老的两个漏掉了。

## 修好隔离之后

一批被掩盖了很久的过时测试暴露出来。每一个我都先判断是**代码错**还是**测试过时**，再动手：

| 失败 | 判断 | 处理 |
|------|------|------|
| 牌组查询全空 | 测试过时 | 导入器把牌组嵌在 `All` 下，`get_or_create_deck(name)` 默认 `parent_id=None` 会**新建一个空牌组**。改为按名字查已存在的牌组 |
| 未到期学习卡出现在 `get_due_cards` | 测试过时 | `WHERE … due < tomorrow` 是**故意的**——`learning_future` 徽章正是数这一批。拦截未到期卡是队列的职责，我核对过 `queue_manager` 确实把它们放进独立的 `intraday` 队列、只在 `due <= now` 时发牌 |
| "学习卡优先于复习卡" | 测试过时 | 这条规则已变成预设开关 `interday_learning_review_order`（默认 `mixed` 按 due 归并，而复习卡的纯日期 due 会排在同日学习卡的 datetime 之前）。测试改为显式设 `learning_first` |
| `test_ai` 需要 `DEEPSEEK_API_KEY` | 测试过时 | 模拟打在 `anthropic.Anthropic` 上，但默认模型早已换成 DeepSeek。改打 `ai._call_api`（所有提供商的唯一出口），今后换默认模型不会再静默失效 |
| `test_ai` 期望 JSON | 测试过时 | AI 早就改成返回**编号列表**，翻译由 `_fill_translations` 事后补。测试数据与断言按新契约重写 |
| `_hsk_to_int("4/5")` 返回 None | **代码问题** | 这类跨级写法会让词条**静默丢掉 HSK 等级**。改为取高值——把静默丢数据变成正确行为 |

### 用户侧保证没有被删掉，是被搬到了正确的层

原来那条"计时器没到就不能出现"的断言，我没有直接删——它本来就没被任何测试真正覆盖过。新增到 `test_queue_manager.py`：

- `test_learning_card_due_later_today_is_not_served_yet`——今天到期所以仍被收集，但 `/api/today` 不发牌
- `test_learning_card_is_served_once_its_timer_expired`——计时器一到就发

### 顺带堵住的两个坑（`tests/conftest.py`）

1. `DB_PATH` 兜底指向临时目录：以后再有人漏打补丁，最坏也只是在临时目录留个文件，不会写到 `data/`
2. autouse 夹具打桩 `tts._ensure_cached`：隔离修好后，故事测试开始**真的去连 edge-tts**，`test_api` 从 2 秒变成 85 秒，断网必挂

## 结果

```
修复前： 8 failed, 112 passed, 4 skipped, 33 errors  in 223.67s
修复后：           158 passed, 4 skipped             in  11.34s
```

跑完全套后 `data/srs.db` 的修改时间戳不变——污染确认堵住。

Closes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)
