### PR TITLE
本地模式：有网时全功能 + 一键同步（#625）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,27 +124,38 @@ Daniel 在中国需要 VPN 访问 GitHub。`gh` 命令报 `EOF` 错误时（`cur
 
 ---
 
-## 离线模式（2026-08-02，议题 #612）
+## 笔记本模式：本地 + 离线（议题 #612、#625）
 
-飞机上／没网时在笔记本上复习。**服务器永远是主库**，笔记本只是临时副本。
+笔记本上跑一份完整的应用，像 Anki 桌面版。**服务器永远是主库**，笔记本是副本。
 
 ```bash
-bash sync_offline.sh pull    # 起飞前（要有网）：拉数据库 + TTS 音频
-bash run.offline.sh          # 飞机上：http://localhost:8001
-bash sync_offline.sh push    # 落地后（要有网）：把复习结果合并回服务器
+bash run.local.sh            # 日常（2026-08-04 起，#625）：有网全功能，断网自动降级
+bash run.offline.sh          # 飞机上：硬离线，连探测都不做
+# 同步：界面顶栏 ⟳ 按钮，或者命令行
+bash sync_offline.sh sync    # 日常：先推后拉，一步到位
+bash sync_offline.sh pull    # 只拉不推（放弃本地改动）
+bash sync_offline.sh push    # 只推不拉，推完归档本地库
 ```
 
-- **`OFFLINE_MODE=1`（`offline.py`）**：隐含 `DISABLE_AI`；TTS 只读 `data/tts/` 缓存，未命中抛 `tts.NotCachedOffline` → `/api/tts-file` 返回 404。**关键**：无网时 edge-tts 的 WebSocket 会挂到超时，拖死整个请求，所以缓存未命中必须立刻失败
+两种模式共用 `data/offline.db`，在家同步好直接带上飞机。
+
+- **`LOCAL_MODE=1`（`run.local.sh`，#625）**：日常实例。有网时 AI 故事、edge-tts 生成、翻译全部可用；断网后自动降级成下面 `OFFLINE_MODE` 的行为，**不用重启**。判断靠 `offline.network_available()`：带缓存的 TCP 探测（在线缓存 60 秒、离线 10 秒，超时 1.5 秒，探测目标 `LOCAL_MODE_PROBE_HOSTS`，默认 DeepSeek + Bing 语音端点——在中国不用 VPN 就能连）
+- **`ai_disabled()` 必须是函数不能是常量**：原来 `routes/utils.DISABLE_AI` 是模块级常量，进程启动时就冻死了，本地模式下 Wi-Fi 回来也解不开。改函数时 story/review/podcast 的调用点都要跟着改
+- **`OFFLINE_MODE=1`（`run.offline.sh`）**：飞机专用的硬开关，保留不变——需要"绝不发出站连接"的保证，连探测都不做。隐含 `DISABLE_AI`；TTS 只读 `data/tts/` 缓存，未命中抛 `tts.NotCachedOffline` → `/api/tts-file` 返回 404。**关键**：无网时 edge-tts 的 WebSocket 会挂到超时，拖死整个请求，所以缓存未命中必须立刻失败
 - 故事沿用同步下来的那一份（`DISABLE_AI` 分支本来就是"有缓存就返回、没有就返回 None"）；Again 单句重生成自动跳过
-- `GET /api/mode` → `{offline}`，前端据此显示顶部横幅并隐藏两个 Regenerate 按钮
+- `GET /api/mode` → `{offline, local, hard_offline}`；`offline` 是**实时值**，本地模式下前端每 60 秒轮询一次，翻转时重放 `showView(_currentView)` 让 Regenerate 按钮跟着出现/消失
+- **界面一键同步（#625）**：顶栏 ⟳ 按钮 →`POST /api/sync/start[?mode=sync|pull]` 起后台线程跑 `sync_offline.sh`，`GET /api/sync/progress` 逐行回传脚本的中文分步日志，成功后失效队列缓存 + 重读日界点 + 清空探测缓存，前端整页刷新（库文件已经被换掉了）。**这两个路由只在 `LOCAL_MODE`/`OFFLINE_MODE` 下注册**（`main.py`）——服务器上必须根本不存在，误调一次就会用某份笔记本快照覆盖生产
+- **合并被拒时要有出路**：无令牌（手工拷贝的库）或令牌已轮换（推过一次了）时 merge 会拒绝，这是对的，但用户会永远卡住。`mode=pull` 是逃生口：只下载、覆盖本地。前端只在日志里出现 `sync token` 时才显示 ⤓ 按钮，并用 `showConfirm` 明说未同步的复习会丢失
 - `PORT` 环境变量（默认 8000）让离线实例跑 8001，不占用 Daniel 浏览器连的端口
 - **同步只合并 `cards` + `review_log` 两张表**（`scripts/offline_sync_server.py`，纯标准库，通过 ssh stdin 管道执行，不依赖服务器已部署该版本）。离线期间服务器 cron 仍在写入（播客单集、预生成故事、成本日志），整库对拷会毁掉这些数据——**绝不整库覆盖**
 - **同步令牌**（`app_settings.offline_sync_token`）：`pull` 时写入服务器并随快照带走，`push` 时两边必须一致，合并后轮换 → 同一份离线库无法重复 push；手工拷贝的库没有令牌，直接拒绝
+- **冲突按 `cards.last_review` 谁晚谁赢**（#625）：原来笔记本无条件覆盖服务器，飞机上没问题，但本地模式变日常后，手机上复习完再一同步就静默丢进度。`review_log` 两边的记录始终都保留，所以调度输了的那次复习仍然进统计
+- **下载先落 `.incoming` 再 `mv` 就位**（#625）：应用可能正开着这个库，`scp` 直接覆盖会让它好几秒读到写了一半的文件；rename 是原子的。换库后还要删掉可能残留的 `-wal`/`-shm`/`-journal`，旧日志套新库会直接损坏数据
 - **传输量优化**（实测链路 ~2.7 MB/s，整个 pull 十几秒；这两项优化仍然保留，只是并非为了救命）：
   - 快照**瘦身**：`prepare` 在快照上（不动生产库）清空 `api_call_log`、`podcast_episodes.transcript_*`、`stories.prompt_text` 再 VACUUM → 29.6 MB 降到 18.5 MB。`prepare … --full` 可保留全部
   - 音频**按需**：`scripts/offline_tts_manifest.py` 从拉下来的库算出真正会用到的语音（故事句子 `sentence_zh` + 到期词 `word_zh`，前端只请求这两种），再与服务器实际存在的文件取交集 → 一百多个文件 / 几 MB，而不是整个 118 MB 的 `data/tts/`。**必须取交集**，否则 rsync 会为缺失文件返回非零码，`set -e` 会中断整个脚本
 - **中文提示里紧跟变量必须写 `${VAR}`**：`"…下载到 $LOCAL_DB（约 7 MB）"` 会让 bash 把全角括号的字节也算进变量名，配合 `set -u` 直接退出（#619）。这个仓库的脚本提示全是中文，极易踩
-- **脚本改动必须实机跑一遍，`bash -n` 不够**：它只查语法，`set -u` 的 unbound variable、选项不被支持（#617）都要到运行时才暴露。离线同步脚本可以用 `ANKI_REMOTE_DIR=/tmp/xxx` 指向服务器上的一份副本来安全演练 push
+- **脚本改动必须实机跑一遍，`bash -n` 不够**：它只查语法，`set -u` 的 unbound variable、选项不被支持（#617）都要到运行时才暴露。离线同步脚本用 `ANKI_REMOTE_DIR=/tmp/xxx`（服务器上的副本靶子）+ `ANKI_LOCAL_DB=/tmp/yyy.db`（临时本地库）就能安全演练，**两个都要设**——只设前者会给真的 `data/offline.db` 盖上演练令牌，之后它再也推不回生产库了
 - **rsync 只能用两边都支持的选项**：脚本跑在 Daniel 的 macOS 上，系统自带的是 **openrsync**，不认 GNU 的 `--info=progress2`（#617 因此挂掉）。用 `--progress`。凡是只在服务器上验证过的命令，都要想一想 Mac 上是不是同一个实现
 - 测试见 `tests/test_offline_sync.py`
 
