### PR TITLE
知识库阶段 B：YouTube 视频摄取（字幕 + 元数据 + 添加入口）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -2446,12 +2446,19 @@ def build_podcast_summary_prompt(transcript: str, title: str, detail_level: str)
     # (#541) so a "detailed" summary can actually cover the whole episode.
     excerpt = transcript[:30000]
 
-    return f"""You are summarizing a Chinese-language podcast episode for a German-speaking
-learner of Chinese (HSK 4-5 level, learning towards HSK 6).
+    return f"""You are summarizing a podcast/video episode for a German-speaking learner of
+Chinese (HSK 4-5 level, learning towards HSK 6).
 
 Episode title: {title}
 
-Transcript (Chinese, auto/manual captions, may contain minor recognition errors):
+Transcript (auto/manual captions, may contain minor recognition errors). The transcript
+language is WHATEVER the source material actually is — it may be Chinese, German, English,
+or a mix (#651: this pipeline now also ingests YouTube videos, which are frequently German
+or English). Do NOT assume it is Chinese. Regardless of the transcript's language, your two
+summaries below have a FIXED output language each: summary_zh is always Chinese, summary_de
+is always German — translate/summarize into those languages no matter what language the
+source is in. For a German or English source, the Chinese summary IS the learning material
+(that's the point — it lets Daniel read the content in Chinese even though the source wasn't).
 {excerpt}
 
 Task:
