### PR TITLE
播客：补漏到每个词都有句子；加载界面显示生成日志（#642）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -46,6 +46,30 @@ def _set_progress(key: str | None, **kwargs) -> None:
         _story_progress[key] = kwargs
 
 
+# Cumulative log lines per progress key (issue #642). _set_progress overwrites
+# the whole dict on every update, so its single `msg` can only ever show the
+# current step — never what already happened or where a run got stuck. The
+# loading screen renders these lines under the progress bar.
+_story_log: dict[str, list[str]] = {}
+_STORY_LOG_MAX = 200
+
+
+def reset_story_log(key: str | None) -> None:
+    if key:
+        _story_log.pop(key, None)
+
+
+def log_progress(key: str | None, line: str) -> None:
+    """Append one Chinese log line for the loading screen, and mirror it to the
+    server log so the same trace is available in journalctl after the fact."""
+    logger.info("story-log  %s", line)
+    if not key:
+        return
+    lines = _story_log.setdefault(key, [])
+    lines.append(line)
+    del lines[:-_STORY_LOG_MAX]
+
+
 # ---------------------------------------------------------------------------
 # Provider routing
 # ---------------------------------------------------------------------------
@@ -1370,6 +1394,14 @@ MAX_NEWS_BATCH = 10
 # adherence starts slipping — and gpt-5 shares the 8192 budget with reasoning.
 MAX_PODCAST_BATCH = 20
 