@@ -166,15 +177,17 @@ bash sync_offline.sh push    # 落地后（要有网）：把复习结果合并�
 ├── news_fetcher.py        # 新闻抓取（Tagesschau API + RSS；按天缓存 data/news_cache/）
 ├── podcast.py              # 播客爬虫（#479）：播客 RSS 直链发现新单集（#497，退役 YouTube/yt-dlp）、每源 auto_process 开关+非自动源只入库元数据（#502，podcast_feeds 表）、转录链 NotebookLM 免费主力+听悟+Whisper 保底、单步异常不中止整链（#510 重排，链式降级，原 #498/#485/#486）、摘要 NotebookLM chat.ask 免费优先+DeepSeek/gpt API 链回退（api 路径内部 DeepSeek 优先省钱，#532）、HSK生词、邮件通知+Signal 通知（signal-cli 关联设备，发 Note to Self，#521，二者独立可选、互不影响；消息抬头播客名·星期·日期、链接在末尾，单集日期按 Europe/Berlin 显示，#532）、摘要 table.media 风格（`<p>` 段落+每段首句 `<b>` 加粗总结，#567）+详情页 Regenerate summary 按钮
 ├── tts.py                 # edge-tts 封装（离线模式下只读缓存，#612）
-├── offline.py             # OFFLINE_MODE 全局开关（#612）
-├── sync_offline.sh        # 离线同步 pull/push（#612）
-├── run.offline.sh         # 离线启动（#612）
+├── offline.py             # OFFLINE_MODE / LOCAL_MODE + 联网探测（#612、#625）
+├── sync_offline.sh        # 同步 sync/pull/push（#612、#625）
+├── run.offline.sh         # 硬离线启动，飞机用（#612）
+├── run.local.sh           # 本地模式启动，日常用（#625）
 ├── translator.py          # 翻译（Google Translate，deep-translator，可选）
 ├── yaml_fixer.py          # 修复 AI 生成的格式错误 YAML
 ├── schema.sql             # 数据库模式
 ├── static/                # 前端（index.html + app.js + style.css）
 ├── routes/                # FastAPI 路由模块
 │   ├── browse.py / decks.py / imports.py / review.py / story.py / podcast.py
+│   ├── sync.py            # 一键同步（#625，只在笔记本实例注册）
 │   ├── queue_manager.py   # Anki v3 风格持久会话队列
 │   └── utils.py           # 共用工具（DISABLE_AI, leaf_ids, queue_manager 单例）
 ├── requirements.txt       # Python 依赖清单
@@ -310,7 +323,11 @@ POST   /api/decks ；PUT/DELETE /api/decks/{id}       → 创建 / 重命名 / �
 GET/PUT /api/decks/{id}/preset                       → 预设（yùshè - preset）设置
 GET/POST /api/presets ；DELETE /api/presets/{id}
 GET    /api/langs                                    → 当前使用的语言列表
-GET    /api/mode                                     → {offline}（#612，前端据此显示离线横幅）
+GET    /api/mode                                     → {offline, local, hard_offline}（#612/#625；offline 是实时值，本地模式下每 60 秒轮询）
+
+# 一键同步（#625，只在 LOCAL_MODE/OFFLINE_MODE 下注册；服务器上返回 404）
+POST   /api/sync/start[?mode=sync|pull]              → 后台跑 sync_offline.sh，立即返回；重复提交 409
+GET    /api/sync/progress                            → {running, lines[], ok, error, started_at, finished_at}
 
 # 垃圾桶
 GET  /api/trash ；POST /api/trash/{deck_id}/restore
@@ -387,7 +404,10 @@ python main.py status [--deck X]     # 显示每个牌组/类别的到期数量
 | `OPENAI_API_KEY` | 可选 | 新闻模式默认模型 `gpt-5-mini`（DeepSeek 会审查新闻，故用 OpenAI） |
 | `DB_PATH` | `data/srs.db` | 数据库路径（开发用 `data/dev.db`） |
 | `DISABLE_AI` | `0` | 设为 `1` 跳过 AI 故事生成 |
-| `OFFLINE_MODE` | `0` | 设为 `1` 进入离线模式（#612）：隐含 `DISABLE_AI`，TTS 只读缓存，零网络请求 |
+| `OFFLINE_MODE` | `0` | 设为 `1` 进入硬离线模式（#612）：隐含 `DISABLE_AI`，TTS 只读缓存，零网络请求，连探测都不做 |
+| `LOCAL_MODE` | `0` | 设为 `1` 进入本地模式（#625）：有网全功能，断网自动降级为离线行为 |
+| `LOCAL_MODE_PROBE_HOSTS` | `api.deepseek.com,speech.platform.bing.com` | 本地模式判断有没有网时探测的主机（443 端口，任一连通即算在线） |
+| `ANKI_LOCAL_DB` | `data/offline.db` | 同步脚本的本地库路径；配合 `ANKI_REMOTE_DIR` 做演练时必须一起设 |
 | `PORT` | `8000` | 服务监听端口（`run.offline.sh` 用 8001） |
 | `LOG_LEVEL` | `INFO` | 日志级别（`DEBUG` 输出详细日志） |
 | `DEV_CLEAR_DB` | `` | 设为任意值启动时清空数据库——生产环境绝不要设置 |

--- a/main.py
+++ b/main.py
@@ -193,6 +193,7 @@ try:
     from starlette.middleware.gzip import GZipMiddleware
     import uvicorn
 
+    from offline import LOCAL_MODE, OFFLINE_MODE
     from routes import decks, review, story, browse, imports, podcast as podcast_routes
 
     @asynccontextmanager
@@ -376,6 +377,11 @@ try:
     app.include_router(browse.router)
     app.include_router(imports.router)
     app.include_router(podcast_routes.router)
+    # Sync only makes sense on a laptop copy — on the server these routes must
+    # not exist at all, or a stray call would overwrite production (#625).
+    if LOCAL_MODE or OFFLINE_MODE:
+        from routes import sync as sync_routes
+        app.include_router(sync_routes.router)
 
     import threading
     import time

