### PR TITLE
播客生词 Add 谎报成功且字段空白，统一走完整 DeepSeek 管线（#643）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,15 +226,18 @@ bash sync_offline.sh push    # 只推不拉，推完归档本地库
 
 导入机制本身仍然存在（`importer.py`、`POST /api/import`、`python main.py import`，读取 `imports/<Source>/*.yaml`）：需要批量导入新词汇时，重新创建该目录放入 YAML 即可。日常添加单个词条：界面顶栏 `＋` 按钮（见下），或 `de-zh-bot` 技能生成 YAML 后导入。
 
-### 界面内添加生词（#627）
+### 界面内添加生词（#627、#636、#643）
 
-顶栏 `＋` → 输入中文词 → 回车 → 后台 DeepSeek 生成完整词条 → 进 `Daily::<今天>`，当天到期。
+顶栏 `＋` → 输入中文词 → 回车或点"加" → 后台 DeepSeek 生成完整词条 → 进 `Daily::<今天|明天>`，当天到期。
 
 - `ai.generate_word_entry_yaml()` 把 `de-zh-bot` 技能的中文词条规则移植成服务端提示词，输出 **YAML** 而不是 JSON —— 这样能直接交给 `importer.import_yaml_content()`，例句/量词/同义反义词/汉字分解/词源全部复用既有下游逻辑，**没有一行特例建卡代码**。这也意味着卡片与手工导入的词条完全一致（`importer._create_cards` 的 due 就是 `anki_today()`，`_make_leaf_decks` 建的子牌组名与 `get_or_create_category_decks` 相同）
 - 模型没返回 YAML 列表项时抛 `ValueError`；导入数为 0 的"完成"任务前端也报错 —— **绝不把垃圾内容悄悄写进库，也不假装成功**
 - **已有的词不能"再加到今天"**：`cards` 有 `UNIQUE(word_id, category)`，一个词终身只有三张卡，`insert_card` 对它是静默无效果的。所以只有卡片仅存在于 `Saved` 牌组（没有调度进度可丢）时才 `promote_saved_word` 到今天；否则如实返回 `already_exists` 和所在牌组名，不去重置人家的 FSRS 状态。同理已有词**不调 AI**（重新生成的内容会被 importer 当重复丢掉，纯烧钱）
 - 生成约 30 秒，所以走后台线程 + `job_id` 轮询（复用 `_import_jobs` 机制）
 - 只接受中文输入：德/英输入需要 AI 反问是哪个意思（`de-zh-bot` 就是这么做的），一个无交互的输入框做不到，猜错会静默存进一个错词
+- **今天/明天可选**（#636）：`day` 参数同时决定 Daily 牌组、`promote_saved_word` 的 due 和 `importer.import_yaml_content(due_offset_days=)`。**牌组和 due 必须一起后移** —— 未来日期的 Daily 牌组被 `parse_daily_deck_date` 锁住不可复习，卡片若还 due 今天就永远够不到
+- **不阻塞连续输入**（#636）：提交后立刻清空输入框，每个词进弹窗里的队列各自轮询自己的 job
+- **`/api/add-word-ai` 是全应用唯一的加词入口**（#643）：顶栏 ＋、播客单集的 HSK 生词表格、复习界面长按词的菜单三处共用 `app.js` 的 `addWordViaAi()`。原来播客/长按走的 `/api/quick-add-word` 已删除 —— 它只让 AI 填四个字段（无例句/汉字分解/量词/同义反义词），而且 `added_to_deck` 分支在词已学过时被 `INSERT OR IGNORE` + `UNIQUE(word_id, category)` 全部静默丢弃，却照样返回成功。**加词只能有一条管线**，否则修好的坑会在第二条路上重新出现
 
 - **YAML 格式完整文档：** `docs/yaml-format.md`（中文格式：词性/例句/词源/汉字分解；法语格式：`lang: fr` + `type: word|sentence`，经 `importer._normalize_fr_entry` 适配后复用全部下游逻辑）
 - 文件顶部可选 `lang:` 字段（默认 `zh`）决定导入到哪个语言的牌组
@@ -407,7 +410,7 @@ GET  /api/costs/call/{id}                            → {prompt, response}（�
 
 # 其他
 POST /api/import                                     → 触发 YAML 导入
-POST /api/add-word-ai                                → 界面内添加生词（#627）；新词返回 {job_id}，已有词直接返回 {status}
+POST /api/add-word-ai                                → 界面内添加生词（#627）；body {word_zh, day?:today|tomorrow}（#636）；新词返回 {job_id}，已有词直接返回 {status}。**全应用唯一的加词入口**（#643）：顶栏 ＋、播客生词表格、复习界面长按菜单都走它
 GET  /api/add-word-ai/progress/{job_id}              → 轮询后台生成+导入的结果
 GET  /api/browse                                     → {deck_id?, category?, state?, q?, lang?}
 GET  /api/stats ；/api/retention ；/api/card-evolution（均支持 ?lang=）

