### PR TITLE
播客通知改进：主题行加播客名、更多拼音标注、开头加中文总结（#631）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -2339,7 +2339,12 @@ Transcript (Chinese, auto/manual captions, may contain minor recognition errors)
 {excerpt}
 
 Task:
-1. Write a detailed German-language summary of what is discussed in the episode, so the
+1. Write a SHORT Chinese-language summary of the episode: 3-5 sentences, placed before the
+   German summary so Daniel can grasp what the episode is about in Chinese first.
+   Write it at HSK 4-5 level — his actual reading level. Use plain, common vocabulary and
+   short sentences. This is a comprehension aid, not another study exercise, so do NOT
+   reach for literary or specialist words where an everyday one works. Plain text, no HTML.
+2. Write a detailed German-language summary of what is discussed in the episode, so the
    listener understands the content before listening. Target length: {words_target} words.
    Structure it into multiple paragraphs, in the style of the table.media briefings:
    - Wrap every paragraph in <p>...</p> tags.
@@ -2354,23 +2359,28 @@ Task:
    - Whenever you name a company, organization, brand or institution, add its common Chinese
      name in parentheses right after it, e.g. "Airbnb (爱彼迎)", "Lawn Tennis Association
      (英国草地网球协会)". If no established Chinese name exists, give a natural Chinese rendering.
-   - Whenever you use one of the HSK5+ vocabulary words you extract in Task 2 inside the
-     German summary, add its pinyin AND Chinese form in parentheses right after the German
-     rendering, in the format "pinyin/汉字",
+   - Annotate Chinese vocabulary generously. Whenever the German text expresses a concept,
+     term or set phrase that is HSK 5 or above in Chinese, add its pinyin AND Chinese form
+     in parentheses right after the German rendering, in the format "pinyin/汉字",
      e.g. "Rezession (jīngjì shuāituì/经济衰退)", "Lieferkette (gōngyìng liàn/供应链)", so
-     Daniel links the German meaning to the Chinese word — and its pronunciation — he is
-     pre-learning. Use the same pinyin (with tone marks) you give for that word in Task 2.
+     Daniel links the German meaning to the Chinese word — and its pronunciation.
+     This is NOT limited to the words you extract in Task 3 — annotate any non-basic Chinese
+     term the episode uses, including ones that did not make that list. When in doubt,
+     annotate: a redundant annotation costs Daniel nothing, a missing one costs him the link
+     between the German meaning and the Chinese word he is about to hear. For words that ARE
+     in the Task 3 list, use the same pinyin (with tone marks) you give there.
    - If (and ONLY if) the transcript contains timestamps, add an approximate timestamp in
      parentheses when you introduce each major topic, e.g. "(ca. 12:30)", so the listener can
      jump to it. If the transcript contains no timestamps, do NOT invent any.
    Wrap the most important vocabulary/terms/names in <strong>...</strong> HTML tags (these
    become the highlighted words in the email).