--- a/offline.py
+++ b/offline.py
@@ -1,23 +1,102 @@
-"""Offline mode flag (issue #612).
+"""Local / offline mode flags (issues #612, #625).
 
-Set OFFLINE_MODE=1 (see run.offline.sh) to run the app on a laptop with no
-network at all — on a flight, for example. In this mode the app must never
-open an outbound connection, because a hanging socket blocks the whole
-request for as long as its timeout lasts.
+Two different laptop modes, plus the server's normal mode:
 
-What it turns off:
+  OFFLINE_MODE=1  (run.offline.sh)  — hard offline, for a flight.
+      The app must never open an outbound connection, because a hanging
+      socket blocks the whole request for as long as its timeout lasts.
+      Not even the connectivity probe below runs.
+
+  LOCAL_MODE=1    (run.local.sh)    — the everyday laptop instance.
+      Fully featured while the network is up (AI stories, edge-tts
+      generation, translation), and degrades to the OFFLINE_MODE behaviour
+      by itself once the network goes away. Reachability is decided by a
+      cached TCP probe rather than by a flag, so pulling the Wi-Fi plug is
+      handled without a restart.
+
+  neither                           — the server. Always considered online.
+
+What "offline" turns off, in both laptop modes:
   - AI calls of every kind (implies DISABLE_AI — see routes/utils.py)
   - edge-tts generation: data/tts/ is served read-only, a cache miss is a
     fast 404 instead of a WebSocket attempt (see tts.py)
   - news fetching, translation, podcast processing (all AI/HTTP paths)
 
-Everything already stored in the local database still works: reviews,
+Everything stored in the local database still works either way: reviews,
 scheduling, browsing, stats, and any story + audio synced down beforehand.
 
-This module deliberately has no imports beyond os so that anything can
+This module deliberately imports nothing from the app so that anything can
 import it without creating a cycle.
 """
 
 import os
+import socket
+import threading
+import time
 
 OFFLINE_MODE = os.getenv("OFFLINE_MODE", "").lower() in ("1", "true", "yes")
+LOCAL_MODE = os.getenv("LOCAL_MODE", "").lower() in ("1", "true", "yes")
+
+# Any one of these answering on 443 means "the network is usable". DeepSeek
+# covers the AI path and the Bing endpoint covers edge-tts; both are reachable
+# from China without a VPN, which the GitHub/Google hosts are not.
+_PROBE_HOSTS = [
+    h.strip() for h in os.getenv(
+        "LOCAL_MODE_PROBE_HOSTS", "api.deepseek.com,speech.platform.bing.com"
+    ).split(",") if h.strip()
+]
+_PROBE_PORT = 443
+_PROBE_TIMEOUT = 1.5
+
+# Asymmetric on purpose: while online we can afford a stale answer for a
+# minute, but once offline we want to notice the Wi-Fi coming back quickly.
+_TTL_ONLINE = 60.0
+_TTL_OFFLINE = 10.0
+
+_probe_lock = threading.Lock()
+_probe_cache: tuple[bool, float] | None = None   # (online, expires_at)
+
+
+def _probe() -> bool:
+    for host in _PROBE_HOSTS:
+        try:
+            socket.create_connection((host, _PROBE_PORT), _PROBE_TIMEOUT).close()
+            return True
+        except OSError:
+            continue
+    return False
+
+
+def network_available() -> bool:
+    """True if an outbound connection is likely to succeed.
+
+    Only ever probes in LOCAL_MODE. The server answers True without touching
+    the network, and a hard-offline instance answers False the same way.
+    The probe runs under a lock so a burst of concurrent requests waits for
+    one probe instead of starting a dozen.
+    """
+    if OFFLINE_MODE:
+        return False
+    if not LOCAL_MODE:
+        return True
+    global _probe_cache
+    with _probe_lock:
+        now = time.monotonic()
+        if _probe_cache is not None and now < _probe_cache[1]:
+            return _probe_cache[0]
+        online = _probe()
+        _probe_cache = (online, now + (_TTL_ONLINE if online else _TTL_OFFLINE))
+        return online
+
+
+def is_offline() -> bool:
+    """True when no outbound call may be attempted. The check every caller wants."""
+    return not network_available()
+
+
+def invalidate_network_cache() -> None:
+    """Force the next network_available() to probe again — called after a sync,
+    when the user has just demonstrated that the network works."""
+    global _probe_cache
+    with _probe_lock:
+        _probe_cache = None

--- a/podcast.py
+++ b/podcast.py
@@ -892,8 +892,8 @@ def fetch_transcript(video: dict) -> tuple[str | None, dict]:
         logger.info("podcast: transcriber=off, skipping transcription for %s", video_id)
         return None, meta
 
-    from routes.utils import DISABLE_AI
-    if DISABLE_AI:
+    from routes.utils import ai_disabled
+    if ai_disabled():
         # Dev mode must never trigger transcription (Tingwu/Whisper cost
         # money; NotebookLM is free but still an external side effect).
         logger.info("podcast: DISABLE_AI set, skipping transcription for %s", video_id)
@@ -1326,7 +1326,7 @@ def _process_episode(episode_id: int, video: dict, detail_level: str, summary: d
     summary['failed'] (a missing transcript is 'no_transcript', not a
     failure); success bumps summary['summarized'] / summary['emailed'].
     """
-    from routes.utils import DISABLE_AI
+    from routes.utils import ai_disabled
 
     label = f"Transcribe & Summarize: {video['title'][:30]}"
     with database.action_context(label):
@@ -1364,7 +1364,7 @@ def _process_episode(episode_id: int, video: dict, detail_level: str, summary: d
                     transcript_source=meta.get("transcript_source"),
                 )
 
-            if DISABLE_AI:
+            if ai_disabled():
                 # Dev mode: stop at pending with the transcript stored, no AI
                 # call, no email — matches DISABLE_AI's behavior for stories.
                 return

--- a/routes/decks.py
+++ b/routes/decks.py
@@ -4,7 +4,7 @@ import database
 import languages
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-from offline import OFFLINE_MODE
+from offline import LOCAL_MODE, OFFLINE_MODE, is_offline
 from .utils import queue_mgr
 
 logger = logging.getLogger(__name__)
@@ -94,12 +94,19 @@ def _attach_counts(flat_decks: list) -> None:
 
 @router.get("/api/mode")
 def get_mode():
-    """Runtime flags the frontend needs to know about (issue #612).
+    """Runtime flags the frontend needs to know about (issues #612, #625).
 
-    offline=True means this instance has no network: the UI hides everything
-    that would trigger an AI call and shows the offline banner instead.
+    offline=True means no outbound call can be made right now: the UI hides
+    everything that would trigger an AI call and shows the offline banner.
+    In LOCAL_MODE this flips by itself as the network comes and goes, so the
+    frontend re-polls this endpoint periodically.
+
+    local=True marks a laptop instance, which is what makes the sync button
+    appear; hard_offline=True additionally means the flag was forced for a
+    flight, so no probing happens at all.
     """
-    return {"offline": OFFLINE_MODE}
+    return {"offline": is_offline(), "local": LOCAL_MODE or OFFLINE_MODE,
+            "hard_offline": OFFLINE_MODE}
 
 
 @router.get("/api/langs")

--- a/routes/review.py
+++ b/routes/review.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, HTTPException
 import database
 import srs
 import tts
-from .utils import leaf_ids, queue_mgr as _queue_mgr, DISABLE_AI
+from .utils import leaf_ids, queue_mgr as _queue_mgr, ai_disabled
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -40,7 +40,7 @@ def _attach_again_sentence(card: dict | None) -> dict | None:
 def _spawn_again_regen(card: dict) -> None:
     """Fire-and-forget: regenerate one fresh sentence for this word in the
     background so the card shows something new when it reappears (~1-10 min)."""
-    if DISABLE_AI or card.get("note_type") == "sentence" or not card.get("word_id"):
+    if ai_disabled() or card.get("note_type") == "sentence" or not card.get("word_id"):
         return
     # All three vocab categories use story sentences (listening audio, reading text,
     # creating cloze/word-bank), so regenerate a fresh sentence for any of them.

--- a/routes/story.py
+++ b/routes/story.py
@@ -16,7 +16,7 @@ import tts
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse
 
-from .utils import DISABLE_AI, leaf_ids, queue_mgr
+from .utils import ai_disabled, leaf_ids, queue_mgr
 
 KAHNEMAN_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "kahneman_chapters.json")
 
@@ -578,7 +578,7 @@ def get_story(deck_id: int, category: str,
         logger.info("story  NO-GEN (no_generate=1) deck=%d cat=%s — no cached story", deck_id, category)
         return None
 
-    if DISABLE_AI:
+    if ai_disabled():
         logger.info("story  DISABLED (DISABLE_AI=1) deck=%d cat=%s", deck_id, category)
         return None
 
@@ -651,7 +651,7 @@ def regenerate_story(deck_id: int, category: str,
     episode_id's German summary directly, no articles involved (reworked #561).
     mode="news" (the old auto-fetch-only mode) has been removed (issue #512) and
     is rejected."""
-    if DISABLE_AI:
+    if ai_disabled():
         return None
     chosen_model = _validated_model(model)
     today = database.anki_today().isoformat()
@@ -1146,7 +1146,7 @@ async def pregen_today():
     skipped_no_due: list[str] = []
     failed: list[dict] = []
 
-    if DISABLE_AI:
+    if ai_disabled():
         logger.info("pregen-today  DISABLED (DISABLE_AI=1), %d candidate keys skipped", len(keys))
         skipped_no_due = [f"{k['deck_id']}/{k['category']}/{k['lang']}" for k in keys]
         return {"date": today, "keys": len(keys), "generated": generated,

--- a/routes/sync.py
+++ b/routes/sync.py
@@ -51,12 +51,12 @@ def _append(line: str) -> None:
             _state["lines"].append("…（输出过长，后续行已省略）")
 
 
-def _run_sync() -> None:
+def _run_sync(action: str) -> None:
     ok = False
     error = None
     try:
         proc = subprocess.Popen(
-            ["bash", "sync_offline.sh", "sync"],
+            ["bash", "sync_offline.sh", action],
             cwd=REPO_ROOT, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
             text=True, bufsize=1,
         )
@@ -82,16 +82,26 @@ def _run_sync() -> None:
 
 
 @router.post("/api/sync/start")
-def start_sync():
-    """Kick off a push-then-pull sync. Returns immediately; poll /api/sync/progress."""
+def start_sync(mode: str = "sync"):
+    """Kick off a sync. Returns immediately; poll /api/sync/progress.
+
+    mode='sync'  push local reviews, then pull the fresh database (the normal path)
+    mode='pull'  download only, discarding whatever is in the local database.
+                 The escape hatch for a local copy the server refuses to merge —
+                 no sync token (it never came from a pull) or a rotated one (it
+                 was already pushed). Merging those is correctly refused, but
+                 without this the button would be stuck failing forever.
+    """
+    if mode not in ("sync", "pull"):
+        raise HTTPException(400, f"unknown sync mode {mode!r}")
     with _lock:
         if _state["running"]:
             raise HTTPException(409, "A sync is already running")
         _state.update(running=True, lines=[], ok=None, error=None,
                       started_at=datetime.now().isoformat(timespec="seconds"),
                       finished_at=None)
-    threading.Thread(target=_run_sync, daemon=True).start()
-    return {"started": True}
+    threading.Thread(target=_run_sync, args=(mode,), daemon=True).start()
+    return {"started": True, "mode": mode}
 
 
 @router.get("/api/sync/progress")

--- a/routes/sync.py
+++ b/routes/sync.py
@@ -1,0 +1,107 @@
+"""One-click sync with the server (issue #625) — laptop instances only.
+
+The heavy lifting stays in sync_offline.sh: it already knows the ssh/scp/rsync
+incantations and prints numbered Chinese progress steps. This module runs that
+script in a background thread and streams its output to the frontend, so the
+button shows exactly what the terminal would have shown.
+
+These routes are registered only when LOCAL_MODE or OFFLINE_MODE is set (see
+main.py). On the server they do not exist at all — syncing "the server with
+itself" is meaningless, and the script would happily overwrite production.
+"""
+
+import logging
+import os
+import subprocess
+import threading
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException
+
+import database
+from offline import invalidate_network_cache
+
+from .utils import queue_mgr
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Enough to hold a full run's output; the tts step is the only chatty one and
+# it prints a handful of lines now that --progress is off for pipes.
+_MAX_LINES = 2000
+
+_lock = threading.Lock()
+_state: dict = {
+    "running": False,
+    "lines": [],
+    "ok": None,          # None while running, then True/False
+    "error": None,
+    "started_at": None,
+    "finished_at": None,
+}
+
+
+def _append(line: str) -> None:
+    with _lock:
+        if len(_state["lines"]) < _MAX_LINES:
+            _state["lines"].append(line)
+        elif len(_state["lines"]) == _MAX_LINES:
+            _state["lines"].append("…（输出过长，后续行已省略）")
+
+
+def _run_sync() -> None:
+    ok = False
+    error = None
+    try:
+        proc = subprocess.Popen(
+            ["bash", "sync_offline.sh", "sync"],
+            cwd=REPO_ROOT, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, bufsize=1,
+        )
+        for line in proc.stdout:
+            _append(line.rstrip("\n"))
+        code = proc.wait()
+        ok = code == 0
+        if not ok:
+            error = f"同步脚本以退出码 {code} 结束"
+    except Exception as e:                       # noqa: BLE001 — surfaced to the UI
+        logger.exception("sync failed")
+        error = f"{type(e).__name__}: {e}"
+    finally:
+        if ok:
+            # The database file underneath us was just replaced, and the sync
+            # itself proved the network works.
+            queue_mgr.invalidate()
+            database.refresh_day_cutoff_hour()
+            invalidate_network_cache()
+        with _lock:
+            _state.update(running=False, ok=ok, error=error,
+                          finished_at=datetime.now().isoformat(timespec="seconds"))
+
+
+@router.post("/api/sync/start")
+def start_sync():
+    """Kick off a push-then-pull sync. Returns immediately; poll /api/sync/progress."""
+    with _lock:
+        if _state["running"]:
+            raise HTTPException(409, "A sync is already running")
+        _state.update(running=True, lines=[], ok=None, error=None,
+                      started_at=datetime.now().isoformat(timespec="seconds"),
+                      finished_at=None)
+    threading.Thread(target=_run_sync, daemon=True).start()
+    return {"started": True}
+
+
+@router.get("/api/sync/progress")
+def sync_progress():
+    with _lock:
+        return {
+            "running": _state["running"],
+            "lines": list(_state["lines"]),
+            "ok": _state["ok"],
+            "error": _state["error"],
+            "started_at": _state["started_at"],
+            "finished_at": _state["finished_at"],
+        }

--- a/routes/utils.py
+++ b/routes/utils.py
@@ -1,12 +1,21 @@
 import os
 
 import database
-from offline import OFFLINE_MODE
+from offline import is_offline
 from .queue_manager import QueueManager
 
 # Set DISABLE_AI=1 in run.dev.sh to skip story generation during development.
-# Offline mode (issue #612) implies it — no network, so no AI either.
-DISABLE_AI = OFFLINE_MODE or os.getenv("DISABLE_AI", "").lower() in ("1", "true", "yes")
+_DISABLE_AI_ENV = os.getenv("DISABLE_AI", "").lower() in ("1", "true", "yes")
+
+
+def ai_disabled() -> bool:
+    """True when no AI call may be made.
+
+    A function rather than a constant because LOCAL_MODE decides this at
+    request time: the laptop has AI while the Wi-Fi is up and loses it when
+    the network goes away, with no restart in between (#625).
+    """
+    return _DISABLE_AI_ENV or is_offline()
 
 # Shared singleton — imported by review.py and browse.py
 queue_mgr = QueueManager()

--- a/run.local.sh
+++ b/run.local.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# 本地模式启动（议题 #625）——笔记本上的日常实例，像 Anki 桌面版。
+#
+# 和 run.offline.sh 的区别：这个模式**有网就全功能**（AI 故事、edge-tts 生成、
+# 翻译都能用），断网后自动降级成只读缓存，不需要重启。
+# 飞机上请改用 run.offline.sh——那个模式连探测都不做，保证零出站连接。
+#
+# 数据库和离线模式共用 data/offline.db，所以在家同步好就能直接带上飞机。
+# 同步不再需要命令行：界面顶栏点同步按钮即可（也可以 bash sync_offline.sh sync）。
+set -e
+cd "$(dirname "$0")"
+
+if [ ! -f data/offline.db ]; then
+    echo "❌ 找不到 data/offline.db —— 还没从服务器同步过。"
+    echo "   先运行： bash sync_offline.sh sync"
+    exit 1
+fi
+
+# 需要 .env：本地模式要用 AI 密钥。但不加载 AUTH_*——本机 localhost 不需要 Basic Auth。
+if [ -f .env ]; then
+    set -a
+    # shellcheck disable=SC1091
+    source .env
+    set +a
+fi
+unset AUTH_USERNAME AUTH_PASSWORD
+
+PY=.venv/bin/python
+[ -x "$PY" ] || PY=python3
+
+echo "💻 本地模式启动中…"
+echo "    数据库： data/offline.db"
+echo "    地址：   http://localhost:8001"
+echo "    （有网时 AI 和语音生成全部可用；断网后自动降级为只读缓存）"
+echo
+
+LOCAL_MODE=1 DB_PATH=data/offline.db PORT=8001 "$PY" main.py

--- a/scripts/offline_sync_server.py
+++ b/scripts/offline_sync_server.py
@@ -138,10 +138,15 @@ def cmd_merge(prod_db: str, incoming_db: str) -> None:
     server_token = _get_setting(conn, TOKEN_KEY)
     offline_token = _get_setting(conn, TOKEN_KEY, schema="off")
     if not server_token or not offline_token:
-        sys.exit("ERROR: no sync token — this database was never prepared by `pull`.")
+        sys.exit("ERROR: no sync token — this database never came from a `pull`, so "
+                 "there is no way to tell what is already merged. Refusing to merge. "
+                 "If its reviews are expendable, re-download instead: "
+                 "`sync_offline.sh pull` (or the 'discard local' button).")
     if server_token != offline_token:
         sys.exit("ERROR: sync token mismatch. This offline database was already "
-                 "pushed, or it came from a different pull. Refusing to merge.")
+                 "pushed, or it came from a different pull. Refusing to merge. "
+                 "If its reviews are expendable, re-download instead: "
+                 "`sync_offline.sh pull` (or the 'discard local' button).")
 
     watermark = int(_get_setting(conn, WATERMARK_KEY, schema="off") or 0)
 

--- a/scripts/offline_sync_server.py
+++ b/scripts/offline_sync_server.py
@@ -23,7 +23,8 @@ whole database back would destroy that work. Offline reviewing can only touch
 two tables, and only those two are merged:
 
     review_log  — rows newer than the watermark are appended (fresh ids)
-    cards       — rows whose scheduling state differs are updated in place
+    cards       — rows whose scheduling state differs are updated in place,
+                  unless the server's own last_review is newer (#625)
 
 Cards that exist offline but not on the server are ignored: the offline
 instance cannot create entries or cards.
@@ -158,16 +159,30 @@ def cmd_merge(prod_db: str, incoming_db: str) -> None:
     skipped_reviews = len(new_reviews) - len(kept)
 
     # ── cards: update rows whose scheduling state changed ─────────────────────
+    # Last review wins. The laptop used to overwrite the server unconditionally,
+    # which is fine for a flight but silently loses progress once the laptop is
+    # an everyday instance and Daniel also reviews on his phone (#625).
+    # last_review is an ISO string, so plain string comparison is chronological.
     field_list = ", ".join(CARD_FIELDS)
+    lr = CARD_FIELDS.index("last_review")
     server_cards = {
         r["id"]: tuple(r)[1:]
         for r in conn.execute(f"SELECT id, {field_list} FROM main.cards")
     }
     changed = []
+    kept_server = 0
     for row in conn.execute(f"SELECT id, {field_list} FROM off.cards"):
         before = server_cards.get(row["id"])
-        if before is not None and before != tuple(row)[1:]:
-            changed.append(tuple(row)[1:] + (row["id"],))
+        after = tuple(row)[1:]
+        if before is None or before == after:
+            continue
+        # A card reviewed on the server after the pull is newer than whatever
+        # the laptop has. Its own review rows were already appended above, so
+        # skipping the card row is all that's needed to preserve it.
+        if before[lr] is not None and (after[lr] is None or before[lr] > after[lr]):
+            kept_server += 1
+            continue
+        changed.append(after + (row["id"],))
     assignments = ", ".join(f"{f} = ?" for f in CARD_FIELDS)
     conn.executemany(f"UPDATE main.cards SET {assignments} WHERE id = ?", changed)
 
@@ -180,6 +195,7 @@ def cmd_merge(prod_db: str, incoming_db: str) -> None:
     print(f"reviews_merged={len(kept)}")
     print(f"reviews_skipped_deleted_card={skipped_reviews}")
     print(f"cards_updated={len(changed)}")
+    print(f"cards_kept_server_newer={kept_server}")
 
 
 if __name__ == "__main__":

--- a/static/app.js
+++ b/static/app.js
@@ -1101,17 +1101,27 @@ function closeSyncPopup() {
   document.getElementById('sync-modal').style.display = 'none';
 }
 
-async function startSync() {
-  const btn = document.getElementById('sync-run-btn');
-  btn.disabled = true;
+async function startSync(mode = 'sync') {
+  document.getElementById('sync-run-btn').disabled = true;
+  document.getElementById('sync-force-btn').style.display = 'none';
   document.getElementById('sync-status').textContent = 'Starting…';
   try {
-    await api('POST', '/api/sync/start');
+    await api('POST', `/api/sync/start?mode=${mode}`);
   } catch (e) {
     // 409 means a run is already going — just attach to it.
     document.getElementById('sync-status').textContent = String(e.message || e);
   }
   _pollSyncProgress();
+}
+
+// Escape hatch for a local database the server refuses to merge: no sync token
+// (it never came from a pull) or a rotated one (already pushed). Downloading
+// over it is the only way forward, so make the data loss explicit (#625).
+async function forcePull() {
+  const ok = await showConfirm(
+    'Throw away this local database and download the server\'s copy?\n\n' +
+    'Any reviews done here that were never synced will be lost.');
+  if (ok) startSync('pull');
 }
 
 // Polls until the run finishes. The database was swapped underneath us, so a
@@ -1144,6 +1154,9 @@ async function _pollSyncProgress() {
     setTimeout(() => location.reload(), 1200);
   } else if (p.ok === false) {
     status.textContent = `❌ ${p.error || 'Sync failed'}`;
+    // A refused merge is the one failure the user can resolve from here.
+    const refused = p.lines.some(l => l.includes('sync token'));
+    document.getElementById('sync-force-btn').style.display = refused ? '' : 'none';
   } else {
     status.textContent = '';
   }

--- a/static/app.js
+++ b/static/app.js
@@ -68,7 +68,11 @@ let _retentionData = null;  // cached result from GET /api/retention
 let _cachedDecks = null;       // last fetched deck tree (for toggle re-renders)
 let _deckLangById = {};        // deckId → 'zh'|'fr', rebuilt whenever decks load (flatten(decks))
 let _availableLangs = ['zh'];  // distinct langs in use, from GET /api/langs — tab bar shows only when > 1
-let _offlineMode = false;      // GET /api/mode — true for the run.offline.sh instance (#612)
+let _offlineMode = false;      // GET /api/mode — no outbound calls possible right now (#612)
+let _localMode = false;        // GET /api/mode — laptop instance; shows the sync button (#625)
+let _currentView = 'loading';  // last name passed to showView(), so the mode poll can re-apply it
+let _modePollTimer = null;     // LOCAL_MODE only: re-checks connectivity every 60s (#625)
+let _syncPollTimer = null;     // active /api/sync/progress poll (#625)
 
 // The main-page language tab bar (issue #436) is the single source of truth for
 // "what language am I studying right now" on the home page: deck list, All-deck
@@ -816,6 +820,7 @@ function _triggerClapAnimation() {
 }
 
 function showView(name) {
+  _currentView = name;
   if (name === 'done' && _sessionReviewedCount > 0) _triggerClapAnimation();
   // Leaving the podcast view (#502): stop the episode-list "processing"
   // poll loop — it has no reason to keep firing once the view isn't visible.
@@ -1031,6 +1036,8 @@ function showNotice(msg) {
 // story or a silent sentence is expected rather than a bug (issue #612).
 // Dismissal is per browser session only — a permanently hidden banner would
 // leave Daniel wondering why regenerate is missing days later (#621).
+// In LOCAL_MODE the banner comes and goes with the Wi-Fi, so it is re-rendered
+// on every mode poll rather than built once (#625).
 function _renderOfflineBanner() {
   const existing = document.getElementById('offline-banner');
   if (!_offlineMode || sessionStorage.getItem('offlineBannerDismissed')) {
@@ -1041,7 +1048,9 @@ function _renderOfflineBanner() {
   const el = document.createElement('div');
   el.id = 'offline-banner';
   const text = document.createElement('span');
-  text.textContent = '✈️ Offline mode — stories and audio are read-only from the last sync';
+  text.textContent = _localMode
+    ? '✈️ No network — stories and audio are read-only until the connection is back'
+    : '✈️ Offline mode — stories and audio are read-only from the last sync';
   const close = document.createElement('button');
   close.id = 'offline-banner-close';
   close.type = 'button';
@@ -1057,6 +1066,90 @@ function _renderOfflineBanner() {
 }
 
 
+// ── Local mode + sync (#625) ────────────────────────────────────────────────
+// The laptop instance is a full copy of the app that happens to lose its AI
+// and TTS when the network goes away, so `offline` is a live value: poll it and
+// re-apply the UI bits that depend on it.
+
+async function _refreshMode() {
+  const mode = await api('GET', '/api/mode').catch(() => null);
+  if (!mode) return;
+  const wasOffline = _offlineMode;
+  _offlineMode = !!mode.offline;
+  _localMode = !!mode.local;
+  const syncBtn = document.getElementById('sync-btn');
+  if (syncBtn) syncBtn.style.display = _localMode ? '' : 'none';
+  _renderOfflineBanner();
+  // The regenerate affordances are hidden while offline; re-run the logic that
+  // owns them if the network state actually flipped.
+  if (wasOffline !== _offlineMode) showView(_currentView);
+}
+
+function _startModePolling() {
+  if (!_localMode || _modePollTimer) return;
+  _modePollTimer = setInterval(_refreshMode, 60000);
+}
+
+function openSyncPopup() {
+  document.getElementById('sync-modal-overlay').style.display = 'block';
+  document.getElementById('sync-modal').style.display = 'block';
+  if (!_syncPollTimer) _pollSyncProgress();   // pick up a run started earlier
+}
+
+function closeSyncPopup() {
+  document.getElementById('sync-modal-overlay').style.display = 'none';
+  document.getElementById('sync-modal').style.display = 'none';
+}
+
+async function startSync() {
+  const btn = document.getElementById('sync-run-btn');
+  btn.disabled = true;
+  document.getElementById('sync-status').textContent = 'Starting…';
+  try {
+    await api('POST', '/api/sync/start');
+  } catch (e) {
+    // 409 means a run is already going — just attach to it.
+    document.getElementById('sync-status').textContent = String(e.message || e);
+  }
+  _pollSyncProgress();
+}
+
+// Polls until the run finishes. The database was swapped underneath us, so a
+// successful sync ends in a full reload rather than a partial refresh.
+async function _pollSyncProgress() {
+  clearTimeout(_syncPollTimer);
+  const p = await api('GET', '/api/sync/progress').catch(() => null);
+  if (!p) { _syncPollTimer = setTimeout(_pollSyncProgress, 2000); return; }
+
+  const log = document.getElementById('sync-log');
+  if (p.lines.length) {
+    const atBottom = log.scrollTop + log.clientHeight >= log.scrollHeight - 20;
+    log.style.display = 'block';
+    log.textContent = p.lines.join('\n');
+    if (atBottom) log.scrollTop = log.scrollHeight;
+  }
+  const status = document.getElementById('sync-status');
+  const btn = document.getElementById('sync-run-btn');
+
+  if (p.running) {
+    status.textContent = 'Syncing…';
+    btn.disabled = true;
+    _syncPollTimer = setTimeout(_pollSyncProgress, 1000);
+    return;
+  }
+  _syncPollTimer = null;
+  btn.disabled = false;
+  if (p.ok === true) {
+    status.textContent = '✅ Done — reloading…';
+    setTimeout(() => location.reload(), 1200);
+  } else if (p.ok === false) {
+    status.textContent = `❌ ${p.error || 'Sync failed'}`;
+  } else {
+    status.textContent = '';
+  }
+}
+
+
 // ── Deck list ───────────────────────────────────────────────────────────────
 async function loadDecks() {
   setLoading('Loading decks…');
@@ -1067,7 +1160,11 @@ async function loadDecks() {
     ]);
     _availableLangs = langs && langs.length ? langs : ['zh'];
     _offlineMode = !!(mode && mode.offline);
+    _localMode = !!(mode && mode.local);
+    const syncBtn = document.getElementById('sync-btn');
+    if (syncBtn) syncBtn.style.display = _localMode ? '' : 'none';
     _renderOfflineBanner();
+    _startModePolling();
     // Only scope requests to the active tab once there's more than one language
     // in use — keeps a pure-Chinese install byte-identical to pre-#436 behavior.
     const langParam = _availableLangs.length > 1 ? `&lang=${activeLang()}` : '';

--- a/static/index.html
+++ b/static/index.html
@@ -50,6 +50,8 @@
     <button class="undo-btn" id="session-graph-btn" onclick="openSessionSummary()" title="Graph of cards reviewed this session">📈 Session</button>
   </div>
   <div class="header-right">
+    <!-- Local instance only — injected visible by _renderOfflineBanner() (#625) -->
+    <button id="sync-btn" onclick="openSyncPopup()" title="Sync with the server" style="display:none">⟳</button>
     <button id="random-words-btn" onclick="openRandomWords()" title="10 random words for today">🎲</button>
     <button id="header-regen-btn" onclick="regenerateStory()" title="Regenerate story" style="display:none">↺</button>
   </div>
@@ -878,6 +880,25 @@
     </label>
   </div>
   <pre id="logs-body"></pre>
+</div>
+
+<!-- Sync modal (local instance only, #625) -->
+<div id="sync-modal-overlay" onclick="closeSyncPopup()" style="display:none"></div>
+<div id="sync-modal" style="display:none">
+  <div class="edit-modal-header">
+    <span class="edit-modal-title">Sync with server</span>
+    <button class="edit-modal-close" onclick="closeSyncPopup()">✕</button>
+  </div>
+  <div id="sync-modal-intro">
+    Pushes the reviews done here back to the server, then pulls the latest
+    database and audio. Cards reviewed on both sides keep whichever review
+    came last.
+  </div>
+  <pre id="sync-log" style="display:none"></pre>
+  <div class="sync-actions">
+    <button id="sync-run-btn" class="keymap-reset-all" onclick="startSync()">⟳ Sync now</button>
+    <span id="sync-status"></span>
+  </div>
 </div>
 
 <!-- Import modal -->

--- a/static/index.html
+++ b/static/index.html
@@ -897,6 +897,10 @@
   <pre id="sync-log" style="display:none"></pre>
   <div class="sync-actions">
     <button id="sync-run-btn" class="keymap-reset-all" onclick="startSync()">⟳ Sync now</button>
+    <!-- Only offered once a merge has been refused — see _pollSyncProgress() -->
+    <button id="sync-force-btn" class="keymap-reset-all" onclick="forcePull()"
+            title="Throw away this local database and download the server's"
+            style="display:none">⤓ Discard local &amp; re-download</button>
     <span id="sync-status"></span>
   </div>
 </div>

--- a/static/style.css
+++ b/static/style.css
@@ -5044,3 +5044,56 @@ table.fsrs-table td.ivl { font-weight: 700; }
   opacity: 1;
   background: rgba(255, 255, 255, 0.15);
 }
+
+/* ── Sync modal (#625) ────────────────────────────────────────────────────── */
+#sync-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 900;
+}
+#sync-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(720px, 92vw);
+  max-height: 84vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  z-index: 901;
+  overflow: hidden;
+}
+#sync-modal-intro {
+  padding: 12px 16px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+#sync-log {
+  flex: 1;
+  min-height: 120px;
+  margin: 0 16px;
+  padding: 10px;
+  overflow: auto;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 12px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.sync-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+}
+#sync-status {
+  font-size: 13px;
+  color: var(--muted);
+}

--- a/sync_offline.sh
+++ b/sync_offline.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
-# 离线模式同步脚本（议题 #612）
+# 笔记本 ↔ 服务器同步脚本（议题 #612、#625）
 #
-#   bash sync_offline.sh pull    上飞机前：把服务器的数据库和音频拉到笔记本
-#   bash sync_offline.sh push    落地后：把飞机上的复习结果合并回服务器
+#   bash sync_offline.sh sync    日常：一步搞定（先推回复习结果，再拉最新的库）
+#   bash sync_offline.sh pull    只拉不推（第一次用，或者本地库已经推过了）
+#   bash sync_offline.sh push    只推不拉，推完把本地库归档（上飞机那套老流程）
 #
-# 服务器永远是主库。push 只合并 cards + review_log 两张表，
-# 离线期间服务器 cron 新增的播客单集、预生成故事都不会被覆盖。
+# 界面顶栏的同步按钮跑的就是 `sync`（见 routes/sync.py）。
+#
+# 服务器永远是主库。push/sync 只合并 cards + review_log 两张表，
+# 服务器上新增的播客单集、预生成故事都不会被覆盖。同一张卡两边都复习过时，
+# 按 last_review 谁晚谁赢（#625）。
 set -euo pipefail
 
 SERVER="${ANKI_SERVER:-anki@207.180.204.135}"
@@ -21,6 +25,11 @@ MANIFEST="data/.offline_tts_manifest"
 # 提前多少天的到期词也一起同步音频——离线期间可以往前学
 DAYS_AHEAD="${ANKI_OFFLINE_DAYS_AHEAD:-14}"
 
+# rsync 的 --progress 会刷一堆回车，从界面按钮跑的时候只是噪音。
+# 只有在真正的终端里才开（脚本被 routes/sync.py 用管道调用时 stdout 不是 tty）。
+RSYNC_OPTS=(-a)
+[ -t 1 ] && RSYNC_OPTS+=(--progress)
+
 ACTION="${1:-}"
 
 # 服务器端脚本通过 stdin 管道执行——不依赖服务器上是否已经部署了这个版本的代码
@@ -28,34 +37,48 @@ run_remote() {
     ssh "$SERVER" "python3 - $*" < "$SERVER_SCRIPT"
 }
 
-case "$ACTION" in
-pull)
-    echo "== 步骤 1/5：检查 SSH 连接 =="
+check_ssh() {
     echo "   连接 $SERVER …"
     ssh -o ConnectTimeout=10 "$SERVER" "test -f '$REMOTE_DB'" \
         || { echo "❌ 连不上服务器，或找不到 ${REMOTE_DB}。你现在有网／VPN 吗？"; exit 1; }
     echo "   ✅ 连接正常，生产数据库存在"
+}
 
-    echo
-    echo "== 步骤 2/5：在服务器上生成同步令牌并做数据库快照（约 20 秒）=="
-    echo "   （令牌保证这份离线库只能被推回一次；快照对正在运行的服务是安全的）"
-    echo "   快照会剔除飞机上用不到的大块数据：API 调用日志、播客转录全文、故事提示词"
+# 把本地库推上去合并。合并失败（比如令牌不匹配）会因为 set -e 中断整个流程——
+# 这是故意的：绝不能在没推成功的情况下继续 pull，那会直接覆盖掉本地的复习记录。
+do_merge() {
+    echo "   上传 ${LOCAL_DB}（压缩后约 7 MB）…"
+    scp -C "$LOCAL_DB" "$SERVER:$REMOTE_INCOMING"
+    echo "   在服务器上合并（只动 cards + review_log；令牌不匹配会直接拒绝）…"
+    run_remote "merge '$REMOTE_DB' '$REMOTE_INCOMING'"
+    ssh "$SERVER" "rm -f '$REMOTE_INCOMING'"
+    echo "   ✅ 合并完成"
+}
+
+do_snapshot_and_download() {
+    echo "   在服务器上生成同步令牌并做快照（约 20 秒）…"
+    echo "   （令牌保证这份库只能被推回一次；快照对正在运行的服务是安全的）"
+    echo "   快照会剔除用不到的大块数据：API 调用日志、播客转录全文、故事提示词"
     run_remote "prepare '$REMOTE_DB' '$REMOTE_SNAPSHOT'"
-    echo "   ✅ 快照完成"
 
-    echo
-    echo "== 步骤 3/5：下载数据库到 ${LOCAL_DB}（压缩后约 7 MB，几秒钟）=="
     mkdir -p data
+    echo "   下载到 ${LOCAL_DB}（压缩后约 7 MB，几秒钟）…"
+    # 先落到 .incoming 再 mv 就位：应用可能正开着，直接 scp 覆盖会让它在
+    # 好几秒里读到一个写了一半的库。rename 是原子的，窗口缩到几乎为零（#625）。
+    scp -C "$SERVER:$REMOTE_SNAPSHOT" "$LOCAL_DB.incoming"
+    ssh "$SERVER" "rm -f '$REMOTE_SNAPSHOT'"
     if [ -f "$LOCAL_DB" ]; then
         mv "$LOCAL_DB" "$LOCAL_DB.replaced-$(date +%Y%m%d-%H%M%S)"
-        echo "   （上一份离线库已改名备份，没有覆盖）"
+        echo "   （上一份本地库已改名备份，没有删除）"
     fi
-    scp -C "$SERVER:$REMOTE_SNAPSHOT" "$LOCAL_DB"
-    ssh "$SERVER" "rm -f '$REMOTE_SNAPSHOT'"
-    echo "   ✅ 数据库已下载"
+    mv "$LOCAL_DB.incoming" "$LOCAL_DB"
+    # 旧库的日志文件套到新库上会直接损坏数据。现在用的是默认 rollback journal，
+    # 不该有这些文件，但删一下不花钱。
+    rm -f "$LOCAL_DB-wal" "$LOCAL_DB-shm" "$LOCAL_DB-journal"
+    echo "   ✅ 数据库已就位"
+}
 
-    echo
-    echo "== 步骤 4/5：同步会用到的 TTS 音频 =="
+do_tts() {
     echo "   服务器上攒了 ~120 MB 音频，绝大部分是不到期的旧词。"
     echo "   这里只算出接下来真正会听到的那些文件（故事句子 + 到期词），通常几 MB。"
     mkdir -p data/tts
@@ -70,54 +93,80 @@ pull)
     comm -12 "$MANIFEST.want" "$MANIFEST.have" > "$MANIFEST"
     echo "   服务器上实际存在 $(wc -l < "$MANIFEST" | tr -d ' ') 个（其余的词服务器也还没生成过音频）"
     if [ -s "$MANIFEST" ]; then
-        # --progress（不是 GNU 专有的 --info=progress2）：macOS 自带的
-        # openrsync 不认后者，会直接报错退出（议题 #617）
-        rsync -a --progress --files-from="$MANIFEST" \
+        # 不能用 GNU 专有的 --info=progress2：macOS 自带的 openrsync 不认（议题 #617）
+        rsync "${RSYNC_OPTS[@]}" --files-from="$MANIFEST" \
             "$SERVER:$REMOTE_DIR/data/tts/" data/tts/
     fi
     rm -f "$MANIFEST" "$MANIFEST.want" "$MANIFEST.have"
     echo "   ✅ 音频同步完成"
+}
+
+case "$ACTION" in
+sync)
+    echo "== 步骤 1/4：检查 SSH 连接 =="
+    check_ssh
 
     echo
-    echo "== 步骤 5/5：完成 =="
-    echo "   现在可以断网了。飞机上运行："
-    echo "       bash run.offline.sh"
-    echo "   然后浏览器打开 http://localhost:8001"
+    if [ -f "$LOCAL_DB" ]; then
+        echo "== 步骤 2/4：把本地的复习结果推回服务器 =="
+        do_merge
+    else
+        echo "== 步骤 2/4：跳过推送 =="
+        echo "   本地还没有 ${LOCAL_DB}——这是第一次同步，只需要下载。"
+    fi
+
     echo
-    echo "   落地有网后运行： bash sync_offline.sh push"
+    echo "== 步骤 3/4：拉取服务器最新数据库 =="
+    do_snapshot_and_download
+
+    echo
+    echo "== 步骤 4/4：同步会用到的 TTS 音频 =="
+    do_tts
+
+    echo
+    echo "🎉 同步完成。"
+    ;;
+
+pull)
+    echo "== 步骤 1/3：检查 SSH 连接 =="
+    check_ssh
+    echo
+    echo "== 步骤 2/3：快照 + 下载 =="
+    echo "   ⚠️  只拉不推：本地库里还没同步的复习记录会被覆盖。"
+    echo "      想保住它们请改用： bash sync_offline.sh sync"
+    do_snapshot_and_download
+    echo
+    echo "== 步骤 3/3：同步会用到的 TTS 音频 =="
+    do_tts
+    echo
+    echo "   现在可以断网了。飞机上运行 bash run.offline.sh，"
+    echo "   平时（有网全功能）运行 bash run.local.sh，都是 http://localhost:8001"
     echo
     echo "把以上全部输出发给 Claude。"
     ;;
 
 push)
