### PR TITLE
新功能：界面内一键添加生词（DeepSeek 生成完整词条 → 今天的 Daily 牌组）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,17 @@ bash sync_offline.sh push    # 只推不拉，推完归档本地库
 
 **数据库是唯一事实来源。** 原来的 `imports/` YAML 目录已于 2026-07-07 删除——所有历史词条都已在数据库里，生产数据库在服务器上。
 
-导入机制本身仍然存在（`importer.py`、`POST /api/import`、`python main.py import`，读取 `imports/<Source>/*.yaml`）：需要批量导入新词汇时，重新创建该目录放入 YAML 即可。日常添加单个词条用 `de-zh-bot` 技能生成 YAML。
+导入机制本身仍然存在（`importer.py`、`POST /api/import`、`python main.py import`，读取 `imports/<Source>/*.yaml`）：需要批量导入新词汇时，重新创建该目录放入 YAML 即可。日常添加单个词条：界面顶栏 `＋` 按钮（见下），或 `de-zh-bot` 技能生成 YAML 后导入。
+
+### 界面内添加生词（#627）
+
+顶栏 `＋` → 输入中文词 → 回车 → 后台 DeepSeek 生成完整词条 → 进 `Daily::<今天>`，当天到期。
+
+- `ai.generate_word_entry_yaml()` 把 `de-zh-bot` 技能的中文词条规则移植成服务端提示词，输出 **YAML** 而不是 JSON —— 这样能直接交给 `importer.import_yaml_content()`，例句/量词/同义反义词/汉字分解/词源全部复用既有下游逻辑，**没有一行特例建卡代码**。这也意味着卡片与手工导入的词条完全一致（`importer._create_cards` 的 due 就是 `anki_today()`，`_make_leaf_decks` 建的子牌组名与 `get_or_create_category_decks` 相同）
+- 模型没返回 YAML 列表项时抛 `ValueError`；导入数为 0 的"完成"任务前端也报错 —— **绝不把垃圾内容悄悄写进库，也不假装成功**
+- **已有的词不能"再加到今天"**：`cards` 有 `UNIQUE(word_id, category)`，一个词终身只有三张卡，`insert_card` 对它是静默无效果的。所以只有卡片仅存在于 `Saved` 牌组（没有调度进度可丢）时才 `promote_saved_word` 到今天；否则如实返回 `already_exists` 和所在牌组名，不去重置人家的 FSRS 状态。同理已有词**不调 AI**（重新生成的内容会被 importer 当重复丢掉，纯烧钱）
+- 生成约 30 秒，所以走后台线程 + `job_id` 轮询（复用 `_import_jobs` 机制）
+- 只接受中文输入：德/英输入需要 AI 反问是哪个意思（`de-zh-bot` 就是这么做的），一个无交互的输入框做不到，猜错会静默存进一个错词
 
 - **YAML 格式完整文档：** `docs/yaml-format.md`（中文格式：词性/例句/词源/汉字分解；法语格式：`lang: fr` + `type: word|sentence`，经 `importer._normalize_fr_entry` 适配后复用全部下游逻辑）
 - 文件顶部可选 `lang:` 字段（默认 `zh`）决定导入到哪个语言的牌组
@@ -381,6 +391,8 @@ GET  /api/costs/call/{id}                            → {prompt, response}（�
 
 # 其他
 POST /api/import                                     → 触发 YAML 导入