-2. Extract the 20-35 most important Chinese words/phrases from the transcript that are HSK
+3. Extract the 20-35 most important Chinese words/phrases from the transcript that are HSK
    level 5 or above (i.e. non-basic vocabulary Daniel would benefit from pre-learning). For
    each, give pinyin and a German definition.
 
 Return ONLY a JSON object, no other text, no markdown fences:
 {{
+  "summary_zh": "中文总结，3-5 句，HSK 4-5 水平的简单中文，纯文本",
   "summary_de": "<German HTML summary: <p> paragraphs, each starting with a <b> lead sentence, <strong> highlights>",
   "words": [
     {{"word": "词语", "pinyin": "cí yǔ", "definition_de": "kurze deutsche Definition", "hsk": 5}}
@@ -2384,9 +2394,14 @@ def parse_podcast_summary_json(raw: str) -> dict:
     markers like "[1]" before parsing — harmless no-op for plain API
     responses, which never contain them.
 
-    Returns {"summary_de": str, "words": [...]}; summary_de is "" and
-    words is [] on any parse failure (mirrors the previous inline
+    Returns {"summary_zh": str, "summary_de": str, "words": [...]}; summary_de
+    is "" and words is [] on any parse failure (mirrors the previous inline
     behavior in summarize_podcast_transcript).
+
+    summary_zh (#631) is a bonus, not a requirement: an older model reply — or
+    one that simply omitted the field — still yields a perfectly usable German
+    summary, so callers gate success on summary_de alone and treat an empty
+    summary_zh as "no Chinese intro this time".
     """
     raw = re.sub(r"\[\d+\]", "", raw)
     start, end = raw.find("{"), raw.rfind("}") + 1
@@ -2395,6 +2410,7 @@ def parse_podcast_summary_json(raw: str) -> dict:
     except (TypeError, ValueError, json.JSONDecodeError):
         data = {}
     summary_de = (data.get("summary_de") or "").strip()
+    summary_zh = (data.get("summary_zh") or "").strip()
     words = []
     for w in data.get("words") or []:
         word = (w.get("word") or "").strip()
@@ -2406,7 +2422,7 @@ def parse_podcast_summary_json(raw: str) -> dict:
             "definition_de": (w.get("definition_de") or "").strip(),
             "hsk": w.get("hsk") if isinstance(w.get("hsk"), int) else 5,
         })
-    return {"summary_de": summary_de, "words": words}
+    return {"summary_zh": summary_zh, "summary_de": summary_de, "words": words}
 
 
 def summarize_podcast_transcript(transcript: str, title: str,
@@ -2451,7 +2467,7 @@ def summarize_podcast_transcript(transcript: str, title: str,
             logger.warning("summarize_podcast_transcript: empty summary_de in AI reply (%s)", model)
         except Exception as e:
             logger.warning("summarize_podcast_transcript failed on %s (%s)", model, e)
-    return {"summary_de": "", "words": []}
+    return {"summary_zh": "", "summary_de": "", "words": []}
 
 
 def estimate_story_tokens(num_cards: int) -> int:

--- a/database/core.py
+++ b/database/core.py
@@ -646,6 +646,8 @@ def init_db() -> None:
             conn.execute("ALTER TABLE podcast_episodes ADD COLUMN transcript_de TEXT")
         if "processing_started_at" not in pe_cols:
             conn.execute("ALTER TABLE podcast_episodes ADD COLUMN processing_started_at TEXT")
+        if "summary_zh" not in pe_cols:
+            conn.execute("ALTER TABLE podcast_episodes ADD COLUMN summary_zh TEXT")
         conn.commit()
 
         # Purge stale legacy YouTube rows (#497): yt-dlp is retired, so any

--- a/podcast.py
+++ b/podcast.py
@@ -1140,6 +1140,31 @@ def _bilingual_transcript_html(pairs: list[dict]) -> str:
     return f"<h3>Transkript (中德对照)</h3><div style='font-size:14px'>{rows}</div>"
 
 
+def _feed_title(episode: dict) -> str | None:
+    """The podcast's own name, looked up from podcast_feeds via the episode's
+    channel_id (which holds the feed URL). Shared by the email subject line
+    and the Signal header (#631). Returns None when the feed row is gone or
+    unnamed — callers fall back to showing just the episode title."""
+    channel_id = episode.get("channel_id")
+    if not channel_id:
+        return None
+    feed = database.get_feed_by_url(channel_id)
+    return (feed.get("title") or None) if feed else None
+
+
+def _summary_zh_html(summary_zh: str) -> str:
+    """Render the short Chinese summary block that opens the email (#631).
+    Escaped — the prompt asks for plain text, and a model that ignores that
+    must not get to inject markup into the mail."""
+    if not summary_zh:
+        return ""
+    return (
+        "<div style='background:#f5f5f5;border-left:3px solid #999;"
+        "padding:10px 14px;margin:0 0 16px;font-size:15px;line-height:1.7'>"
+        f"{html.escape(summary_zh)}</div>"
+    )
+
+
 def send_email(episode: dict) -> bool:
     """Send the HTML notification email for a freshly-summarized episode.
     Returns True if sent, False if skipped (SMTP not configured) — skipping
@@ -1164,6 +1189,7 @@ def send_email(episode: dict) -> bool:
     body_html = f"""
     <html><body style="font-family:sans-serif;max-width:640px">
       <h2>{episode['title']}</h2>
+      {_summary_zh_html(episode.get('summary_zh') or '')}
       <div>{episode.get('summary_de') or ''}</div>
       <h3>Neue HSK5+ Vokabeln</h3>
       {words_html}
@@ -1177,7 +1203,14 @@ def send_email(episode: dict) -> bool:
     """
 
     msg = MIMEMultipart("alternative")
-    msg["Subject"] = f"Neue Podcast-Folge: {episode['title']}"
+    # Subject = "<podcast name> - <episode title>" (#631). The old
+    # "Neue Podcast-Folge:" prefix was identical on every mail and ate the
+    # first 20 characters of the inbox list — the podcast name is what
+    # actually lets Daniel tell one mail from another at a glance. With no
+    # feed name on record the episode title stands alone; the dead prefix
+    # does not come back.
+    feed_title = _feed_title(episode)
+    msg["Subject"] = f"{feed_title} - {episode['title']}" if feed_title else episode["title"]
     msg["From"] = from_addr
     msg["To"] = to_addr
     msg.attach(MIMEText(body_html, "html", "utf-8"))
@@ -1239,12 +1272,7 @@ def send_signal(episode: dict) -> bool:
 
     # 抬头行：播客名 · 星期几（德语） · 日期（#532）。播客名从 channel_id
     # （feed 的 url）反查 podcast_feeds；查不到就省略播客名部分，只留星期+日期。
-    feed_title = None
-    channel_id = episode.get("channel_id")
-    if channel_id:
-        feed = database.get_feed_by_url(channel_id)
-        if feed:
-            feed_title = feed.get("title")
+    feed_title = _feed_title(episode)
 
     weekday_de = ["Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag", "Sonntag"]
     date_part = None
@@ -1259,6 +1287,11 @@ def send_signal(episode: dict) -> bool:
     header_parts = [p for p in (feed_title, date_part) if p]
     lines = [" · ".join(header_parts)] if header_parts else []
     lines.append(f"🎙 {episode['title']}")
+    # 中文总结先行（#631）：Daniel 想先用中文快速抓住这集讲什么，再读德语细节。
+    summary_zh = (episode.get("summary_zh") or "").strip()
+    if summary_zh:
+        lines.append("")
+        lines.append(summary_zh)
     if summary_de:
         lines.append("")
         lines.append(summary_de)
@@ -1392,6 +1425,7 @@ def _process_episode(episode_id: int, video: dict, detail_level: str, summary: d
             spotify_url = find_spotify_url(video["title"])
             database.update_episode(
                 episode_id,
+                summary_zh=result.get("summary_zh") or "",
                 summary_de=result["summary_de"],
                 hsk_words=words,
                 detail_level=detail_level,
@@ -1466,6 +1500,7 @@ def regenerate_summary(episode_id: int) -> dict:
     words = filter_new_words(result.get("words") or [])
     database.update_episode(
         episode_id,
+        summary_zh=result.get("summary_zh") or "",
         summary_de=result["summary_de"],
         hsk_words=words,
         detail_level=detail_level,

--- a/schema.sql
+++ b/schema.sql
@@ -628,6 +628,7 @@ CREATE TABLE IF NOT EXISTS podcast_episodes (
     transcript_zh    TEXT,
     transcript_de    TEXT,   -- JSON array of {"zh","de"} bilingual segment pairs (#553)
     summary_de       TEXT,
+    summary_zh       TEXT,   -- short Chinese summary shown before the German one (#631)
     hsk_words        TEXT,   -- JSON array of {word, pinyin, definition_de, hsk}
     detail_level     TEXT,   -- detail_level used for the summary (short|medium|detailed)
     status           TEXT NOT NULL DEFAULT 'pending'

--- a/static/app.js
+++ b/static/app.js
@@ -3267,6 +3267,7 @@ function _renderPodcastDetail(ep) {
       <h2 class="keymap-heading">${_escHtml(ep.title || '(untitled)')}</h2>
       <p class="keymap-hint">${date}</p>
       <div style="margin:4px 0 10px">${links}</div>
+      ${ep.summary_zh ? `<div id="podcast-summary-zh">${_escHtml(ep.summary_zh)}</div>` : ''}
       <div id="podcast-summary-de">${ep.summary_de || ''}</div>
     </div>
     <div class="keymap-panel">

--- a/static/style.css
+++ b/static/style.css
@@ -3045,6 +3045,19 @@ a.news-source-line:hover {
 .podcast-transcribe-btn { font-size: 12px; padding: 3px 10px; }
 #podcast-summary-de { line-height: 1.6; color: var(--text); }
 
+/* Short Chinese summary (#631) — sits above the German one as a quick
+   "what is this episode about" pass. Set apart so it reads as a lead-in
+   rather than as the first paragraph of the German text. */
+#podcast-summary-zh {
+  line-height: 1.8;
+  color: var(--text);
+  background: var(--bg-alt, rgba(128, 128, 128, 0.08));
+  border-left: 3px solid var(--border);
+  padding: 10px 14px;
+  margin: 0 0 14px;
+  white-space: pre-wrap;
+}
+
 /* — Podcast feed manager (#502) — */
 .podcast-feed-list { display: flex; flex-direction: column; gap: 6px; margin-top: 12px; }
 .podcast-feed-card {

--- a/tests/test_podcast.py
+++ b/tests/test_podcast.py
@@ -49,3 +49,170 @@ def test_fmt_timestamp_boundaries():
     assert podcast._fmt_timestamp(59999) == "[00:59]"
     assert podcast._fmt_timestamp(60000) == "[01:00]"
     assert podcast._fmt_timestamp(3600000) == "[1:00:00]"
+
+
+# ---------------------------------------------------------------------------
+# Notification improvements (#631): subject line, Chinese summary
+# ---------------------------------------------------------------------------
+
+import ai
+import database
+
+
+EPISODE = {
+    "id": 7,
+    "video_id": "ep7",
+    "channel_id": "https://feeds.example/show.xml",
+    "title": "第 12 集：人工智能与就业",
+    "youtube_url": "https://example/ep7",
+    "spotify_url": "",
+    "summary_zh": "这集讨论人工智能对就业的影响。嘉宾认为短期内影响有限。",
+    "summary_de": "<p><b>Es geht um KI.</b> Details folgen.</p>",
+    "hsk_words": [{"word": "就业", "pinyin": "jiù yè", "definition_de": "Beschäftigung", "hsk": 5}],
+    "transcript_de": [],
+    "published_at": "2026-08-05T06:00:00+00:00",
+}
+
+
+def _send_email_capture(monkeypatch, episode, feed_title):
+    """Run send_email against stubbed SMTP/database and return the sent MIME text."""
+    for k, v in [("SMTP_HOST", "smtp.example"), ("SMTP_USERNAME", "u"),
+                 ("SMTP_PASSWORD", "p"), ("SMTP_FROM", "from@example")]:
+        monkeypatch.setenv(k, v)
+    monkeypatch.setattr(database, "get_podcast_config", lambda: {"email_to": "to@example"})
+    monkeypatch.setattr(database, "get_feed_by_url",
+                        lambda url: {"title": feed_title} if feed_title else None)
+
+    sent = {}
+
+    class FakeSMTP:
+        def __init__(self, *a, **kw): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def starttls(self): pass
+        def login(self, *a): pass
+        def sendmail(self, frm, to, msg): sent["msg"] = msg
+
+    monkeypatch.setattr(podcast.smtplib, "SMTP", FakeSMTP)
+    assert podcast.send_email(episode) is True
+    return sent["msg"]
+
+
+def _email_subject(raw: str) -> str:
+    import email as email_mod
+    from email.header import decode_header, make_header
+    return str(make_header(decode_header(str(email_mod.message_from_string(raw)["Subject"]))))
+
+
+def _email_body(raw: str) -> str:
+    import email as email_mod
+    msg = email_mod.message_from_string(raw)
+    part = next(p for p in msg.walk() if p.get_content_type() == "text/html")
+    return part.get_payload(decode=True).decode("utf-8", "replace")
+
+
+def test_email_subject_is_podcast_name_dash_title(monkeypatch):
+    raw = _send_email_capture(monkeypatch, EPISODE, "中文播客秀")
+    assert _email_subject(raw) == "中文播客秀 - 第 12 集：人工智能与就业"
+
+
+def test_email_subject_falls_back_to_title_without_dead_prefix(monkeypatch):
+    """No feed name on record: the episode title stands alone. The old
+    'Neue Podcast-Folge' prefix must not come back as a fallback."""
+    raw = _send_email_capture(monkeypatch, EPISODE, None)
+    subject = _email_subject(raw)
+    assert subject == "第 12 集：人工智能与就业"
+    assert "Neue Podcast" not in subject
+
+
+def test_email_body_leads_with_chinese_summary(monkeypatch):
+    """The Chinese summary must appear, and appear before the German one."""
+    raw = _send_email_capture(monkeypatch, EPISODE, "中文播客秀")
+    body = _email_body(raw)
+    assert "这集讨论人工智能对就业的影响" in body
+    assert body.index("这集讨论") < body.index("Es geht um KI")
+
+
+def test_email_without_chinese_summary_renders_nothing_extra(monkeypatch):
+    ep = dict(EPISODE, summary_zh="")
+    body = _email_body(_send_email_capture(monkeypatch, ep, "中文播客秀"))
+    assert "Es geht um KI" in body
+    assert podcast._summary_zh_html("") == ""
+
+
+def test_summary_zh_html_escapes_markup():
+    """The prompt asks for plain text; a model that ignores it must not get
+    to inject markup into the mail."""
+    out = podcast._summary_zh_html("<script>alert(1)</script>")
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+
+
+def test_feed_title_lookup(monkeypatch):
+    monkeypatch.setattr(database, "get_feed_by_url", lambda url: {"title": "某播客"})
+    assert podcast._feed_title(EPISODE) == "某播客"
+
+    monkeypatch.setattr(database, "get_feed_by_url", lambda url: None)
+    assert podcast._feed_title(EPISODE) is None
+
+    monkeypatch.setattr(database, "get_feed_by_url", lambda url: {"title": ""})
+    assert podcast._feed_title(EPISODE) is None
+
+    assert podcast._feed_title({"channel_id": None}) is None
+
+
+def test_signal_message_leads_with_chinese_summary(monkeypatch):
+    monkeypatch.setenv("SIGNAL_ACCOUNT", "+490000")
+    monkeypatch.setattr(database, "get_feed_by_url", lambda url: {"title": "中文播客秀"})
+
+    captured = {}
+
+    class Result:
+        returncode = 0
+        stderr = b""
+
+    def fake_run(cmd, **kw):
+        captured["text"] = cmd[cmd.index("-m") + 1]
+        return Result()
+
+    monkeypatch.setattr(podcast.subprocess, "run", fake_run)
+    assert podcast.send_signal(EPISODE) is True
+
+    text = captured["text"]
+    assert "这集讨论人工智能对就业的影响" in text
+    # Chinese intro comes before the German summary, and after the title line.
+    assert text.index("第 12 集") < text.index("这集讨论") < text.index("Es geht um KI")
+
+
+# --- prompt & parser --------------------------------------------------------
+
+def test_prompt_asks_for_chinese_summary_and_generous_annotation():
+    prompt = ai.build_podcast_summary_prompt("转录文本", "标题", "detailed")
+    assert "summary_zh" in prompt
+    assert "HSK 4-5 level" in prompt
+    # Annotation must no longer be restricted to the extracted word list.
+    assert "NOT limited to" in prompt
+
+
+def test_parse_summary_json_reads_chinese_summary():
+    raw = '{"summary_zh": "简短总结。", "summary_de": "<p>Text</p>", "words": []}'
+    out = ai.parse_podcast_summary_json(raw)
+    assert out["summary_zh"] == "简短总结。"
+    assert out["summary_de"] == "<p>Text</p>"
+
+
+def test_parse_summary_json_tolerates_missing_chinese_summary():
+    """summary_zh is a bonus — a reply without it still yields a usable
+    German summary rather than failing the whole episode."""
+    out = ai.parse_podcast_summary_json('{"summary_de": "<p>Text</p>", "words": []}')
+    assert out["summary_zh"] == ""
+    assert out["summary_de"] == "<p>Text</p>"
+
+
+def test_parse_summary_json_failure_still_has_chinese_key():
+    """Callers read result['summary_zh'] unconditionally; the key must exist
+    even on a totally unparseable reply."""
+    out = ai.parse_podcast_summary_json("not json at all")
+    assert out["summary_zh"] == ""
+    assert out["summary_de"] == ""
+    assert out["words"] == []


### PR DESCRIPTION
## 改了什么

Daniel 提的三点播客通知改进。

### 1. 邮件主题行：`Neue Podcast-Folge: <标题>` → `<播客名> - <标题>`

旧前缀每封邮件都一模一样，占掉收件箱列表里最宝贵的前 20 个字符，而真正能让 Daniel 一眼分辨的**播客名**根本不出现。

播客名从 `episode.channel_id`（feed 的 url）反查 `podcast_feeds.title`。Signal 抬头本来就在做同一件事，所以抽成 `_feed_title()` 共用，而不是复制第二份。**查不到播客名时只用单集标题** —— 死前缀不作为回退复活。

### 2. 摘要里更频繁地标注拼音和翻译

原提示词只有当德语文本用到「任务 3 提取的那 20-35 个 HSK5+ 词」时才加 `pinyin/汉字`。但摘要里出现的许多中文概念、术语、固定表达并不在那张词表里，Daniel 读到时就没有中文锚点。

改为：任何 HSK 5 及以上的中文概念都标注，明确不限于词表，并写明**宁多勿少** —— 多标一次对他零成本，漏标一次就断掉德语词义与他即将听到的那个中文词之间的连接。

### 3. 摘要开头加一段中文总结

新增 `podcast_episodes.summary_zh`：3-5 句、**HSK 4-5 水平**的中文（他的实际阅读水平），排在德语摘要前面，让他先用中文抓住这集在讲什么。提示词明确要求用日常词，因为这是理解辅助，不是又一个学习任务。

渲染在三处：邮件正文开头、Signal 消息开头、前端详情页。

## 两个刻意的设计

**`summary_zh` 是增量，不是必需。** 判定摘要成功与否仍然只看 `summary_de` —— 模型漏掉中文总结时，这一集照样正常入库、正常通知，只是没有中文引子。parser 在任何解析失败下也保证返回 `summary_zh` 键，因为调用方无条件读它。

**中文总结渲染时转义。** 提示词要求纯文本，但不听话的模型不该因此就能往邮件里注入标记。德语摘要是 AI 生成的 HTML（既有行为，不变），中文这段不是。

## 怎么测试

```
python -m pytest tests/test_podcast.py -q   # 16 passed
python -m pytest tests/ -q                  # 199 passed, 4 skipped
```

新增 11 个测试，覆盖：主题行拼装（有播客名 / 无播客名且不退回死前缀）、中文总结在邮件与 Signal 里出现且**排在德语摘要之前**、`_feed_title` 的四种边界（正常/feed 不存在/title 为空/无 channel_id）、转义、`summary_zh` 存在与缺失两种解析、解析彻底失败时键仍存在。

迁移在生产库副本上验证过：`summary_zh` 列已加，133 个既有单集完好无损，`summary_zh` 为 NULL 时三处渲染都不报错。

Closes #631