-    echo "== 步骤 1/4：检查本地离线数据库 =="
-    [ -f "$LOCAL_DB" ] || { echo "❌ 找不到 ${LOCAL_DB}——是不是还没 pull，或者已经 push 过了？"; exit 1; }
+    echo "== 步骤 1/3：检查本地数据库 =="
+    [ -f "$LOCAL_DB" ] || { echo "❌ 找不到 ${LOCAL_DB}——是不是还没同步过，或者已经 push 过了？"; exit 1; }
     echo "   ✅ 找到 ${LOCAL_DB}（$(du -h "$LOCAL_DB" | cut -f1)）"
-    echo "   提示：如果离线服务还开着，先按 Ctrl+C 停掉，确保数据全部写盘"
+    echo "   提示：如果本地服务还开着，先按 Ctrl+C 停掉，确保数据全部写盘"
 
     echo
-    echo "== 步骤 2/4：上传到服务器（压缩后约 7 MB）=="
-    scp -C "$LOCAL_DB" "$SERVER:$REMOTE_INCOMING"
-    echo "   ✅ 上传完成"
+    echo "== 步骤 2/3：上传并合并 =="
+    do_merge
 
     echo
-    echo "== 步骤 3/4：在服务器上合并复习结果 =="
-    echo "   （只合并 cards + review_log；令牌不匹配会直接拒绝，防止重复合并）"
-    run_remote "merge '$REMOTE_DB' '$REMOTE_INCOMING'"
-    ssh "$SERVER" "rm -f '$REMOTE_INCOMING'"
-    echo "   ✅ 合并完成"
-
-    echo
-    echo "== 步骤 4/4：归档本地离线库 =="
+    echo "== 步骤 3/3：归档本地库 =="
     mv "$LOCAL_DB" "$LOCAL_DB.pushed-$(date +%Y%m%d-%H%M%S)"