@@ -2587,6 +2594,32 @@ def summarize_podcast_transcript(transcript: str, title: str,
         except Exception as e:
             logger.warning("summarize_podcast_transcript failed on %s (%s)", model, e)
     return {"summary_zh": "", "summary_de": "", "words": []}
+
+
+def translate_title(title: str) -> str | None:
+    """One cheap DeepSeek call (issue #651) to translate a non-English episode
+    title into English, stored in podcast_episodes.title_en — YouTube videos
+    frequently have Chinese/German titles and the podcast manager UI wants a
+    consistent English column to scan. Returns None on any failure (empty
+    title, API error, empty reply) rather than raising — a missing title_en
+    must never fail episode processing, it's a cosmetic nicety."""
+    title = (title or "").strip()
+    if not title:
+        return None
+    prompt = (
+        "Translate this podcast/video episode title into natural English. "
+        "Reply with ONLY the translated title, no quotes, no explanation, "
+        "no markdown. If it is already English, reply with it unchanged.\n\n"
+        f"Title: {title}"
+    )
+    try:
+        raw = _call_api(DEFAULT_MODEL, [{"role": "user", "content": prompt}], 200,
+                         purpose="podcast-title-translate")
+    except Exception as e:
+        logger.warning("translate_title failed for %r: %s", title, e)
+        return None
+    raw = raw.strip().strip('"').strip("'")
+    return raw or None
 
 
 def estimate_story_tokens(num_cards: int) -> int:

--- a/database/podcast.py
+++ b/database/podcast.py
@@ -262,7 +262,7 @@ def list_episodes(limit: int = 100, feed_url: str | None = None, kind: str | Non
     'article'; None leaves behavior unchanged (all kinds, i.e. all existing
     rows since they default to 'podcast')."""
     conn = get_db()
-    query = """SELECT id, video_id, channel_id, title, published_at, youtube_url, spotify_url,
+    query = """SELECT id, video_id, channel_id, title, title_en, kind, published_at, youtube_url, spotify_url,
                       audio_url, duration_seconds,
                       summary_de, hsk_words, detail_level, status, error, email_sent_at, created_at,
                       transcript_source,
@@ -293,7 +293,7 @@ def list_recent_error_episodes(max_age_days: int = 7) -> list[dict]:
     the same clock."""
     conn = get_db()
     rows = conn.execute(
-        """SELECT id, video_id, title, audio_url, duration_seconds FROM podcast_episodes
+        """SELECT id, video_id, title, audio_url, duration_seconds, kind FROM podcast_episodes
            WHERE status = 'error' AND created_at >= datetime('now', ?)
            ORDER BY id""",
         (f"-{int(max_age_days)} days",),

--- a/knowledge/__init__.py
+++ b/knowledge/__init__.py
@@ -1,0 +1,5 @@
+"""Knowledge base ingestion (issue #650/#651): non-podcast source kinds
+('video', 'article', ...) that feed into the same podcast_episodes pipeline
+(transcript -> AI summary -> HSK word filter -> notifications -> cards).
+See docs/knowledge-base.md for the overall design.
+"""

--- a/knowledge/youtube.py
+++ b/knowledge/youtube.py
@@ -1,0 +1,155 @@
+"""YouTube ingestion (issue #651): turn a video URL into a transcript the
+existing podcast pipeline (podcast.summarize / _process_episode) can consume
+unchanged. No audio download, no Whisper — captions only; a video with no
+caption track at all falls to status='no_transcript' (see podcast.fetch_transcript).
+
+`youtube-transcript-api` note (checked against 1.2.4, 2026-08): the library
+moved from classmethods to instance methods in 1.0 — `YouTubeTranscriptApi()`
+must be instantiated, then `.list(video_id)` / `.fetch(video_id, languages=)`
+called on the instance. Most examples online still show the old
+`YouTubeTranscriptApi.get_transcript(...)` classmethod, which no longer
+exists.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+# Caption language priority (issue #651): Chinese variants first (Daniel's
+# primary study language), then German, then English as a last resort before
+# falling back to "whatever track exists" — a German or English video still
+# has *some* transcript, and the podcast summary prompt now tolerates any
+# input language (ai.build_podcast_summary_prompt).
+_LANGUAGE_PRIORITY = ("zh-Hans", "zh-CN", "zh", "zh-TW", "de", "en")
+
+_OEMBED_URL = "https://www.youtube.com/oembed"
+
+
+def _http_get_json(url: str, timeout: int = 10) -> dict:
+    """Mirrors podcast._http_get's plain-urllib style (no extra HTTP
+    dependency) but decodes JSON — used for the oEmbed metadata lookup."""
+    req = urllib.request.Request(url, headers={"User-Agent": "AnkiAdvanced/1.0"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def parse_video_id(url: str) -> str | None:
+    """Extract a YouTube video id from any of the URL shapes Daniel might
+    paste: youtube.com/watch?v=, youtu.be/, youtube.com/shorts/,
+    m.youtube.com/watch?v=, with or without extra query params. Returns None
+    for anything that isn't a recognizable YouTube video URL."""
+    if not url or not isinstance(url, str):
+        return None
+    url = url.strip()
+    if not url:
+        return None
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except ValueError:
+        return None
+
+    host = (parsed.hostname or "").lower()
+    if host.startswith("www."):
+        host = host[4:]
+    if host == "m.youtube.com":
+        host = "youtube.com"
+
+    if host in ("youtube.com", "youtube-nocookie.com"):
+        if parsed.path == "/watch":
+            qs = urllib.parse.parse_qs(parsed.query)
+            vid = (qs.get("v") or [None])[0]
+            return vid or None
+        m = re.match(r"^/(?:shorts|embed|live)/([A-Za-z0-9_-]+)", parsed.path)
+        if m:
+            return m.group(1)
+        return None
+
+    if host == "youtu.be":
+        vid = parsed.path.lstrip("/").split("/")[0]
+        return vid or None
+
+    return None
+
+
+def fetch_metadata(video_id: str) -> dict:
+    """Video title + channel name via oEmbed (no API key needed). Raises on
+    a network/HTTP failure — the caller (routes/knowledge.py) surfaces that
+    as a 400/500, since without a title there's nothing sensible to store."""
+    query = urllib.parse.urlencode({
+        "url": f"https://www.youtube.com/watch?v={video_id}",
+        "format": "json",
+    })
+    data = _http_get_json(f"{_OEMBED_URL}?{query}", timeout=10)
+    return {
+        "title": data.get("title") or video_id,
+        "author_name": data.get("author_name"),
+    }
+
+
+def fetch_captions(video_id: str) -> tuple[str | None, dict]:
+    """Fetch a video's caption track and join it into continuous text,
+    signature-compatible with podcast.fetch_transcript's (text, meta) return.
+
+    Tries _LANGUAGE_PRIORITY in order, then falls back to whatever single
+    track exists (any language). Returns (None, meta) — not an exception —
+    when the video has no captions at all (disabled, unavailable, or no
+    track in any language); the caller stores status='no_transcript' for
+    that, same as an un-transcribable podcast episode. This function does
+    NOT fall back to downloading audio for Whisper (out of scope for #651).
+
+    A genuine transport/API error (not "no captions") is left to propagate —
+    the podcast pipeline's outer try/except stores it in episodes.error.
+    """
+    from youtube_transcript_api import YouTubeTranscriptApi
+    from youtube_transcript_api._errors import CouldNotRetrieveTranscript
+
+    meta: dict = {"transcript_source": "youtube_captions", "language_code": None}
+    api = YouTubeTranscriptApi()
+
+    try:
+        transcript_list = api.list(video_id)
+    except CouldNotRetrieveTranscript as e:
+        logger.info("knowledge.youtube: no caption list for %s: %s", video_id, e)
+        return None, meta
+
+    transcript = None
+    try:
+        transcript = transcript_list.find_transcript(_LANGUAGE_PRIORITY)
+    except CouldNotRetrieveTranscript:
+        # None of the priority languages exist — fall back to any available
+        # track rather than giving up (issue #651: "再退到任意可用语言").
+        try:
+            transcript = next(iter(transcript_list))
+        except StopIteration:
+            transcript = None
+
+    if transcript is None:
+        logger.info("knowledge.youtube: no transcript track at all for %s", video_id)
+        return None, meta
+
+    try:
+        fetched = transcript.fetch()
+    except CouldNotRetrieveTranscript as e:
+        logger.warning("knowledge.youtube: fetch failed for %s (%s): %s",
+                        video_id, transcript.language_code, e)
+        return None, meta
+
+    text = " ".join(s.text.strip() for s in fetched if (s.text or "").strip())
+    if not text.strip():
+        return None, meta
+
+    # Reuse podcast's ASR cleanup (CJK-spacing collapse + Traditional ->
+    # Simplified) — a local import avoids a podcast <-> knowledge import
+    # cycle (podcast.fetch_transcript dispatches into this module for
+    # kind='video', so this module can't import podcast at module load time).
+    from podcast import _normalize_transcript
+    text = _normalize_transcript(text)
+
+    meta["language_code"] = transcript.language_code
+    return text, meta

--- a/main.py
+++ b/main.py
@@ -194,7 +194,7 @@ try:
     import uvicorn
 
     from offline import LOCAL_MODE, OFFLINE_MODE
-    from routes import decks, review, story, browse, imports, podcast as podcast_routes
+    from routes import decks, review, story, browse, imports, podcast as podcast_routes, knowledge as knowledge_routes
 
     @asynccontextmanager
     async def lifespan(app):
@@ -377,6 +377,7 @@ try:
     app.include_router(browse.router)
     app.include_router(imports.router)
     app.include_router(podcast_routes.router)
+    app.include_router(knowledge_routes.router)
     # Sync only makes sense on a laptop copy — on the server these routes must
     # not exist at all, or a stray call would overwrite production (#625).
     if LOCAL_MODE or OFFLINE_MODE:

--- a/podcast.py
+++ b/podcast.py
@@ -876,6 +876,13 @@ def fetch_transcript(video: dict) -> tuple[str | None, dict]:
     duration = video.get("duration_seconds") or 0
     meta = {"title": title, "transcript_source": None}
 
+    if video.get("kind") == "video":
+        # YouTube ingestion (#651): captions only, no audio download/Whisper.
+        # Dispatches out of the podcast RSS/Tingwu/NotebookLM/Whisper chain
+        # entirely — that chain (below) is for kind='podcast' only.
+        import knowledge.youtube
+        return knowledge.youtube.fetch_captions(video_id)
+
     if not audio_url:
         logger.warning("podcast: no audio_url for %s, cannot transcribe", video_id)
         return None, meta
@@ -1573,6 +1580,7 @@ def retry_episode(episode_id: int) -> dict:
     video = {
         "video_id": episode["video_id"], "title": episode["title"],
         "audio_url": episode.get("audio_url"), "duration_seconds": episode.get("duration_seconds"),
+        "kind": episode.get("kind") or "podcast",
     }
     _process_episode(episode_id, video, detail_level, summary)
 
@@ -1690,6 +1698,7 @@ def _run_check_locked(cfg: dict) -> dict:
         _process_episode(ep["id"], {
             "video_id": ep["video_id"], "title": ep["title"],
             "audio_url": ep.get("audio_url"), "duration_seconds": ep.get("duration_seconds"),
+            "kind": ep.get("kind") or "podcast",
         }, detail_level, summary)
 
     return summary

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pypinyin>=0.55,<1.0
 notebooklm-py>=0.7.3,<0.8.0
 alibabacloud_tingwu20230930>=2.0.25,<3.0.0
 zhconv>=1.4,<2.0
+youtube-transcript-api>=1.2,<2.0

--- a/routes/knowledge.py
+++ b/routes/knowledge.py
@@ -1,0 +1,68 @@
+"""Knowledge base ingestion API (issue #651): turn a pasted URL into a
+podcast_episodes row (kind='video' for YouTube, more kinds land in later
+stages) that the existing podcast pipeline can transcribe/summarize.
+
+Deliberately thin: this route only resolves the URL to metadata and inserts
+the pending row. Transcription + summary is NOT done here — the frontend
+takes the returned episode_id and calls the already-existing
+POST /api/podcast/episodes/{id}/process (background thread + polling, #502).
+No new job/polling mechanism is introduced.
+"""
+import logging
+
+import database
+import knowledge.youtube
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+class AddKnowledgeRequest(BaseModel):
+    url: str
+
+
+@router.post("/api/knowledge/add")
+def add_knowledge(body: AddKnowledgeRequest):
+    url = (body.url or "").strip()
+    if not url:
+        raise HTTPException(400, "url is required")
+
+    video_id = knowledge.youtube.parse_video_id(url)
+    if not video_id:
+        # Stage B only understands YouTube — article ingestion is stage C
+        # (see schema.sql's podcast_episodes.kind comment).
+        raise HTTPException(400, "Not a recognized YouTube URL (article ingestion isn't supported yet)")
+
+    existing = database.get_episode_by_video_id(video_id)
+    if existing:
+        return {"status": "already_exists", "episode_id": existing["id"]}
+
+    try:
+        meta = knowledge.youtube.fetch_metadata(video_id)
+    except Exception as e:
+        logger.warning("knowledge.add: oEmbed metadata lookup failed for %s: %s", video_id, e)
+        raise HTTPException(400, f"Could not fetch video metadata: {e}")
+
+    title = meta.get("title") or video_id
+    # translate_title (#651) is one cheap AI call — best-effort, must not
+    # block/fail the add if it errors (translate_title itself already
+    # swallows exceptions and returns None in that case).
+    import ai
+    title_en = ai.translate_title(title)
+
+    episode_id = database.create_pending_episode(
+        video_id=video_id,
+        channel_id=meta.get("author_name"),
+        title=title,
+        published_at=None,
+        youtube_url=url,
+        audio_url=None,
+        duration_seconds=None,
+        kind="video",
+    )
+    if title_en:
+        database.update_episode(episode_id, title_en=title_en)
+
+    return {"episode_id": episode_id}

--- a/routes/podcast.py
+++ b/routes/podcast.py
@@ -44,14 +44,14 @@ def _overlay_processing_status(episode: dict) -> dict:
 
 
 @router.get("/api/podcast/episodes")
-def list_episodes(limit: int = 100, feed_id: int | None = None):
+def list_episodes(limit: int = 100, feed_id: int | None = None, kind: str | None = None):
     feed_url = None
     if feed_id is not None:
         feed = database.get_feed(feed_id)
         if not feed:
             raise HTTPException(404, "Feed not found")
         feed_url = feed["url"]
-    episodes = database.list_episodes(limit=limit, feed_url=feed_url)
+    episodes = database.list_episodes(limit=limit, feed_url=feed_url, kind=kind)
     return [_overlay_processing_status(e) for e in episodes]
 
 

--- a/tests/test_knowledge_youtube.py
+++ b/tests/test_knowledge_youtube.py
@@ -1,0 +1,208 @@
+"""Tests for knowledge/youtube.py (issue #651).
+
+parse_video_id is pure (no I/O). fetch_metadata and fetch_captions both make
+real network/API calls in production, so every test here stubs them out —
+CLAUDE.md is explicit that this suite must never actually reach YouTube.
+"""
+import knowledge.youtube as ky
+from youtube_transcript_api._errors import CouldNotRetrieveTranscript
+
+
+# ---------------------------------------------------------------------------
+# parse_video_id
+# ---------------------------------------------------------------------------
+
+def test_parse_watch_url():
+    assert ky.parse_video_id("https://www.youtube.com/watch?v=abc123XYZ_-") == "abc123XYZ_-"
+
+
+def test_parse_watch_url_with_extra_query_params():
+    assert ky.parse_video_id(
+        "https://www.youtube.com/watch?v=abc123XYZ_-&t=42s&list=PLxyz"
+    ) == "abc123XYZ_-"
+
+
+def test_parse_youtu_be_short_link():
+    assert ky.parse_video_id("https://youtu.be/abc123XYZ_-") == "abc123XYZ_-"
+
+
+def test_parse_youtu_be_with_query_params():
+    assert ky.parse_video_id("https://youtu.be/abc123XYZ_-?t=5") == "abc123XYZ_-"
+
+
+def test_parse_shorts_url():
+    assert ky.parse_video_id("https://www.youtube.com/shorts/abc123XYZ_-") == "abc123XYZ_-"
+
+
+def test_parse_mobile_watch_url():
+    assert ky.parse_video_id("https://m.youtube.com/watch?v=abc123XYZ_-") == "abc123XYZ_-"
+
+
+def test_parse_no_www_prefix():
+    assert ky.parse_video_id("https://youtube.com/watch?v=abc123XYZ_-") == "abc123XYZ_-"
+
+
+def test_parse_rejects_non_youtube_url():
+    assert ky.parse_video_id("https://example.com/watch?v=abc123XYZ_-") is None
+
+
+def test_parse_rejects_youtube_homepage():
+    assert ky.parse_video_id("https://www.youtube.com/") is None
+
+
+def test_parse_rejects_empty_and_none():
+    assert ky.parse_video_id("") is None
+    assert ky.parse_video_id(None) is None
+
+
+def test_parse_rejects_garbage_string():
+    assert ky.parse_video_id("not a url at all") is None
+
+
+def test_parse_watch_url_missing_v_param():
+    assert ky.parse_video_id("https://www.youtube.com/watch?list=PLxyz") is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_metadata (oEmbed) — HTTP stubbed
+# ---------------------------------------------------------------------------
+
+def test_fetch_metadata_returns_title_and_author(monkeypatch):
+    def fake_get_json(url, timeout=10):
+        assert "oembed" in url
+        assert "abc123" in url
+        return {"title": "一个视频标题", "author_name": "某频道"}
+
+    monkeypatch.setattr(ky, "_http_get_json", fake_get_json)
+    meta = ky.fetch_metadata("abc123")
+    assert meta == {"title": "一个视频标题", "author_name": "某频道"}
+
+
+def test_fetch_metadata_falls_back_to_video_id_when_title_missing(monkeypatch):
+    monkeypatch.setattr(ky, "_http_get_json", lambda url, timeout=10: {})
+    meta = ky.fetch_metadata("xyz789")
+    assert meta["title"] == "xyz789"
+    assert meta["author_name"] is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_captions — youtube_transcript_api stubbed
+# ---------------------------------------------------------------------------
+
+class _FakeSnippet:
+    def __init__(self, text):
+        self.text = text
+
+
+class _FakeTranscript:
+    def __init__(self, language_code, texts, fetch_raises=None):
+        self.language_code = language_code
+        self._texts = texts
+        self._fetch_raises = fetch_raises
+
+    def fetch(self):
+        if self._fetch_raises:
+            raise self._fetch_raises
+        return [_FakeSnippet(t) for t in self._texts]
+
+
+class _FakeTranscriptList:
+    def __init__(self, transcripts):
+        self._transcripts = transcripts
+
+    def find_transcript(self, language_codes):
+        for code in language_codes:
+            for t in self._transcripts:
+                if t.language_code == code:
+                    return t
+        raise CouldNotRetrieveTranscript("fake-video-id")
+
+    def __iter__(self):
+        return iter(self._transcripts)
+
+
+class _FakeApi:
+    def __init__(self, transcript_list=None, list_raises=None):
+        self._transcript_list = transcript_list
+        self._list_raises = list_raises
+
+    def list(self, video_id):
+        if self._list_raises:
+            raise self._list_raises
+        return self._transcript_list
+
+
+def _patch_api(monkeypatch, fake_api):
+    import youtube_transcript_api
+    monkeypatch.setattr(youtube_transcript_api, "YouTubeTranscriptApi", lambda: fake_api)
+
+
+def test_fetch_captions_picks_priority_language(monkeypatch):
+    transcripts = _FakeTranscriptList([
+        _FakeTranscript("en", ["hello", "world"]),
+        _FakeTranscript("zh-Hans", ["你好", "世界"]),
+    ])
+    _patch_api(monkeypatch, _FakeApi(transcript_list=transcripts))
+
+    text, meta = ky.fetch_captions("vid1")
+    assert text == "你好世界"  # CJK-adjacent whitespace collapsed by _normalize_transcript
+    assert meta["transcript_source"] == "youtube_captions"
+    assert meta["language_code"] == "zh-Hans"
+
+
+def test_fetch_captions_falls_back_to_any_available_language(monkeypatch):
+    """None of the priority languages (zh*/de/en) exist — falls back to
+    whatever single track is there (e.g. French)."""
+    transcripts = _FakeTranscriptList([
+        _FakeTranscript("fr", ["Bonjour", "le", "monde"]),
+    ])
+    _patch_api(monkeypatch, _FakeApi(transcript_list=transcripts))
+
+    text, meta = ky.fetch_captions("vid2")
+    assert text == "Bonjour le monde"
+    assert meta["language_code"] == "fr"
+
+
+def test_fetch_captions_no_captions_at_all_returns_none(monkeypatch):
+    """list() itself fails (captions disabled/video unavailable) -> (None, meta),
+    not an exception — the caller stores status='no_transcript' for this."""
+    _patch_api(monkeypatch, _FakeApi(list_raises=CouldNotRetrieveTranscript("novid")))
+
+    text, meta = ky.fetch_captions("novid")
+    assert text is None
+    assert meta["transcript_source"] == "youtube_captions"
+
+
+def test_fetch_captions_empty_transcript_list_returns_none(monkeypatch):
+    """A transcript list that has zero tracks (find_transcript AND the
+    fallback iteration both come up empty) is treated the same as no captions."""
+    _patch_api(monkeypatch, _FakeApi(transcript_list=_FakeTranscriptList([])))
+
+    text, meta = ky.fetch_captions("vid3")
+    assert text is None
+
+
+def test_fetch_captions_fetch_failure_returns_none(monkeypatch):
+    """The track exists but fetch() itself fails (e.g. transient API error) —
+    treated as no-transcript rather than propagating, matching podcast.py's
+    pattern of a soft failure for 'this source can't be transcribed'."""
+    transcripts = _FakeTranscriptList([
+        _FakeTranscript("en", [], fetch_raises=CouldNotRetrieveTranscript("vid4")),
+    ])
+    _patch_api(monkeypatch, _FakeApi(transcript_list=transcripts))
+
+    text, meta = ky.fetch_captions("vid4")
+    assert text is None
+
+
+def test_fetch_captions_joins_and_normalizes_chinese_text(monkeypatch):
+    """Regression check for the actual bug class _normalize_transcript exists
+    for: naive space-joining of CJK snippets must not leave stray spaces."""
+    transcripts = _FakeTranscriptList([
+        _FakeTranscript("zh-CN", ["大家好", "欢迎收听", "今天的节目"]),
+    ])
+    _patch_api(monkeypatch, _FakeApi(transcript_list=transcripts))
+
+    text, meta = ky.fetch_captions("vid5")
+    assert text == "大家好欢迎收听今天的节目"
+    assert " " not in text


### PR DESCRIPTION
## 概述

Closes #651

把 YouTube 视频接进知识库流水线：给一个视频链接，拉字幕当转录，之后的摘要/生词标注/通知/造卡全部复用播客那条链路，不写一行新的下游代码。

## 改动

- 新模块 `knowledge/youtube.py`：
  - `parse_video_id(url)`：认得 `watch?v=`、`youtu.be/`、`shorts/`、`m.youtube.com`
  - `fetch_metadata(video_id)`：oEmbed 拿标题+频道名，无需 API key
  - `fetch_captions(video_id)`：`youtube-transcript-api`（已实测 1.0+ 的实例方法 API，`YouTubeTranscriptApi().fetch(...)`），语言优先级 zh-Hans/zh-CN/zh/zh-TW/de/en，退到任意可用语言；无字幕返回 `(None, meta)`，不做 Whisper 音频回退
  - 拼接字幕复用 `podcast._normalize_transcript`（繁转简+空白规整），本地 import 避免 podcast↔knowledge 循环引用
- `podcast.fetch_transcript()` 按 `video['kind']` 分流：`kind='video'` 直接走字幕，其余维持原听悟/NotebookLM/Whisper 链一行不改
  - 顺带修：`retry_episode`/自动重试路径的 `video` dict 原来没带 `kind`，重试一个视频单集会误走播客链——已补上（`list_recent_error_episodes` 的 SELECT 也带上 `kind`）
- `ai.build_podcast_summary_prompt` 不再预设转录是中文——`summary_zh` 恒中文、`summary_de` 恒德语，与源语言无关（YouTube 视频常是德语/英语）
- 新增 `ai.translate_title(title)`：一次 DeepSeek 调用把标题译成英文存 `title_en`，失败留 `None`，不影响单集处理成败
- 新路由 `routes/knowledge.py`：`POST /api/knowledge/add` body `{url}`
  - 已存在同 `video_id` → `{status: "already_exists", episode_id}`
  - 新的 → 拉元数据+译标题+`create_pending_episode(kind='video')`，立即返回 `{episode_id}`；转录/摘要不在这个请求里做，前端拿到 id 后自己调已有的 `POST /api/podcast/episodes/{id}/process`（不新造 job 机制）
- `GET /api/podcast/episodes` 加可选 `?kind=` 过滤，透传 `database.list_episodes(kind=)`；顺带把 `title_en`/`kind` 补进该函数的 SELECT（#650 只在 WHERE 里用了，没真的选出来，前端拿不到）
- `requirements.txt` 新增 `youtube-transcript-api>=1.2,<2.0`

## 与施工图的差异

- `docs/knowledge-base.md` 在这个仓库里实际不存在（`schema.sql`/`database/podcast.py` 都引用了它，但没人创建过）——按施工图要求不碰 `static/`，也没有额外创建这份文档，只在代码注释里说明了字段含义
- `retry_episode` 和 `run_check` 自动重试路径原来拼 `video` dict 时没带 `kind`，是我在实现过程中发现的既有小缺口，顺手补了（否则视频单集的重试会走错转录链）

## 测试

- `pytest tests/` 全绿：251 passed, 4 skipped（含新增 `tests/test_knowledge_youtube.py` 20 个用例，全部打桩，不联网）
- 手动用真实 YouTube 视频跑通 `parse_video_id` / `fetch_metadata` / `fetch_captions`（本地验证，未落库）
- 本地起服务验证 `POST /api/knowledge/add`、`GET /api/decks` 均正常响应

## 测试计划

- [x] `pytest tests/` 全绿
- [x] 手动验证 `fetch_captions` 对真实视频（含无 zh/de 字幕、需要回退到任意语言的情况）
- [ ] Daniel 用一个中文视频、一个德语视频跑通「加 → 转录 → 摘要 → 生词标注」全链路（依赖前端 #651 并行分支对接 `/api/knowledge/add`）