### PR TITLE
修复中文提示里变量展开导致 pull/push 中断（#619）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,8 @@ bash sync_offline.sh push    # 落地后（要有网）：把复习结果合并�
 - **传输量优化**（实测链路 ~2.7 MB/s，整个 pull 十几秒；这两项优化仍然保留，只是并非为了救命）：
   - 快照**瘦身**：`prepare` 在快照上（不动生产库）清空 `api_call_log`、`podcast_episodes.transcript_*`、`stories.prompt_text` 再 VACUUM → 29.6 MB 降到 18.5 MB。`prepare … --full` 可保留全部
   - 音频**按需**：`scripts/offline_tts_manifest.py` 从拉下来的库算出真正会用到的语音（故事句子 `sentence_zh` + 到期词 `word_zh`，前端只请求这两种），再与服务器实际存在的文件取交集 → 一百多个文件 / 几 MB，而不是整个 118 MB 的 `data/tts/`。**必须取交集**，否则 rsync 会为缺失文件返回非零码，`set -e` 会中断整个脚本
+- **中文提示里紧跟变量必须写 `${VAR}`**：`"…下载到 $LOCAL_DB（约 7 MB）"` 会让 bash 把全角括号的字节也算进变量名，配合 `set -u` 直接退出（#619）。这个仓库的脚本提示全是中文，极易踩
+- **脚本改动必须实机跑一遍，`bash -n` 不够**：它只查语法，`set -u` 的 unbound variable、选项不被支持（#617）都要到运行时才暴露。离线同步脚本可以用 `ANKI_REMOTE_DIR=/tmp/xxx` 指向服务器上的一份副本来安全演练 push
 - **rsync 只能用两边都支持的选项**：脚本跑在 Daniel 的 macOS 上，系统自带的是 **openrsync**，不认 GNU 的 `--info=progress2`（#617 因此挂掉）。用 `--progress`。凡是只在服务器上验证过的命令，都要想一想 Mac 上是不是同一个实现
 - 测试见 `tests/test_offline_sync.py`
 

--- a/sync_offline.sh
+++ b/sync_offline.sh
@@ -33,7 +33,7 @@ pull)
     echo "== 步骤 1/5：检查 SSH 连接 =="
     echo "   连接 $SERVER …"
     ssh -o ConnectTimeout=10 "$SERVER" "test -f '$REMOTE_DB'" \
-        || { echo "❌ 连不上服务器，或找不到 $REMOTE_DB。你现在有网／VPN 吗？"; exit 1; }
+        || { echo "❌ 连不上服务器，或找不到 ${REMOTE_DB}。你现在有网／VPN 吗？"; exit 1; }
     echo "   ✅ 连接正常，生产数据库存在"
 
     echo
@@ -44,7 +44,7 @@ pull)
     echo "   ✅ 快照完成"
 
     echo
-    echo "== 步骤 3/5：下载数据库到 $LOCAL_DB（压缩后约 7 MB，几秒钟）=="
+    echo "== 步骤 3/5：下载数据库到 ${LOCAL_DB}（压缩后约 7 MB，几秒钟）=="
     mkdir -p data
     if [ -f "$LOCAL_DB" ]; then
         mv "$LOCAL_DB" "$LOCAL_DB.replaced-$(date +%Y%m%d-%H%M%S)"
@@ -91,8 +91,8 @@ pull)
 
 push)
     echo "== 步骤 1/4：检查本地离线数据库 =="
-    [ -f "$LOCAL_DB" ] || { echo "❌ 找不到 $LOCAL_DB——是不是还没 pull，或者已经 push 过了？"; exit 1; }
-    echo "   ✅ 找到 $LOCAL_DB（$(du -h "$LOCAL_DB" | cut -f1)）"
+    [ -f "$LOCAL_DB" ] || { echo "❌ 找不到 ${LOCAL_DB}——是不是还没 pull，或者已经 push 过了？"; exit 1; }
+    echo "   ✅ 找到 ${LOCAL_DB}（$(du -h "$LOCAL_DB" | cut -f1)）"
     echo "   提示：如果离线服务还开着，先按 Ctrl+C 停掉，确保数据全部写盘"
 
     echo


### PR DESCRIPTION
## 问题

```
sync_offline.sh: line 47: LOCAL_DB<乱码>: unbound variable
```

## 根因

```bash
echo "== 步骤 3/5：下载数据库到 $LOCAL_DB（压缩后约 7 MB）=="
```

`$LOCAL_DB` 后面紧跟全角括号 `（`。bash 解析变量名时把这个多字节字符的字节也吞了进去，于是去找一个叫 `LOCAL_DB（` 的变量，配合 `set -u` 直接报错退出。必须写 `${LOCAL_DB}（`。

全脚本 4 处（第 36、47、94、95 行），**其中 94/95 在 push 路径上**——不修的话落地后同步同样会挂。

## 为什么前两次没发现

`bash -n` 只做语法检查，这是 `set -u` 的运行时错误。前两个 PR 我都只做了语法检查就合并，连着漏了两次（#617 的 rsync 选项、这次的变量展开）。

**所以这次实机跑通了完整流程才提交：**

```
pull  → 退出码 0，全部 5 步走完
        data/offline.db 19 MB，data/tts/ 29894 个文件

离线实例（8012 端口，用拉下来的库）
        /api/mode → {"offline":true}
        混合复习 → 检方 (creating, learning)，计数 新4/学97/复213
        听力队列 → 运营 (learning)
        今天的故事 → All/unified，322 句，15 毫秒返回（未生成，直接用已有的）
        语音覆盖 → 322/322，100%

push  → 退出码 0，全部 4 步走完
        目标指向服务器上的一份副本（ANKI_REMOTE_DIR=/tmp/pushtest），
        生产库全程未被触碰
        reviews_merged=0（本来就没复习过，符合预期）
        测试后已还原 data/offline.db、清理服务器临时文件，
        并核对本地与生产的同步令牌一致——这份离线库仍可正常推回
```

CLAUDE.md 已补一条约定：中文提示里紧跟变量必须用 `${VAR}`；且脚本改动要实机跑，`bash -n` 不够。

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)