-    echo "   ✅ 已改名归档——下次要离线复习，重新跑一次 pull"
+    echo "   ✅ 已改名归档——下次要在笔记本上复习，重新跑一次 sync"
     echo
     echo "把以上全部输出发给 Claude。"
     ;;
 
 *)
-    echo "用法： bash sync_offline.sh pull   （上飞机前，需要网络）"
-    echo "       bash sync_offline.sh push   （落地后，需要网络）"
+    echo "用法： bash sync_offline.sh sync   （日常：先推后拉，一步到位）"
+    echo "       bash sync_offline.sh pull   （只拉不推）"
+    echo "       bash sync_offline.sh push   （只推不拉，推完归档本地库）"
     exit 1
     ;;
 esac

--- a/sync_offline.sh
+++ b/sync_offline.sh
@@ -19,7 +19,8 @@ REMOTE_SNAPSHOT="/tmp/anki_offline_snapshot.db"
 REMOTE_INCOMING="/tmp/anki_offline_incoming.db"
 
 cd "$(dirname "$0")"
-LOCAL_DB="data/offline.db"
+# 覆盖它就能拿一份临时库对着服务器上的副本安全演练，不动真的 data/offline.db
+LOCAL_DB="${ANKI_LOCAL_DB:-data/offline.db}"
 SERVER_SCRIPT="scripts/offline_sync_server.py"
 MANIFEST="data/.offline_tts_manifest"
 # 提前多少天的到期词也一起同步音频——离线期间可以往前学