--- a/ai.py
+++ b/ai.py
@@ -46,6 +46,30 @@ def _set_progress(key: str | None, **kwargs) -> None:
         _story_progress[key] = kwargs
 
 
+# Cumulative log lines per progress key (issue #642). _set_progress overwrites
+# the whole dict on every update, so its single `msg` can only ever show the
+# current step — never what already happened or where a run got stuck. The
+# loading screen renders these lines under the progress bar.
+_story_log: dict[str, list[str]] = {}
+_STORY_LOG_MAX = 200
+
+
+def reset_story_log(key: str | None) -> None:
+    if key:
+        _story_log.pop(key, None)
+
+
+def log_progress(key: str | None, line: str) -> None:
+    """Append one Chinese log line for the loading screen, and mirror it to the
+    server log so the same trace is available in journalctl after the fact."""
+    logger.info("story-log  %s", line)
+    if not key:
+        return
+    lines = _story_log.setdefault(key, [])
+    lines.append(line)
+    del lines[:-_STORY_LOG_MAX]
+
+
 # ---------------------------------------------------------------------------
 # Provider routing
 # ---------------------------------------------------------------------------
@@ -1370,6 +1394,14 @@ MAX_NEWS_BATCH = 10
 # adherence starts slipping — and gpt-5 shares the 8192 budget with reasoning.
 MAX_PODCAST_BATCH = 20
 
