### PR TITLE
离线横幅加关闭叉号（#621）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1029,13 +1029,30 @@ function showNotice(msg) {
 
 // Persistent reminder that this instance can't reach the network, so an empty
 // story or a silent sentence is expected rather than a bug (issue #612).
+// Dismissal is per browser session only — a permanently hidden banner would
+// leave Daniel wondering why regenerate is missing days later (#621).
 function _renderOfflineBanner() {
   const existing = document.getElementById('offline-banner');
-  if (!_offlineMode) { if (existing) existing.remove(); return; }
+  if (!_offlineMode || sessionStorage.getItem('offlineBannerDismissed')) {
+    if (existing) existing.remove();
+    return;
+  }
   if (existing) return;
   const el = document.createElement('div');
   el.id = 'offline-banner';
-  el.textContent = '✈️ Offline mode — stories and audio are read-only from the last sync';
+  const text = document.createElement('span');
+  text.textContent = '✈️ Offline mode — stories and audio are read-only from the last sync';
+  const close = document.createElement('button');
+  close.id = 'offline-banner-close';
+  close.type = 'button';
+  close.title = 'Hide until next browser session';
+  close.setAttribute('aria-label', 'Dismiss offline notice');
+  close.textContent = '×';
+  close.onclick = () => {
+    sessionStorage.setItem('offlineBannerDismissed', '1');
+    el.remove();
+  };
+  el.append(text, close);
   document.body.prepend(el);
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -5011,3 +5011,22 @@ table.fsrs-table td.ivl { font-weight: 700; }
   text-align: center;
   letter-spacing: 0.3px;
 }
+#offline-banner-close {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 18px;
+  line-height: 1;
+  padding: 0 6px;
+  cursor: pointer;
+  opacity: 0.7;
+  border-radius: 4px;
+}
+#offline-banner-close:hover {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.15);
+}


### PR DESCRIPTION
## 改了什么
- `static/app.js`：`_renderOfflineBanner()` 改为构造 `<span>文字</span> + <button>×</button>`，点击写入 `sessionStorage.offlineBannerDismissed` 并移除横幅；渲染时先检查该标记
- `static/style.css`：`#offline-banner-close` 绝对定位在右侧，悬停加淡白底

## 为什么用 sessionStorage 而不是 localStorage
永久隐藏会让人几天后忘了自己在离线模式，纳闷 Regenerate 按钮为什么不见了。关掉标签页重开就会再次提醒。

## 怎么测试
`bash run.offline.sh` → 打开 http://localhost:8001 → 点右上角 × → 横幅消失；刷新仍隐藏；重开标签页又出现。

Closes #621