### PR TITLE
播客故事模式默认改用 DeepSeek（#640）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -2176,7 +2176,7 @@ def generate_podcast_sentences(
     cards: list[dict],
     summary: str,            # the episode's German summary_de (caller ensures non-empty)
     episode_title: str,
-    model: str = "gpt-5-mini",
+    model: str = DEFAULT_MODEL,     # #640: DeepSeek, same as kahneman
     max_hsk: int = 3,
     progress_key: str | None = None,
     attempt_label: str = "",

--- a/routes/story.py
+++ b/routes/story.py
@@ -305,8 +305,13 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
             # #541, never the full transcript), one lean call per batch of
             # MAX_NEWS_BATCH words plus missing-word top-ups, no fact-check.
             # The model is the user's dropdown pick, no longer locked to
-            # BRIEFING_MODEL; default gpt-5-mini (glm-4.7 once Daniel's Zhipu
-            # registration clears — a dropdown click, no code change).
+            # BRIEFING_MODEL. Default is ai.DEFAULT_MODEL (DeepSeek) since #640
+            # — the gpt-5-mini default was inherited from the news path, whose
+            # reason (DeepSeek censors news content) doesn't apply here: the
+            # input is a German episode summary, and kahneman has always run on
+            # DeepSeek. If an episode's topic does trip DeepSeek's filter, the
+            # per-word fallback sentences make it obvious and the dropdown
+            # switches back to GPT without a code change.
             if not episode_id:
                 raise ValueError("Podcast mode requires selecting an episode.")
             episode = database.get_episode(episode_id)
@@ -315,7 +320,7 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
             summary = (episode.get("summary_de") or "").strip()
             if not summary:
                 raise ValueError("Selected podcast episode has no summary yet.")
-            model = _validated_model(model, default="gpt-5-mini")
+            model = _validated_model(model, default=ai.DEFAULT_MODEL)
             logger.info("story  podcast model in use: %s batch_size=%s", model, batch_size)
             # batch_size (issue #563): user-controlled words-per-call from the
             # setup modal; empty/0 = one single call, capped at MAX_PODCAST_BATCH
@@ -497,7 +502,7 @@ def generate_sentence_for_word(card: dict, gen_params: dict | None) -> dict | No
                 if summary:
                     sentences = ai.generate_podcast_sentences(
                         [card], summary, ep.get("title") or "",
-                        model=_validated_model(gp.get("model"), default="gpt-5-mini"),
+                        model=_validated_model(gp.get("model"), default=ai.DEFAULT_MODEL),
                         max_hsk=gp.get("max_hsk", 3),
                         source_url=ep.get("youtube_url") or f"/#podcast-{ep['id']}",
                         source_title=ep.get("title"))

--- a/static/app.js
+++ b/static/app.js
@@ -7268,9 +7268,11 @@ function updateSetupMode() {
 // below) instead of sharing BRIEFING_MODEL.
 let _modelBeforeNewsMode = null;
 
-// Per-mode remembered model (issue #561): podcast defaults to gpt-5-mini the
-// first time it's opened, then remembers whatever the user picked last.
-const MODE_MODEL_DEFAULTS = { podcast: 'gpt-5-mini' };
+// Per-mode remembered model (issue #561): podcast has its own first-time
+// default, then remembers whatever the user picked last. Since #640 that
+// default is DeepSeek (like kahneman) rather than gpt-5-mini — must stay in
+// sync with ai.DEFAULT_MODEL, which is the backend-side default.
+const MODE_MODEL_DEFAULTS = { podcast: 'deepseek-v4-flash' };
 let _modelSelMode = 'story';   // mode the model dropdown's current value belongs to
 
 function _autoSwitchModelForMode(mode) {


### PR DESCRIPTION
## 改了什么

播客故事模式的默认模型 `gpt-5-mini` → `ai.DEFAULT_MODEL`（`deepseek-v4-flash`），与 kahneman 一致。

**为什么**：这个默认值是 #561 从新闻简报路径继承来的。简报锁 OpenAI 是因为 DeepSeek 会审查新闻内容，
但播客模式的输入只是一段德语单集摘要，不是新闻原文。价格上 $0.25/$2.00 → $0.14/$0.28，
而播客生成是输出密集型（每个词一句话＋ #634 新加的 reasoning_zh），输出便宜 7 倍。

改动三处默认值：

- `ai.generate_podcast_sentences` 的 `model` 参数
- `routes/story.py`：生成入口 + Again 单句重生成入口
- `static/app.js` 的 `MODE_MODEL_DEFAULTS.podcast`（前端首次打开时的预选值）

下拉框仍然自由选择（#561 起播客不锁模型）。

## 已知风险

DeepSeek 对政治敏感话题可能拒答。遇到这类单集时会落到 per-word 兜底句（`我学了X这个词。`），
一眼就能看出来，在界面下拉框切回 gpt-5-mini 即可，无需改代码。

## 怎么测试

- `pytest tests/` 全绿（220 passed）
- `node --check static/app.js` 通过

Closes #640