### PR TITLE
用代码（非 AI）标注播客总结里的生词，中文总结加长到 1000 字（#638）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,13 +175,14 @@ bash sync_offline.sh push    # 只推不拉，推完归档本地库
 ├── importer.py            # YAML 词汇导入器（中文 + 法语格式）
 ├── ai.py                  # AI 提供商调用（每种提示词类型一个函数）
 ├── news_fetcher.py        # 新闻抓取（Tagesschau API + RSS；按天缓存 data/news_cache/）
-├── podcast.py              # 播客爬虫（#479）：播客 RSS 直链发现新单集（#497，退役 YouTube/yt-dlp）、每源 auto_process 开关+非自动源只入库元数据（#502，podcast_feeds 表）、转录链 NotebookLM 免费主力+听悟+Whisper 保底、单步异常不中止整链（#510 重排，链式降级，原 #498/#485/#486）、摘要 NotebookLM chat.ask 免费优先+DeepSeek/gpt API 链回退（api 路径内部 DeepSeek 优先省钱，#532）、HSK生词、邮件通知+Signal 通知（signal-cli 关联设备，发 Note to Self，#521，二者独立可选、互不影响；消息抬头播客名·星期·日期、链接在末尾，单集日期按 Europe/Berlin 显示，#532）、摘要 table.media 风格（`<p>` 段落+每段首句 `<b>` 加粗总结，#567）+详情页 Regenerate summary 按钮、邮件主题=`播客名 - 单集标题`（查不到播客名只用标题，不要退回死前缀）+ `summary_zh` 开头中文总结（3-5 句 HSK4-5，邮件/Signal/详情页三处；**是增量不是必需**——成功判定只看 `summary_de`，模型漏掉中文总结不能让整集失败）+ 摘要里任何 HSK5+ 中文概念都标 `pinyin/汉字`（不限于提取的词表，宁多勿少，#631）
+├── podcast.py              # 播客爬虫（#479）：播客 RSS 直链发现新单集（#497，退役 YouTube/yt-dlp）、每源 auto_process 开关+非自动源只入库元数据（#502，podcast_feeds 表）、转录链 NotebookLM 免费主力+听悟+Whisper 保底、单步异常不中止整链（#510 重排，链式降级，原 #498/#485/#486）、摘要 NotebookLM chat.ask 免费优先+DeepSeek/gpt API 链回退（api 路径内部 DeepSeek 优先省钱，#532）、HSK生词、邮件通知+Signal 通知（signal-cli 关联设备，发 Note to Self，#521，二者独立可选、互不影响；消息抬头播客名·星期·日期、链接在末尾，单集日期按 Europe/Berlin 显示，#532）、摘要 table.media 风格（`<p>` 段落+每段首句 `<b>` 加粗总结，#567）+详情页 Regenerate summary 按钮、邮件主题=`播客名 - 单集标题`（查不到播客名只用标题，不要退回死前缀）+ `summary_zh` 开头中文总结（600-1000 字分段，HSK4-5，邮件/Signal/详情页三处；**是增量不是必需**——成功判定只看 `summary_de`，模型漏掉中文总结不能让整集失败）+ 摘要里任何 HSK5+ 中文概念都标 `pinyin/汉字`（不限于提取的词表，宁多勿少，#631）+ 生词标注由代码兜底（`zh_annotate.py`，#638）
 ├── tts.py                 # edge-tts 封装（离线模式下只读缓存，#612）
 ├── offline.py             # OFFLINE_MODE / LOCAL_MODE + 联网探测（#612、#625）
 ├── sync_offline.sh        # 同步 sync/pull/push（#612、#625）
 ├── run.offline.sh         # 硬离线启动，飞机用（#612）
 ├── run.local.sh           # 本地模式启动，日常用（#625）
 ├── translator.py          # 翻译（Google Translate，deep-translator，可选）
