### PR TITLE
修复 macOS 上 rsync 报错导致 pull 中断（#617）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,9 +140,10 @@ bash sync_offline.sh push    # 落地后（要有网）：把复习结果合并�
 - `PORT` 环境变量（默认 8000）让离线实例跑 8001，不占用 Daniel 浏览器连的端口
 - **同步只合并 `cards` + `review_log` 两张表**（`scripts/offline_sync_server.py`，纯标准库，通过 ssh stdin 管道执行，不依赖服务器已部署该版本）。离线期间服务器 cron 仍在写入（播客单集、预生成故事、成本日志），整库对拷会毁掉这些数据——**绝不整库覆盖**
 - **同步令牌**（`app_settings.offline_sync_token`）：`pull` 时写入服务器并随快照带走，`push` 时两边必须一致，合并后轮换 → 同一份离线库无法重复 push；手工拷贝的库没有令牌，直接拒绝
-- **传输量优化（链路很慢，实测到服务器只有 ~8 KB/s）**：
-  - 快照**瘦身**：`prepare` 在快照上（不动生产库）清空 `api_call_log`、`podcast_episodes.transcript_*`、`stories.prompt_text` 再 VACUUM → 29.6 MB 降到 18.5 MB，`scp -C` 压缩后实际传 ~7 MB。`prepare … --full` 可保留全部
-  - 音频**按需**：`scripts/offline_tts_manifest.py` 从拉下来的库算出真正会用到的语音（故事句子 `sentence_zh` + 到期词 `word_zh`，前端只请求这两种），再与服务器实际存在的文件取交集 → ~250 个文件 / 6.3 MB，而不是整个 118 MB 的 `data/tts/`。**必须取交集**，否则 rsync 会为缺失文件返回非零码，`set -e` 会中断整个脚本
+- **传输量优化**（实测链路 ~2.7 MB/s，整个 pull 十几秒；这两项优化仍然保留，只是并非为了救命）：
+  - 快照**瘦身**：`prepare` 在快照上（不动生产库）清空 `api_call_log`、`podcast_episodes.transcript_*`、`stories.prompt_text` 再 VACUUM → 29.6 MB 降到 18.5 MB。`prepare … --full` 可保留全部
+  - 音频**按需**：`scripts/offline_tts_manifest.py` 从拉下来的库算出真正会用到的语音（故事句子 `sentence_zh` + 到期词 `word_zh`，前端只请求这两种），再与服务器实际存在的文件取交集 → 一百多个文件 / 几 MB，而不是整个 118 MB 的 `data/tts/`。**必须取交集**，否则 rsync 会为缺失文件返回非零码，`set -e` 会中断整个脚本
+- **rsync 只能用两边都支持的选项**：脚本跑在 Daniel 的 macOS 上，系统自带的是 **openrsync**，不认 GNU 的 `--info=progress2`（#617 因此挂掉）。用 `--progress`。凡是只在服务器上验证过的命令，都要想一想 Mac 上是不是同一个实现
 - 测试见 `tests/test_offline_sync.py`
 
 ---

--- a/sync_offline.sh
+++ b/sync_offline.sh
@@ -44,8 +44,7 @@ pull)
     echo "   ✅ 快照完成"
 
     echo
-    echo "== 步骤 3/5：下载数据库到 $LOCAL_DB =="
-    echo "   压缩后约 7 MB。链路慢的话（实测过 ~8 KB/s）这一步可能要十几分钟。"
+    echo "== 步骤 3/5：下载数据库到 $LOCAL_DB（压缩后约 7 MB，几秒钟）=="
     mkdir -p data
     if [ -f "$LOCAL_DB" ]; then
         mv "$LOCAL_DB" "$LOCAL_DB.replaced-$(date +%Y%m%d-%H%M%S)"
@@ -71,7 +70,9 @@ pull)
     comm -12 "$MANIFEST.want" "$MANIFEST.have" > "$MANIFEST"
     echo "   服务器上实际存在 $(wc -l < "$MANIFEST" | tr -d ' ') 个（其余的词服务器也还没生成过音频）"
     if [ -s "$MANIFEST" ]; then
-        rsync -a --info=progress2 --files-from="$MANIFEST" \
+        # --progress（不是 GNU 专有的 --info=progress2）：macOS 自带的
+        # openrsync 不认后者，会直接报错退出（议题 #617）
+        rsync -a --progress --files-from="$MANIFEST" \
             "$SERVER:$REMOTE_DIR/data/tts/" data/tts/
     fi
     rm -f "$MANIFEST" "$MANIFEST.want" "$MANIFEST.have"


### PR DESCRIPTION
## 问题

`bash sync_offline.sh pull` 走到步骤 4 直接报错退出：

```
rsync: unrecognized option `--info=progress2'
```

数据库已经下载成功，只有音频同步这一步挂掉。

## 根因

`--info=progress2` 是 GNU rsync 3.1+ 的标志。macOS 现在自带的是 **openrsync**（`openrsync: protocol version 29 / rsync version 2.6.9 compatible`），不认这个选项。

我之前只在服务器（Linux，GNU rsync）上验证过传输，但脚本实际是在 Daniel 的 Mac 上跑的——这条路径没测到。`--progress` 两边都支持。

## 顺带修正一个错误的实测数字

之前脚本和 CLAUDE.md 里写着「链路实测约 8.5 KB/s」，并据此提示 pull 要等十几分钟。真实情况是：

```
anki_offline_snapshot.db  100%  18MB  2.7MB/s  00:06
```

**2.7 MB/s**，快了三百倍。原来那个数是用 20 个小文件通过 rsync 测的，被逐文件握手开销和当时的网络抖动带偏，不是链路真实带宽。所有基于它的耗时提示一并改掉。

（为此做的两项优化——快照瘦身、音频按需——仍然保留：传得少总是好事，只是动机没那么紧迫。）

## 怎么测试的

在 Daniel 的 Mac 上直接跑了修正后的命令：

```
rsync --version → openrsync: protocol version 29 / rsync version 2.6.9 compatible
rsync -a --progress --files-from=… → 退出码 0，5 个文件全部下载
```

CLAUDE.md 里补了一条约定：脚本跑在 macOS 上，rsync 只能用两边都支持的选项；凡是只在服务器上验证过的命令，都要想一想 Mac 上是不是同一个实现。

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)