### PR TITLE
浏览页 Leeched 列表支持一键取消难词标记（#623）

### DIFF
--- a/database/browse.py
+++ b/database/browse.py
@@ -123,6 +123,40 @@ def mark_leech_suspend(card_id: int) -> None:
     conn.close()
 
 
+_CLEAR_LEECH_SQL = """
+    UPDATE cards
+       SET is_leech = 0, lapses = 0, learning_again_count = 0, probation = 0,
+           state = CASE WHEN state = 'suspended' THEN COALESCE(pre_suspend_state, 'new') ELSE state END,
+           pre_suspend_state = NULL
+     WHERE is_leech = 1 AND deleted_at IS NULL
+"""
+
+
+def clear_leech(card_id: int) -> dict:
+    """Clear a card's leech flag, restoring it from the leech suspension.
+
+    Mirrors what unsuspending a leech does in toggle_card_suspension: the Again
+    counters are reset so the card does not immediately trip the threshold again.
+    """
+    conn = get_db()
+    conn.execute(_CLEAR_LEECH_SQL + " AND id = ?", (card_id,))
+    conn.commit()
+    conn.close()
+    return get_card(card_id)
+
+
+def bulk_clear_leech_by_words(word_ids: list[int]) -> int:
+    """Clear the leech flag on every leeched card of the given words."""
+    if not word_ids:
+        return 0
+    conn = get_db()
+    ph = ','.join('?' * len(word_ids))
+    cur = conn.execute(_CLEAR_LEECH_SQL + f" AND word_id IN ({ph})", word_ids)
+    conn.commit()
+    conn.close()
+    return cur.rowcount
+
+
 def toggle_card_suspension(card_id: int) -> dict:
     """Toggle a card between suspended and new.
 

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -396,6 +396,23 @@ def leech_card_endpoint(card_id: int):
     return database.get_card(card_id)
 
 
+@router.post("/api/cards/{card_id}/unleech")
+def unleech_card_endpoint(card_id: int):
+    """Clear a card's leech flag and restore it from the leech suspension."""
+    card = database.clear_leech(card_id)
+    if not card:
+        raise HTTPException(status_code=404, detail="Card not found")
+    _queue_mgr.invalidate()
+    return card
+
+
+@router.post("/api/cards/bulk-unleech")
+def bulk_unleech(body: dict):
+    count = database.bulk_clear_leech_by_words(body.get("word_ids", []))
+    _queue_mgr.invalidate()
+    return {"ok": True, "count": count}
+
+
 @router.post("/api/cards/{card_id}/reset")
 def reset_card_endpoint(card_id: int):
     return database.reset_card(card_id)