--- a/tests/test_offline_sync.py
+++ b/tests/test_offline_sync.py
@@ -136,7 +136,8 @@ def test_merge_without_prepare_is_refused(server_db, tmp_path):
     _make_db(tmp_path / "stray.db", pytest.MonkeyPatch())
     with pytest.raises(SystemExit) as exc:
         sync_server.cmd_merge(server_db, stray)
-    assert "never prepared" in str(exc.value)
+    # Assert the reason, not the wording — the message also carries recovery advice.
+    assert "no sync token" in str(exc.value)
 
 
 def test_slim_strips_bulk_from_the_snapshot_only(server_db, tmp_path):

--- a/tests/test_offline_sync.py
+++ b/tests/test_offline_sync.py
@@ -185,3 +185,61 @@ def test_untouched_cards_are_not_rewritten(server_db, tmp_path):
     after = sqlite3.connect(server_db).execute(
         "SELECT state, due FROM cards WHERE id = 1").fetchone()
     assert before == after
+
+
+# ── Conflict resolution: last review wins (#625) ─────────────────────────────
+# Once the laptop is an everyday instance and not just a plane companion, the
+# same card can be reviewed on both sides between two syncs.
+
+def _review_with_timestamp(db, when, due, card_id=1):
+    conn = sqlite3.connect(db)
+    conn.execute("INSERT INTO review_log (card_id, reviewed_at, rating) VALUES (?, ?, 3)",
+                 (card_id, when))
+    conn.execute("UPDATE cards SET state = 'review', due = ?, last_review = ? WHERE id = ?",
+                 (due, when, card_id))
+    conn.commit()
+    conn.close()
+
+
+def test_merge_prefers_the_laptop_when_it_reviewed_later(server_db, tmp_path):
+    snapshot = _prepare(server_db, tmp_path)
+    _review_with_timestamp(server_db, '2026-08-03T09:00:00', '2026-08-09')
+    _review_with_timestamp(snapshot, '2026-08-03T21:00:00', '2026-08-20')
+
+    sync_server.cmd_merge(server_db, snapshot)
+
+    due, last = sqlite3.connect(server_db).execute(
+        "SELECT due, last_review FROM cards WHERE id = 1").fetchone()
+    assert (due, last) == ('2026-08-20', '2026-08-03T21:00:00')
+
+
+def test_merge_keeps_the_server_when_it_reviewed_later(server_db, tmp_path):
+    """Reviewing on the phone after the pull must not be undone by the laptop."""
+    snapshot = _prepare(server_db, tmp_path)
+    _review_with_timestamp(snapshot, '2026-08-03T09:00:00', '2026-08-20')
+    _review_with_timestamp(server_db, '2026-08-03T21:00:00', '2026-08-09')
+
+    sync_server.cmd_merge(server_db, snapshot)
+
+    due, last = sqlite3.connect(server_db).execute(
+        "SELECT due, last_review FROM cards WHERE id = 1").fetchone()
+    assert (due, last) == ('2026-08-09', '2026-08-03T21:00:00')
+    # The laptop's review is still recorded even though its scheduling lost.
+    times = [r[0] for r in sqlite3.connect(server_db).execute(
+        "SELECT reviewed_at FROM review_log ORDER BY reviewed_at").fetchall()]
+    assert times == ['2026-08-03T09:00:00', '2026-08-03T21:00:00']
+
+
+def test_merge_applies_laptop_changes_that_carry_no_review(server_db, tmp_path):
+    """Bury/suspend don't touch last_review; with the server untouched they apply."""
+    snapshot = _prepare(server_db, tmp_path)
+    conn = sqlite3.connect(snapshot)
+    conn.execute("UPDATE cards SET state = 'suspended' WHERE id = 1")
+    conn.commit()
+    conn.close()
+
+    sync_server.cmd_merge(server_db, snapshot)
+
+    state = sqlite3.connect(server_db).execute(
+        "SELECT state FROM cards WHERE id = 1").fetchone()[0]
+    assert state == 'suspended'