+├── zh_annotate.py         # 生词标注（#638，零 AI）：HSK 表+词库+jieba+pypinyin+谷歌翻译
 ├── yaml_fixer.py          # 修复 AI 生成的格式错误 YAML
 ├── schema.sql             # 数据库模式
 ├── static/                # 前端（index.html + app.js + style.css）
@@ -327,6 +328,17 @@ FSRS 用毕业评分播种初始 stability/difficulty：默认权重下 **Good �
 - `podcast`（#482）——从已摘要的播客单集（`database.get_episode(episode_id)`）生成句子：单篇文章 = 该集 `transcript_zh`（截断到 15000 字），同样走 briefing 管线（`generate_briefing_sentences(generic=True, include_context=False)`），但**不允许上下文句**——每句都必须含一个目标词。`episode_id` 沿用 kahneman 的 `chapter_ids` 传参模式（GET 查询参数/regenerate POST body/gen_params），设置弹窗提供单选单集选择器（仅列 `status=summarized` 的单集）；不在早晨预生成 `_PREGEN_MODES` 里，因为选集是一次性的
 
 ---
+
+## 生词标注：代码做，不用 AI（`zh_annotate.py`，#638）
+
+#631 靠提示词让模型标 `pinyin/汉字`，模型经常漏（德语总结里出现光秃秃的 `(浙江)`），中文总结更是一个都没标。所有材料仓库里都有，所以改成确定性代码，**零 AI 调用**：`static/hsk_levels.json`（4991 词的 HSK 1-6 表）+ `entries.word_zh`（Daniel 的词库）+ `jieba` + `pypinyin` + `translator.py`。
+
+- **生词判定**：不在词库 **且**（HSK ≥ 5 **或** 根本不在 HSK 表里）
+- **中文总结**（`annotate_zh_summary`）→ 行内 `词（pīnyīn - 德语释义）`，每词只标首次；跳过人名地名（jieba 词性 `nr`/`ns`）和单字词
+- **德语总结**（`annotate_de_summary`）→ 只在中文片段前补拼音（`(浙江)` → `(Zhèjiāng/浙江)`），**不加释义**（德语原文就在旁边），也**不过滤人名地名**——德语文里的中文恰恰最需要读音；前面已经是 `/` 的说明模型自己标过了，不重复标
+- **透明组合过滤只用于中文总结**：HSK 表只有 4991 个词条，`十年`/`巨大变化`/`死掉` 这类普通组合全都"不在表里"，直接标会淹没真生词。规则是"表外词若每个字都是 HSK≤4 就跳过"，字的等级由**词表反推**（`_char_levels`：字出现在任何 HSK≤4 的词里就算基础字）——表里单字词只有 696 个，直接查单字覆盖太薄
+- **接入点在 `podcast.summarize()` 的返回处**（`_annotate_summary`）：NotebookLM 和 API 两条摘要路径、`_process_episode` 和 `regenerate_summary` 两个调用方全都经过这里，标注后的文本才写库，邮件/Signal/详情页三处自然一致，也不会各自重跑谷歌翻译
+- **全程吞异常**：HSK 表读不到、jieba 挂了、翻译超时，一律返回原文（翻译失败降级为只有拼音）。少个拼音是小事，为它丢掉整集摘要是荒唐的
 
 ## API 接口
 

--- a/ai.py
+++ b/ai.py
@@ -2386,8 +2386,11 @@ Transcript (Chinese, auto/manual captions, may contain minor recognition errors)
 {excerpt}
 
 Task:
-1. Write a SHORT Chinese-language summary of the episode: 3-5 sentences, placed before the
-   German summary so Daniel can grasp what the episode is about in Chinese first.
+1. Write a Chinese-language summary of the episode, placed before the German summary so
+   Daniel can grasp what the episode is about in Chinese first. Length: 600-1000 Chinese
+   characters — a full summary of the episode's content, not a teaser. Cover the actual
+   topics, arguments, examples and conclusions in the order the episode presents them,
+   and split it into several paragraphs (blank line between paragraphs).
    Write it at HSK 4-5 level — his actual reading level. Use plain, common vocabulary and
    short sentences. This is a comprehension aid, not another study exercise, so do NOT
    reach for literary or specialist words where an everyday one works. Plain text, no HTML.