--- a/static/app.js
+++ b/static/app.js
@@ -1896,6 +1896,10 @@ function _wordRow(w) {
     rightHtml =
       `<button class="bw-saved-btn" onclick="event.stopPropagation();savedGenerate(${w.id},this)" title="Generate content with AI">✨ Generate</button>` +
       `<button class="bw-saved-btn bw-saved-promote" onclick="event.stopPropagation();savedPromote(${w.id},this)" title="Add to tomorrow's Daily deck">→ Add to Daily</button>`;
+  } else if (_browseCardStatus === 'leech' && w.cards.some(c => c.is_leech)) {
+    rightHtml =
+      `<button class="bw-unleech-btn" onclick="event.stopPropagation();browseUnleechWord(${w.id},this)"` +
+      ` title="Clear the leech flag and unsuspend">✓ Unleech</button>`;
   } else if (w.cards.length === 0) {
     rightHtml = `<button class="bw-add-btn" onclick="openAddToDeckModal(event,${w.id})" title="添加到牌组">＋ 添加</button>`;
   } else {
@@ -1921,6 +1925,22 @@ function _wordRow(w) {
       </div>
       <div class="bw-right">${rightHtml}</div>
     </div>`;
+}
+
+// Clear the leech flag on every leeched card of a word (Leeched list, single row).
+async function browseUnleechWord(wordId, btn) {
+  btn.disabled = true;
+  const orig = btn.textContent;
+  btn.textContent = '…';
+  try {
+    await api('POST', '/api/cards/bulk-unleech', { word_ids: [wordId] });
+    await _browseReload();
+    showQuickAddBanner('✓ Leech cleared', false);
+  } catch (e) {
+    btn.disabled = false;
+    btn.textContent = orig;
+    showError('Unleech failed: ' + e.message);
+  }
 }
 
 // Generate AI content for a saved word (stays in the Saved list, now filled in).
@@ -2012,6 +2032,15 @@ async function browseActionSuspend() {
     await api('POST', '/api/cards/bulk-suspend', { word_ids });
     await _browseReload();
   } catch (e) { showError('Suspend failed: ' + e.message); }
+}
+
+async function browseActionUnleech() {
+  const word_ids = [..._browseSelected];
+  try {
+    const r = await api('POST', '/api/cards/bulk-unleech', { word_ids });
+    await _browseReload();
+    showQuickAddBanner(`✓ Leech cleared on ${r.count} card${r.count === 1 ? '' : 's'}`, false);
+  } catch (e) { showError('Unleech failed: ' + e.message); }
 }
 
 async function browseActionDelete() {

--- a/static/index.html
+++ b/static/index.html
@@ -379,6 +379,7 @@
         <div class="ba-actions">
           <button onclick="browseActionBury()">Bury</button>
           <button onclick="browseActionSuspend()">Suspend</button>
+          <button onclick="browseActionUnleech()" title="Clear the leech flag and unsuspend">Unleech</button>
           <span class="ba-move-wrap">
             <button onclick="toggleBrowseMovePanel()">Move to…</button>
             <span id="ba-move-panel" style="display:none">

--- a/static/style.css
+++ b/static/style.css
@@ -2570,6 +2570,20 @@ a.news-source-line:hover {
 }
 .bw-add-btn:hover { background: #dbeafe; }
 
+/* Leeched-list per-row action: clear the leech flag */
+.bw-unleech-btn {
+  font-size: 11px;
+  background: none;
+  border: 1px solid #16a34a;
+  color: #16a34a;
+  border-radius: 4px;
+  padding: 2px 7px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.bw-unleech-btn:hover:not(:disabled) { background: #dcfce7; }
+.bw-unleech-btn:disabled { opacity: 0.5; cursor: default; }
+
 /* Saved-list per-row actions: Generate content / Add to Daily */
 .bw-saved-btn {
   font-size: 11px;

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -257,3 +257,72 @@ class TestSpeak:
             r = client.post("/api/speak", params={"text": "你好"})
 
         assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# POST /api/cards/{card_id}/unleech  +  POST /api/cards/bulk-unleech  (#623)
+# ---------------------------------------------------------------------------
+
+class TestUnleech:
+    """Clearing the leech flag straight from the Browse window."""
+
+    def _leeched_card(self, deck_id, word_zh="你好"):
+        """Return a card of that word, suspended and flagged as a leech."""
+        word_id = next(w["id"] for w in database.get_words_for_browse()
+                       if w["word_zh"] == word_zh)
+        card = next(c for c in database.get_cards_for_word(word_id))
+        conn = database.core.get_db()
+        conn.execute(
+            "UPDATE cards SET state='review', lapses=5, learning_again_count=7 WHERE id=?",
+            (card["id"],),
+        )
+        conn.commit()
+        conn.close()
+        database.mark_leech_suspend(card["id"])
+        return word_id, card["id"]
+
+    def test_unleech_restores_pre_suspend_state_and_resets_counters(self, populated_db):
+        word_id, card_id = self._leeched_card(populated_db)
+        assert database.get_card(card_id)["state"] == "suspended"
+
+        r = client.post(f"/api/cards/{card_id}/unleech")
+
+        assert r.status_code == 200
+        card = database.get_card(card_id)
+        assert card["is_leech"] == 0
+        # Restored to what it was before the leech suspend, not blindly to 'new'.
+        assert card["state"] == "review"
+        assert card["lapses"] == 0
+        assert card["learning_again_count"] == 0
+
+    def test_unleech_leaves_non_leech_cards_alone(self, populated_db):
+        """A suspended card that is not a leech must keep its suspension."""
+        word_id = next(w["id"] for w in database.get_words_for_browse()
+                       if w["word_zh"] == "谢谢")
+        card_id = database.get_cards_for_word(word_id)[0]["id"]
+        database.suspend_card(card_id)
+
+        client.post(f"/api/cards/{card_id}/unleech")
+
+        assert database.get_card(card_id)["state"] == "suspended"
+
+    def test_unleech_unknown_card_returns_404(self, populated_db):
+        assert client.post("/api/cards/999999/unleech").status_code == 404
+
+    def test_bulk_unleech_clears_every_leeched_card_of_the_words(self, populated_db):
+        word_id, card_id = self._leeched_card(populated_db)
+        other_id = [c["id"] for c in database.get_cards_for_word(word_id)
+                    if c["id"] != card_id][0]
+        database.mark_leech_suspend(other_id)
+
+        r = client.post("/api/cards/bulk-unleech", json={"word_ids": [word_id]})
+
+        assert r.status_code == 200
+        assert r.json()["count"] == 2
+        for cid in (card_id, other_id):
+            assert database.get_card(cid)["is_leech"] == 0
+            assert database.get_card(cid)["state"] != "suspended"
+
+    def test_bulk_unleech_with_no_words_is_a_noop(self, populated_db):
+        r = client.post("/api/cards/bulk-unleech", json={"word_ids": []})
+        assert r.json() == {"ok": True, "count": 0}


### PR DESCRIPTION
## 改了什么

在 Browse 的 **Leeched** 列表里可以直接取消难词标记，不用再逐个打开词条详情。

- **每行一个 `✓ Unleech` 按钮**（只在 Leeched 过滤器下、且该词确有 leech 卡片时显示）
- **多选操作栏加了 `Unleech` 批量按钮**
- 后端 `database.clear_leech(card_id)` / `bulk_clear_leech_by_words(word_ids)`：清除 `is_leech`，把因难词而暂停的卡片按 `COALESCE(pre_suspend_state,'new')` 恢复，并把 `lapses`/`learning_again_count`/`probation` 归零——与现有解除暂停（`toggle_card_suspension`）的行为保持一致，避免刚恢复就再次触发阈值
- 新接口 `POST /api/cards/{card_id}/unleech`（卡片不存在返回 404）与 `POST /api/cards/bulk-unleech`，两者都 invalidate 队列缓存，因为恢复的卡片会重新进入到期队列

## 为什么

只点 L/R/C 圆点不够：`toggle_card_suspension` 只在卡片处于 suspended 时才顺带清 `is_leech`；`leech_action='tag'` 的卡片点圆点反而会被暂停。所以需要一个语义明确的"取消难词"操作。

## 怎么测试

- `pytest tests/` → 163 通过（新增 `TestUnleech` 5 个用例：恢复暂停前状态+计数归零、非难词的暂停卡不受影响、404、批量清除、空列表 noop）
- 手动：Browse → Leeched → 点某行 Unleech，该行从列表消失，卡片恢复可复习

Closes #623