+POST /api/add-word-ai                                → 界面内添加生词（#627）；新词返回 {job_id}，已有词直接返回 {status}
+GET  /api/add-word-ai/progress/{job_id}              → 轮询后台生成+导入的结果
 GET  /api/browse                                     → {deck_id?, category?, state?, q?, lang?}
 GET  /api/stats ；/api/retention ；/api/card-evolution（均支持 ?lang=）
 ```

--- a/ai.py
+++ b/ai.py
@@ -790,6 +790,167 @@ def regenerate_entry_fields(
         return {}
 
 
+# ---------------------------------------------------------------------------
+# Full dictionary entry as YAML (issue #627) — the in-app twin of the de-zh-bot
+# skill. The output goes straight into importer.import_yaml_content(), so it
+# must follow docs/yaml-format.md exactly; every field below has a consumer in
+# importer._entry_to_word / _process_characters / _process_word_relations.
+# ---------------------------------------------------------------------------
+
+_ENTRY_YAML_EXAMPLE = """- type: word
+  date: "03/27"
+  simplified: 生态
+  traditional: 生態
+  pinyin: shēngtài
+  english: ecology / ecosystem / (figurative) environment
+  german: Ökologie / Ökosystem / (übertragen) Umfeld
+  definition_zh: 生物与环境相互作用形成的系统；引申指互相关联的整体
+  pos: noun
+  hsk: "5"
+  register: formal_written
+  measure_word:
+    - simplified: 种
+      pinyin: zhǒng
+      meaning: Art oder Typ (für Ökosysteme)
+  note: |
+    Ein Substantiv, das im wissenschaftlichen Sinne "Ökologie" und im weiteren
+    Sinne "Ökosystem" bedeutet. Ursprünglich aus der Biologie, hat es sich auf
+    vernetzte Systeme in Wirtschaft und Gesellschaft ausgeweitet.
+
+    **Häufige Ausdrücke:**
+    - 生态环境 (shēngtài huánjìng) — ökologische Umwelt
+    - 生态系统 (shēngtài xìtǒng) — Ökosystem
+  examples:
+    - zh: 保护生态环境是我们每个人的责任。
+      pinyin: Bǎohù shēngtài huánjìng shì wǒmen měi gè rén de zérèn.
+      english: Protecting the ecological environment is everyone's responsibility.
+      de: Die ökologische Umwelt zu schützen ist die Verantwortung eines jeden.
+    - zh: 阿里巴巴构建了一个庞大的商业生态系统。
+      pinyin: Ālǐbābā gòujiànle yī gè pángdà de shāngyè shēngtài xìtǒng.
+      english: Alibaba has built a vast business ecosystem.
+      de: Alibaba hat ein riesiges Geschäftsökosystem aufgebaut.
+  synonyms:
+    - simplified: 环境
+      pinyin: huánjìng
+      meaning: Umwelt, Umgebung
+  word_analyses:
+    - char_only: 生
+      pinyin: shēng
+      hsk: "1"
+    - type: word
+      simplified: 态
+      traditional: 態
+      pinyin: tài
+      english: state, condition, form
+      hsk: "4"
+      characters:
+        - char: 态
+          simplified: 态
+          traditional: 態
+          pinyin: tài
+          hsk: "4"
+          detailed_analysis: true
+          meaning_in_context: Zustand, Beschaffenheit
+          compounds:
+            - simplified: 状态
+              pinyin: zhuàngtài
+              meaning: Zustand, Verfassung
+            - simplified: 态度
+              pinyin: tàidù
+              meaning: Haltung, Einstellung
+          etymology: |
+            Phonosemantische Verbindung. Die traditionelle Form 態 besteht aus
+            dem Radikal 心 (Herz) und der phonetischen Komponente 能 (néng,
+            "Fähigkeit"). Das Herzradikal weist auf einen geistigen Zustand hin.
+"""
+
+_ENTRY_YAML_PROMPT = """You are a Chinese dictionary expert producing an SRS flashcard entry for a
+German-speaking learner (HSK 4-5). Generate a complete YAML entry for: {word}
+
+Return ONLY the YAML — a single list item starting with "- type:". No markdown
+fences, no commentary before or after.
+
+TYPE — pick exactly one:
+  word        a single word or compound (most common)
+  chengyu     a four-character idiom
+  expression  a fixed multi-word phrase or colloquial expression
+  sentence    a full sentence (ends with 。？！)
+
+REQUIRED FIELDS (all types): type, simplified, pinyin, english, german,
+definition_zh, pos, hsk, date: "{today}".
+  - traditional: only when it differs from simplified
+  - register: one of spoken_colloquial, spoken_neutral, neutral, formal_written,
+    literary, slang
+  - hsk: a quoted single digit "1"-"6" (use the closest level for non-HSK words)
+  - definition_zh: the meaning in simple Chinese (HSK 1-4 vocabulary)
+  - pos: noun, verb, adjective, adverb, conjunction, measure word, …
+
+LANGUAGE RULES — these fields MUST be German:
+  note, explanations, etymology, meaning_in_context, compounds[].meaning,
+  measure_word[].meaning, synonyms[].meaning, antonyms[].meaning, examples[].de
+  examples[].english is English; simplified/pinyin are Chinese/pinyin.
+
+CONTENT:
+  - note (word/chengyu/expression) or explanations (sentence): German prose
+    block scalar (|) explaining usage, common collocations, nuance
+  - examples: 2-4 sentences, EACH with all four keys zh, pinyin, english, de
+  - measure_word: only for nouns
+  - synonyms / antonyms: include when they add real value (always for chengyu)
+  - word_analyses: for word/chengyu/expression cover every component character:
+      * HSK 1-2 characters → `char_only:` + pinyin + hsk
+      * HSK 3+ characters → `type: word` block with a nested `characters:` list
+        whose entry has detailed_analysis: true, meaning_in_context, 2-4
+        compounds and a prose `etymology:` block scalar (no bullet points)
+    For `sentence`, cover the 2-4 most important vocabulary items instead.
+
+YAML SAFETY — the output is parsed by a strict loader:
+  - Never use double quotes for meaning/english/german fields. If a colon is
+    unavoidable inside an inline string, wrap it in single quotes; better yet,
+    rephrase to avoid the colon.
+  - note / explanations / etymology use block scalars (|) — colons are safe there.
+  - Indent consistently with two spaces; no tab characters.
+
+EXAMPLE of the expected shape (for 生态):
+
+{example}
+"""
+
+
+def generate_word_entry_yaml(word_zh: str, model: str = DEFAULT_MODEL) -> str:
+    """Generate a complete de-zh-bot style YAML entry for a Chinese word.
+
+    Returns the raw YAML text (a one-item list), ready for
+    importer.import_yaml_content(). Raises ValueError if the model returns
+    something that isn't a YAML list item — callers surface that to the user
+    rather than importing garbage.
+    """
+    from datetime import date as _date
+
+    prompt = _ENTRY_YAML_PROMPT.format(
+        word=word_zh,
+        today=_date.today().strftime("%m/%d"),
+        example=_ENTRY_YAML_EXAMPLE,
+    )
+
+    logger.info("[%s] generate_word_entry_yaml: %s", model, word_zh)
+    raw = _call_api(model, [{"role": "user", "content": prompt}], max_tokens=4000,
+                    purpose=f"add_word:{word_zh}")
+
+    # Strip markdown fences if the model wrapped the YAML despite being told not to
+    fenced = re.search(r"```(?:yaml|yml)?\s*\n(.*?)```", raw, re.DOTALL)
+    if fenced:
+        raw = fenced.group(1)
+
+    # Drop any prose before the list item (some models add a lead-in line)
+    start = raw.find("- type:")
+    if start == -1:
+        logger.error("generate_word_entry_yaml: no list item in response for %r: %s",
+                     word_zh, raw[:300])
+        raise ValueError("AI did not return a YAML entry")
+
+    return raw[start:].rstrip() + "\n"
+
+
 def generate_character_info(char: str, pinyin: str, model: str = DEFAULT_MODEL) -> dict:
     """
     Generate etymology and translation for a single Chinese character.

--- a/routes/imports.py
+++ b/routes/imports.py
@@ -244,17 +244,15 @@ async def import_from_directory(
 # ---------------------------------------------------------------------------
 
 
-def _cards_in_decks(entry_id: int, deck_ids: tuple[int, ...]) -> bool:
-    """True if the entry already has a live card in any of these decks."""
+def _card_deck_ids(entry_id: int) -> set[int]:
+    """Deck ids holding this entry's live cards."""
     conn = database.get_db()
-    placeholders = ",".join("?" * len(deck_ids))
-    row = conn.execute(
-        f"SELECT id FROM cards WHERE word_id = ? AND deck_id IN ({placeholders}) "
-        "AND deleted_at IS NULL LIMIT 1",
-        (entry_id, *deck_ids),
-    ).fetchone()
+    rows = conn.execute(
+        "SELECT DISTINCT deck_id FROM cards WHERE word_id = ? AND deleted_at IS NULL",
+        (entry_id,),
+    ).fetchall()
     conn.close()
-    return row is not None
+    return {r["deck_id"] for r in rows}
 
 
 @router.post("/api/add-word-ai")
@@ -277,20 +275,27 @@ def add_word_ai(body: dict):
     deck_path = f"Daily::{today}"
     deck_id = database.get_or_create_deck_path(deck_path)
 
-    # Known word → the entry already has all its content; just schedule it for
-    # today. Generating it again would cost money and be discarded anyway
-    # (importer skips duplicates without creating cards).
+    # Known word → don't pay for a second generation; the importer would skip
+    # it as a duplicate anyway. What we can do depends on where its cards are:
+    # `cards` has UNIQUE(word_id, category), so a word owns exactly one card per
+    # category for its whole lifetime — there is no "also add it to today".
     existing = database.get_word_by_zh(word_zh)
     if existing:
-        leaf_decks = database.get_or_create_category_decks(deck_id, today)
-        if _cards_in_decks(existing["id"], tuple(leaf_decks.values())):
-            return {"status": "already_in_deck", "word_zh": word_zh,
-                    "entry_id": existing["id"], "deck_path": deck_path, "deck_id": deck_id}
-        for category in ("listening", "reading", "creating"):
-            database.insert_card(existing["id"], category, leaf_decks[category],
-                                 state="new", due=today)
-        return {"status": "added_to_deck", "word_zh": word_zh,
-                "entry_id": existing["id"], "deck_path": deck_path, "deck_id": deck_id}
+        card_decks = _card_deck_ids(existing["id"])
+        saved_deck_id = database.get_or_create_saved_deck()
+        if card_decks and card_decks <= {saved_deck_id}:
+            # Only staged in Saved — promoting is exactly what the user wants.
+            leaf_decks = database.get_or_create_category_decks(deck_id, today)
+            database.promote_saved_word(existing["id"], leaf_decks, saved_deck_id, today)
+            return {"status": "promoted", "word_zh": word_zh, "entry_id": existing["id"],
+                    "deck_path": deck_path, "deck_id": deck_id}
+        # Already being studied somewhere. Moving it here would reset its FSRS
+        # state and lose real scheduling progress, so report instead of acting.
+        deck_names = sorted(
+            (database.get_deck(d) or {}).get("name") or f"deck {d}" for d in card_decks
+        )
+        return {"status": "already_exists", "word_zh": word_zh, "entry_id": existing["id"],
+                "decks": deck_names}
 
     if ai_disabled():
         raise HTTPException(status_code=503,

--- a/routes/imports.py
+++ b/routes/imports.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 import threading
 import time
 import uuid
@@ -10,6 +11,8 @@ import ai
 import database
 import importer
 from fastapi import APIRouter, Form, HTTPException, UploadFile
+
+from .utils import ai_disabled
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -226,6 +229,120 @@ async def import_from_directory(
         "errors": errors,
         "files_processed": len(yaml_files),
     }
+
+
+# ---------------------------------------------------------------------------
+# In-app "add a word" (issue #627) — one button, one Chinese word, a full
+# de-zh-bot style entry in today's Daily deck.
+#
+# Everything downstream is the ordinary import path: importer._create_cards
+# dues cards at database.anki_today() and importer._make_leaf_decks builds the
+# very same '<date> · Listening/Reading/Creating' children that
+# database.get_or_create_category_decks does. So handing the generated YAML to
+# import_yaml_content() with today's Daily deck yields cards indistinguishable
+# from a hand-imported entry — no special-case card creation here.
+# ---------------------------------------------------------------------------
+
+
+def _cards_in_decks(entry_id: int, deck_ids: tuple[int, ...]) -> bool:
+    """True if the entry already has a live card in any of these decks."""
+    conn = database.get_db()
+    placeholders = ",".join("?" * len(deck_ids))
+    row = conn.execute(
+        f"SELECT id FROM cards WHERE word_id = ? AND deck_id IN ({placeholders}) "
+        "AND deleted_at IS NULL LIMIT 1",
+        (entry_id, *deck_ids),
+    ).fetchone()
+    conn.close()
+    return row is not None
+
+
+@router.post("/api/add-word-ai")
+def add_word_ai(body: dict):
+    """Add one Chinese word to today's Daily deck with an AI-generated entry.
+
+    Body: { word_zh }
+    Returns either {job_id, deck_path} — generation runs in the background,
+    poll /api/add-word-ai/progress/{job_id} — or, when the word is already in
+    the database, a finished {status, ...} with no AI call at all.
+    """
+    word_zh = (body.get("word_zh") or "").strip()
+    if not word_zh:
+        raise HTTPException(status_code=400, detail="word_zh is required")
+    if not re.search(r"[一-鿿]", word_zh):
+        raise HTTPException(status_code=400,
+                            detail="Please enter the word in Chinese characters")
+
+    today = date.today().isoformat()
+    deck_path = f"Daily::{today}"
+    deck_id = database.get_or_create_deck_path(deck_path)
+
+    # Known word → the entry already has all its content; just schedule it for
+    # today. Generating it again would cost money and be discarded anyway
+    # (importer skips duplicates without creating cards).
+    existing = database.get_word_by_zh(word_zh)
+    if existing:
+        leaf_decks = database.get_or_create_category_decks(deck_id, today)
+        if _cards_in_decks(existing["id"], tuple(leaf_decks.values())):
+            return {"status": "already_in_deck", "word_zh": word_zh,
+                    "entry_id": existing["id"], "deck_path": deck_path, "deck_id": deck_id}
+        for category in ("listening", "reading", "creating"):
+            database.insert_card(existing["id"], category, leaf_decks[category],
+                                 state="new", due=today)
+        return {"status": "added_to_deck", "word_zh": word_zh,
+                "entry_id": existing["id"], "deck_path": deck_path, "deck_id": deck_id}
+
+    if ai_disabled():
+        raise HTTPException(status_code=503,
+                            detail="AI is disabled (offline mode) — cannot generate a new entry")
+
+    job_id = uuid.uuid4().hex[:8]
+    with _import_jobs_lock:
+        _import_jobs[job_id] = {
+            "status": "running",
+            "message": f"Generating entry for {word_zh}…",
+            "started_at": time.time(),
+        }
+    _prune_import_jobs()
+
+    def _run():
+        try:
+            yaml_text = ai.generate_word_entry_yaml(word_zh)
+            result = importer.import_yaml_content(yaml_text, deck_id)
+            if result.get("yaml_error"):
+                raise ValueError(
+                    f"AI returned invalid YAML: {result['yaml_error'].get('problem', 'parse error')}")
+            with _import_jobs_lock:
+                started_at = _import_jobs[job_id]["started_at"]
+                _import_jobs[job_id] = {
+                    "status": "done",
+                    "message": "Entry added",
+                    "summary": {"word_zh": word_zh, "deck_id": deck_id,
+                                "deck_path": deck_path, **result},
+                    "started_at": started_at,
+                }
+        except Exception as e:
+            logger.exception("add_word_ai failed for %r: %s", word_zh, e)
+            with _import_jobs_lock:
+                started_at = _import_jobs.get(job_id, {}).get("started_at", time.time())
+                _import_jobs[job_id] = {
+                    "status": "error",
+                    "message": "Failed to add word",
+                    "error": str(e),
+                    "started_at": started_at,
+                }
+
+    threading.Thread(target=_run, daemon=True).start()
+    return {"job_id": job_id, "deck_path": deck_path}
+
+
+@router.get("/api/add-word-ai/progress/{job_id}")
+def add_word_ai_progress(job_id: str):
+    """Poll status for a background add-word job started by /api/add-word-ai."""
+    job = _import_jobs.get(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Unknown job id")
+    return job
 
 
 @router.post("/api/quick-add-word")

--- a/static/app.js
+++ b/static/app.js
@@ -6054,6 +6054,95 @@ function showQuickAddBanner(msg, isInfo) {
   el._hideTimer = setTimeout(() => { el.style.display = 'none'; }, 3500);
 }
 
+// ── Add a word from the header (#627) ───────────────────────────────────────
+// Type a Chinese word → DeepSeek writes a full de-zh-bot style entry → it lands
+// in today's Daily deck, due today. Generation takes ~30s, so the request only
+// returns a job id and we poll for the outcome.
+
+let _addWordPollTimer = null;
+
+function openAddWordModal() {
+  document.getElementById('add-word-overlay').style.display = 'block';
+  document.getElementById('add-word-modal').style.display = 'block';
+  const today = new Date();
+  document.getElementById('add-word-deck').textContent =
+    'Daily::' + today.toISOString().slice(0, 10);
+  const input = document.getElementById('add-word-input');
+  input.value = '';
+  input.disabled = false;
+  document.getElementById('add-word-status').textContent = '';
+  input.focus();
+}
+
+function closeAddWordModal() {
+  document.getElementById('add-word-overlay').style.display = 'none';
+  document.getElementById('add-word-modal').style.display = 'none';
+  // A running job keeps going server-side; closing just stops us watching it.
+  clearTimeout(_addWordPollTimer);
+  _addWordPollTimer = null;
+}
+
+async function submitAddWord() {
+  const input = document.getElementById('add-word-input');
+  const status = document.getElementById('add-word-status');
+  const wordZh = input.value.trim();
+  if (!wordZh) return;
+
+  input.disabled = true;
+  status.textContent = `Generating entry for ${wordZh}…`;
+
+  let result;
+  try {
+    result = await api('POST', '/api/add-word-ai', { word_zh: wordZh });
+  } catch (e) {
+    input.disabled = false;
+    status.textContent = `❌ ${e.message || 'Failed to add word'}`;
+    return;
+  }
+
+  // Known words come back finished — no AI call, no job to poll.
+  if (!result.job_id) {
+    closeAddWordModal();
+    const msgs = {
+      added_to_deck:   `✓ "${wordZh}" added to ${result.deck_path}`,
+      already_in_deck: `"${wordZh}" is already in ${result.deck_path}`,
+    };
+    showQuickAddBanner(msgs[result.status] || `✓ Done`,
+                       result.status === 'already_in_deck');
+    loadDecks();
+    return;
+  }
+
+  _pollAddWord(result.job_id, wordZh, result.deck_path);
+}
+
+async function _pollAddWord(jobId, wordZh, deckPath) {
+  clearTimeout(_addWordPollTimer);
+  const status = document.getElementById('add-word-status');
+  const job = await api('GET', `/api/add-word-ai/progress/${jobId}`).catch(() => null);
+
+  if (!job || job.status === 'running') {
+    _addWordPollTimer = setTimeout(() => _pollAddWord(jobId, wordZh, deckPath), 1500);
+    return;
+  }
+  _addWordPollTimer = null;
+  document.getElementById('add-word-input').disabled = false;
+
+  if (job.status === 'error') {
+    status.textContent = `❌ ${job.error || 'Failed to add word'}`;
+    return;
+  }
+  // A "done" job that imported nothing means the AI produced an entry the
+  // importer rejected — say so instead of claiming success.
+  if (!job.summary || !job.summary.imported) {
+    status.textContent = `❌ "${wordZh}" could not be imported — check the logs`;
+    return;
+  }
+  closeAddWordModal();
+  showQuickAddBanner(`✓ "${wordZh}" added to ${deckPath}`, false);
+  loadDecks();
+}
+
 // ── Listening hint slider (HSK-aware) ───────────────────────────────────────
 let _hskLevels = null; // {word: hsk_level_number} — loaded once from static file
 

--- a/static/app.js
+++ b/static/app.js
@@ -6102,13 +6102,19 @@ async function submitAddWord() {
 
   // Known words come back finished — no AI call, no job to poll.
   if (!result.job_id) {
+    if (result.status === 'already_exists') {
+      // A word owns one card per category for life (UNIQUE(word_id, category)),
+      // so there is nothing to add — say where it lives instead of pretending.
+      input.disabled = false;
+      status.textContent =
+        `"${wordZh}" is already in your collection (${result.decks.join(', ')})`;
+      return;
+    }
     closeAddWordModal();
     const msgs = {
-      added_to_deck:   `✓ "${wordZh}" added to ${result.deck_path}`,
-      already_in_deck: `"${wordZh}" is already in ${result.deck_path}`,
+      promoted: `✓ "${wordZh}" moved from Saved into ${result.deck_path}`,
     };
-    showQuickAddBanner(msgs[result.status] || `✓ Done`,
-                       result.status === 'already_in_deck');
+    showQuickAddBanner(msgs[result.status] || `✓ Done`, false);
     loadDecks();
     return;
   }

--- a/static/index.html
+++ b/static/index.html
@@ -52,6 +52,7 @@
   <div class="header-right">
     <!-- Local instance only — injected visible by _renderOfflineBanner() (#625) -->
     <button id="sync-btn" onclick="openSyncPopup()" title="Sync with the server" style="display:none">⟳</button>
+    <button id="add-word-btn" onclick="openAddWordModal()" title="Add a new word to today's deck">＋</button>
     <button id="random-words-btn" onclick="openRandomWords()" title="10 random words for today">🎲</button>
     <button id="header-regen-btn" onclick="regenerateStory()" title="Regenerate story" style="display:none">↺</button>
   </div>
@@ -902,6 +903,24 @@
             title="Throw away this local database and download the server's"
             style="display:none">⤓ Discard local &amp; re-download</button>
     <span id="sync-status"></span>
+  </div>
+</div>
+
+<!-- Add-word modal (#627) — type a Chinese word, DeepSeek writes the full entry -->
+<div id="add-word-overlay" onclick="closeAddWordModal()" style="display:none"></div>
+<div id="add-word-modal" style="display:none">
+  <div class="edit-modal-header">
+    <span class="edit-modal-title">Add a word</span>
+    <button class="edit-modal-close" onclick="closeAddWordModal()">✕</button>
+  </div>
+  <div id="add-word-body">
+    <input id="add-word-input" type="text" placeholder="新词…" autocomplete="off"
+           onkeydown="if (event.key === 'Enter') submitAddWord()">
+    <div id="add-word-hint">
+      Enter a Chinese word — DeepSeek writes the full entry (definitions,
+      examples, character breakdown) into <b id="add-word-deck">today's deck</b>.
+    </div>
+    <div id="add-word-status"></div>
   </div>
 </div>
 

--- a/static/style.css
+++ b/static/style.css
@@ -5046,6 +5046,52 @@ table.fsrs-table td.ivl { font-weight: 700; }
 }
 
 /* ── Sync modal (#625) ────────────────────────────────────────────────────── */
+/* Add-word modal (#627) */
+#add-word-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 900;
+}
+#add-word-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(460px, 92vw);
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  z-index: 901;
+  overflow: hidden;
+}
+#add-word-body {
+  padding: 14px 16px 16px;
+}
+#add-word-input {
+  width: 100%;
+  padding: 10px 12px;
+  font-size: 22px;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+#add-word-input:disabled {
+  opacity: 0.6;
+}
+#add-word-hint {
+  margin-top: 10px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+#add-word-status:not(:empty) {
+  margin-top: 12px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
 #sync-modal-overlay {
   position: fixed;
   inset: 0;

--- a/tests/test_add_word.py
+++ b/tests/test_add_word.py
@@ -1,0 +1,199 @@
+"""Tests for the in-app "add a word" flow (issue #627).
+
+The AI is stubbed at ai._call_api — the single choke point every provider goes
+through. Patching a provider client instead would silently stop working the
+next time DEFAULT_MODEL changes (issue #615).
+"""
+
+from datetime import date
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+import ai
+import database
+import main
+import routes.imports
+
+client = TestClient(main.app)
+
+
+ENTRY_YAML = """- type: word
+  date: "08/06"
+  simplified: 生态
+  traditional: 生態
+  pinyin: shēngtài
+  english: ecology / ecosystem
+  german: Ökologie / Ökosystem
+  definition_zh: 生物与环境相互作用形成的系统
+  pos: noun
+  hsk: "5"
+  register: formal_written
+  note: |
+    Ein Substantiv aus der Biologie.
+  examples:
+    - zh: 保护生态环境是我们的责任。
+      pinyin: Bǎohù shēngtài huánjìng shì wǒmen de zérèn.
+      english: Protecting the ecological environment is our responsibility.
+      de: Die ökologische Umwelt zu schützen ist unsere Verantwortung.
+  synonyms:
+    - simplified: 环境
+      pinyin: huánjìng
+      meaning: Umwelt, Umgebung
+  word_analyses:
+    - char_only: 生
+      pinyin: shēng
+      hsk: "1"
+"""
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    """Fresh temp database. Patch database.core.DB_PATH — the package-level
+    name is only a copy (issue #615)."""
+    monkeypatch.setattr(database.core, "DB_PATH", str(tmp_path / "test.db"))
+    database.init_db()
+    # The route refuses to call the AI when DISABLE_AI is set; routes.utils
+    # reads the env var at import time, so patch the resolved flag instead.
+    monkeypatch.setattr(routes.imports, "ai_disabled", lambda: False)
+    return tmp_path
+
+
+def _run_add_word(word_zh, yaml_text=ENTRY_YAML):
+    """POST the word and, if a background job started, wait for it to finish."""
+    with patch.object(ai, "_call_api", return_value=yaml_text):
+        r = client.post("/api/add-word-ai", json={"word_zh": word_zh})
+        assert r.status_code == 200, r.text
+        body = r.json()
+        if "job_id" not in body:
+            return body
+        for _ in range(200):
+            job = client.get(f"/api/add-word-ai/progress/{body['job_id']}").json()
+            if job["status"] != "running":
+                return {**body, "job": job}
+            import time
+            time.sleep(0.05)
+        pytest.fail("add-word job never finished")
+
+
+def _today_leaf_decks():
+    today = date.today().isoformat()
+    deck_id = database.get_or_create_deck_path(f"Daily::{today}")
+    return database.get_or_create_category_decks(deck_id, today)
+
+
+def test_new_word_lands_in_todays_deck_due_today(tmp_db):
+    result = _run_add_word("生态")
+    assert result["job"]["status"] == "done", result["job"]
+    assert result["job"]["summary"]["imported"] == 1
+
+    entry = database.get_word_by_zh("生态")
+    assert entry is not None
+    assert entry["pinyin"] == "shēngtài"
+    assert entry["definition_de"] == "Ökologie / Ökosystem"
+
+    today = date.today().isoformat()
+    leaf_ids = set(_today_leaf_decks().values())
+    conn = database.get_db()
+    cards = conn.execute(
+        "SELECT category, deck_id, due, state FROM cards WHERE word_id=? AND deleted_at IS NULL",
+        (entry["id"],),
+    ).fetchall()
+    conn.close()
+
+    assert {c["category"] for c in cards} == {"listening", "reading", "creating"}
+    assert {c["deck_id"] for c in cards} <= leaf_ids
+    # Suspended cards (reading, by importer default) carry no due date.
+    assert all(c["due"] == today for c in cards if c["state"] != "suspended")
+
+
+def test_full_entry_content_is_stored(tmp_db):
+    """The point of the feature: the same richness as a hand-imported entry."""
+    _run_add_word("生态")
+    entry = database.get_word_by_zh("生态")
+    detail = database.get_word_full(entry["id"])
+
+    assert detail["examples"], "examples were not imported"
+    assert detail["examples"][0]["example_de"].startswith("Die ökologische")
+    assert any(r["related_zh"] == "环境" for r in detail["relations"])
+    assert detail["notes"] and "Substantiv" in detail["notes"]
+
+
+def test_known_word_is_reported_without_calling_the_ai(tmp_db):
+    """cards has UNIQUE(word_id, category) — a studied word cannot also be
+    added to today, and re-generating it would just burn an API call."""
+    import importer
+
+    other_deck = database.get_or_create_deck_path("Kouyu::Test")
+    importer.import_yaml_content(ENTRY_YAML, other_deck)
+
+    with patch.object(ai, "_call_api", side_effect=AssertionError("AI was called")):
+        r = client.post("/api/add-word-ai", json={"word_zh": "生态"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "already_exists"
+    assert any("Test" in name for name in body["decks"])
+
+
+def test_saved_word_is_promoted_into_todays_deck(tmp_db):
+    """A word only staged in the Saved deck has no scheduling progress to lose,
+    so adding it means promoting it — still without an AI call."""
+    r = client.post("/api/save-word", json={"word_zh": "生态", "pinyin": "shēngtài"})
+    assert r.json()["status"] == "saved"
+    entry_id = r.json()["entry_id"]
+
+    with patch.object(ai, "_call_api", side_effect=AssertionError("AI was called")):
+        r = client.post("/api/add-word-ai", json={"word_zh": "生态"})
+    assert r.json()["status"] == "promoted"
+
+    today = date.today().isoformat()
+    leaf_ids = set(_today_leaf_decks().values())
+    conn = database.get_db()
+    rows = conn.execute(
+        "SELECT deck_id, state, due FROM cards WHERE word_id=? AND deleted_at IS NULL",
+        (entry_id,),
+    ).fetchall()
+    conn.close()
+    assert {r["deck_id"] for r in rows} == leaf_ids
+    assert all(r["state"] == "new" and r["due"] == today for r in rows)
+
+
+def test_non_chinese_input_is_rejected(tmp_db):
+    r = client.post("/api/add-word-ai", json={"word_zh": "Ökologie"})
+    assert r.status_code == 400
+
+
+def test_empty_input_is_rejected(tmp_db):
+    assert client.post("/api/add-word-ai", json={"word_zh": "   "}).status_code == 400
+
+
+def test_ai_returning_prose_fails_the_job(tmp_db):
+    """A model that answers in prose must surface as an error, not a silent
+    no-op that leaves the user staring at an empty deck."""
+    result = _run_add_word("生态", yaml_text="Sorry, I cannot help with that.")
+    assert result["job"]["status"] == "error"
+    assert database.get_word_by_zh("生态") is None
+
+
+def test_offline_returns_explicit_error(tmp_db, monkeypatch):
+    monkeypatch.setattr(routes.imports, "ai_disabled", lambda: True)
+    r = client.post("/api/add-word-ai", json={"word_zh": "生态"})
+    assert r.status_code == 503
+
+
+def test_generate_word_entry_yaml_strips_markdown_fence():
+    fenced = "Here you go:\n```yaml\n" + ENTRY_YAML + "```\n"
+    with patch.object(ai, "_call_api", return_value=fenced):
+        out = ai.generate_word_entry_yaml("生态")
+    assert out.startswith("- type: word")
+    assert "```" not in out
+
+
+def test_generate_word_entry_yaml_raises_without_entry():
+    with patch.object(ai, "_call_api", return_value="I don't know this word."):
+        with pytest.raises(ValueError):
+            ai.generate_word_entry_yaml("生态")

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -168,15 +168,19 @@ class TestGenerateStory:
 # Run with: pytest -m live_api
 # ---------------------------------------------------------------------------
 