@@ -2427,7 +2430,7 @@ Task:
 
 Return ONLY a JSON object, no other text, no markdown fences:
 {{
-  "summary_zh": "中文总结，3-5 句，HSK 4-5 水平的简单中文，纯文本",
+  "summary_zh": "中文总结，600-1000 字，分段（段落之间空一行），HSK 4-5 水平的简单中文，纯文本",
   "summary_de": "<German HTML summary: <p> paragraphs, each starting with a <b> lead sentence, <strong> highlights>",
   "words": [
     {{"word": "词语", "pinyin": "cí yǔ", "definition_de": "kurze deutsche Definition", "hsk": 5}}

--- a/podcast.py
+++ b/podcast.py
@@ -41,6 +41,7 @@ from zoneinfo import ZoneInfo
 import ai
 import database
 import translator
+import zh_annotate
 
 logger = logging.getLogger(__name__)
 
@@ -996,8 +997,24 @@ def summarize(transcript: str, title: str, detail_level: str) -> dict:
     if summarizer == "auto" and _notebooklm_credentials_available():
         result = _summarize_via_notebooklm(transcript, title, detail_level)
         if result:
-            return result
-    return ai.summarize_podcast_transcript(transcript, title, detail_level)
+            return _annotate_summary(result)
+    return _annotate_summary(ai.summarize_podcast_transcript(transcript, title, detail_level))
+
+
+def _annotate_summary(result: dict) -> dict:
+    """Add the AI-free vocabulary annotations (#638) to a fresh summary. Done
+    here, at the single choke point both summarizer paths and both callers
+    (_process_episode, regenerate_summary) pass through, so the annotated text
+    is what gets stored — email, Signal and the detail page then all show it
+    without each re-running Google Translate.
+
+    zh_annotate never raises: on any failure the untouched text comes back, so
+    a missing pinyin table can't cost Daniel the episode."""
+    if result.get("summary_zh"):
+        result["summary_zh"] = zh_annotate.annotate_zh_summary(result["summary_zh"])
+    if result.get("summary_de"):
+        result["summary_de"] = zh_annotate.annotate_de_summary(result["summary_de"])
+    return result
 
 
 def filter_new_words(words: list[dict]) -> list[dict]:
@@ -1153,15 +1170,23 @@ def _feed_title(episode: dict) -> str | None:
 
 
 def _summary_zh_html(summary_zh: str) -> str:
-    """Render the short Chinese summary block that opens the email (#631).
+    """Render the Chinese summary block that opens the email (#631).
     Escaped — the prompt asks for plain text, and a model that ignores that
-    must not get to inject markup into the mail."""
+    must not get to inject markup into the mail.
+
+    Since #638 the summary runs up to 1000 characters across several
+    paragraphs, so blank-line-separated blocks become real <p> tags; relying on
+    white-space:pre-wrap would be a gamble across mail clients."""
     if not summary_zh:
         return ""
+    paragraphs = [p.strip() for p in re.split(r"\n\s*\n", summary_zh) if p.strip()]
+    body = "".join(
+        f"<p style='margin:0 0 10px'>{html.escape(p)}</p>" for p in paragraphs
+    )
     return (
         "<div style='background:#f5f5f5;border-left:3px solid #999;"
         "padding:10px 14px;margin:0 0 16px;font-size:15px;line-height:1.7'>"
-        f"{html.escape(summary_zh)}</div>"
+        f"{body}</div>"
     )
 
 

--- a/tests/test_zh_annotate.py
+++ b/tests/test_zh_annotate.py
@@ -1,0 +1,135 @@
+"""
+Tests for zh_annotate.py — AI-free vocabulary annotation of podcast summaries
+(#638).
+
+No network and no real database: the HSK table, the collection lookup and
+Google Translate are all stubbed, so these tests assert the annotation *rules*
+(what counts as a new word, where the annotation lands, what happens when a
+piece fails) rather than the contents of the shipped word list. jieba does the
+real segmentation — it is a pure local dependency and its behavior is what the
+module actually relies on.
+"""
+
+import pytest
+
+import zh_annotate
+
+
+@pytest.fixture
+def collection():
+    """The stubbed contents of Daniel's collection — tests add to it."""
+    return set()
+
+
+@pytest.fixture(autouse=True)
+def stub_io(monkeypatch, collection):
+    """Stub the two things that reach outside the process: the collection
+    lookup (SQLite) and Google Translate. The HSK table is NOT stubbed — it
+    ships in this repo (static/hsk_levels.json) and is exactly what the rules
+    are supposed to be judged against."""
+    monkeypatch.setattr(zh_annotate, "_translation_cache", {})
+    monkeypatch.setattr(zh_annotate, "_known_words",
+                        lambda words: collection & set(words))
+    monkeypatch.setattr(zh_annotate, "_gloss_de", lambda w: f"DE:{w}")
+
+
+def test_hsk5_word_outside_collection_is_annotated():
+    out = zh_annotate.annotate_zh_summary("这集讨论对就业的影响。")
+    assert "就业（jiùyè - DE:就业）" in out
+
+
+def test_word_in_collection_is_not_annotated(collection):
+    """就业 is HSK 5, but once it is in Daniel's collection he knows it."""
+    collection.add("就业")
+    assert zh_annotate.annotate_zh_summary("这集讨论对就业的影响。") == "这集讨论对就业的影响。"
+
+
+def test_hsk4_and_below_is_not_annotated():
+    out = zh_annotate.annotate_zh_summary("这对公司的影响很大。")
+    assert out == "这对公司的影响很大。"
+
+
+def test_unlisted_word_of_basic_characters_is_skipped():
+    """"十年" is missing from the word list, but every character of it appears
+    in an HSK 1-4 word — Daniel can read it, so it must stay clean. This is the
+    main noise filter (#638)."""
+    out = zh_annotate.annotate_zh_summary("过去十年的变化。")
+    assert out == "过去十年的变化。"
+
+
+def test_unlisted_word_with_advanced_characters_is_annotated():
+    """"硅谷" is in neither the word list nor the collection, and 硅 appears in
+    no basic word — exactly the case the annotation exists for."""
+    out = zh_annotate.annotate_zh_summary("他在硅谷工作。")
+    assert "硅谷（guīgǔ - DE:硅谷）" in out
+
+
+def test_only_first_occurrence_is_annotated():
+    out = zh_annotate.annotate_zh_summary("就业问题。就业问题。")
+    assert out.count("jiùyè") == 1
+
+
+def test_non_annotated_text_is_returned_unchanged():
+    """Everything jieba emits is concatenated back, so untouched text must
+    survive byte-for-byte, including punctuation and line breaks."""
+    text = "他说：“好的。”\n\n第二段，还有 AI 和 2026 年。"
+    assert zh_annotate.annotate_zh_summary(text) == text
+
+
+def test_annotation_falls_back_to_pinyin_when_translation_fails(monkeypatch):
+    """Google Translate being down must cost the gloss, not the annotation."""
+    monkeypatch.setattr(zh_annotate, "_gloss_de", lambda w: "")
+    out = zh_annotate.annotate_zh_summary("对就业的影响。")
+    assert "就业（jiùyè）" in out
+
+
+def test_segmentation_failure_returns_original_text(monkeypatch):
+    monkeypatch.setattr(zh_annotate, "_segment", lambda text: [])
+    assert zh_annotate.annotate_zh_summary("对就业的影响。") == "对就业的影响。"
+
+
+def test_person_and_place_names_are_skipped_in_chinese(monkeypatch):
+    """Daniel chose not to have names glossed in the Chinese summary; the
+    filter is jieba's POS tag, so stub the segmentation to pin the rule down
+    independently of the dictionary."""
+    monkeypatch.setattr(zh_annotate, "_segment",
+                        lambda text: [("北京", "ns"), ("的", "uj"), ("瓶颈", "n")])
+    out = zh_annotate.annotate_zh_summary("北京的瓶颈")
+    assert "北京（" not in out
+    assert "瓶颈（píngjǐng - DE:瓶颈）" in out
+
+
+# --- German summary: pinyin only, no gloss ---------------------------------
+
+def test_bare_chinese_run_in_german_gets_pinyin():
+    out = zh_annotate.annotate_de_summary("<p>Engpass (瓶颈) im Chipsektor.</p>")
+    assert "(píngjǐng/瓶颈)" in out
+
+
+def test_run_already_annotated_by_the_model_is_left_alone():
+    """"pinyin/汉字" written by the AI must not get a second pinyin."""
+    text = "<p>Rezession (jīngjì shuāituì/经济衰退) trifft alle.</p>"
+    assert zh_annotate.annotate_de_summary(text) == text
+
+
+def test_basic_run_in_german_needs_no_pinyin():
+    text = "<p>Die Firma in China (中国) wächst.</p>"
+    assert zh_annotate.annotate_de_summary(text) == text
+
+
+def test_place_names_are_annotated_in_german():
+    """Unlike the Chinese summary, a place name in German prose is exactly what
+    Daniel cannot pronounce — no POS filtering here."""
+    out = zh_annotate.annotate_de_summary("<p>Provinz Zhejiang (浙江).</p>")
+    assert "(zhèjiāng/浙江)" in out
+
+
+def test_german_text_without_chinese_is_untouched():
+    text = "<p><b>Nur Deutsch.</b> Kein Chinesisch hier.</p>"
+    assert zh_annotate.annotate_de_summary(text) == text
+
+
+def test_empty_input_is_passed_through():
+    assert zh_annotate.annotate_zh_summary("") == ""
+    assert zh_annotate.annotate_de_summary("") == ""
+    assert zh_annotate.annotate_zh_summary(None) is None

--- a/zh_annotate.py
+++ b/zh_annotate.py
@@ -1,0 +1,256 @@
+"""
+Code-based (AI-free) vocabulary annotation for podcast summaries (#638).
+
+#631 asked the summarizing model to mark HSK5+ vocabulary with "pinyin/汉字".
+Models forget: the German summary regularly ships bare Chinese like "(浙江)",
+and the Chinese summary got no annotations at all. Everything needed to do it
+deterministically is already in the repo, so no AI call is involved here:
+
+  * `static/hsk_levels.json` — 4991 words with their HSK 1-6 level
+  * `entries.word_zh`        — the words Daniel already studies (his collection)
+  * `jieba` / `pypinyin`     — segmentation and toned pinyin
+  * `translator.py`          — Google Translate for the German gloss
+
+A word is "new" when it is NOT in Daniel's collection AND is either HSK 5+ or
+absent from the HSK list entirely (per #638: annotate generously, a redundant
+annotation costs nothing, a missing one costs him a lookup).
+
+Two entry points, deliberately different because the two texts need different
+things:
+
+  annotate_zh_summary()  Chinese summary -> inline "词（pīnyīn - Gloss）",
+                         first occurrence only, skips person/place names.
+  annotate_de_summary()  German summary -> prefixes bare Chinese runs with
+                         pinyin ("(浙江)" -> "(Zhèjiāng/浙江)"). No gloss: the
+                         German meaning is already right there in the sentence.
+                         No name filtering either — a Chinese name inside German
+                         prose is exactly what Daniel cannot pronounce.
+
+Both are best-effort: any failure returns the original text unchanged, because
+losing a whole episode over a missing pinyin table would be absurd.
+"""
+import json
+import logging
+import os
+import re
+
+logger = logging.getLogger(__name__)
+
+_HSK_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                         "static", "hsk_levels.json")
+
+# Words at or below this level count as known — Daniel reads at HSK 4-5.
+KNOWN_HSK_MAX = 4
+
+# jieba POS tags skipped in the Chinese summary: person names (nr) and place
+# names (ns). Institution names (nt) are kept — "清华大学" is worth a gloss.
+_SKIP_POS = ("nr", "ns")
+
+_CJK = r"一-鿿"
+_CJK_RUN = re.compile(f"[{_CJK}]+")
+_ALL_CJK = re.compile(f"^[{_CJK}]+$")
+
+_hsk_cache: dict[str, int] | None = None
+_char_cache: dict[str, int] | None = None
+_translation_cache: dict[str, str] = {}
+
+
+def _hsk_levels() -> dict[str, int]:
+    """The HSK 1-6 word list, loaded once. An unreadable file degrades to an
+    empty table, which makes every word look unknown — noisy, but it still
+    annotates rather than silently doing nothing."""
+    global _hsk_cache
+    if _hsk_cache is None:
+        try:
+            with open(_HSK_PATH, encoding="utf-8") as f:
+                _hsk_cache = {k: int(v) for k, v in json.load(f).items()}
+        except Exception as e:
+            logger.error("zh_annotate: cannot read %s — %s", _HSK_PATH, e)
+            _hsk_cache = {}
+    return _hsk_cache
+
+
+def _char_levels() -> dict[str, int]:
+    """Lowest HSK level each character appears at, derived from the word list
+    itself. The list only carries 696 single-character entries, far too few to
+    judge "is this character basic?", but a character used in any HSK 1-4 word
+    ("变" in "变化") is basic by definition. Built once, alongside the word
+    table."""
+    global _char_cache
+    if _char_cache is None:
+        levels: dict[str, int] = {}
+        for word, level in _hsk_levels().items():
+            for ch in word:
+                if level < levels.get(ch, 99):
+                    levels[ch] = level
+        _char_cache = levels
+    return _char_cache
+
+
+def _known_words(words: list[str]) -> set[str]:
+    """Which of these words are already in Daniel's collection. Queried per
+    call (the collection grows daily, and it is one indexed IN query)."""
+    if not words:
+        return set()
+    try:
+        import database
+        return database.word_zh_exists(words)
+    except Exception as e:
+        logger.warning("zh_annotate: collection lookup failed — %s", e)
+        return set()
+
+
+def _is_new_word(word: str, hsk: dict[str, int], known: set[str],
+                 skip_transparent: bool = False) -> bool:
+    """Is this a word Daniel would have to look up? Not in his collection, and
+    either HSK 5+ or missing from the list entirely.
+
+    `skip_transparent` (Chinese summary only) drops the main source of noise in
+    the "missing from the list" bucket: the list holds 4991 dictionary words,
+    so ordinary compounds built from basic characters ("十年", "巨大变化",
+    "死掉") land there too. If every character of an unlisted word is itself
+    HSK 1-4, Daniel can read it — no annotation. The German summary does not
+    use this: a bare Chinese run in German prose needs its pinyin regardless of
+    how common its characters are."""
+    if word in known:
+        return False
+    level = hsk.get(word)
+    if level is not None:
+        return level > KNOWN_HSK_MAX
+    if skip_transparent:
+        chars = _char_levels()
+        return not all(chars.get(ch, 99) <= KNOWN_HSK_MAX for ch in word)
+    return True
+
+
+def pinyin_of(text: str) -> str:
+    """Toned pinyin for one word, syllables joined without spaces
+    ("就业" -> "jiùyè"). Returns "" if pypinyin is unavailable."""
+    try:
+        from pypinyin import pinyin as _pinyin, Style
+        return "".join(s[0] for s in _pinyin(text, style=Style.TONE))
+    except Exception as e:
+        logger.warning("zh_annotate: pinyin failed for %r — %s", text, e)
+        return ""
+
+
+def _gloss_de(word: str) -> str:
+    """German gloss via Google Translate, memoized for the process. Returns ""
+    when translation is unavailable or hands back the input unchanged (which is
+    what translator.translate_zh does on failure) — the caller then annotates
+    with pinyin alone instead of printing "就业（jiùyè - 就业）"."""
+    if word in _translation_cache:
+        return _translation_cache[word]
+    gloss = ""
+    try:
+        import translator
+        result = (translator.translate_zh(word, target="de") or "").strip()
+        if result and result != word:
+            gloss = result
+    except Exception as e:
+        logger.warning("zh_annotate: translation failed for %r — %s", word, e)
+    _translation_cache[word] = gloss
+    return gloss
+
+
+def _segment(text: str) -> list[tuple[str, str]]:
+    """(word, pos) pairs from jieba. An import failure yields no pairs, so the
+    caller returns the text untouched."""
+    try:
+        import jieba.posseg as pseg
+        return [(w.word, w.flag) for w in pseg.cut(text)]
+    except Exception as e:
+        logger.warning("zh_annotate: segmentation failed — %s", e)
+        return []
+
+
+def find_new_words(text: str) -> list[str]:
+    """The annotatable words of a Chinese text, in order of first appearance:
+    multi-character, all-CJK, not a person/place name, not in the collection,
+    HSK 5+ or unlisted."""
+    return _new_words_from_pairs(_segment(text))
+
+
+def _new_words_from_pairs(pairs: list[tuple[str, str]]) -> list[str]:
+    if not pairs:
+        return []
+    candidates: list[str] = []
+    for word, pos in pairs:
+        if (len(word) >= 2 and _ALL_CJK.match(word)
+                and pos not in _SKIP_POS and word not in candidates):
+            candidates.append(word)
+    hsk = _hsk_levels()
+    known = _known_words(candidates)
+    return [w for w in candidates
+            if _is_new_word(w, hsk, known, skip_transparent=True)]
+
+
+def annotate_zh_summary(text: str) -> str:
+    """Annotate the first occurrence of every new word inline:
+    "对就业的影响" -> "对就业（jiùyè - Beschäftigung）的影响".
+
+    The text is rebuilt from the segmentation instead of being string-replaced:
+    jieba's tokens concatenate back to the exact input, and a token boundary is
+    the only place an annotation may go. Replacing by string would let a short
+    word ("模型") match inside a longer one already annotated ("大语言模型（…）")
+    and mangle it."""
+    if not text or not text.strip():
+        return text
+    try:
+        pairs = _segment(text)
+        if not pairs:
+            return text
+        new_words = set(_new_words_from_pairs(pairs))
+        if not new_words:
+            return text
+        out, done = [], set()
+        for word, _pos in pairs:
+            out.append(word)
+            if word not in new_words or word in done:
+                continue
+            done.add(word)
+            py = pinyin_of(word)
+            gloss = _gloss_de(word)
+            if not py and not gloss:
+                continue
+            note = f"{py} - {gloss}" if py and gloss else (py or gloss)
+            out.append(f"（{note}）")
+        return "".join(out)
+    except Exception as e:
+        logger.warning("zh_annotate: Chinese annotation failed — %s", e)
+        return text
+
+
+def annotate_de_summary(html: str) -> str:
+    """Prefix pinyin to Chinese runs in the German summary that the model left
+    bare: "Provinz Zhejiang (浙江)" -> "Provinz Zhejiang (Zhèjiāng/浙江)".
+
+    A run already preceded by "/" is one the model annotated itself
+    ("(jīngjì shuāituì/经济衰退)") and is left alone. Runs made up entirely of
+    HSK1-4 / collection words ("(中国)") need no help either. HTML tags are
+    never touched — they contain no CJK."""
+    if not html or not html.strip():
+        return html
+    try:
+        runs = _CJK_RUN.findall(html)
+        if not runs:
+            return html
+        hsk = _hsk_levels()
+        # Judge a run word by word: a run is worth annotating if any of its
+        # words is new. Names are NOT skipped here — see the module docstring.
+        run_words = {run: [w for w, _pos in _segment(run)] or [run] for run in runs}
+        known = _known_words(sorted({w for ws in run_words.values() for w in ws}))
+
+        def _replace(m: re.Match) -> str:
+            run = m.group(0)
+            if m.start() > 0 and html[m.start() - 1] == "/":
+                return run  # already annotated by the model
+            if not any(_is_new_word(w, hsk, known) for w in run_words.get(run, [run])):
+                return run
+            py = pinyin_of(run)
+            return f"{py}/{run}" if py else run
+
+        return _CJK_RUN.sub(_replace, html)
+    except Exception as e:
+        logger.warning("zh_annotate: German annotation failed — %s", e)
+        return html


### PR DESCRIPTION
## 改了什么

### 1. 新模块 `zh_annotate.py` —— 零 AI 的生词标注

#631 靠提示词让模型标 `pinyin/汉字`，模型经常漏（详情页上 `(浙江)`、`(清华大学)` 都是光秃秃的），中文总结更是一个都没标。材料仓库里全都有，所以改成确定性代码：

| 用途 | 来源 |
|------|------|
| HSK 等级 | `static/hsk_levels.json`（4991 词） |
| 已学词 | `entries.word_zh`（`database.word_zh_exists`） |
| 分词 | `jieba.posseg` |
| 拼音 | `pypinyin`（带声调） |
| 释义 | `translator.py`（谷歌翻译 → 德语） |

**生词判定**：不在词库 且（HSK ≥ 5 或不在 HSK 表里）。

- **中文总结**：行内 `芯片（xīnpiàn - Chip）`，每词只标首次；跳过人名地名（`nr`/`ns`）与单字词
- **德语总结**：只给模型漏标的中文片段补拼音，`Provinz Zhejiang (浙江)` → `Provinz Zhejiang (Zhèjiāng/浙江)`。不加释义（德语原文就在旁边），也不过滤人名地名——德语文里的中文恰恰最需要读音；已经是 `pinyin/汉字` 形式的不重复标

**噪音过滤**（只用于中文总结）：HSK 表只有 4991 词条，`十年`/`巨大变化`/`死掉` 这类普通组合全都"不在表里"，直接标会淹没真生词。规则是"表外词若每个字都是 HSK≤4 就跳过"，字的等级由词表反推（字出现在任何 HSK≤4 的词里 = 基础字）——表里单字词只有 696 个，直接查单字覆盖太薄。实测同一段总结的候选词从 14 个降到 8 个，留下的是 `芯片`/`供应链`/`瓶颈`/`模型` 这类真生词。

### 2. 中文总结加长

提示词 "3-5 句" → **600-1000 字、分段**，按集内顺序覆盖话题/论点/例子/结论。邮件里按空行渲染成 `<p>`（不赌邮件客户端支持 `white-space: pre-wrap`）；前端和 Signal 本来就支持换行。

## 为什么这样接

标注放在 `podcast.summarize()` 的返回处（`_annotate_summary`）——NotebookLM 与 API 两条摘要路径、`_process_episode` 与 `regenerate_summary` 两个调用方全都经过这一个点。标注后的文本才写库，所以邮件/Signal/详情页三处天然一致，也不会各自重跑谷歌翻译。

全程吞异常：HSK 表读不到、jieba 挂了、翻译超时，一律返回原文（翻译失败降级为只有拼音）。少个拼音是小事，为它丢掉整集摘要是荒唐的。

## 怎么测的

- 新增 `tests/test_zh_annotate.py`（16 个用例）：不联网、不碰真库——词库查询和谷歌翻译打桩，HSK 表用仓库里真实的那份（它就是规则要对照的东西），jieba 跑真的分词
- 覆盖：HSK5+ 标注、已学词不标、HSK≤4 不标、透明组合跳过、非透明表外词标注、只标首次、未标注文本逐字节还原、翻译失败降级为纯拼音、分词失败原样返回、人名地名过滤；德语侧的补拼音/不重复标/基础词不标/人名地名照标
- `pytest tests/` 全套 **220 passed, 4 skipped**
- 端到端冒烟：`_annotate_summary` + `_summary_zh_html` 输出人工核对过

Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)