### PR TITLE
把 OpenAI GPT-5.6 系列加入模型列表和价格表（#648）

### DIFF
--- a/database/stats.py
+++ b/database/stats.py
@@ -89,9 +89,12 @@ def get_stats(deck_id: int | None = None, lang: str | None = None) -> dict:
 # this table is hand-maintained — update it (and the static price table in
 # static/index.html's story-setup modal) whenever a provider changes pricing
 # or a new model is adopted. See CLAUDE.md "规范与约束".
-_PRICING_AS_OF = "2026-07-16"
+_PRICING_AS_OF = "2026-08-09"
 _MODEL_PRICING: dict[str, dict[str, float]] = {
     # OpenAI (news/briefing/podcast summaries)
+    "gpt-5.6-sol":   {"input": 5.00, "cached": 0.50, "output": 30.00},
+    "gpt-5.6-terra": {"input": 2.00, "cached": 0.20, "output": 12.00},
+    "gpt-5.6-luna":  {"input": 0.20, "cached": 0.02, "output": 1.20},
     "gpt-5.1":      {"input": 1.25, "cached": 0.125, "output": 10.00},
     "gpt-5":        {"input": 1.25, "cached": 0.125, "output": 10.00},
     "gpt-5-mini":   {"input": 0.25, "cached": 0.025, "output": 2.00},

--- a/static/index.html
+++ b/static/index.html
@@ -791,6 +791,9 @@
             <tr><td>GPT-5 Mini</td><td>OpenAI</td><td>$0.25</td><td>$2.00</td></tr>
             <tr><td>GPT-5</td><td>OpenAI</td><td>$1.25</td><td>$10.00</td></tr>
             <tr><td>GPT-5.1</td><td>OpenAI</td><td>$1.25</td><td>$10.00</td></tr>
+            <tr><td>GPT-5.6 Luna</td><td>OpenAI</td><td>$0.20</td><td>$1.20</td></tr>
+            <tr><td>GPT-5.6 Terra</td><td>OpenAI</td><td>$2.00</td><td>$12.00</td></tr>
+            <tr><td>GPT-5.6 Sol</td><td>OpenAI</td><td>$5.00</td><td>$30.00</td></tr>
           </tbody>
         </table>
         <p class="price-table-note">Prices per 1M tokens (USD)</p>
@@ -810,6 +813,9 @@
         <option value="gpt-5-mini">GPT-5 Mini — OpenAI, $0.25/$2.00</option>
         <option value="gpt-5">GPT-5 — OpenAI, $1.25/$10.00</option>
         <option value="gpt-5.1">GPT-5.1 — OpenAI, $1.25/$10.00</option>
+        <option value="gpt-5.6-luna">GPT-5.6 Luna — OpenAI, $0.20/$1.20</option>
+        <option value="gpt-5.6-terra">GPT-5.6 Terra — OpenAI, $2.00/$12.00</option>
+        <option value="gpt-5.6-sol">GPT-5.6 Sol — OpenAI, $5.00/$30.00</option>
       </select>
     </label>
     <!-- Words per AI call (issue #563 podcast-only, #574 all modes):
@@ -1204,6 +1210,9 @@
         <option value="claude-haiku-4-5-20251001">Haiku — Anthropic fast</option>
         <option value="claude-sonnet-4-6">Sonnet — Anthropic balanced</option>
         <option value="gpt-5-mini">GPT-5 Mini — OpenAI, news mode</option>
+        <option value="gpt-5.6-luna">GPT-5.6 Luna — OpenAI, cheap + newest</option>
+        <option value="gpt-5.6-terra">GPT-5.6 Terra — OpenAI, balanced</option>
+        <option value="gpt-5.6-sol">GPT-5.6 Sol — OpenAI flagship</option>
       </select>
     </label>
   </div>


### PR DESCRIPTION
Closes #648

## 改了什么

新增 OpenAI 最新的 GPT-5.6 三个型号（2026-07-09 GA，1.05M 上下文窗口）：

| 模型 ID | 输入 | 缓存输入 | 输出 |
|---|---|---|---|
| `gpt-5.6-luna` | $0.20 | $0.02 | $1.20 |
| `gpt-5.6-terra` | $2.00 | $0.20 | $12.00 |
| `gpt-5.6-sol` | $5.00 | $0.50 | $30.00 |

- `database/stats.py`：`_MODEL_PRICING` 加三条，`_PRICING_AS_OF` → `2026-08-09`
- `static/index.html`：故事模型选择器（`#setup-model`）+ 生成失败后的换个模型重试选择器（`#story-error-model`）两处下拉框
- `static/index.html`：设置弹窗 ℹ 的静态价格表同步（CLAUDE.md 规定两处必须一起改）

## 为什么不用改 ai.py

`_openai_client()` 和 `_call_api` 里 `max_completion_tokens` 的分支都按 `model.startswith("gpt-")` 判断，新 ID 自动走 OpenAI 客户端和正确的参数名，没有硬编码的型号白名单。

## 怎么测试的

- `_lookup_pricing()` 手工验证：三个新 ID 及带日期快照后缀的 `gpt-5.6-terra-2026-07-09` 都返回正确价格；`gpt-5` / `gpt-5.1` / `gpt-5-mini` 未受影响 —— 这里有个真实风险，该函数用最长前缀匹配，需确认 `gpt-5.6-*` 不会被更短的 `gpt-5` 抢走，已确认没有
- `pytest tests/`：223 passed, 4 skipped

## 说明

价格来自两个独立第三方来源交叉核对，数字完全一致；OpenAI 官方定价页对抓取返回 403，无法直接引用。

**不在本次范围**：没有改 `BRIEFING_MODEL` 默认值和 `BRIEFING_MODEL_FALLBACKS`。换默认模型是行为改变，等 Daniel 实际用新模型跑过再决定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)