### PR TITLE
主页牌组行的重新生成按钮改为始终可见（#646）

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2253,20 +2253,35 @@ a.news-source-line:hover {
   line-height: 1;
 }
 .gear-btn:hover { background: var(--border); }
+/* Always visible (#646): this used to be opacity:0 with a .tree-row:hover
+   reveal, which meant it simply did not exist on touch devices — and the phone
+   is where Daniel actually reviews. The generous padding is the touch target;
+   the glyph itself stays the same size. */
 .deck-regen-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;   /* a long deck name must not squash it to nothing */
+  min-width: 32px;
+  min-height: 32px;
   background: none;
   border: none;
   font-size: 15px;
   cursor: pointer;
   color: var(--muted);
-  padding: 2px 4px;
+  padding: 0 4px;
   border-radius: 6px;
   line-height: 1;
-  opacity: 0;
-  transition: opacity 0.15s;
+  transition: color 0.15s, background 0.15s;
 }
-.tree-row:hover .deck-regen-btn { opacity: 1; }
 .deck-regen-btn:hover { background: var(--border); color: #6366f1; }
+/* Touch devices get a taller target — there is no hover to fall back on if the
+   tap misses. Height is free (the row is already ~48px with its padding);
+   width stays modest because this button sits inside .tree-name-wrap and every
+   pixel it takes is a pixel off the deck name on a narrow phone. */
+@media (hover: none) {
+  .deck-regen-btn { min-width: 36px; min-height: 44px; }
+}
 .bury-btn {
   background: none;
   border: none;


### PR DESCRIPTION
## 问题

Daniel 想在主页牌组行上有一个重新生成故事的按钮 —— 这个按钮（`.deck-regen-btn` ↺）其实一直都在，看不到是因为样式：

```css
.deck-regen-btn { opacity: 0; }
.tree-row:hover .deck-regen-btn { opacity: 1; }
```

默认完全透明，只在鼠标悬停牌组行时显现。**触摸设备没有 hover**，所以这个按钮在手机上从来就不存在 —— 而手机正是 Daniel 复习的地方。

## 改了什么

- 去掉 `opacity:0` / hover 才显示的机制，按钮在每个 `!deck.no_story` 的牌组行上始终可见。
- 触摸目标从约 20px 撑到 32px（桌面）/ 36×44px（`@media (hover: none)`）。行本来就有 12px 上下内边距、总高约 48px，所以加高不会撑乱布局；**宽度保持克制** —— 这个按钮在 `.tree-name-wrap` 里面，多占一像素就少一像素给牌组名。
- `flex-shrink: 0`，长牌组名不会把它压扁。
- 常态仍是 `--muted` 灰，hover 才变主色，桌面端不会显得吵。

只改了 CSS 一处规则，没有动 `renderDeckRows` 的结构。

## 怎么测试的

`pytest tests/` 223 passed / 4 skipped（CSS 改动不在测试覆盖内，需要 Daniel 在手机上实际确认）。

Closes #646