+# Podcast top-up rounds (issue #642): keep re-requesting the words the model
+# skipped instead of dumping them on the 我学了X这个词。fallback after 3 rounds.
+# From PODCAST_SOLO_ROUND onwards each remaining word gets its own call — by
+# then only a few are left, and one word per call is the shape the model is
+# least able to wriggle out of.
+MAX_PODCAST_ROUNDS = 6
+PODCAST_SOLO_ROUND = 4
+
 
 def generate_news_sentences(
     cards: list[dict],
@@ -2228,31 +2260,28 @@ def generate_podcast_sentences(
     sentences: list[dict] = []
     remaining = list(cards)
 
-    for attempt in range(3):
-        if not remaining:
-            break
-        msg = (f"生成播客总结…{attempt_label}" if attempt == 0
-               else f"补漏 {len(remaining)} 个词（第{attempt + 1}轮）…{attempt_label}")
-        _set_progress(progress_key, phase="request", msg=msg, percent=20 + attempt * 25)
+    def _run_round(batch: list[dict], extra_hint: str, label: str) -> None:
+        """One AI call for `batch`; moves every word it covered out of `remaining`."""
         # 8192: all-at-once batching (issue #563) can mean 30+ sentences in one
         # response, and the gpt-5 series shares this budget with internal
         # reasoning tokens (same rationale as the briefing call).
-        raw = _call_api(model, [{"role": "user", "content": _build_prompt(remaining)}],
+        raw = _call_api(model, [{"role": "user", "content": _build_prompt(batch, extra_hint)}],
                          8192, purpose="podcast")
 
         json_start = raw.find("[")
         json_end = raw.rfind("]") + 1
         if json_start == -1 or json_end == 0:
-            logger.warning("podcast attempt %d: no JSON array found", attempt + 1)
-            continue
+            log_progress(progress_key, f"{label}：AI 回复里找不到 JSON 数组，本轮作废")
+            return
         try:
             items = json.loads(raw[json_start:json_end])
         except json.JSONDecodeError as e:
-            logger.warning("podcast attempt %d: JSON parse error: %s", attempt + 1, e)
-            continue
+            log_progress(progress_key, f"{label}：JSON 解析失败（{e}），本轮作废")
+            return
 
         # Scan in order: not trusting the AI's target_word tag, only the actual
         # sentence content counts (same approach as briefing).
+        got = 0
         for item in items:
             s_zh = (item.get("sentence_zh") or "").strip()
             if not s_zh:
@@ -2261,6 +2290,7 @@ def generate_podcast_sentences(
             if matched is None:
                 continue          # no target word → drop (this mode allows no context sentences)
             remaining.remove(matched)
+            got += 1
             sentences.append({
                 "word_ids": [matched["word_id"]],
                 "sentence_zh": s_zh,
@@ -2275,14 +2305,53 @@ def generate_podcast_sentences(
                 "source_title": source_title,
                 "tokens": [],
             })
+        log_progress(progress_key, f"{label}：拿到 {got} 句，还差 {len(remaining)} 个词")
 
-        if remaining:
-            logger.warning("podcast attempt %d: missing words (will re-request): %s",
-                           attempt + 1, [c["word_zh"] for c in remaining])
+    log_progress(progress_key, f"开始生成播客句子：{len(cards)} 个词，模型 {model}")
 
-    # Per-word fallback so every card ends up with a sentence.
+    # Keep re-requesting the words the model skipped until none are left
+    # (issue #642). The old 3-round cap left plenty of words on the fallback
+    # sentence 我学了X这个词。
+    for round_no in range(1, MAX_PODCAST_ROUNDS + 1):
+        if not remaining:
+            break
+        missing = "、".join(c["word_zh"] for c in remaining)
+        if round_no == 1:
+            hint = ""
+            msg = f"生成播客句子…{attempt_label}"
+            batches = [remaining]
+        else:
+            # #642: the retry used to resend the *identical* prompt, so the model
+            # simply reproduced the same omissions. Name the skipped words and
+            # relax topic coverage — with a handful of words left, "cover every
+            # topic" is an instruction that cannot be satisfied.
+            hint = (f"\n\n【补漏轮】上一轮你漏掉了这些词：{missing}。"
+                    f"这一轮只需要为上面列出的每一个词各写一句话，一个都不能少。"
+                    f"词少的时候不必覆盖摘要里的所有话题，但每句仍然必须包含"
+                    f"一个来自摘要的专有名词。")
+            msg = f"补漏 {len(remaining)} 个词（第{round_no}轮）…{attempt_label}"
+            # Late rounds go one word per call: with only a few words left this
+            # is the most reliable shape — the model has no room to "pick the
+            # easy ones" and drop the rest.
+            batches = ([[c] for c in remaining] if round_no >= PODCAST_SOLO_ROUND
+                       else [list(remaining)])
+        _set_progress(progress_key, phase="request", msg=msg,
+                      percent=min(20 + round_no * 12, 90))
+        if round_no > 1:
+            log_progress(progress_key,
+                         f"第{round_no}轮补漏"
+                         f"{'（每词单独一次调用）' if round_no >= PODCAST_SOLO_ROUND else ''}"
+                         f"：{missing}")
+        for batch in batches:
+            if not any(c in remaining for c in batch):
+                continue          # already covered by an earlier batch this round
+            _run_round(batch, hint, f"第{round_no}轮")
+
+    # Per-word fallback so every card ends up with a sentence. After #642 this
+    # only triggers when every round failed outright (API errors, censored
+    # replies) — not merely because the model skipped a word.
     for card in remaining:
-        logger.warning("podcast: using fallback sentence for %s", card["word_zh"])
+        log_progress(progress_key, f"⚠️ {card['word_zh']}：{MAX_PODCAST_ROUNDS} 轮都没写出句子，用兜底句")
         sentences.append({
             "word_ids": [card["word_id"]],
             "sentence_zh": card.get("source_sentence") or f"我学了{card['word_zh']}这个词。",

--- a/routes/story.py
+++ b/routes/story.py
@@ -217,6 +217,9 @@ def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
         return None
     lang = lang or database.get_deck_lang(deck_id)
     ai._story_progress[progress_key] = {"phase": "starting", "msg": "Starting…", "percent": 5}
+    # #642: a fresh run starts with a fresh log — the previous run's lines would
+    # otherwise stay on the loading screen and read as if they belonged to this one.
+    ai.reset_story_log(progress_key)
     with database.action_context(_action_label_for_story(mode, deck_id)):
         # Inside the action context (issue #578): fix_commas calls previously ran
         # before it and showed up as orphan "fix_commas · legacy" cost rows.
@@ -1289,4 +1292,8 @@ def put_pregen_config(body: dict):
 def story_progress_endpoint(deck_id: int, category: str, lang: str | None = None):
     lang = lang or database.get_deck_lang(deck_id)
     key = f"{deck_id}/{category}/{lang}"
-    return ai._story_progress.get(key, {"phase": "idle", "msg": "", "percent": 0})
+    prog = dict(ai._story_progress.get(key, {"phase": "idle", "msg": "", "percent": 0}))
+    # #642: the cumulative log lives outside _story_progress (which gets fully
+    # overwritten on each update), so merge it in here for the loading screen.
+    prog["log"] = ai._story_log.get(key, [])
+    return prog

--- a/static/app.js
+++ b/static/app.js
@@ -953,6 +953,23 @@ function _startStoryProgressPoll(deckId, cat) {
         }
         artEl.style.display = titles.length ? 'block' : 'none';
       }
+      // Generation log (issue #642): cumulative backend lines, appended only
+      // (re-rendering the whole list every 400ms would fight the scrollbar).
+      // Auto-scrolls to the newest line unless the user scrolled up to read.
+      const logEl = document.getElementById('loading-log');
+      if (logEl) {
+        const lines = Array.isArray(p.log) ? p.log : [];
+        const shown = logEl.childElementCount;
+        if (lines.length < shown) logEl.innerHTML = '';   // new run reset the log
+        const atBottom = logEl.scrollHeight - logEl.scrollTop - logEl.clientHeight < 20;
+        for (const line of lines.slice(logEl.childElementCount)) {
+          const div = document.createElement('div');
+          div.textContent = line;      // backend text, never HTML
+          logEl.appendChild(div);
+        }
+        logEl.style.display = lines.length ? 'block' : 'none';
+        if (atBottom) logEl.scrollTop = logEl.scrollHeight;
+      }
     } catch (_) {}
   }, 400);
 }
@@ -3237,7 +3254,13 @@ function _renderPodcastDetail(ep) {
       <td><button id="podcast-add-word-${idx}" class="btn-secondary" onclick="doPodcastAddWord(${idx})">+ Add</button></td>
     </tr>`).join('');
   const hskTable = hskRows
-    ? `<table class="cost-table"><thead><tr><th>Word</th><th>Pinyin</th><th>German</th><th>Add</th></tr></thead><tbody>${hskRows}</tbody></table>`
+    ? `<div id="podcast-add-day" class="add-word-day-row">
+         <button type="button" class="add-word-day-btn" data-day="today"
+                 onclick="setPodcastAddDay('today')">Today</button>
+         <button type="button" class="add-word-day-btn" data-day="tomorrow"
+                 onclick="setPodcastAddDay('tomorrow')">Tomorrow</button>
+       </div>
+       <table class="cost-table"><thead><tr><th>Word</th><th>Pinyin</th><th>German</th><th>Add</th></tr></thead><tbody>${hskRows}</tbody></table>`
     : '<p class="keymap-hint">No HSK vocabulary extracted.</p>';
   const links = [
     ep.youtube_url ? `<a href="${_escHtml(ep.youtube_url)}" target="_blank" rel="noopener" class="btn-secondary">YouTube ↗</a>` : '',
@@ -3355,30 +3378,34 @@ async function doPodcastNotify(channel) {
   }
 }
 
-async function doPodcastAddWord(idx) {
+// Which day the podcast vocabulary table adds to. Podcasts are usually
+// listened to in the evening, so tomorrow stays the default (#643).
+let _podcastAddDay = 'tomorrow';
+
+function setPodcastAddDay(day) {
+  _podcastAddDay = day === 'today' ? 'today' : 'tomorrow';
+  for (const btn of document.querySelectorAll('#podcast-add-day .add-word-day-btn')) {
+    btn.classList.toggle('active', btn.dataset.day === _podcastAddDay);
+  }
+}
+
+function doPodcastAddWord(idx) {
   const w = _podcastDetailWords[idx];
   const btn = document.getElementById(`podcast-add-word-${idx}`);
   if (!w || !btn) return;
+  const wordZh = w.word || w.word_zh || '';
+  if (!wordZh) return;
+
   btn.disabled = true;
   btn.textContent = '…';
-  try {
-    const result = await api('POST', '/api/quick-add-word', {
-      word_zh: w.word || w.word_zh || '',
-      pinyin: w.pinyin,
-      meaning: w.definition_de || w.definition,
-    });
-    const labels = {
-      created: '✓ added',
-      added_to_deck: '✓ added',
-      already_in_deck: '✓ in deck',
-    };
-    btn.textContent = labels[result.status] || '✓ added';
-    // Stays disabled — button reflects a completed, non-repeatable action.
-  } catch (e) {
-    btn.disabled = false;
-    btn.textContent = '+ Add';
-    showError(e.message || 'Failed to add word');
-  }
+  // Generation takes ~30s in the background — the other rows stay clickable,
+  // so several words can be queued up at once.
+  addWordViaAi(wordZh, _podcastAddDay, (state, text) => {
+    btn.textContent = text;
+    btn.classList.toggle('podcast-add-error', state === 'error');
+    // Only a failure is worth retrying; a finished add is not repeatable.
+    if (state === 'error') btn.disabled = false;
+  });
 }
 
 // Hash direct-link support: emails link to /#podcast-<id> (episode detail).
@@ -6125,7 +6152,60 @@ function _setAddWordItem(item, state, text) {
   _renderAddWordQueue();
 }
 
-async function submitAddWord() {
+// The one way to add a word anywhere in the app (#643): the full DeepSeek
+// pipeline behind /api/add-word-ai, which writes a complete de-zh-bot entry
+// (examples, character breakdown, measure words, synonyms, etymology) through
+// the ordinary importer. The old /api/quick-add-word only filled four fields
+// and — worse — reported success even when cards has UNIQUE(word_id, category)
+// silently dropped the insert for a word already studied elsewhere.
+//
+// onUpdate(state, text) is called with 'running' | 'done' | 'error'.
+async function addWordViaAi(wordZh, day, onUpdate) {
+  let result;
+  try {
+    result = await api('POST', '/api/add-word-ai', { word_zh: wordZh, day });
+  } catch (e) {
+    onUpdate('error', e.message || 'Failed to add word');
+    return;
+  }
+
+  // Known words come back finished — no AI call, no job to poll.
+  if (!result.job_id) {
+    if (result.status === 'already_exists') {
+      // A word owns one card per category for life, so there is nothing to
+      // add — say where it lives instead of pretending it worked.
+      onUpdate('error', `already in ${result.decks.join(', ')}`);
+      return;
+    }
+    onUpdate('done', `✓ moved from Saved → ${result.deck_path}`, result.deck_path);
+    loadDecks();
+    return;
+  }
+
+  onUpdate('running', 'Generating…');
+  const poll = async () => {
+    const job = await api('GET', `/api/add-word-ai/progress/${result.job_id}`).catch(() => null);
+    if (!job || job.status === 'running') {
+      setTimeout(poll, 1500);
+      return;
+    }
+    if (job.status === 'error') {
+      onUpdate('error', job.error || 'Failed to add word');
+      return;
+    }
+    // A "done" job that imported nothing means the AI produced an entry the
+    // importer rejected — say so instead of claiming success.
+    if (!job.summary || !job.summary.imported) {
+      onUpdate('error', 'could not be imported — check the logs');
+      return;
+    }
+    onUpdate('done', `✓ ${result.deck_path}`, result.deck_path);
+    loadDecks();
+  };
+  setTimeout(poll, 1500);
+}
+
+function submitAddWord() {
   const input = document.getElementById('add-word-input');
   const wordZh = input.value.trim();
   if (!wordZh) return;
@@ -6140,54 +6220,14 @@ async function submitAddWord() {
   _addWordQueue.unshift(item);
   _renderAddWordQueue();
 
-  let result;
-  try {
-    result = await api('POST', '/api/add-word-ai', { word_zh: wordZh, day: _addWordDay });
-  } catch (e) {
-    _setAddWordItem(item, 'error', e.message || 'Failed to add word');
-    return;
-  }
-
-  // Known words come back finished — no AI call, no job to poll.
-  if (!result.job_id) {
-    if (result.status === 'already_exists') {
-      // A word owns one card per category for life (UNIQUE(word_id, category)),
-      // so there is nothing to add — say where it lives instead of pretending.
-      _setAddWordItem(item, 'error', `already in ${result.decks.join(', ')}`);
-      return;
+  addWordViaAi(wordZh, _addWordDay, (state, text, deckPath) => {
+    _setAddWordItem(item, state, text);
+    // The modal may already be closed; the banner is how the user finds out.
+    if (state === 'done' &&
+        document.getElementById('add-word-modal').style.display === 'none') {
+      showQuickAddBanner(`✓ "${wordZh}" added to ${deckPath}`, false);
     }
-    _setAddWordItem(item, 'done', `✓ moved from Saved → ${result.deck_path}`);
-    loadDecks();
-    return;
-  }
-
-  _pollAddWord(result.job_id, item, result.deck_path);
-}
-
-async function _pollAddWord(jobId, item, deckPath) {
-  const job = await api('GET', `/api/add-word-ai/progress/${jobId}`).catch(() => null);
-
-  if (!job || job.status === 'running') {
-    setTimeout(() => _pollAddWord(jobId, item, deckPath), 1500);
-    return;
-  }
-
-  if (job.status === 'error') {
-    _setAddWordItem(item, 'error', job.error || 'Failed to add word');
-    return;
-  }
-  // A "done" job that imported nothing means the AI produced an entry the
-  // importer rejected — say so instead of claiming success.
-  if (!job.summary || !job.summary.imported) {
-    _setAddWordItem(item, 'error', 'could not be imported — check the logs');
-    return;
-  }
-  _setAddWordItem(item, 'done', `✓ ${deckPath}`);
-  // The modal may already be closed; the banner is how the user finds out.
-  if (document.getElementById('add-word-modal').style.display === 'none') {
-    showQuickAddBanner(`✓ "${item.wordZh}" added to ${deckPath}`, false);
-  }
-  loadDecks();
+  });
 }
 
 // ── Listening hint slider (HSK-aware) ───────────────────────────────────────

--- a/static/index.html
+++ b/static/index.html
@@ -73,6 +73,9 @@
     <div id="loading-sub"></div>
     <!-- News flow: headlines currently being summarized (filled by the progress poll) -->
     <div id="loading-articles" style="display:none"></div>
+    <!-- Generation log (issue #642): cumulative step-by-step lines from the
+         backend, so a long run shows what it already did and where it is now -->
+    <div id="loading-log" style="display:none"></div>
     <button id="loading-bg-btn" style="display:none" onclick="_continueStoryInBackground()">
       Continue in background ⏎
     </button>

--- a/static/style.css
+++ b/static/style.css
@@ -171,6 +171,22 @@ main.browse-open {
   line-height: 1.7;
   opacity: 0.85;
 }
+/* Generation log (issue #642) — scrolls internally so a long run can't push
+   the "Continue in background" button off the screen. */
+#loading-log {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 10px auto 0;
+  max-width: 520px;
+  max-height: 180px;
+  overflow-y: auto;
+  text-align: left;
+  line-height: 1.7;
+  opacity: 0.85;
+  font-variant-numeric: tabular-nums;
+}
+#loading-log div:last-child { color: var(--text); opacity: 1; }
+
 .spinner.hidden { display: none; }
 
 /* "Continue in background" button on the story-generation loading screen */

--- a/tests/test_podcast_sentences.py
+++ b/tests/test_podcast_sentences.py
@@ -43,3 +43,48 @@ def test_missing_reasoning_is_not_fatal(monkeypatch):
 
     assert [s["reasoning_zh"] for s in sentences] == ["", ""]
     assert len(sentences) == 2
+
+
+def test_skipped_word_is_re_requested(monkeypatch):
+    """#642：模型漏词时继续补漏，而不是 3 轮后丢给兜底句。
+    补漏轮的提示词必须点名漏掉的词——原来重发的是一模一样的提示词。"""
+    prompts = []
+
+    def fake_call(model, messages, *a, **kw):
+        prompts.append(messages[0]["content"])
+        if len(prompts) == 1:                      # 第一轮只写了一个词
+            return _reply([{"sentence_zh": "张一鸣承认公司暂时落后。"}])
+        return _reply([{"sentence_zh": "他在抖音上刷视频，顺便就下了单。"}])
+
+    monkeypatch.setattr(ai, "_call_api", fake_call)
+    sentences = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
+
+    assert len(prompts) == 2
+    assert "顺便" in prompts[1] and "补漏轮" in prompts[1]
+    assert sorted(s["word_ids"][0] for s in sentences) == [1, 2]
+    assert not any("我学了" in s["sentence_zh"] for s in sentences)
+
+
+def test_fallback_only_after_all_rounds(monkeypatch):
+    """AI 始终不写句子时仍然收敛：每张卡都有句子，且轮数有上限。"""
+    monkeypatch.setattr(ai, "_call_api", lambda *a, **kw: _reply([]))
+    sentences = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
+
+    assert len(sentences) == 2
+    assert all("我学了" in s["sentence_zh"] for s in sentences)
+
+
+def test_progress_log_is_recorded(monkeypatch):
+    """#642：加载界面的日志按 progress_key 累积，供 /api/story-progress 返回。"""
+    monkeypatch.setattr(ai, "_call_api", lambda *a, **kw: _reply([
+        {"sentence_zh": "张一鸣承认公司暂时落后。"},
+        {"sentence_zh": "他在抖音上刷视频，顺便就下了单。"},
+    ]))
+    key = "test/reading/zh"
+    ai.reset_story_log(key)
+    ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题", progress_key=key)
+
+    log = ai._story_log[key]
+    assert any("开始生成播客句子" in line for line in log)
+    assert any("还差 0 个词" in line for line in log)
+    ai.reset_story_log(key)


### PR DESCRIPTION
## A：补漏轮一直重试

**为什么还会看到 `我学了X这个词。`**：两个原因叠加。

1. `for attempt in range(3)` —— 3 轮就放弃
2. **补漏轮发的提示词跟第一轮一模一样**。`_build_prompt` 一直有 `extra_hint` 参数，
   但补漏调用从来没传过它，模型看到相同输入就重复相同的遗漏

改动：

- `MAX_PODCAST_ROUNDS = 6`（原来写死 3）
- 补漏轮传 `extra_hint`：点名漏掉的词，要求每个词都必须有句子，
  并**放宽话题覆盖要求**——只剩几个词时「覆盖摘要里所有话题」根本无法满足，
  留着只会干扰模型
- `PODCAST_SOLO_ROUND = 4`：第 4 轮起每个词单独一次调用。
  此时只剩少数几个词，单词单请求模型没有"挑简单的写"的余地
- 兜底句保留（`_call_api` 可能整轮失败），但不再因为"模型漏了个词"而出现

## B：加载界面的生成日志

`_story_progress[key]` 每次更新是整个 dict 覆盖，只有一行 `msg`——结构上就不存在
可以显示的历史。所以新加了一份按 key 累积的日志：

- `ai._story_log` + `log_progress()` / `reset_story_log()`，同时 `logger.info` 一份，
  journalctl 里事后也查得到
- `GET /api/story-progress/{deck}/{cat}` 返回值合入 `log` 字段
- `#loading-log` 容器（`index.html` / `style.css`），`app.js` 的轮询**增量追加**渲染——
  每 400ms 重画整个列表会跟滚动条打架；用户往上翻看历史时不强制滚到底

日志长这样：

```
开始生成播客句子：18 个词，模型 deepseek-v4-flash
第1轮：拿到 14 句，还差 4 个词
第2轮补漏：预算、成熟、损耗、竞争
第2轮：拿到 3 句，还差 1 个词
第4轮补漏（每词单独一次调用）：损耗
第4轮：拿到 1 句，还差 0 个词
```

## 怎么测试

- `pytest tests/` 全绿（223 passed）
- `tests/test_podcast_sentences.py` 新增 3 个用例：漏词会被点名重发、
  AI 始终不写句子时仍然收敛且每张卡都有句子、日志按 key 累积
- `node --check static/app.js` 通过

Closes #642