### PR TITLE
优化界面内添加生词：今天/明天可选 + 加按钮 + 连续输入（#636）

### DIFF
--- a/importer.py
+++ b/importer.py
@@ -127,12 +127,15 @@ def import_yaml_file(filepath: str, deck_path: list[str]) -> dict:
 def import_yaml_content(content: str, parent_deck_id: int,
                         resolutions: dict | None = None,
                         card_configs: dict | None = None,
-                        custom_fields: dict | None = None) -> dict:
+                        custom_fields: dict | None = None,
+                        due_offset_days: int = 0) -> dict:
     """Import YAML from a string into an existing parent deck.
 
     resolutions:   {word_zh: "keep"|"update"|"custom"} for component word conflicts.
     card_configs:  {word_zh: {include, deck_path, suspended, ai_fill}}
     custom_fields: {word_zh: {pinyin, definition, traditional}} merged values for "custom" resolutions.
+    due_offset_days: shift every new card's due date by this many days (1 = tomorrow),
+                   so a word can be staged for a future daily deck (#636).
     """
     try:
         data = yaml.safe_load(fix_yaml_content(content))
@@ -158,7 +161,8 @@ def import_yaml_content(content: str, parent_deck_id: int,
                            resolutions=resolutions or {},
                            card_configs=card_configs or {},
                            custom_fields=custom_fields or {},
-                           lang=lang)
+                           lang=lang,
+                           due_offset_days=due_offset_days)
 
 
 def preview_yaml_content(content: str) -> dict:
@@ -642,7 +646,8 @@ def _import_entries(entries: list, deck_ids: dict, source: str, label: str,
                     resolutions: dict | None = None,
                     card_configs: dict | None = None,
                     custom_fields: dict | None = None,
-                    lang: str = "zh") -> dict:
+                    lang: str = "zh",
+                    due_offset_days: int = 0) -> dict:
     if resolutions is None:
         resolutions = {}
     if card_configs is None:
@@ -834,7 +839,8 @@ def _import_entries(entries: list, deck_ids: dict, source: str, label: str,
             logger.info("CATEGORIES %s: %r active=%r", label, word_zh, list(active))
         else:
             suspended_states = card_cfg.get("suspended") or None
-        _create_cards(word_id, target_deck_ids, suspended_states, word_zh=word_zh)
+        _create_cards(word_id, target_deck_ids, suspended_states, word_zh=word_zh,
+                      due_offset_days=due_offset_days)
         imported += 1
 
       except Exception as _entry_exc:
@@ -878,7 +884,7 @@ _CATEGORY_DUE_OFFSET: dict[str, int] = {
 
 def _create_cards(word_id: int, deck_ids: dict,
                   suspended_states: dict[str, bool] | None = None,
-                  word_zh: str = "") -> None:
+                  word_zh: str = "", due_offset_days: int = 0) -> None:
     if suspended_states is None:
         suspended_states = _DEFAULT_SUSPENDED
     today = database.anki_today()
@@ -888,7 +894,7 @@ def _create_cards(word_id: int, deck_ids: dict,
         is_suspended = suspended_states.get(category,
                                             _DEFAULT_SUSPENDED.get(category, False))
         state = "suspended" if is_suspended else "new"
-        offset = _CATEGORY_DUE_OFFSET.get(category, 0)
+        offset = _CATEGORY_DUE_OFFSET.get(category, 0) + due_offset_days
         due = (today + timedelta(days=offset)).isoformat() if not is_suspended else None
         tag = "  [SUSPENDED]" if is_suspended else ""
         lines.append(f"  {category:<10}  due={due or '(none)'}  (+{offset}d){tag}")

--- a/routes/imports.py
+++ b/routes/imports.py
@@ -257,9 +257,9 @@ def _card_deck_ids(entry_id: int) -> set[int]:
 
 @router.post("/api/add-word-ai")
 def add_word_ai(body: dict):
-    """Add one Chinese word to today's Daily deck with an AI-generated entry.
+    """Add one Chinese word to a Daily deck with an AI-generated entry.
 
-    Body: { word_zh }
+    Body: { word_zh, day?: "today"|"tomorrow" }
     Returns either {job_id, deck_path} — generation runs in the background,
     poll /api/add-word-ai/progress/{job_id} — or, when the word is already in
     the database, a finished {status, ...} with no AI call at all.
@@ -271,8 +271,15 @@ def add_word_ai(body: dict):
         raise HTTPException(status_code=400,
                             detail="Please enter the word in Chinese characters")
 
-    today = date.today().isoformat()
-    deck_path = f"Daily::{today}"
+    day = (body.get("day") or "today").strip()
+    if day not in ("today", "tomorrow"):
+        raise HTTPException(status_code=400, detail="day must be 'today' or 'tomorrow'")
+    # A daily deck dated in the future is locked until its date arrives
+    # (database.parse_daily_deck_date), which is exactly the "stage it for
+    # tomorrow" semantics — the cards just have to be due then too (#636).
+    due_offset_days = 1 if day == "tomorrow" else 0
+    target_day = (date.today() + timedelta(days=due_offset_days)).isoformat()
+    deck_path = f"Daily::{target_day}"
     deck_id = database.get_or_create_deck_path(deck_path)
 
     # Known word → don't pay for a second generation; the importer would skip
@@ -285,8 +292,8 @@ def add_word_ai(body: dict):
         saved_deck_id = database.get_or_create_saved_deck()
         if card_decks and card_decks <= {saved_deck_id}:
             # Only staged in Saved — promoting is exactly what the user wants.
-            leaf_decks = database.get_or_create_category_decks(deck_id, today)
-            database.promote_saved_word(existing["id"], leaf_decks, saved_deck_id, today)
+            leaf_decks = database.get_or_create_category_decks(deck_id, target_day)
+            database.promote_saved_word(existing["id"], leaf_decks, saved_deck_id, target_day)
             return {"status": "promoted", "word_zh": word_zh, "entry_id": existing["id"],
                     "deck_path": deck_path, "deck_id": deck_id}
         # Already being studied somewhere. Moving it here would reset its FSRS
@@ -313,7 +320,8 @@ def add_word_ai(body: dict):
     def _run():
         try:
             yaml_text = ai.generate_word_entry_yaml(word_zh)
-            result = importer.import_yaml_content(yaml_text, deck_id)
+            result = importer.import_yaml_content(yaml_text, deck_id,
+                                                  due_offset_days=due_offset_days)
             if result.get("yaml_error"):
                 raise ValueError(
                     f"AI returned invalid YAML: {result['yaml_error'].get('problem', 'parse error')}")

--- a/static/app.js
+++ b/static/app.js
@@ -6060,44 +6060,91 @@ function showQuickAddBanner(msg, isInfo) {
 // in today's Daily deck, due today. Generation takes ~30s, so the request only
 // returns a job id and we poll for the outcome.
 
-let _addWordPollTimer = null;
+// Generation takes ~30s but the request returns a job id immediately, so the
+// input never blocks: each submitted word becomes a queue entry that polls its
+// own job while the user types the next one (#636).
+let _addWordDay = 'today';          // 'today' | 'tomorrow'
+let _addWordQueue = [];             // [{key, wordZh, state, text}]
+let _addWordSeq = 0;
 
 function openAddWordModal() {
   document.getElementById('add-word-overlay').style.display = 'block';
   document.getElementById('add-word-modal').style.display = 'block';
-  const today = new Date();
-  document.getElementById('add-word-deck').textContent =
-    'Daily::' + today.toISOString().slice(0, 10);
+  setAddWordDay(_addWordDay);
   const input = document.getElementById('add-word-input');
   input.value = '';
   input.disabled = false;
   document.getElementById('add-word-status').textContent = '';
+  // Jobs that finished while the modal was closed already reported via banner.
+  _addWordQueue = _addWordQueue.filter(item => item.state === 'running');
+  _renderAddWordQueue();
   input.focus();
 }
 
 function closeAddWordModal() {
   document.getElementById('add-word-overlay').style.display = 'none';
   document.getElementById('add-word-modal').style.display = 'none';
-  // A running job keeps going server-side; closing just stops us watching it.
-  clearTimeout(_addWordPollTimer);
-  _addWordPollTimer = null;
+  // Running jobs keep going server-side and their polls keep the queue up to
+  // date; closing only hides the list. Drop finished rows so reopening the
+  // modal shows a clean slate.
+  _addWordQueue = _addWordQueue.filter(item => item.state === 'running');
+}
+
+function setAddWordDay(day) {
+  _addWordDay = day === 'tomorrow' ? 'tomorrow' : 'today';
+  for (const btn of document.querySelectorAll('.add-word-day-btn')) {
+    btn.classList.toggle('active', btn.dataset.day === _addWordDay);
+  }
+  const d = new Date();
+  if (_addWordDay === 'tomorrow') d.setDate(d.getDate() + 1);
+  document.getElementById('add-word-deck').textContent =
+    'Daily::' + `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  document.getElementById('add-word-input').focus();
+}
+
+function _renderAddWordQueue() {
+  const el = document.getElementById('add-word-queue');
+  if (!el) return;
+  // Built with textContent, not innerHTML — the word is free user input.
+  el.textContent = '';
+  for (const item of _addWordQueue) {
+    const row = document.createElement('div');
+    row.className = 'add-word-queue-item awq-' + item.state;
+    const word = document.createElement('b');
+    word.textContent = item.wordZh;
+    const state = document.createElement('span');
+    state.textContent = item.text;
+    row.append(word, state);
+    el.appendChild(row);
+  }
+}
+
+function _setAddWordItem(item, state, text) {
+  item.state = state;
+  item.text = text;
+  _renderAddWordQueue();
 }
 
 async function submitAddWord() {
   const input = document.getElementById('add-word-input');
-  const status = document.getElementById('add-word-status');
   const wordZh = input.value.trim();
   if (!wordZh) return;
 
-  input.disabled = true;
-  status.textContent = `Generating entry for ${wordZh}…`;
+  // Clear right away — the whole point is being able to type the next word
+  // while this one generates in the background.
+  input.value = '';
+  input.focus();
+  document.getElementById('add-word-status').textContent = '';
+
+  const item = { key: ++_addWordSeq, wordZh, state: 'running', text: 'Generating…' };
+  _addWordQueue.unshift(item);
+  _renderAddWordQueue();
 
   let result;
   try {
-    result = await api('POST', '/api/add-word-ai', { word_zh: wordZh });
+    result = await api('POST', '/api/add-word-ai', { word_zh: wordZh, day: _addWordDay });
   } catch (e) {
-    input.disabled = false;
-    status.textContent = `❌ ${e.message || 'Failed to add word'}`;
+    _setAddWordItem(item, 'error', e.message || 'Failed to add word');
     return;
   }
 
@@ -6106,47 +6153,40 @@ async function submitAddWord() {
     if (result.status === 'already_exists') {
       // A word owns one card per category for life (UNIQUE(word_id, category)),
       // so there is nothing to add — say where it lives instead of pretending.
-      input.disabled = false;
-      status.textContent =
-        `"${wordZh}" is already in your collection (${result.decks.join(', ')})`;
+      _setAddWordItem(item, 'error', `already in ${result.decks.join(', ')}`);
       return;
     }
-    closeAddWordModal();
-    const msgs = {
-      promoted: `✓ "${wordZh}" moved from Saved into ${result.deck_path}`,
-    };
-    showQuickAddBanner(msgs[result.status] || `✓ Done`, false);
+    _setAddWordItem(item, 'done', `✓ moved from Saved → ${result.deck_path}`);
     loadDecks();
     return;
   }
 
-  _pollAddWord(result.job_id, wordZh, result.deck_path);
+  _pollAddWord(result.job_id, item, result.deck_path);
 }
 
-async function _pollAddWord(jobId, wordZh, deckPath) {
-  clearTimeout(_addWordPollTimer);
-  const status = document.getElementById('add-word-status');
+async function _pollAddWord(jobId, item, deckPath) {
   const job = await api('GET', `/api/add-word-ai/progress/${jobId}`).catch(() => null);
 
   if (!job || job.status === 'running') {
-    _addWordPollTimer = setTimeout(() => _pollAddWord(jobId, wordZh, deckPath), 1500);
+    setTimeout(() => _pollAddWord(jobId, item, deckPath), 1500);
     return;
   }
-  _addWordPollTimer = null;
-  document.getElementById('add-word-input').disabled = false;
 
   if (job.status === 'error') {
-    status.textContent = `❌ ${job.error || 'Failed to add word'}`;
+    _setAddWordItem(item, 'error', job.error || 'Failed to add word');
     return;
   }
   // A "done" job that imported nothing means the AI produced an entry the
   // importer rejected — say so instead of claiming success.
   if (!job.summary || !job.summary.imported) {
-    status.textContent = `❌ "${wordZh}" could not be imported — check the logs`;
+    _setAddWordItem(item, 'error', 'could not be imported — check the logs');
     return;
   }
-  closeAddWordModal();
-  showQuickAddBanner(`✓ "${wordZh}" added to ${deckPath}`, false);
+  _setAddWordItem(item, 'done', `✓ ${deckPath}`);
+  // The modal may already be closed; the banner is how the user finds out.
+  if (document.getElementById('add-word-modal').style.display === 'none') {
+    showQuickAddBanner(`✓ "${item.wordZh}" added to ${deckPath}`, false);
+  }
   loadDecks();
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -914,13 +914,24 @@
     <button class="edit-modal-close" onclick="closeAddWordModal()">✕</button>
   </div>
   <div id="add-word-body">
-    <input id="add-word-input" type="text" placeholder="新词…" autocomplete="off"
-           onkeydown="if (event.key === 'Enter') submitAddWord()">
+    <div id="add-word-day">
+      <button type="button" class="add-word-day-btn active" data-day="today"
+              onclick="setAddWordDay('today')">Today</button>
+      <button type="button" class="add-word-day-btn" data-day="tomorrow"
+              onclick="setAddWordDay('tomorrow')">Tomorrow</button>
+    </div>
+    <div id="add-word-row">
+      <input id="add-word-input" type="text" placeholder="新词…" autocomplete="off"
+             onkeydown="if (event.key === 'Enter') submitAddWord()">
+      <button id="add-word-submit" type="button" onclick="submitAddWord()">加</button>
+    </div>
     <div id="add-word-hint">
       Enter a Chinese word — DeepSeek writes the full entry (definitions,
       examples, character breakdown) into <b id="add-word-deck">today's deck</b>.
+      Generation runs in the background, so you can keep typing the next word.
     </div>
     <div id="add-word-status"></div>
+    <div id="add-word-queue"></div>
   </div>
 </div>
 

--- a/static/style.css
+++ b/static/style.css
@@ -87,6 +87,26 @@ header h1 { font-size: 18px; font-weight: 700; }
   margin-left: 4px;
 }
 #random-words-btn:hover { background: var(--border); }
+/* The one action button in the header that creates something — give it the
+   primary colour and a real touch target instead of the browser default (#636) */
+#add-word-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  margin-left: 4px;
+  font-size: 20px;
+  line-height: 1;
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+}
+#add-word-btn:hover { filter: brightness(1.1); }
+#add-word-btn:active { transform: scale(0.92); }
 
 /* ── Layout ──────────────────────────────────────────── */
 main {
@@ -5059,7 +5079,7 @@ table.fsrs-table td.ivl { font-weight: 700; }
 }
 
 /* ── Sync modal (#625) ────────────────────────────────────────────────────── */
-/* Add-word modal (#627) */
+/* Add-word modal (#627, restyled for touch in #636) */
 #add-word-overlay {
   position: fixed;
   inset: 0;
@@ -5074,25 +5094,86 @@ table.fsrs-table td.ivl { font-weight: 700; }
   width: min(460px, 92vw);
   background: var(--card);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: 16px;
+  box-shadow: var(--shadow);
   z-index: 901;
   overflow: hidden;
 }
 #add-word-body {
-  padding: 14px 16px 16px;
+  padding: 16px;
+}
+
+/* Today / Tomorrow segmented control */
+#add-word-day {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  margin-bottom: 12px;
+  background: var(--bg);
+  border-radius: 12px;
+}
+.add-word-day-btn {
+  flex: 1;
+  padding: 10px 12px;
+  min-height: 44px;
+  font-size: 15px;
+  font-weight: 600;
+  background: none;
+  color: var(--muted);
+  border: none;
+  border-radius: 9px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.add-word-day-btn.active {
+  background: var(--card);
+  color: var(--primary);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+}
+
+#add-word-row {
+  display: flex;
+  gap: 8px;
 }
 #add-word-input {
-  width: 100%;
-  padding: 10px 12px;
+  flex: 1;
+  min-width: 0;
+  padding: 12px 14px;
+  min-height: 52px;
   font-size: 22px;
   background: var(--bg);
   color: var(--text);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 12px;
+}
+#add-word-input:focus {
+  outline: none;
+  border-color: var(--primary);
 }
 #add-word-input:disabled {
   opacity: 0.6;
 }
+#add-word-submit {
+  flex: 0 0 auto;
+  padding: 0 24px;
+  min-height: 52px;
+  font-size: 20px;
+  font-weight: 700;
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+}
+#add-word-submit:active {
+  transform: scale(0.97);
+}
+#add-word-submit:disabled {
+  opacity: 0.45;
+  cursor: default;
+  transform: none;
+}
+
 #add-word-hint {
   margin-top: 10px;
   color: var(--muted);
@@ -5103,6 +5184,51 @@ table.fsrs-table td.ivl { font-weight: 700; }
   margin-top: 12px;
   font-size: 13px;
   color: var(--muted);
+}
+
+/* Queue of words being generated in the background (#636) */
+#add-word-queue:not(:empty) {
+  margin-top: 14px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+  max-height: 220px;
+  overflow-y: auto;
+}
+.add-word-queue-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 7px 0;
+  font-size: 14px;
+  color: var(--muted);
+}
+.add-word-queue-item b {
+  color: var(--text);
+  font-size: 16px;
+  font-weight: 600;
+}
+.add-word-queue-item span {
+  text-align: right;
+}
+.add-word-queue-item.awq-error span { color: var(--again); }
+.add-word-queue-item.awq-done  span { color: var(--good); }
+
+/* Phones: dock the modal to the bottom so it sits above the keyboard */
+@media (max-width: 560px) {
+  #add-word-modal {
+    top: auto;
+    bottom: 0;
+    left: 0;
+    transform: none;
+    width: 100%;
+    border-radius: 16px 16px 0 0;
+    border-bottom: none;
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+  #add-word-body { padding: 14px 14px 18px; }
+  /* iOS zooms the page in when a focused input is under 16px */
+  #add-word-input { font-size: 24px; }
 }
 
 #sync-modal-overlay {

--- a/tests/test_add_word.py
+++ b/tests/test_add_word.py
@@ -5,7 +5,7 @@ through. Patching a provider client instead would silently stop working the
 next time DEFAULT_MODEL changes (issue #615).
 """
 
-from datetime import date
+from datetime import date, timedelta
 
 import pytest
 
@@ -63,10 +63,13 @@ def tmp_db(tmp_path, monkeypatch):
     return tmp_path
 
 
-def _run_add_word(word_zh, yaml_text=ENTRY_YAML):
+def _run_add_word(word_zh, yaml_text=ENTRY_YAML, day=None):
     """POST the word and, if a background job started, wait for it to finish."""
+    payload = {"word_zh": word_zh}
+    if day:
+        payload["day"] = day
     with patch.object(ai, "_call_api", return_value=yaml_text):
-        r = client.post("/api/add-word-ai", json={"word_zh": word_zh})
+        r = client.post("/api/add-word-ai", json=payload)
         assert r.status_code == 200, r.text
         body = r.json()
         if "job_id" not in body:
@@ -80,10 +83,14 @@ def _run_add_word(word_zh, yaml_text=ENTRY_YAML):
         pytest.fail("add-word job never finished")
 
 
+def _daily_leaf_decks(day=None):
+    day = day or date.today().isoformat()
+    deck_id = database.get_or_create_deck_path(f"Daily::{day}")
+    return database.get_or_create_category_decks(deck_id, day)
+
+
 def _today_leaf_decks():
-    today = date.today().isoformat()
-    deck_id = database.get_or_create_deck_path(f"Daily::{today}")
-    return database.get_or_create_category_decks(deck_id, today)
+    return _daily_leaf_decks()
 
 
 def test_new_word_lands_in_todays_deck_due_today(tmp_db):
@@ -160,6 +167,53 @@ def test_saved_word_is_promoted_into_todays_deck(tmp_db):
     conn.close()
     assert {r["deck_id"] for r in rows} == leaf_ids
     assert all(r["state"] == "new" and r["due"] == today for r in rows)
+
+
+def test_tomorrow_lands_in_tomorrows_deck_due_tomorrow(tmp_db):
+    """day='tomorrow' (#636): both the deck and the cards' due date move a day
+    forward — a future-dated daily deck stays locked until its date arrives, so
+    a card left due today would be unreachable."""
+    result = _run_add_word("生态", day="tomorrow")
+    assert result["job"]["status"] == "done", result["job"]
+
+    tomorrow = (date.today() + timedelta(days=1)).isoformat()
+    assert result["deck_path"] == f"Daily::{tomorrow}"
+
+    entry = database.get_word_by_zh("生态")
+    leaf_ids = set(_daily_leaf_decks(tomorrow).values())
+    conn = database.get_db()
+    cards = conn.execute(
+        "SELECT deck_id, due, state FROM cards WHERE word_id=? AND deleted_at IS NULL",
+        (entry["id"],),
+    ).fetchall()
+    conn.close()
+
+    assert {c["deck_id"] for c in cards} <= leaf_ids
+    assert all(c["due"] == tomorrow for c in cards if c["state"] != "suspended")
+
+
+def test_saved_word_promoted_to_tomorrow(tmp_db):
+    r = client.post("/api/save-word", json={"word_zh": "生态", "pinyin": "shēngtài"})
+    entry_id = r.json()["entry_id"]
+
+    with patch.object(ai, "_call_api", side_effect=AssertionError("AI was called")):
+        r = client.post("/api/add-word-ai", json={"word_zh": "生态", "day": "tomorrow"})
+    assert r.json()["status"] == "promoted"
+
+    tomorrow = (date.today() + timedelta(days=1)).isoformat()
+    conn = database.get_db()
+    rows = conn.execute(
+        "SELECT deck_id, due FROM cards WHERE word_id=? AND deleted_at IS NULL",
+        (entry_id,),
+    ).fetchall()
+    conn.close()
+    assert {r["deck_id"] for r in rows} == set(_daily_leaf_decks(tomorrow).values())
+    assert all(r["due"] == tomorrow for r in rows)
+
+
+def test_invalid_day_is_rejected(tmp_db):
+    r = client.post("/api/add-word-ai", json={"word_zh": "生态", "day": "next week"})
+    assert r.status_code == 400
 
 
 def test_non_chinese_input_is_rejected(tmp_db):


### PR DESCRIPTION
## 改了什么

顶栏 `＋` 添加生词（#627）原来只能加到今天，而且提交后输入框被禁用、要干等约 30 秒。

1. **今天 / 明天可选** — 弹窗顶部分段控件。选明天时词进 `Daily::<明天>`，**卡片 due 也一起后移**：未来日期的 Daily 牌组本来就被 `parse_daily_deck_date` 锁住，如果卡片还 due 今天就永远够不到。
2. **显式的"加"按钮** — 不再只能按回车。
3. **连续输入** — 点"加"后请求立即返回，输入框马上清空并重新聚焦；每个词进弹窗里的队列列表，各自轮询自己的 job，显示"生成中 / ✓ 牌组名 / 错误原因"。关掉弹窗后完成的词照旧弹横幅通知。
4. **按钮变好看（Daniel 反馈：手机上难看）** — 顶栏 `＋` 原来根本没有 CSS，用的是浏览器默认灰方块，现在是圆形主色按钮；弹窗按触摸重做：44px 以上的触摸目标、手机上贴底显示（避开键盘）、输入框 24px 防止 iOS 聚焦时整页放大。

## 怎么实现的

- `importer.import_yaml_content(..., due_offset_days=0)` → `_import_entries` → `_create_cards`，只是把类别偏移加上这个天数。**仍然是同一条导入管线**，没有一行特例建卡代码，卡片和手工导入的词条完全一致。
- `POST /api/add-word-ai` body 新增 `day`（默认 `today`，非法值 400），同时决定 deck_path、`promote_saved_word` 的 due 和 `due_offset_days`。
- 队列行用 `document.createElement` + `textContent` 构建 —— 生词是自由用户输入，不走 `innerHTML`。

## 怎么测试的

`pytest tests/` 全套 204 passed / 4 skipped。新增三个测试：明天路径的牌组与 due、Saved 词提升到明天、非法 `day` 返回 400。

Closes #636