### PR TITLE
重写播客故事模式的提示词：锚定专有名词＋覆盖所有话题（#634）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -313,34 +313,62 @@ Rules:
 Return ONLY a numbered list of Chinese sentences, no explanation:
 1. ...
 2. ...""",
-    "podcast": """任务：下面是一期播客单集的内容摘要（德语）。请用简体中文写一篇该单集内容的连贯总结，
-帮助 HSK 4-5 学习者复习词汇。
+    "podcast": """任务：下面是一期播客单集的内容摘要（德语）。请写若干简体中文句子，帮助 HSK 4-5
+学习者复习词汇。这些句子不需要合起来构成一篇摘要——每一句只要"发生在这一集的世界里"就可以。
 
 单集标题：{title}
 
 内容摘要（德语）：
 {summary}
 
-目标词汇（每个词必须在总结中恰好出现一次，以原文形式出现）：
+目标词汇（每个词恰好用在一个句子里，以原文形式出现）：
 {words}
 
-规则：
-- 总结按句子输出为 JSON 数组，数组顺序就是阅读顺序
-- 【重要】每一句话都必须恰好包含一个目标词汇——不允许出现任何不含目标词的句子，
-  因此句子总数必须恰好等于目标词数量
-- 【词序自由】任意安排目标词出现的先后顺序，选择能写出最自然、最连贯总结的顺序
-- 【难度控制，严格遵守】每句 8 到 20 个字，其中除目标词外只允许 HSK 1-{max_hsk} 的词汇；
-  如果某个事实需要更难的词才能表达，就换一种更简单的说法，或省略这个细节
-- 【重要】每句都必须传达摘要中的一个具体事实（是什么、涉及谁、有多少），
-  严禁没有信息量的空洞句子，例如"内容很有趣。""他说了很多。"这类句子绝对不可以出现
-- 【重要】只允许使用摘要中明确陈述的事实——禁止编造摘要没有的细节或主观评论
-- 所有输出只用简体中文，绝对不要出现繁体字；不要使用markdown格式
+【硬性锚点规则，最重要】
+每一句话都必须至少包含一个来自上面摘要的专有名词——人名、公司名、品牌名、产品名或地名
+（例如摘要里出现的公司、创始人、店名、城市）。没有专有名词的句子一律不合格，必须重写。
+
+【就近三档原则】
+对每个目标词，从上往下选第一个能写得自然的档位；写着别扭就往下降一档，
+绝对不要为了写成事实句而生硬拼凑：
+  A档 事实句：这个词正好能表达摘要中的一个事实。
+     例：张一鸣承认，公司的AI能力可能会暂时落后。
+  B档 评论句：某人对本集内容的反应、评价或愿望。
+     例：我真羡慕那些能天天吃和牛的人。
+  C档 场景句：一个发生在本集人物或公司周围的日常小场景。
+     例：他在抖音上刷视频，顺便就下了单。
+
+【话题覆盖规则】
+摘要里通常有好几个互不相关的话题（例如公司人事、电商、饮食文化）。
+- 把目标词大致平均地分配到这些话题上；摘要里的每一个话题都至少要有一句话
+- 严禁所有句子都围绕同一个话题，也不要只用摘要开头的内容
+- 属于同一话题的句子尽量排在一起，让整篇按话题一块一块地读下来，不要来回跳
+
+【写作步骤】（每个词按顺序思考，把结论写进 reasoning_zh）
+1. 先决定这句话属于摘要里的哪个话题
+2. 再从该话题里挑一个专有名词做锚点
+3. 然后定档位（A/B/C）和具体情境：谁、在哪、在做什么
+4. 最后写 sentence_zh：把情境浓缩成一句自然的中文，把目标词自然地嵌进去
+
+【其他规则】
+- 每句恰好包含一个目标词汇，一个词都不能漏，也不要在一句里塞进两个目标词
+- 除专有名词和目标词外，只用 HSK 1-{max_hsk} 的词汇
+- 每句 10 到 28 个字，用自然的中文口语，标点用中文标点
+- C档允许虚构日常细节（谁在排队、谁在点菜），但绝不可以编造摘要里没有的数字、
+  结论或事实性主张，也不可以与摘要矛盾
+- 严禁空洞句子，例如"这一集很有趣。""他说了很多。"
+- 只用简体中文，绝对不要出现繁体字；不要使用markdown格式
+- 不要给目标词加引号、括号或任何标记，直接写进句子里
 - target_word 是该句包含的目标词汇原文
+
+reasoning_zh 的规则：
+- 用中文写1-2句，说明这句属于哪个话题、锚点是哪个专有名词、选了哪一档、在讲什么
+- 面向 HSK 4-5 学习者，用词不要太难
 {extra_hint}
 
-仅返回如下JSON数组，不加任何其他文字：
+仅返回如下JSON数组，不加任何其他文字（reasoning_zh 在前，sentence_zh 在后）：
 [
-  {"sentence_zh": "含目标词的句子", "target_word": "词汇"}
+  {"reasoning_zh": "解释内容", "sentence_zh": "含目标词的句子", "target_word": "词汇"}
 ]""",
 }
 