+# Opt-in via RUN_LIVE_AI_TESTS=1, not via the mere presence of an API key:
+# main.py loads .env at import time, so any test module that imports the app
+# would silently arm these — and whether that happened depended on collection
+# order (issue #627 tripped exactly that). Skipping must not be an accident.
 @pytest.mark.skipif(
-    not os.environ.get("ANTHROPIC_API_KEY"),
-    reason="requires ANTHROPIC_API_KEY — run manually to verify real story quality",
+    not os.environ.get("RUN_LIVE_AI_TESTS"),
+    reason="set RUN_LIVE_AI_TESTS=1 to verify real story quality against the live API",
 )
 class TestGenerateStoryLive:
     """
-    These tests call the real Haiku API and check structural quality of the
-    output. They are slow (~3-5s) and cost API tokens, so they are skipped
-    by default and only run when ANTHROPIC_API_KEY is set.
+    These tests call the real API and check structural quality of the
+    output. They are slow (~3-5s) and cost API tokens, so they only run when
+    RUN_LIVE_AI_TESTS is set.
 
     What we check (without needing another AI to evaluate):
       - Target word appears in its sentence


### PR DESCRIPTION
## 做了什么

顶栏加一个 `＋` 按钮：点开小窗，输入中文生词，按回车 → 后台用 DeepSeek 生成**完整词条**（释义英/中/德、词性、HSK、register、例句、量词、同义反义词、汉字分解 + 词源）→ 直接进 `Daily::<今天>`，当天就能复习。

Closes #627

## 为什么这么设计

**生成 YAML 而不是 JSON。** `ai.generate_word_entry_yaml()` 把 `de-zh-bot` 技能的中文词条规则移植成服务端提示词，输出格式就是 `docs/yaml-format.md`。这样能把结果直接交给 `importer.import_yaml_content()`，例句、量词、同义反义词、`word_analyses` 汉字分解全部走既有下游逻辑——**没有一行特例建卡代码**。而且 `importer._create_cards` 的 due 本来就是 `anki_today()`，`_make_leaf_decks` 建的子牌组名和 `get_or_create_category_decks` 完全一致，所以卡片和手工导入的词条毫无区别。

**已有的词不能"再加到今天"。** `cards` 表有 `UNIQUE(word_id, category)`——一个词终身只有三张卡，`insert_card` 对它是静默无效果的（现有的 `/api/quick-add-word` 也踩着这个坑）。所以：卡片仅在 `Saved` 牌组（没有调度进度可丢）时 `promote_saved_word` 到今天；已在别处学习的词如实返回 `already_exists` + 所在牌组名，不去重置人家的 FSRS 状态。已有词一律**不调 AI**——重新生成的内容会被 importer 当重复丢掉，纯烧钱。

**失败必须看得见。** 模型没返回 YAML 列表项 → `ValueError`；导入数为 0 的"完成"任务前端也报错。绝不把垃圾写进库，也不假装成功。离线/`DISABLE_AI` 时返回 503 明确报错。

**只接受中文输入。** 德/英输入需要 AI 反问是哪个意思（`de-zh-bot` 正是这么做的），一个无交互的输入框做不到，猜错会静默存进一个错词。

生成约 30 秒，所以走后台线程 + `job_id` 轮询（复用 `_import_jobs` 机制）。

## 顺带修的

`tests/test_ai.py` 的 live 测试原来靠"环境里有没有 `ANTHROPIC_API_KEY`"决定跳过，而 `main.py` 导入时会加载 `.env`——于是任何先导入应用的测试模块都会静默武装它们，跑不跑取决于 pytest 的收集顺序。本 PR 新增的测试文件按字母序排在 `test_ai` 前面，正好触发了：4 个 live 测试真的调了 API 并崩在没建表的库上。改成显式 `RUN_LIVE_AI_TESTS=1` 才跑。

## 改动文件

- `ai.py` — `generate_word_entry_yaml()` + 提示词
- `routes/imports.py` — `POST /api/add-word-ai`、`GET /api/add-word-ai/progress/{job_id}`
- `static/index.html` / `app.js` / `style.css` — 顶栏按钮 + 弹窗 + 轮询
- `tests/test_add_word.py` — 10 个测试
- `tests/test_ai.py` — live 测试改为显式 opt-in
- `CLAUDE.md`

## 怎么测的

`pytest tests/` 全套 **176 passed, 4 skipped**（7 秒）。新测试覆盖：新词落在今天的牌组且 due=今天、完整字段真的进库（例句/同义词/note）、已有词不调 AI、Saved 词被 promote、非中文/空输入拒绝、AI 返回散文时任务报错且不写库、离线 503、markdown 围栏被剥离。

AI 全程打桩在 `ai._call_api`（唯一的提供商汇聚点），没有真实 API 调用。

**还没做真机验证**——需要 Daniel 在浏览器里点一次按钮，确认真实 DeepSeek 返回的 YAML 能被 importer 正常吃下（提示词质量只有真调用才看得出来）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
