### PR TITLE
知识库阶段 A：数据模型泛化 + 生词表统一到 zh_annotate

### DIFF
--- a/database/core.py
+++ b/database/core.py
@@ -648,6 +648,10 @@ def init_db() -> None:
             conn.execute("ALTER TABLE podcast_episodes ADD COLUMN processing_started_at TEXT")
         if "summary_zh" not in pe_cols:
             conn.execute("ALTER TABLE podcast_episodes ADD COLUMN summary_zh TEXT")
+        if "kind" not in pe_cols:
+            conn.execute("ALTER TABLE podcast_episodes ADD COLUMN kind TEXT NOT NULL DEFAULT 'podcast'")
+        if "title_en" not in pe_cols:
+            conn.execute("ALTER TABLE podcast_episodes ADD COLUMN title_en TEXT")
         conn.commit()
 
         # Purge stale legacy YouTube rows (#497): yt-dlp is retired, so any

--- a/database/podcast.py
+++ b/database/podcast.py
@@ -163,21 +163,23 @@ def has_any_episode_for_feed(feed_url: str) -> bool:
 def create_pending_episode(video_id: str, channel_id: str | None, title: str,
                            published_at: str | None, youtube_url: str,
                            audio_url: str | None = None,
-                           duration_seconds: int | None = None) -> int:
+                           duration_seconds: int | None = None,
+                           kind: str = 'podcast') -> int:
     """Insert a new episode row with status=pending. Returns the new id.
 
     `channel_id` stores the source RSS feed URL (#497, was a YouTube channel
     id pre-#497). `youtube_url` stores the episode's webpage link (item
     <link>; name kept for backward compat with existing rows/column).
     `audio_url`/`duration_seconds` (#497) come from the RSS enclosure and
-    itunes:duration.
+    itunes:duration. `kind` (#650) is 'podcast' | 'video' | 'article' — see
+    docs/knowledge-base.md for what the generic columns mean per kind.
     """
     conn = get_db()
     cur = conn.execute(
         """INSERT INTO podcast_episodes
-           (video_id, channel_id, title, published_at, youtube_url, audio_url, duration_seconds, status)
-           VALUES (?, ?, ?, ?, ?, ?, ?, 'pending')""",
-        (video_id, channel_id, title, published_at, youtube_url, audio_url, duration_seconds),
+           (video_id, channel_id, title, published_at, youtube_url, audio_url, duration_seconds, status, kind)
+           VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?)""",
+        (video_id, channel_id, title, published_at, youtube_url, audio_url, duration_seconds, kind),
     )
     conn.commit()
     episode_id = cur.lastrowid
@@ -252,11 +254,13 @@ def get_episode(episode_id: int) -> dict | None:
     return _hydrate(row) if row else None
 
 
-def list_episodes(limit: int = 100, feed_url: str | None = None) -> list[dict]:
+def list_episodes(limit: int = 100, feed_url: str | None = None, kind: str | None = None) -> list[dict]:
     """Episode list without the transcript full text (kept out for payload
     size). `feed_url` (#502, the podcast_feeds.url / episode's channel_id)
     optionally restricts the list to one source, for the per-feed episode
-    list view."""
+    list view. `kind` (#650) optionally restricts to 'podcast' | 'video' |
+    'article'; None leaves behavior unchanged (all kinds, i.e. all existing
+    rows since they default to 'podcast')."""
     conn = get_db()
     query = """SELECT id, video_id, channel_id, title, published_at, youtube_url, spotify_url,
                       audio_url, duration_seconds,
@@ -264,10 +268,16 @@ def list_episodes(limit: int = 100, feed_url: str | None = None) -> list[dict]:
                       transcript_source,
                       (transcript_zh IS NOT NULL AND transcript_zh != '') AS has_transcript
                FROM podcast_episodes"""
+    clauses: list = []
     params: list = []
     if feed_url:
-        query += " WHERE channel_id = ?"
+        clauses.append("channel_id = ?")
         params.append(feed_url)
+    if kind:
+        clauses.append("kind = ?")
+        params.append(kind)
+    if clauses:
+        query += " WHERE " + " AND ".join(clauses)
     query += " ORDER BY COALESCE(published_at, created_at) DESC, id DESC LIMIT ?"
     params.append(limit)
     rows = conn.execute(query, params).fetchall()

--- a/docs/knowledge-base.md
+++ b/docs/knowledge-base.md
@@ -1,0 +1,86 @@
+# 知识库（Knowledge Base）总体设计
+
+> 把现有的「播客」功能泛化成一个统一的知识库：播客单集、YouTube 视频、报刊文章
+> 三类素材走**同一条流水线**（获取 → 转录/正文 → 中文+德语摘要 → 生词标注 →
+> 通知 → 造卡）。本文件是这个功能的唯一设计说明，各阶段 Issue 都引用它。
+
+---
+
+## 核心判断：不新建表，泛化现有表
+
+`podcast_episodes` 已经承载了整条链路所需的全部列（`transcript_zh`、
+`summary_de`、`summary_zh`、`hsk_words`、`status`、`transcript_source`…）。
+YouTube 视频和文章的**唯一区别是「怎么拿到中文正文」**，下游 100% 相同。
+
+因此：
+
+- **表名保持 `podcast_episodes`**，加一列 `kind`（`podcast` | `video` | `article`）。
+  改表名要重建表 + 迁移生产库，风险远大于收益。本仓库已有多处同类先例
+  （`youtube_url` 列现在存播客网页链接、`word_zh` 对法语存法语词形）。
+- **`database.get_episode(id)` 保持不变** → 造卡侧（`routes/story.py` 的
+  podcast 模式）几乎零改动就能吃到视频和文章。
+- 列名的历史含义在 `schema.sql` 注释里写清楚，不要重命名。
+
+### 列的新含义
+
+| 列 | podcast | video | article |
+|---|---|---|---|
+| `kind` | `podcast` | `video` | `article` |
+| `video_id` | RSS guid | YouTube video id | 规范化后的 URL（去 utm 参数）|
+| `channel_id` | RSS feed URL | YouTube 频道 id（拿得到就存）| 站点域名 |
+| `youtube_url` | 单集网页 | 视频链接 | 文章链接 |
+| `audio_url` | mp3 直链 | NULL | NULL |
+| `transcript_zh` | 转录 | 字幕全文 | 正文全文 |
+| `transcript_source` | tingwu/whisper/notebooklm | `captions` | `article` |
+| `title_en`（新列）| AI 译的英文标题 | 同左 | 同左 |
+
+## 素材来源与投递渠道
+
+三个渠道，**分阶段做，不要一次全上**：
+
+1. **界面输入框**（阶段 B 一起做）：知识页顶部粘贴 URL → 「添加」。零新依赖、
+   零故障点，手机浏览器也能用（已有 HTTPS + Basic Auth）。
+2. **邮件收件**（阶段 F，最后做）：手机「分享 → 邮件」发到专用邮箱，服务器
+   cron 用 `imaplib` 轮询取 URL 入库。
+3. **Signal 接收**：**不做**。`signal-cli` 需要常驻 `receive` 轮询，关联设备掉线
+   会静默停摆，比发送脆弱得多。
+
+## 生词：只信 `zh_annotate`，不信 AI（修 Daniel 报的「不准」）
+
+现状有**两套并存**的生词逻辑，这就是不准的根因：
+
+- 正文标注 → `zh_annotate.py`（#638，确定性代码，已查 `entries.word_zh`）✅
+- 底部表格 `hsk_words` → **AI 在摘要提示词里自己挑的**，漏词、挑已学过的词 ❌
+
+阶段 A 统一到 `zh_annotate`：表格由代码从 `summary_zh` + `summary_de` 里的中文
+扫描生成，与正文标注**同源同规则**，看到的括号注释和表格里的行一一对应。
+
+**生词判定规则**（维持 #638 现状，Daniel 2026-08-09 确认）：
+不在 `entries.word_zh` **且**（HSK ≥ 5 **或** 不在 4991 词的 HSK 表里）；
+表外词再过一道「每个字都是 HSK≤4 就跳过」的透明组合过滤，
+挡掉 `十年`/`巨大变化` 这类刷屏噪音。
+
+## 成本（Daniel 问的）：不用担心
+
+一小时素材 ≈ 1.5 万字 ≈ 1.1 万 token。DeepSeek 输入 $0.27/M：
+
+- 摘要一次 ≈ **$0.003**
+- 造卡再发一次全文 ≈ **$0.003**
+
+整篇转录直接喂给模型完全不心疼，**不需要为省钱做截断优化**。现有的 15000 字
+截断保留即可（那是为了上下文窗口，不是为了钱）。
+
+---
+
+## 阶段划分
+
+| 阶段 | Issue | 内容 | 依赖 |
+|---|---|---|---|
+| A | #650 | 数据模型泛化（`kind`/`title_en` 列）+ 生词统一到 `zh_annotate` | — |
+| B | #651 | YouTube 摄取（字幕 API + oEmbed 标题）+ `POST /api/knowledge/add` | A |
+| C | #652 | 文章摄取（正文抽取） | B |
+| D | #653 | 前端：播客页 → 知识页（播客/视频/文章三个子标签） | A |
+| E | #654 | 造卡：故事的 podcast 模式 → 知识库模式（按类型筛选选素材） | A、D |
+| F | #655 | 邮件收件（IMAP 轮询） | B、C |
+
+每阶段一个分支、一个 PR、CI 绿了才合并。

--- a/podcast.py
+++ b/podcast.py
@@ -1009,11 +1009,27 @@ def _annotate_summary(result: dict) -> dict:
     without each re-running Google Translate.
 
     zh_annotate never raises: on any failure the untouched text comes back, so
-    a missing pinyin table can't cost Daniel the episode."""
+    a missing pinyin table can't cost Daniel the episode.
+
+    Also replaces result["words"] (#650) — the AI's own pick from the summary
+    prompt, which regularly misses words and includes ones Daniel already
+    knows — with a deterministic scan of the just-annotated summaries using
+    zh_annotate.extract_new_words(). That's the exact same "new word" rule
+    used for the inline annotations above, so the bottom word table and the
+    parenthetical annotations in the text are guaranteed to agree. An empty
+    scan (extraction failed, or genuinely no new words) keeps the AI's list
+    as a fallback rather than wiping the table."""
     if result.get("summary_zh"):
         result["summary_zh"] = zh_annotate.annotate_zh_summary(result["summary_zh"])
     if result.get("summary_de"):
         result["summary_de"] = zh_annotate.annotate_de_summary(result["summary_de"])
+    try:
+        combined = f"{result.get('summary_zh') or ''} {result.get('summary_de') or ''}"
+        scanned = zh_annotate.extract_new_words(combined)
+        if scanned:
+            result["words"] = scanned
+    except Exception as e:
+        logger.warning("podcast: word-list extraction failed, keeping AI list — %s", e)
     return result
 
 

--- a/schema.sql
+++ b/schema.sql
@@ -617,15 +617,24 @@ CREATE TABLE IF NOT EXISTS app_settings (
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS podcast_episodes (
     id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    -- kind = 'podcast' | 'video' | 'article' (#650, knowledge base stage A).
+    -- The generic columns below are reused across all three kinds with
+    -- different meanings — see docs/knowledge-base.md for the full mapping:
+    --   video_id:    RSS item guid (podcast) | YouTube video id (video) | normalized URL, utm params stripped (article)
+    --   channel_id:  source RSS feed URL (podcast) | YouTube channel id if available (video) | site domain (article)
+    --   youtube_url: episode webpage link (podcast) | video link (video) | article link (article)
+    --   transcript_zh: transcript (podcast) | caption/subtitle text (video) | article body (article) — i.e. "source material, any language", not podcast-specific
+    kind             TEXT NOT NULL DEFAULT 'podcast',
     video_id         TEXT NOT NULL UNIQUE,  -- RSS item guid (or enclosure URL if no guid), #497; legacy rows used the YouTube video id
     channel_id       TEXT,   -- source RSS feed URL, #497; legacy rows used the YouTube channel id
     title            TEXT NOT NULL,
+    title_en         TEXT,   -- English title, AI-translated starting stage B (#650); NULL for stage-A rows
     published_at     TEXT,
     youtube_url      TEXT NOT NULL,  -- episode webpage link (RSS item <link>), #497; column name kept for backward compat
     audio_url        TEXT,   -- RSS enclosure MP3 direct link, #497
     duration_seconds INTEGER, -- parsed itunes:duration, #497 — used as a pre-download guardrail/gate
     spotify_url      TEXT,
-    transcript_zh    TEXT,
+    transcript_zh    TEXT,   -- source material full text, any language (podcast transcript | video captions | article body); name kept for backward compat (#650)
     transcript_de    TEXT,   -- JSON array of {"zh","de"} bilingual segment pairs (#553)
     summary_de       TEXT,
     summary_zh       TEXT,   -- short Chinese summary shown before the German one (#631)

--- a/tests/test_zh_annotate.py
+++ b/tests/test_zh_annotate.py
@@ -133,3 +133,57 @@ def test_empty_input_is_passed_through():
     assert zh_annotate.annotate_zh_summary("") == ""
     assert zh_annotate.annotate_de_summary("") == ""
     assert zh_annotate.annotate_zh_summary(None) is None
+
+
+# --- extract_new_words (#650) -----------------------------------------------
+
+def test_extract_new_words_picks_up_new_word():
+    out = zh_annotate.extract_new_words("这集讨论对就业的影响。")
+    words = [w["word"] for w in out]
+    assert "就业" in words
+    entry = next(w for w in out if w["word"] == "就业")
+    assert entry["pinyin"] == "jiùyè"
+    assert entry["definition_de"] == "DE:就业"
+    assert entry["hsk"] == 6
+
+
+def test_extract_new_words_excludes_words_in_collection(collection):
+    collection.add("就业")
+    out = zh_annotate.extract_new_words("这集讨论对就业的影响。")
+    assert "就业" not in [w["word"] for w in out]
+
+
+def test_extract_new_words_excludes_hsk4_and_below():
+    out = zh_annotate.extract_new_words("这对公司的影响很大。")
+    assert out == []
+
+
+def test_extract_new_words_excludes_transparent_compounds():
+    """"十年" is built entirely from basic (HSK<=4) characters — same
+    transparent-compound filter as annotate_zh_summary."""
+    out = zh_annotate.extract_new_words("过去十年的变化。")
+    assert out == []
+
+
+def test_extract_new_words_empty_input_returns_empty_list():
+    assert zh_annotate.extract_new_words("") == []
+    assert zh_annotate.extract_new_words(None) == []
+
+
+def test_extract_new_words_deduplicates_in_first_appearance_order():
+    out = zh_annotate.extract_new_words("硅谷很大。硅谷也很贵。他去了就业市场。")
+    words = [w["word"] for w in out]
+    assert words.count("硅谷") == 1
+    assert words.index("硅谷") < words.index("就业")
+
+
+def test_extract_new_words_reads_chinese_embedded_in_html():
+    """extract_new_words must not need pre-stripped HTML — the German summary
+    ships raw HTML with embedded Chinese runs (#650)."""
+    out = zh_annotate.extract_new_words("<p>Beschäftigung (就业) ist wichtig.</p>")
+    assert "就业" in [w["word"] for w in out]
+
+
+def test_extract_new_words_segmentation_failure_returns_empty_list(monkeypatch):
+    monkeypatch.setattr(zh_annotate, "_segment", lambda text: [])
+    assert zh_annotate.extract_new_words("对就业的影响。") == []

--- a/zh_annotate.py
+++ b/zh_annotate.py
@@ -185,6 +185,41 @@ def _new_words_from_pairs(pairs: list[tuple[str, str]]) -> list[str]:
             if _is_new_word(w, hsk, known, skip_transparent=True)]
 
 
+def extract_new_words(text: str) -> list[dict]:
+    """Scan `text` for every new word (same criteria as annotate_zh_summary,
+    reusing _segment/_new_words_from_pairs) and return
+    [{word, pinyin, definition_de, hsk}] in order of first appearance.
+    `hsk` is None for words absent from the HSK 1-6 table.
+
+    `text` may be plain Chinese or HTML with embedded Chinese runs (e.g. a
+    German summary) — jieba tokenizes non-CJK characters (tags, punctuation,
+    German words) into their own tokens, and only whole-token, multi-char,
+    all-CJK candidates are considered (see _new_words_from_pairs), so no
+    pre-stripping of HTML is needed.
+
+    Best-effort like the rest of this module: any failure returns []."""
+    if not text or not text.strip():
+        return []
+    try:
+        pairs = _segment(text)
+        if not pairs:
+            return []
+        words = _new_words_from_pairs(pairs)
+        hsk = _hsk_levels()
+        return [
+            {
+                "word": w,
+                "pinyin": pinyin_of(w),
+                "definition_de": _gloss_de(w),
+                "hsk": hsk.get(w),
+            }
+            for w in words
+        ]
+    except Exception as e:
+        logger.warning("zh_annotate: extract_new_words failed — %s", e)
+        return []
+
+
 def annotate_zh_summary(text: str) -> str:
     """Annotate the first occurrence of every new word inline:
     "对就业的影响" -> "对就业（jiùyè - Beschäftigung）的影响".


### PR DESCRIPTION
## 概述

知识库功能第一阶段，只动后端，界面行为不变，为后面的视频/文章摄取铺路，同时修掉生词表不准的问题（正文括号标注来自 zh_annotate，底部表格却是 AI 自己挑的，两者不同源）。

## 改动

1. **数据模型泛化**：`podcast_episodes` 加 `kind`（`podcast`|`video`|`article`，默认 `podcast`）和 `title_en` 两列，`database/core.py` 幂等迁移，`schema.sql` 同步；列注释说明各 kind 下 `video_id`/`channel_id`/`youtube_url`/`transcript_zh` 的含义变化（见 `docs/knowledge-base.md`）
2. `database/podcast.py`：`list_episodes()` 加可选 `kind` 过滤参数（None 时行为不变）；`create_pending_episode()` 加可选 `kind` 参数（默认 `'podcast'`）
3. **生词表统一到 zh_annotate**：`zh_annotate.py` 新增 `extract_new_words(text)`，复用现有的 `_segment`/`_new_words_from_pairs`/`pinyin_of`/`_gloss_de`/`_hsk_levels`，扫出全部生词并返回 `[{word, pinyin, definition_de, hsk}]`；`podcast.py` 的 `_annotate_summary()` 标注完 `summary_zh`/`summary_de` 后用扫描结果覆盖 `result["words"]`（AI 自选的那份），扫描为空时保留 AI 那份兜底；`filter_new_words()` 保留作为双保险
4. 补充 `docs/knowledge-base.md`（此前只在主工作区未跟踪，本次纳入版本控制）

## 测试

`pytest tests/` 全绿（231 passed, 4 skipped）。新增 `tests/test_zh_annotate.py` 覆盖 `extract_new_words`：生词被挑出、已在词库的词被排除、HSK≤4 排除、透明组合排除、空输入返回空列表，另加 HTML 内嵌中文识别、去重保序、分词失败降级。

迁移幂等性已手动验证：`init_db()` 连跑两次，`kind`/`title_en` 列稳定存在、不报错。

Closes #650