+# Podcast top-up rounds (issue #642): keep re-requesting the words the model
+# skipped instead of dumping them on the 我学了X这个词。fallback after 3 rounds.
+# From PODCAST_SOLO_ROUND onwards each remaining word gets its own call — by
+# then only a few are left, and one word per call is the shape the model is
+# least able to wriggle out of.
+MAX_PODCAST_ROUNDS = 6
+PODCAST_SOLO_ROUND = 4
+
 
 def generate_news_sentences(
     cards: list[dict],
@@ -2228,31 +2260,28 @@ def generate_podcast_sentences(
     sentences: list[dict] = []
     remaining = list(cards)
 
-    for attempt in range(3):
-        if not remaining:
-            break
-        msg = (f"生成播客总结…{attempt_label}" if attempt == 0
-               else f"补漏 {len(remaining)} 个词（第{attempt + 1}轮）…{attempt_label}")
-        _set_progress(progress_key, phase="request", msg=msg, percent=20 + attempt * 25)
+    def _run_round(batch: list[dict], extra_hint: str, label: str) -> None:
+        """One AI call for `batch`; moves every word it covered out of `remaining`."""
         # 8192: all-at-once batching (issue #563) can mean 30+ sentences in one
         # response, and the gpt-5 series shares this budget with internal
         # reasoning tokens (same rationale as the briefing call).
-        raw = _call_api(model, [{"role": "user", "content": _build_prompt(remaining)}],
+        raw = _call_api(model, [{"role": "user", "content": _build_prompt(batch, extra_hint)}],
                          8192, purpose="podcast")
 
         json_start = raw.find("[")
         json_end = raw.rfind("]") + 1
         if json_start == -1 or json_end == 0:
-            logger.warning("podcast attempt %d: no JSON array found", attempt + 1)
-            continue
+            log_progress(progress_key, f"{label}：AI 回复里找不到 JSON 数组，本轮作废")
+            return
         try:
             items = json.loads(raw[json_start:json_end])
         except json.JSONDecodeError as e:
-            logger.warning("podcast attempt %d: JSON parse error: %s", attempt + 1, e)
-            continue
+            log_progress(progress_key, f"{label}：JSON 解析失败（{e}），本轮作废")
+            return
 
         # Scan in order: not trusting the AI's target_word tag, only the actual
         # sentence content counts (same approach as briefing).
+        got = 0
         for item in items:
             s_zh = (item.get("sentence_zh") or "").strip()
             if not s_zh:
@@ -2261,6 +2290,7 @@ def generate_podcast_sentences(
             if matched is None:
                 continue          # no target word → drop (this mode allows no context sentences)
             remaining.remove(matched)
+            got += 1
             sentences.append({
                 "word_ids": [matched["word_id"]],
                 "sentence_zh": s_zh,
@@ -2275,14 +2305,53 @@ def generate_podcast_sentences(
                 "source_title": source_title,
                 "tokens": [],
             })
+        log_progress(progress_key, f"{label}：拿到 {got} 句，还差 {len(remaining)} 个词")
 
-        if remaining:
-            logger.warning("podcast attempt %d: missing words (will re-request): %s",
-                           attempt + 1, [c["word_zh"] for c in remaining])
+    log_progress(progress_key, f"开始生成播客句子：{len(cards)} 个词，模型 {model}")
 
-    # Per-word fallback so every card ends up with a sentence.
+    # Keep re-requesting the words the model skipped until none are left
+    # (issue #642). The old 3-round cap left plenty of words on the fallback
+    # sentence 我学了X这个词。
+    for round_no in range(1, MAX_PODCAST_ROUNDS + 1):
+        if not remaining:
+            break
+        missing = "、".join(c["word_zh"] for c in remaining)
+        if round_no == 1:
+            hint = ""
+            msg = f"生成播客句子…{attempt_label}"
+            batches = [remaining]
+        else:
+            # #642: the retry used to resend the *identical* prompt, so the model
+            # simply reproduced the same omissions. Name the skipped words and
+            # relax topic coverage — with a handful of words left, "cover every
+            # topic" is an instruction that cannot be satisfied.
+            hint = (f"\n\n【补漏轮】上一轮你漏掉了这些词：{missing}。"
+                    f"这一轮只需要为上面列出的每一个词各写一句话，一个都不能少。"
+                    f"词少的时候不必覆盖摘要里的所有话题，但每句仍然必须包含"
+                    f"一个来自摘要的专有名词。")
+            msg = f"补漏 {len(remaining)} 个词（第{round_no}轮）…{attempt_label}"
+            # Late rounds go one word per call: with only a few words left this
+            # is the most reliable shape — the model has no room to "pick the
+            # easy ones" and drop the rest.
+            batches = ([[c] for c in remaining] if round_no >= PODCAST_SOLO_ROUND
+                       else [list(remaining)])
+        _set_progress(progress_key, phase="request", msg=msg,
+                      percent=min(20 + round_no * 12, 90))
+        if round_no > 1:
+            log_progress(progress_key,
+                         f"第{round_no}轮补漏"
+                         f"{'（每词单独一次调用）' if round_no >= PODCAST_SOLO_ROUND else ''}"
+                         f"：{missing}")
+        for batch in batches:
+            if not any(c in remaining for c in batch):
+                continue          # already covered by an earlier batch this round
+            _run_round(batch, hint, f"第{round_no}轮")
+
+    # Per-word fallback so every card ends up with a sentence. After #642 this
+    # only triggers when every round failed outright (API errors, censored
+    # replies) — not merely because the model skipped a word.
     for card in remaining:
-        logger.warning("podcast: using fallback sentence for %s", card["word_zh"])
+        log_progress(progress_key, f"⚠️ {card['word_zh']}：{MAX_PODCAST_ROUNDS} 轮都没写出句子，用兜底句")
         sentences.append({
             "word_ids": [card["word_id"]],
             "sentence_zh": card.get("source_sentence") or f"我学了{card['word_zh']}这个词。",

--- a/routes/imports.py
+++ b/routes/imports.py
@@ -358,75 +358,18 @@ def add_word_ai_progress(job_id: str):
     return job
 
 
-@router.post("/api/quick-add-word")
-def quick_add_word(body: dict):
-    """Add a compound word to tomorrow's Daily deck with AI-generated fields.
-
-    Body: { word_zh, pinyin?, meaning? }
-    Returns: { status: "created"|"added_to_deck"|"already_in_deck", entry_id, deck_path, deck_id }
-    """
-    word_zh = (body.get("word_zh") or "").strip()
-    if not word_zh:
-        raise HTTPException(status_code=400, detail="word_zh is required")
-
-    pinyin = (body.get("pinyin") or "").strip()
-    meaning = (body.get("meaning") or "").strip()
-
-    tomorrow = (date.today() + timedelta(days=1)).isoformat()
-    deck_path = f"Daily::{tomorrow}"
-    deck_id = database.get_or_create_deck_path(deck_path)
-    # Cards must live in the per-category leaf decks ('<date> · Listening/Reading/Creating'),
-    # not the category-less parent — otherwise due counts and review queues never see them.
-    leaf_decks = database.get_or_create_category_decks(deck_id, tomorrow)
-
-    existing = database.get_word_by_zh(word_zh)
-    if existing:
-        entry_id = existing["id"]
-        conn = database.get_db()
-        leaf_ids = tuple(leaf_decks.values())
-        placeholders = ",".join("?" * len(leaf_ids))
-        already = conn.execute(
-            f"SELECT id FROM cards WHERE word_id = ? AND deck_id IN ({placeholders}) "
-            "AND deleted_at IS NULL LIMIT 1",
-            (entry_id, *leaf_ids),
-        ).fetchone()
-        conn.close()
-        if already:
-            return {"status": "already_in_deck", "entry_id": entry_id,
-                    "deck_path": deck_path, "deck_id": deck_id}
-        status = "added_to_deck"
-    else:
-        word_data = {
-            "word_zh": word_zh,
-            "pinyin": pinyin,
-            "definition": meaning,
-            "note_type": "vocabulary",
-        }
-        if not os.environ.get("DISABLE_AI"):
-            try:
-                result = ai.regenerate_entry_fields(
-                    word_data, [], ["definition", "definition_zh", "definition_de", "pos"]
-                )
-                for field in ("definition", "definition_zh", "definition_de", "pos"):
-                    if result.get(field):
-                        word_data[field] = result[field]
-            except Exception as exc:
-                logger.warning("quick_add_word: AI generation failed for %r: %s", word_zh, exc)
-
-        entry_id = database.insert_word(word_data)
-        status = "created"
-
-    for category in ("listening", "reading", "creating"):
-        database.insert_card(entry_id, category, leaf_decks[category], state="new", due=tomorrow)
-
-    return {"status": status, "entry_id": entry_id, "deck_path": deck_path, "deck_id": deck_id}
+# /api/quick-add-word was removed in #643. It only had the AI fill four fields
+# (definition/definition_zh/definition_de/pos) — no examples, character
+# breakdown, measure words or synonyms — and its "added_to_deck" branch claimed
+# success while cards' UNIQUE(word_id, category) silently dropped every insert
+# for a word already studied elsewhere. Both callers now use /api/add-word-ai.
 
 
 @router.post("/api/save-word")
 def save_word(body: dict):
     """Stage a compound word in the fixed 'Saved' deck as suspended cards.
 
-    Unlike /api/quick-add-word this does NOT call the AI and does NOT activate
+    Unlike /api/add-word-ai this does NOT call the AI and does NOT activate
     the cards — content is generated later on demand, and the word only enters
     the study algorithm when promoted to a Daily deck (see /api/saved/{id}/promote).
 

--- a/routes/story.py
+++ b/routes/story.py
@@ -217,6 +217,9 @@ def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
         return None
     lang = lang or database.get_deck_lang(deck_id)
     ai._story_progress[progress_key] = {"phase": "starting", "msg": "Starting…", "percent": 5}
+    # #642: a fresh run starts with a fresh log — the previous run's lines would
+    # otherwise stay on the loading screen and read as if they belonged to this one.
+    ai.reset_story_log(progress_key)
     with database.action_context(_action_label_for_story(mode, deck_id)):
         # Inside the action context (issue #578): fix_commas calls previously ran
         # before it and showed up as orphan "fix_commas · legacy" cost rows.
@@ -1289,4 +1292,8 @@ def put_pregen_config(body: dict):
 def story_progress_endpoint(deck_id: int, category: str, lang: str | None = None):
     lang = lang or database.get_deck_lang(deck_id)
     key = f"{deck_id}/{category}/{lang}"
-    return ai._story_progress.get(key, {"phase": "idle", "msg": "", "percent": 0})
+    prog = dict(ai._story_progress.get(key, {"phase": "idle", "msg": "", "percent": 0}))
+    # #642: the cumulative log lives outside _story_progress (which gets fully
+    # overwritten on each update), so merge it in here for the loading screen.
+    prog["log"] = ai._story_log.get(key, [])
+    return prog

--- a/static/app.js
+++ b/static/app.js
@@ -953,6 +953,23 @@ function _startStoryProgressPoll(deckId, cat) {
         }
         artEl.style.display = titles.length ? 'block' : 'none';
       }
+      // Generation log (issue #642): cumulative backend lines, appended only
+      // (re-rendering the whole list every 400ms would fight the scrollbar).
+      // Auto-scrolls to the newest line unless the user scrolled up to read.
+      const logEl = document.getElementById('loading-log');
+      if (logEl) {
+        const lines = Array.isArray(p.log) ? p.log : [];
+        const shown = logEl.childElementCount;
+        if (lines.length < shown) logEl.innerHTML = '';   // new run reset the log
+        const atBottom = logEl.scrollHeight - logEl.scrollTop - logEl.clientHeight < 20;
+        for (const line of lines.slice(logEl.childElementCount)) {
+          const div = document.createElement('div');
+          div.textContent = line;      // backend text, never HTML
+          logEl.appendChild(div);
+        }
+        logEl.style.display = lines.length ? 'block' : 'none';
+        if (atBottom) logEl.scrollTop = logEl.scrollHeight;
+      }
     } catch (_) {}
   }, 400);
 }
@@ -3237,7 +3254,13 @@ function _renderPodcastDetail(ep) {
       <td><button id="podcast-add-word-${idx}" class="btn-secondary" onclick="doPodcastAddWord(${idx})">+ Add</button></td>
     </tr>`).join('');
   const hskTable = hskRows
-    ? `<table class="cost-table"><thead><tr><th>Word</th><th>Pinyin</th><th>German</th><th>Add</th></tr></thead><tbody>${hskRows}</tbody></table>`
+    ? `<div id="podcast-add-day" class="add-word-day-row">
+         <button type="button" class="add-word-day-btn" data-day="today"
+                 onclick="setPodcastAddDay('today')">Today</button>
+         <button type="button" class="add-word-day-btn" data-day="tomorrow"
+                 onclick="setPodcastAddDay('tomorrow')">Tomorrow</button>
+       </div>
+       <table class="cost-table"><thead><tr><th>Word</th><th>Pinyin</th><th>German</th><th>Add</th></tr></thead><tbody>${hskRows}</tbody></table>`
     : '<p class="keymap-hint">No HSK vocabulary extracted.</p>';
   const links = [
     ep.youtube_url ? `<a href="${_escHtml(ep.youtube_url)}" target="_blank" rel="noopener" class="btn-secondary">YouTube ↗</a>` : '',
@@ -3355,30 +3378,34 @@ async function doPodcastNotify(channel) {
   }
 }
 
-async function doPodcastAddWord(idx) {
+// Which day the podcast vocabulary table adds to. Podcasts are usually
+// listened to in the evening, so tomorrow stays the default (#643).
+let _podcastAddDay = 'tomorrow';
+
+function setPodcastAddDay(day) {
+  _podcastAddDay = day === 'today' ? 'today' : 'tomorrow';
+  for (const btn of document.querySelectorAll('#podcast-add-day .add-word-day-btn')) {
+    btn.classList.toggle('active', btn.dataset.day === _podcastAddDay);
+  }
+}
+
+function doPodcastAddWord(idx) {
   const w = _podcastDetailWords[idx];
   const btn = document.getElementById(`podcast-add-word-${idx}`);
   if (!w || !btn) return;
+  const wordZh = w.word || w.word_zh || '';
+  if (!wordZh) return;
+
   btn.disabled = true;
   btn.textContent = '…';
-  try {
-    const result = await api('POST', '/api/quick-add-word', {
-      word_zh: w.word || w.word_zh || '',
-      pinyin: w.pinyin,
-      meaning: w.definition_de || w.definition,
-    });
-    const labels = {
-      created: '✓ added',
-      added_to_deck: '✓ added',
-      already_in_deck: '✓ in deck',
-    };
-    btn.textContent = labels[result.status] || '✓ added';
-    // Stays disabled — button reflects a completed, non-repeatable action.
-  } catch (e) {
-    btn.disabled = false;
-    btn.textContent = '+ Add';
-    showError(e.message || 'Failed to add word');
-  }
+  // Generation takes ~30s in the background — the other rows stay clickable,
+  // so several words can be queued up at once.
+  addWordViaAi(wordZh, _podcastAddDay, (state, text) => {
+    btn.textContent = text;
+    btn.classList.toggle('podcast-add-error', state === 'error');
+    // Only a failure is worth retrying; a finished add is not repeatable.
+    if (state === 'error') btn.disabled = false;
+  });
 }
 
 // Hash direct-link support: emails link to /#podcast-<id> (episode detail).
@@ -6125,7 +6152,60 @@ function _setAddWordItem(item, state, text) {
   _renderAddWordQueue();
 }
 
-async function submitAddWord() {
+// The one way to add a word anywhere in the app (#643): the full DeepSeek
+// pipeline behind /api/add-word-ai, which writes a complete de-zh-bot entry
+// (examples, character breakdown, measure words, synonyms, etymology) through
+// the ordinary importer. The old /api/quick-add-word only filled four fields
+// and — worse — reported success even when cards has UNIQUE(word_id, category)
+// silently dropped the insert for a word already studied elsewhere.
+//
+// onUpdate(state, text) is called with 'running' | 'done' | 'error'.
+async function addWordViaAi(wordZh, day, onUpdate) {
+  let result;
+  try {
+    result = await api('POST', '/api/add-word-ai', { word_zh: wordZh, day });
+  } catch (e) {
+    onUpdate('error', e.message || 'Failed to add word');
+    return;
+  }
+
+  // Known words come back finished — no AI call, no job to poll.
+  if (!result.job_id) {
+    if (result.status === 'already_exists') {
+      // A word owns one card per category for life, so there is nothing to
+      // add — say where it lives instead of pretending it worked.
+      onUpdate('error', `already in ${result.decks.join(', ')}`);
+      return;
+    }
+    onUpdate('done', `✓ moved from Saved → ${result.deck_path}`, result.deck_path);
+    loadDecks();
+    return;
+  }
+
+  onUpdate('running', 'Generating…');
+  const poll = async () => {
+    const job = await api('GET', `/api/add-word-ai/progress/${result.job_id}`).catch(() => null);
+    if (!job || job.status === 'running') {
+      setTimeout(poll, 1500);
+      return;
+    }
+    if (job.status === 'error') {
+      onUpdate('error', job.error || 'Failed to add word');
+      return;
+    }
+    // A "done" job that imported nothing means the AI produced an entry the
+    // importer rejected — say so instead of claiming success.
+    if (!job.summary || !job.summary.imported) {
+      onUpdate('error', 'could not be imported — check the logs');
+      return;
+    }
+    onUpdate('done', `✓ ${result.deck_path}`, result.deck_path);
+    loadDecks();
+  };
+  setTimeout(poll, 1500);
+}
+
+function submitAddWord() {
   const input = document.getElementById('add-word-input');
   const wordZh = input.value.trim();
   if (!wordZh) return;
@@ -6140,54 +6220,14 @@ async function submitAddWord() {
   _addWordQueue.unshift(item);
   _renderAddWordQueue();
 
-  let result;
-  try {
-    result = await api('POST', '/api/add-word-ai', { word_zh: wordZh, day: _addWordDay });
-  } catch (e) {
-    _setAddWordItem(item, 'error', e.message || 'Failed to add word');
-    return;
-  }
-
-  // Known words come back finished — no AI call, no job to poll.
-  if (!result.job_id) {
-    if (result.status === 'already_exists') {
-      // A word owns one card per category for life (UNIQUE(word_id, category)),
-      // so there is nothing to add — say where it lives instead of pretending.
-      _setAddWordItem(item, 'error', `already in ${result.decks.join(', ')}`);
-      return;
+  addWordViaAi(wordZh, _addWordDay, (state, text, deckPath) => {
+    _setAddWordItem(item, state, text);
+    // The modal may already be closed; the banner is how the user finds out.
+    if (state === 'done' &&
+        document.getElementById('add-word-modal').style.display === 'none') {
+      showQuickAddBanner(`✓ "${wordZh}" added to ${deckPath}`, false);
     }
-    _setAddWordItem(item, 'done', `✓ moved from Saved → ${result.deck_path}`);
-    loadDecks();
-    return;
-  }
-
-  _pollAddWord(result.job_id, item, result.deck_path);
-}
-
-async function _pollAddWord(jobId, item, deckPath) {
-  const job = await api('GET', `/api/add-word-ai/progress/${jobId}`).catch(() => null);
-
-  if (!job || job.status === 'running') {
-    setTimeout(() => _pollAddWord(jobId, item, deckPath), 1500);
-    return;
-  }
-
-  if (job.status === 'error') {
-    _setAddWordItem(item, 'error', job.error || 'Failed to add word');
-    return;
-  }
-  // A "done" job that imported nothing means the AI produced an entry the
-  // importer rejected — say so instead of claiming success.
-  if (!job.summary || !job.summary.imported) {
-    _setAddWordItem(item, 'error', 'could not be imported — check the logs');
-    return;
-  }
-  _setAddWordItem(item, 'done', `✓ ${deckPath}`);
-  // The modal may already be closed; the banner is how the user finds out.
-  if (document.getElementById('add-word-modal').style.display === 'none') {
-    showQuickAddBanner(`✓ "${item.wordZh}" added to ${deckPath}`, false);
-  }
-  loadDecks();
+  });
 }
 
 // ── Listening hint slider (HSK-aware) ───────────────────────────────────────

--- a/static/app.js
+++ b/static/app.js
@@ -3301,6 +3301,7 @@ function _renderPodcastDetail(ep) {
       <h2 class="keymap-heading">Transcript</h2>
       ${transcript || '<p class="keymap-hint">No transcript available.</p>'}
     </div>`;
+  setPodcastAddDay(_podcastAddDay);  // highlights the active day button
 }
 
 function _togglePodcastTranscript() {
@@ -6007,7 +6008,7 @@ function openQuickAddMenu(event, wordZh, pinyin, meaning) {
     (meaning ? `<div class="qa-meaning">${meaning}</div>` : '') +
     `<button class="qa-add-btn qa-save-btn" onclick="doSaveWord('${wEsc}','${pEsc}','${mEsc}',this)">★ Save for later</button>` +
     `<div class="qa-deck-label">or add now to daily::${tomorrowStr}</div>` +
-    `<button class="qa-add-btn" onclick="doQuickAdd('${wEsc}','${pEsc}','${mEsc}',this)">+ Add to Daily deck</button>`;
+    `<button class="qa-add-btn" onclick="doQuickAdd('${wEsc}',this)">+ Add to Daily deck</button>`;
 
   document.body.appendChild(menu);
   _quickAddMenu = menu;
@@ -6048,23 +6049,20 @@ async function doSaveWord(wordZh, pinyin, meaning, btn) {
   }
 }
 
-async function doQuickAdd(wordZh, pinyin, meaning, btn) {
+// pinyin/meaning are no longer passed: DeepSeek writes every field itself (#643).
+function doQuickAdd(wordZh, btn) {
   btn.disabled = true;
   btn.textContent = '…';
-  try {
-    const result = await api('POST', '/api/quick-add-word', { word_zh: wordZh, pinyin, meaning });
-    closeQuickAddMenu();
-    const msgs = {
-      created:        `✓ "${wordZh}" added to ${result.deck_path}`,
-      added_to_deck:  `✓ "${wordZh}" added to ${result.deck_path}`,
-      already_in_deck:`"${wordZh}" is already in ${result.deck_path}`,
-    };
-    showQuickAddBanner(msgs[result.status] || `✓ Done`, result.status === 'already_in_deck');
-  } catch (e) {
-    btn.disabled = false;
-    btn.textContent = '+ Add to Daily deck';
-    showError(e.message || 'Failed to add word');
-  }
+  // The menu closes immediately — generation takes ~30s in the background and
+  // reports through the banner, so reviewing is never blocked (#643).
+  closeQuickAddMenu();
+  showQuickAddBanner(`⏳ Generating entry for "${wordZh}"…`, true);
+  addWordViaAi(wordZh, 'tomorrow', (state, text, deckPath) => {
+    if (state === 'running') return;
+    showQuickAddBanner(
+      state === 'done' ? `✓ "${wordZh}" added to ${deckPath}` : `❌ "${wordZh}": ${text}`,
+      state !== 'done');
+  });
 }
 
 function showQuickAddBanner(msg, isInfo) {

--- a/static/index.html
+++ b/static/index.html
@@ -73,6 +73,9 @@
     <div id="loading-sub"></div>
     <!-- News flow: headlines currently being summarized (filled by the progress poll) -->
     <div id="loading-articles" style="display:none"></div>
+    <!-- Generation log (issue #642): cumulative step-by-step lines from the
+         backend, so a long run shows what it already did and where it is now -->
+    <div id="loading-log" style="display:none"></div>
     <button id="loading-bg-btn" style="display:none" onclick="_continueStoryInBackground()">
       Continue in background ⏎
     </button>

--- a/static/style.css
+++ b/static/style.css
@@ -5119,14 +5119,29 @@ table.fsrs-table td.ivl { font-weight: 700; }
   padding: 16px;
 }
 
-/* Today / Tomorrow segmented control */
-#add-word-day {
+/* Today / Tomorrow segmented control — shared with the podcast vocabulary
+   table's Add buttons (#643) */
+#add-word-day,
+.add-word-day-row {
   display: flex;
   gap: 4px;
   padding: 4px;
   margin-bottom: 12px;
   background: var(--bg);
   border-radius: 12px;
+}
+/* In the podcast panel it sits above a wide table — keep it compact */
+.add-word-day-row {
+  width: fit-content;
+}
+.add-word-day-row .add-word-day-btn {
+  flex: 0 0 auto;
+  min-width: 96px;
+}
+/* A failed add stays clickable to retry, so it must not look like success */
+.podcast-add-error {
+  color: var(--again);
+  border-color: var(--again);
 }
 .add-word-day-btn {
   flex: 1;

--- a/static/style.css
+++ b/static/style.css
@@ -171,6 +171,22 @@ main.browse-open {
   line-height: 1.7;
   opacity: 0.85;
 }
+/* Generation log (issue #642) — scrolls internally so a long run can't push
+   the "Continue in background" button off the screen. */
+#loading-log {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 10px auto 0;
+  max-width: 520px;
+  max-height: 180px;
+  overflow-y: auto;
+  text-align: left;
+  line-height: 1.7;
+  opacity: 0.85;
+  font-variant-numeric: tabular-nums;
+}
+#loading-log div:last-child { color: var(--text); opacity: 1; }
+
 .spinner.hidden { display: none; }
 
 /* "Continue in background" button on the story-generation loading screen */

--- a/tests/test_add_word.py
+++ b/tests/test_add_word.py
@@ -145,6 +145,20 @@ def test_known_word_is_reported_without_calling_the_ai(tmp_db):
     assert body["status"] == "already_exists"
     assert any("Test" in name for name in body["decks"])
 
+    # The bug behind #643: the old /api/quick-add-word answered "✓ added" here
+    # while INSERT OR IGNORE silently dropped every card, so nothing reached the
+    # daily deck. Prove the word really is absent — the honest report above is
+    # only worth something if it matches reality.
+    conn = database.get_db()
+    leaf_ids = tuple(_today_leaf_decks().values())
+    placeholders = ",".join("?" * len(leaf_ids))
+    in_daily = conn.execute(
+        f"SELECT COUNT(*) c FROM cards WHERE word_id=? AND deck_id IN ({placeholders})",
+        (body["entry_id"], *leaf_ids),
+    ).fetchone()["c"]
+    conn.close()
+    assert in_daily == 0
+
 
 def test_saved_word_is_promoted_into_todays_deck(tmp_db):
     """A word only staged in the Saved deck has no scheduling progress to lose,

--- a/tests/test_podcast_sentences.py
+++ b/tests/test_podcast_sentences.py
@@ -43,3 +43,48 @@ def test_missing_reasoning_is_not_fatal(monkeypatch):
 
     assert [s["reasoning_zh"] for s in sentences] == ["", ""]
     assert len(sentences) == 2
+
+
+def test_skipped_word_is_re_requested(monkeypatch):
+    """#642：模型漏词时继续补漏，而不是 3 轮后丢给兜底句。
+    补漏轮的提示词必须点名漏掉的词——原来重发的是一模一样的提示词。"""
+    prompts = []
+
+    def fake_call(model, messages, *a, **kw):
+        prompts.append(messages[0]["content"])
+        if len(prompts) == 1:                      # 第一轮只写了一个词
+            return _reply([{"sentence_zh": "张一鸣承认公司暂时落后。"}])
+        return _reply([{"sentence_zh": "他在抖音上刷视频，顺便就下了单。"}])
+
+    monkeypatch.setattr(ai, "_call_api", fake_call)
+    sentences = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
+
+    assert len(prompts) == 2
+    assert "顺便" in prompts[1] and "补漏轮" in prompts[1]
+    assert sorted(s["word_ids"][0] for s in sentences) == [1, 2]
+    assert not any("我学了" in s["sentence_zh"] for s in sentences)
+
+
+def test_fallback_only_after_all_rounds(monkeypatch):
+    """AI 始终不写句子时仍然收敛：每张卡都有句子，且轮数有上限。"""
+    monkeypatch.setattr(ai, "_call_api", lambda *a, **kw: _reply([]))
+    sentences = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
+
+    assert len(sentences) == 2
+    assert all("我学了" in s["sentence_zh"] for s in sentences)
+
+
+def test_progress_log_is_recorded(monkeypatch):
+    """#642：加载界面的日志按 progress_key 累积，供 /api/story-progress 返回。"""
+    monkeypatch.setattr(ai, "_call_api", lambda *a, **kw: _reply([
+        {"sentence_zh": "张一鸣承认公司暂时落后。"},
+        {"sentence_zh": "他在抖音上刷视频，顺便就下了单。"},
+    ]))
+    key = "test/reading/zh"
+    ai.reset_story_log(key)
+    ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题", progress_key=key)
+
+    log = ai._story_log[key]
+    assert any("开始生成播客句子" in line for line in log)
+    assert any("还差 0 个词" in line for line in log)
+    ai.reset_story_log(key)


### PR DESCRIPTION
## 问题

Daniel 报告：在播客单集的 HSK vocabulary 表格点 "+ Add"，按钮变成 "✓ added"，但词实际上没进牌组。

排查 `/api/quick-add-word` 发现三个问题：

1. **谎报成功。** `insert_card` 用 `INSERT OR IGNORE`，而 `cards` 有 `UNIQUE(word_id, category)` —— 一个词终身只有三张卡。词若已在**任何**别的牌组学过，`added_to_deck` 分支的三次插入全部静默丢弃，接口却照样返回成功。这正是 #627 明确避开过的坑，在第二条加词路径上原样复现了。
2. **字段几乎空白。** 只调 `ai.regenerate_entry_fields` 填 4 个字段。没有例句、汉字分解、量词、同义反义词、词源 —— 卡片背面基本是空的。
3. **静默降级。** AI 失败只记一条 warning，然后照样建那个空白词条。

复习界面长按词的 "+ Add to Daily deck" 走同一个接口，三个问题一模一样。

## 改了什么

**统一成一条管线。** 新增 `app.js` 的 `addWordViaAi(wordZh, day, onUpdate)`，顶栏 `＋`、播客生词表格、复习界面长按菜单三处共用 `/api/add-word-ai`（#627/#636）：`ai.generate_word_entry_yaml()` → `importer.import_yaml_content()`，例句/量词/同义反义词/汉字分解/词源全部复用既有下游逻辑，已存在的词如实报告在哪个牌组。

- **播客生词面板**加今天/明天分段控件（默认明天 —— 播客通常晚上听）。逐词 Add 后台生成、不阻塞点下一个词；失败的按钮变红且可重试，成功的保持禁用。
- **删除** `/api/quick-add-word`，以及 `doQuickAdd` 的 `pinyin`/`meaning` 参数 —— DeepSeek 自己写所有字段，传进来的值本来就会被覆盖。`/api/save-word` 不动（它本来就不调 AI，语义不同）。
- CLAUDE.md 记录"加词只能有一条管线"这条约束，否则修好的坑会在第二条路上重新出现。

## 怎么测试的

`pytest tests/` 全绿。新增回归断言：已在别处学过的词不仅返回 `already_exists`，还要证明 Daily 牌组里**确实一张卡都没有** —— 诚实的汇报只有和现实一致才有价值。

Closes #643