@@ -1335,6 +1363,13 @@ reasoning_zh 的规则：
 # large batches make the model skip words and dilute sentence quality.
 MAX_NEWS_BATCH = 10
 
+# Max words per AI call for podcast mode (issue #634). Deliberately much larger
+# than MAX_NEWS_BATCH: the topic-coverage rule ("every topic in the summary gets
+# at least one sentence") only works when one call sees ALL the words, so the
+# default stays one single call. This is just the ceiling above which rule
+# adherence starts slipping — and gpt-5 shares the 8192 budget with reasoning.
+MAX_PODCAST_BATCH = 20
+
 
 def generate_news_sentences(
     cards: list[dict],
@@ -2151,6 +2186,15 @@ def generate_podcast_sentences(
     """Podcast mode rework (issue #561) — a lean single-purpose pipeline that
     replaces reuse of the briefing machinery (originally #482).
 
+    Prompt rewritten in #634: the sentences no longer have to add up to a
+    summary of the episode, and no longer have to each state a fact from it —
+    review-queue words like 咳嗽 have nothing to do with the episode, so that
+    demand only produced contortions and invented facts. Instead each sentence
+    just has to happen "in the world of the episode" (kahneman's approach),
+    anchored by a hard rule that every sentence names a proper noun from the
+    summary, plus a topic-coverage rule so the sentences don't all pile onto
+    the summary's first topic.
+
     One main call + up to 2 missing-word retry rounds + fallback sentences.
     Deliberately has NO fact-check and NO whole-summary validation retry —
     those are what make briefing slow and expensive, and podcast summaries
@@ -2223,7 +2267,10 @@ def generate_podcast_sentences(
                 "sentence_en": "",
                 "concept_en": "",
                 "concept_zh": "",
-                "reasoning_zh": "",
+                # #634: the prompt now makes the model plan topic/anchor/tier in
+                # reasoning_zh before writing — keep it, it shows in the card's
+                # background popup like kahneman's does.
+                "reasoning_zh": (item.get("reasoning_zh") or "").strip(),
                 "source_url": source_url,
                 "source_title": source_title,
                 "tokens": [],

--- a/routes/story.py
+++ b/routes/story.py
@@ -318,8 +318,12 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
             model = _validated_model(model, default="gpt-5-mini")
             logger.info("story  podcast model in use: %s batch_size=%s", model, batch_size)
             # batch_size (issue #563): user-controlled words-per-call from the
-            # setup modal; empty/0 = everything in one call (the default).
-            chunk_size = batch_size if batch_size and batch_size > 0 else len(cards)
+            # setup modal; empty/0 = one single call, capped at MAX_PODCAST_BATCH
+            # (#634). Spreading the words over the summary's topics only works if
+            # one call sees them all, so one call stays the default — but past
+            # ~20 words the model starts dropping rules, hence the ceiling.
+            chunk_size = (batch_size if batch_size and batch_size > 0
+                          else min(len(cards), ai.MAX_PODCAST_BATCH))
             chunks = [cards[i:i + chunk_size] for i in range(0, len(cards), chunk_size)]
             sentences = []
             for idx, chunk in enumerate(chunks):

--- a/tests/test_podcast_sentences.py
+++ b/tests/test_podcast_sentences.py
@@ -1,0 +1,45 @@
+"""ai.generate_podcast_sentences（#561，提示词于 #634 重写）。
+
+AI 一律打桩在 ai._call_api 上——打在某个提供商的客户端上会随默认模型变化而静默失效。
+"""
+import json
+
+import ai
+
+
+CARDS = [
+    {"word_id": 1, "word_zh": "承认", "pinyin": "chéngrèn", "definition": "admit"},
+    {"word_id": 2, "word_zh": "顺便", "pinyin": "shùnbiàn", "definition": "by the way"},
+]
+
+
+def _reply(items):
+    return json.dumps(items, ensure_ascii=False)
+
+
+def test_reasoning_is_kept(monkeypatch):
+    """#634：模型先想话题/锚点/档位再写句子，这段推理要存进 reasoning_zh
+    （背景弹窗里显示），以前被硬编码成空字符串。"""
+    monkeypatch.setattr(ai, "_call_api", lambda *a, **kw: _reply([
+        {"reasoning_zh": "话题：字节跳动的AI路线。", "sentence_zh": "张一鸣承认公司暂时落后。",
+         "target_word": "承认"},
+        {"reasoning_zh": "话题：抖音电商。", "sentence_zh": "他在抖音上刷视频，顺便就下了单。",
+         "target_word": "顺便"},
+    ]))
+    sentences = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
+
+    assert [s["reasoning_zh"] for s in sentences] == [
+        "话题：字节跳动的AI路线。", "话题：抖音电商。"]
+    assert [s["word_ids"] for s in sentences] == [[1], [2]]
+
+
+def test_missing_reasoning_is_not_fatal(monkeypatch):
+    """模型漏掉 reasoning_zh 时只是少一段背景说明，句子本身照常入库。"""
+    monkeypatch.setattr(ai, "_call_api", lambda *a, **kw: _reply([
+        {"sentence_zh": "张一鸣承认公司暂时落后。"},
+        {"sentence_zh": "他在抖音上刷视频，顺便就下了单。"},
+    ]))
+    sentences = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
+
+    assert [s["reasoning_zh"] for s in sentences] == ["", ""]
+    assert len(sentences) == 2

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -76,7 +76,8 @@ def test_podcast_template_keeps_json_example_braces():
         "max_hsk": "3", "extra_hint": "",
     })
     # JSON 示例的花括号必须原样保留（替换只针对已知记号）
-    assert '{"sentence_zh": "含目标词的句子", "target_word": "词汇"}' in rendered
+    assert ('{"reasoning_zh": "解释内容", "sentence_zh": "含目标词的句子", '
+            '"target_word": "词汇"}') in rendered
     assert "T" in rendered and "S" in rendered and "HSK 1-3" in rendered
     # 所有记号都已被替换
     for var in ai.PROMPT_TEMPLATE_VARIABLES["podcast"]:


### PR DESCRIPTION
## 改了什么

重写 `ai.DEFAULT_PROMPT_TEMPLATES["podcast"]`，并配套改了两处代码。

**为什么**：原提示词要求「每句都必须传达摘要中的一个具体事实」＋「所有句子合起来构成一篇连贯总结」。
但复习队列里的目标词跟这一集毫无关系（咳嗽、羡慕），模型只能编造事实或写出生硬的怪句。
参考 kahneman 模式的做法：句子不必是事实，只要"发生在这一集的世界里"即可。

| 原提示词 | 新提示词 |
|---|---|
| 所有句子合起来构成连贯总结 | 删除——每句独立成立 |
| 每句必须传达摘要中的一个具体事实 | 就近三档原则：A 事实句 → B 评论句 → C 场景句，写着别扭就降档 |
| 只允许摘要中明确陈述的事实 | C 档可虚构日常细节；数字/结论仍禁止编造，且不得与摘要矛盾 |
| 8–20 字 | 10–28 字（与 kahneman 一致）——否则塞不下专有名词 |
| 无 | **硬性锚点规则**：每句至少含一个来自摘要的专有名词（人名/公司/品牌/地名/产品） |
| 无 | **话题覆盖规则**：每个话题至少一句，禁止全挤在开头那个话题；同话题的句子排在一起 |
| 无 | `reasoning_zh`：先定话题/锚点/档位再写句子 |

配套代码改动：

- `ai.generate_podcast_sentences`：`reasoning_zh` 原来被硬编码成 `""`，现在透传模型返回值
  （和 kahneman 一样显示在卡片背景弹窗里）
- 新增 `ai.MAX_PODCAST_BATCH = 20`，`routes/story.py` 的 podcast 分支默认值从 `len(cards)`
  改为 `min(len(cards), MAX_PODCAST_BATCH)`。话题分配只有在一次调用里看到全部词才做得到，
  所以默认仍是**一次调用**；20 只是规则遵守度开始下滑的上限。设置弹窗里手填的 batch_size 不受影响

## 怎么测试

- `pytest tests/` 全绿（201 passed）
- 新增 `tests/test_podcast_sentences.py`：验证 `reasoning_zh` 透传，以及模型漏掉该字段时不致命
- `tests/test_prompt_templates.py` 的 JSON 花括号断言随示例更新（示例现在多了 `reasoning_zh` 字段）

提示词质量本身需要 Daniel 在真实单集上生成一次来判断。注意：`prompt_presets` 表里
如果存有 podcast 的生效自定义版本（#610），它会覆盖这里的内置默认——那种情况下要在
界面里取消生效才能看到新提示词。

Closes #634