--- a/tts.py
+++ b/tts.py
@@ -25,7 +25,7 @@ import threading
 import edge_tts
 
 import languages
-from offline import OFFLINE_MODE
+from offline import is_offline
 
 # Bypass system proxy (e.g. Shadowrocket in China) for edge-tts WebSocket connections.
 # The VPN tunnel routes traffic at the network level, so direct connections work fine.
@@ -70,7 +70,7 @@ async def _ensure_cached(text: str, voice: str = VOICE) -> str:
         _hot.add(path)
         return path
 
-    if OFFLINE_MODE:
+    if is_offline():
         logger.info("tts  offline cache MISS %r — no audio available", text[:30])
         raise NotCachedOffline(text)
 
@@ -120,7 +120,7 @@ async def preload_all_async(texts: list[str], progress_key: str | None = None,
             _preload_progress[progress_key]["done"] = total
         return
 
-    if OFFLINE_MODE:
+    if is_offline():
         # Nothing to generate without a network. Report the batch as finished
         # so the frontend's progress poll doesn't spin — the uncached
         # sentences just play silently (issue #612).
@@ -168,7 +168,7 @@ async def preload_all_async(texts: list[str], progress_key: str | None = None,
 
 def preload(text: str, lang: str = "zh") -> None:
     """Fire-and-forget single-item preload (background thread)."""
-    if OFFLINE_MODE:
+    if is_offline():
         return
     voice = languages.get_lang_config(lang)["tts_voice"]
     threading.Thread(target=lambda: asyncio.run(_ensure_cached(text, voice)),


### PR DESCRIPTION
笔记本上跑一份完整的应用，像 Anki 桌面版。Closes #625

## 1. 本地模式 `LOCAL_MODE=1`（`run.local.sh`）
有网时 AI 故事、edge-tts 生成、翻译全都可用；断网后自动降级成 `OFFLINE_MODE` 的只读行为，**不用重启**。判断靠带缓存的 TCP 探测（在线缓存 60 秒、离线 10 秒、超时 1.5 秒）。

`run.offline.sh` 原样保留——飞机上需要"绝不发出站连接"的硬保证，那个模式连探测都不做。两种模式共用 `data/offline.db`。

关键改动：`routes/utils.DISABLE_AI` 从模块级常量改成 `ai_disabled()` 函数。常量在进程启动时就把模式冻死了，Wi-Fi 回来也解不开。

## 2. 界面一键同步
顶栏 ⟳ 按钮（只在笔记本实例显示）→ 弹窗跑 `sync_offline.sh sync`，脚本的中文分步日志逐行回传，跑完整页刷新。

- 新增 `sync` 动作：先推后拉，中途不归档本地库。脚本抽出四个函数给三个动作复用
- 下载先落 `.incoming` 再 `mv` 就位——原来 `scp` 直接覆盖，应用开着的话会有好几秒读到写了一半的库
- `/api/sync/*` **只在 LOCAL_MODE/OFFLINE_MODE 下注册**。服务器上必须根本不存在，误调一次就会用某份笔记本快照覆盖生产（已验证服务器模式返回 404）
- 合并被拒时（无令牌／令牌已轮换）提供 `mode=pull` 逃生口，前端弹确认框明说未同步的复习会丢失

## 3. 冲突按最后复习时间取胜
原来笔记本无条件覆盖服务器。飞机场景没问题，但日常双机用，手机上复习完再一同步就静默丢进度。现在比较两边 `cards.last_review`，谁晚用谁的；`review_log` 两边记录都保留。

## 范围之外（与 Daniel 确认）
本地生成的故事/音频**不**推回服务器；本地**不能**新增词条。

## 怎么测试的
`pytest tests/` 166 通过 4 跳过（含 3 个新增的时间戳合并测试）。

实机演练全部在服务器 `/tmp` 的副本靶子上做，**生产库全程未被触碰**（事后核对过卡片值不变）：

| 场景 | 结果 |
|---|---|
| 首次同步（无本地库）→ 纯下载 | ✅ |
| 带复习结果的 sync → merge 闭环，回程也带回来了 | ✅ |
| 服务器 last_review 更晚 → `cards_kept_server_newer=1`，服务器值保住 | ✅ |
| 通过按钮 API 触发，日志逐行回传、重复提交 409 | ✅ |
| 无令牌库 → 失败并给出出路 → `mode=pull` → 拿到新令牌 → 后续 sync 可推可拉 | ✅ |
| 换库全程 `/api/decks` 返回 200（原子 rename 生效） | ✅ |
| 服务器模式下 `/api/sync/*` 返回 404 | ✅ |

## Daniel 需要知道的
你现在的 `data/offline.db` 没有同步令牌（也没有任何复习记录，是一份很旧的库），所以第一次点同步按钮会失败并提示。点 ⤓ 那个按钮重新下载一次就正常了——这份库里没有值得保留的东西。