### PR TITLE
知识库阶段 C：报刊文章摄取（正文抽取）

### DIFF
--- a/knowledge/article.py
+++ b/knowledge/article.py
@@ -1,0 +1,147 @@
+"""Article ingestion (issue #652): turn a news/article URL into the podcast
+pipeline's `transcript_zh`, so the existing summarize/story machinery can
+consume it unchanged (kind='article', transcript_source='article'). See
+docs/knowledge-base.md for the shared podcast_episodes column mapping.
+
+Body extraction uses **trafilatura** (new dependency, pure Python, no
+compilation) rather than a hand-rolled regex/BeautifulSoup scraper. Manually
+verified against a live tagesschau.de article (clean full-text extraction,
+correct title/date/sitename via `extract_metadata`) and a BBC 中文 article
+(clean main body, minor byline/read-time cruft at the top that a generic
+extractor is expected to leave in — not a paywall/JS-wall failure).
+
+Unlike `knowledge.youtube` (cheap oEmbed title lookup, captions fetched
+separately/lazily during processing), there is no cheap "metadata only"
+endpoint for an arbitrary article URL — getting the title reliably requires
+downloading and parsing the whole page, which is the same cost as getting
+the body. So `routes.knowledge.add_knowledge` calls `fetch_article()` once,
+synchronously, at add time, and stores the resulting text as `transcript_zh`
+immediately (landing straight in `_process_episode`'s "reuse existing
+transcript" fast path, see podcast.py) rather than deferring the fetch to
+process time. `fetch_transcript()` below still exists for parity with
+`knowledge.youtube.fetch_captions` and as the retry-time fallback for the
+(unlikely) case of a row whose transcript wasn't stored at add time.
+"""
+from __future__ import annotations
+
+import logging
+import urllib.parse
+
+logger = logging.getLogger(__name__)
+
+# Tracking query params stripped by normalize_url() so the same article
+# shared through different channels (WeChat, Twitter/X, a newsletter, a
+# messaging app) normalizes to the same video_id — podcast_episodes' dedup
+# key (UNIQUE constraint) — instead of creating a duplicate row per link
+# variant.
+_TRACKING_PARAM_PREFIXES = ("utm_",)
+_TRACKING_PARAMS = {
+    "fbclid", "gclid", "gclsrc", "dclid", "msclkid",
+    "igshid", "mc_cid", "mc_eid", "spm", "share_token",
+    "ref", "ref_src", "ref_url", "from",
+}
+
+# Below this many characters, the extracted "body" is almost always a
+# paywall/login-wall stub or a nav-bar fragment from a JS-only page, not a
+# real article — see fetch_article()'s docstring.
+_MIN_ARTICLE_CHARS = 200
+# Length guard, not a cost optimization (DeepSeek input is fractions of a
+# cent either way, see docs/knowledge-base.md) — matches the 15000-char
+# ceiling already used elsewhere in the knowledge base pipeline for
+# transcript-sized inputs.
+_MAX_ARTICLE_CHARS = 15000
+
+
+class ArticleExtractionError(Exception):
+    """Raised when the article body can't be reliably extracted: a
+    paywall/login wall, a page trafilatura can't download at all, or a
+    JS-rendered page that yields only nav-bar/cookie-banner fragments.
+    Callers MUST let this propagate rather than falling back to storing the
+    (garbage) partial text — a stub masquerading as the article would flow
+    straight into a plausible-looking but entirely wrong summary and, from
+    there, into real flashcards (see docs/knowledge-base.md and issue #652).
+    """
+
+
+def normalize_url(url: str) -> str:
+    """Strip tracking query params (utm_*, fbclid, gclid, ...) and the
+    fragment, so the same article shared through different channels
+    normalizes to one canonical URL — used as `podcast_episodes.video_id`,
+    the table's dedup key. Idempotent: normalizing an already-normalized URL
+    is a no-op."""
+    url = (url or "").strip()
+    parsed = urllib.parse.urlsplit(url)
+    kept = [
+        (k, v) for k, v in urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+        if not k.lower().startswith(_TRACKING_PARAM_PREFIXES) and k.lower() not in _TRACKING_PARAMS
+    ]
+    query = urllib.parse.urlencode(kept)
+    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, ""))
+
+
+def _site_domain(url: str) -> str:
+    host = (urllib.parse.urlsplit(url).hostname or "").lower()
+    if host.startswith("www."):
+        host = host[4:]
+    return host
+
+
+def fetch_article(url: str) -> dict:
+    """Download `url` and extract its main text via trafilatura. Returns
+    `{title, text, site, published_at}`.
+
+    Raises ArticleExtractionError when the page can't be downloaded at all,
+    or the extracted body is under `_MIN_ARTICLE_CHARS` (200) — a
+    paywall/login-wall/JS-only page typically yields only a nav-bar
+    fragment at that length, and storing it as if it were the article would
+    silently produce a fake summary and fake cards (see module docstring).
+    Text longer than `_MAX_ARTICLE_CHARS` is truncated (context-window
+    guard, not a cost one — see module docstring).
+    """
+    import trafilatura
+
+    downloaded = trafilatura.fetch_url(url)
+    if not downloaded:
+        raise ArticleExtractionError(f"could not download the page: {url}")
+
+    text = trafilatura.extract(downloaded, include_comments=False, include_tables=False)
+    text = (text or "").strip()
+    if len(text) < _MIN_ARTICLE_CHARS:
+        raise ArticleExtractionError(
+            f"extracted body too short ({len(text)} chars, need >= {_MIN_ARTICLE_CHARS}) "
+            f"— likely a paywall, login wall, or JS-rendered page: {url}"
+        )
+    if len(text) > _MAX_ARTICLE_CHARS:
+        text = text[:_MAX_ARTICLE_CHARS]
+
+    metadata = trafilatura.extract_metadata(downloaded)
+    title = (metadata.title if metadata else None) or url
+    published_at = metadata.date if metadata else None
+
+    return {
+        "title": title,
+        "text": text,
+        "site": _site_domain(url),
+        "published_at": published_at,
+    }
+
+
+def fetch_transcript(video: dict) -> tuple[str | None, dict]:
+    """podcast.fetch_transcript-compatible entry point for kind='article'
+    (signature-compatible with knowledge.youtube.fetch_captions), used by
+    podcast.py's kind dispatch as the retry/reprocess fallback for an
+    episode whose transcript_zh wasn't already stored at add time (the
+    normal path — routes.knowledge.add_knowledge — stores it eagerly, see
+    module docstring, so this mostly matters for future ingestion routes
+    like the planned email intake, #655).
+
+    Unlike knowledge.youtube.fetch_captions (returns (None, meta) when a
+    video simply has no captions — a normal, non-error outcome), an article
+    with no extractable body IS an error and ArticleExtractionError is
+    allowed to propagate — podcast._process_episode's outer except stores
+    it verbatim in episodes.error.
+    """
+    url = video.get("youtube_url") or video.get("video_id")
+    article = fetch_article(url)
+    meta = {"transcript_source": "article"}
+    return article["text"], meta

--- a/podcast.py
+++ b/podcast.py
@@ -883,6 +883,18 @@ def fetch_transcript(video: dict) -> tuple[str | None, dict]:
         import knowledge.youtube
         return knowledge.youtube.fetch_captions(video_id)
 
+    if video.get("kind") == "article":
+        # Article ingestion (#652): body extraction only, no transcription
+        # chain at all. routes.knowledge.add_knowledge already fetches +
+        # stores transcript_zh eagerly at add time (no cheap article-only
+        # metadata endpoint the way YouTube has oEmbed, see
+        # knowledge/article.py's module docstring), so this branch is
+        # normally never reached — _process_episode's "reuse existing
+        # transcript" fast path (above) wins first. It exists as the
+        # retry/reprocess fallback for a row without a stored transcript.
+        import knowledge.article
+        return knowledge.article.fetch_transcript(video)
+
     if not audio_url:
         logger.warning("podcast: no audio_url for %s, cannot transcribe", video_id)
         return None, meta

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ notebooklm-py>=0.7.3,<0.8.0
 alibabacloud_tingwu20230930>=2.0.25,<3.0.0
 zhconv>=1.4,<2.0
 youtube-transcript-api>=1.2,<2.0
+trafilatura>=2.2,<3.0

--- a/routes/knowledge.py
+++ b/routes/knowledge.py
@@ -1,16 +1,23 @@
-"""Knowledge base ingestion API (issue #651): turn a pasted URL into a
-podcast_episodes row (kind='video' for YouTube, more kinds land in later
-stages) that the existing podcast pipeline can transcribe/summarize.
+"""Knowledge base ingestion API (issue #651, extended #652): turn a pasted
+URL into a podcast_episodes row (kind='video' for YouTube, kind='article'
+for everything else that trafilatura can extract a body from) that the
+existing podcast pipeline can transcribe/summarize.
 
-Deliberately thin: this route only resolves the URL to metadata and inserts
-the pending row. Transcription + summary is NOT done here — the frontend
-takes the returned episode_id and calls the already-existing
-POST /api/podcast/episodes/{id}/process (background thread + polling, #502).
-No new job/polling mechanism is introduced.
+Mostly thin: for YouTube this route only resolves the URL to metadata and
+inserts the pending row — transcription happens later via the existing
+POST /api/podcast/episodes/{id}/process (background thread + polling,
+#502). Articles are the exception (#652): there is no cheap "metadata
+only" endpoint for an arbitrary URL the way YouTube has oEmbed — getting a
+title reliably requires downloading and parsing the whole page, which is
+the same cost as getting the body — so this route fetches + stores the
+full article body synchronously here rather than deferring it. See
+knowledge/article.py's module docstring for the full reasoning. Either way,
+no new job/polling mechanism is introduced.
 """
 import logging
 
 import database
+import knowledge.article
 import knowledge.youtube
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
@@ -30,11 +37,12 @@ def add_knowledge(body: AddKnowledgeRequest):
         raise HTTPException(400, "url is required")
 
     video_id = knowledge.youtube.parse_video_id(url)
-    if not video_id:
-        # Stage B only understands YouTube — article ingestion is stage C
-        # (see schema.sql's podcast_episodes.kind comment).
-        raise HTTPException(400, "Not a recognized YouTube URL (article ingestion isn't supported yet)")
+    if video_id:
+        return _add_video(url, video_id)
+    return _add_article(url)
 
+
+def _add_video(url: str, video_id: str) -> dict:
     existing = database.get_episode_by_video_id(video_id)
     if existing:
         return {"status": "already_exists", "episode_id": existing["id"]}
@@ -64,5 +72,53 @@ def add_knowledge(body: AddKnowledgeRequest):
     )
     if title_en:
         database.update_episode(episode_id, title_en=title_en)
+
+    return {"episode_id": episode_id}
+
+
+def _add_article(url: str) -> dict:
+    """Article ingestion (#652): anything that isn't a recognized YouTube
+    URL is treated as an article. normalize_url() (strips utm_*/fbclid/...)
+    is the dedup key, so the same article shared via different links lands
+    on the same row instead of duplicating."""
+    normalized = knowledge.article.normalize_url(url)
+    existing = database.get_episode_by_video_id(normalized)
+    if existing:
+        return {"status": "already_exists", "episode_id": existing["id"]}
+
+    try:
+        article = knowledge.article.fetch_article(url)
+    except knowledge.article.ArticleExtractionError as e:
+        raise HTTPException(400, str(e))
+    except Exception as e:
+        logger.warning("knowledge.add: article extraction failed for %s: %s", url, e)
+        raise HTTPException(400, f"Could not fetch article: {e}")
+
+    title = article["title"]
+    # translate_title (#651) is one cheap AI call — best-effort, must not
+    # block/fail the add if it errors (translate_title itself already
+    # swallows exceptions and returns None in that case).
+    import ai
+    title_en = ai.translate_title(title)
+
+    episode_id = database.create_pending_episode(
+        video_id=normalized,
+        channel_id=article["site"],
+        title=title,
+        published_at=article.get("published_at"),
+        youtube_url=url,
+        audio_url=None,
+        duration_seconds=None,
+        kind="article",
+    )
+    # Store the body now (fetch_article() already paid for the download —
+    # see its module docstring for why there's no cheap "metadata only"
+    # step to defer this to). This lands in _process_episode's "reuse
+    # existing transcript" fast path when the frontend later calls
+    # POST /api/podcast/episodes/{id}/process.
+    updates = {"transcript_zh": article["text"], "transcript_source": "article"}
+    if title_en:
+        updates["title_en"] = title_en
+    database.update_episode(episode_id, **updates)
 
     return {"episode_id": episode_id}

--- a/schema.sql
+++ b/schema.sql
@@ -642,7 +642,7 @@ CREATE TABLE IF NOT EXISTS podcast_episodes (
     detail_level     TEXT,   -- detail_level used for the summary (short|medium|detailed)
     status           TEXT NOT NULL DEFAULT 'pending'
                      CHECK(status IN ('pending', 'no_transcript', 'summarized', 'error')),
-    transcript_source TEXT,  -- 'tingwu' | 'whisper' | 'notebooklm' | NULL (#498/#486); legacy rows may say 'captions'
+    transcript_source TEXT,  -- 'tingwu' | 'whisper' | 'notebooklm' | 'youtube_captions' (#651) | 'article' (#652) | NULL; legacy rows may say 'captions'
     error            TEXT,
     email_sent_at    TEXT,
     processing_started_at TEXT,  -- set while _process_episode runs, cleared on exit; a leftover value = killed mid-transcription, recovered at startup (#598)

--- a/tests/test_knowledge_article.py
+++ b/tests/test_knowledge_article.py
@@ -90,10 +90,6 @@ def test_fetch_article_download_failure_raises(monkeypatch):
         ka.fetch_article("https://example.com/paywalled")
 
 
-def test_fetch_article_too_short_body_raises():
-    pass  # placeholder replaced below to use monkeypatch fixture properly
-
-
 def test_fetch_article_body_too_short_raises(monkeypatch):
     """A paywall/login-wall page typically yields only a short nav-bar
     fragment — anything under 200 chars must be treated as a failure, never

--- a/tests/test_knowledge_article.py
+++ b/tests/test_knowledge_article.py
@@ -1,0 +1,168 @@
+"""Tests for knowledge/article.py (issue #652).
+
+normalize_url is pure (no I/O). fetch_article makes real network calls via
+trafilatura in production, so every test here stubs trafilatura's module
+functions — CLAUDE.md is explicit that this suite must never actually reach
+the network.
+"""
+import pytest
+
+import knowledge.article as ka
+
+
+# ---------------------------------------------------------------------------
+# normalize_url
+# ---------------------------------------------------------------------------
+
+def test_normalize_url_strips_utm_params():
+    url = "https://example.com/news/article-1?utm_source=twitter&utm_medium=social&utm_campaign=x"
+    assert ka.normalize_url(url) == "https://example.com/news/article-1"
+
+
+def test_normalize_url_strips_fbclid_and_gclid():
+    assert ka.normalize_url(
+        "https://example.com/a?fbclid=abc123"
+    ) == "https://example.com/a"
+    assert ka.normalize_url(
+        "https://example.com/a?gclid=xyz789"
+    ) == "https://example.com/a"
+
+
+def test_normalize_url_strips_fragment():
+    assert ka.normalize_url("https://example.com/a#comments") == "https://example.com/a"
+
+
+def test_normalize_url_keeps_real_query_params():
+    """A tracking param sitting next to a real one (e.g. a paginated/query
+    article) must not lose the real param."""
+    url = "https://example.com/search?q=news&utm_source=app"
+    assert ka.normalize_url(url) == "https://example.com/search?q=news"
+
+
+def test_normalize_url_different_share_links_land_on_same_key():
+    """The same article shared via Twitter vs. a newsletter vs. WeChat must
+    normalize to the identical canonical URL — this is podcast_episodes'
+    dedup key (video_id, UNIQUE), so a mismatch here means duplicate rows."""
+    twitter_link = "https://example.com/news/big-story?utm_source=twitter&utm_medium=social"
+    newsletter_link = "https://example.com/news/big-story?utm_source=newsletter&utm_campaign=weekly"
+    wechat_link = "https://example.com/news/big-story?from=wechat&spm=abc.123"
+    assert ka.normalize_url(twitter_link) == ka.normalize_url(newsletter_link) == ka.normalize_url(wechat_link)
+    assert ka.normalize_url(twitter_link) == "https://example.com/news/big-story"
+
+
+def test_normalize_url_idempotent():
+    already_clean = "https://example.com/news/story"
+    assert ka.normalize_url(already_clean) == already_clean
+    assert ka.normalize_url(ka.normalize_url(already_clean)) == ka.normalize_url(already_clean)
+
+
+def test_normalize_url_strips_leading_trailing_whitespace():
+    assert ka.normalize_url("  https://example.com/a?utm_source=x  ") == "https://example.com/a"
+
+
+# ---------------------------------------------------------------------------
+# fetch_article — trafilatura stubbed
+# ---------------------------------------------------------------------------
+
+class _FakeMetadata:
+    def __init__(self, title=None, date=None):
+        self.title = title
+        self.date = date
+
+
+def _patch_trafilatura(monkeypatch, *, downloaded="<html>ok</html>", extracted="", metadata=None,
+                        fetch_raises=None):
+    import trafilatura
+
+    def fake_fetch_url(url, *a, **kw):
+        if fetch_raises:
+            raise fetch_raises
+        return downloaded
+
+    monkeypatch.setattr(trafilatura, "fetch_url", fake_fetch_url)
+    monkeypatch.setattr(trafilatura, "extract", lambda *a, **kw: extracted)
+    monkeypatch.setattr(trafilatura, "extract_metadata", lambda *a, **kw: metadata)
+
+
+def test_fetch_article_download_failure_raises(monkeypatch):
+    _patch_trafilatura(monkeypatch, downloaded=None)
+    with pytest.raises(ka.ArticleExtractionError):
+        ka.fetch_article("https://example.com/paywalled")
+
+
+def test_fetch_article_too_short_body_raises():
+    pass  # placeholder replaced below to use monkeypatch fixture properly
+
+
+def test_fetch_article_body_too_short_raises(monkeypatch):
+    """A paywall/login-wall page typically yields only a short nav-bar
+    fragment — anything under 200 chars must be treated as a failure, never
+    silently stored as if it were the article (see issue #652)."""
+    _patch_trafilatura(monkeypatch, extracted="订阅解锁全文" * 5)  # well under 200 chars
+    with pytest.raises(ka.ArticleExtractionError):
+        ka.fetch_article("https://example.com/paywalled")
+
+
+def test_fetch_article_success_returns_title_text_site_date(monkeypatch):
+    body = "这是一篇完整的新闻文章。" * 30  # comfortably over 200 chars
+    _patch_trafilatura(
+        monkeypatch,
+        extracted=body,
+        metadata=_FakeMetadata(title="新闻标题", date="2026-08-09"),
+    )
+    result = ka.fetch_article("https://www.example.com/news/story")
+    assert result["title"] == "新闻标题"
+    assert result["text"] == body
+    assert result["site"] == "example.com"  # www. stripped
+    assert result["published_at"] == "2026-08-09"
+
+
+def test_fetch_article_falls_back_to_url_when_no_title(monkeypatch):
+    body = "x" * 300
+    _patch_trafilatura(monkeypatch, extracted=body, metadata=None)
+    result = ka.fetch_article("https://example.com/untitled")
+    assert result["title"] == "https://example.com/untitled"
+    assert result["published_at"] is None
+
+
+def test_fetch_article_truncates_long_body(monkeypatch):
+    body = "字" * 20000
+    _patch_trafilatura(monkeypatch, extracted=body, metadata=_FakeMetadata(title="长文"))
+    result = ka.fetch_article("https://example.com/long")
+    assert len(result["text"]) == ka._MAX_ARTICLE_CHARS
+
+
+def test_fetch_article_propagates_download_exceptions(monkeypatch):
+    _patch_trafilatura(monkeypatch, fetch_raises=OSError("network unreachable"))
+    with pytest.raises(OSError):
+        ka.fetch_article("https://example.com/whatever")
+
+
+# ---------------------------------------------------------------------------
+# fetch_transcript — podcast.fetch_transcript-compatible wrapper
+# ---------------------------------------------------------------------------
+
+def test_fetch_transcript_returns_text_and_meta(monkeypatch):
+    body = "文章正文" * 60
+    _patch_trafilatura(monkeypatch, extracted=body, metadata=_FakeMetadata(title="标题"))
+    text, meta = ka.fetch_transcript({"youtube_url": "https://example.com/a", "video_id": "https://example.com/a"})
+    assert text == body
+    assert meta == {"transcript_source": "article"}
+
+
+def test_fetch_transcript_uses_video_id_when_no_youtube_url(monkeypatch):
+    seen = {}
+
+    def fake_fetch_article(url):
+        seen["url"] = url
+        return {"title": "t", "text": "x" * 300, "site": "example.com", "published_at": None}
+
+    monkeypatch.setattr(ka, "fetch_article", fake_fetch_article)
+    ka.fetch_transcript({"video_id": "https://example.com/fallback"})
+    assert seen["url"] == "https://example.com/fallback"
+
+
+def test_fetch_transcript_propagates_extraction_error(monkeypatch):
+    _patch_trafilatura(monkeypatch, extracted="too short")
+    with pytest.raises(ka.ArticleExtractionError):
+        ka.fetch_transcript({"youtube_url": "https://example.com/paywalled"})


### PR DESCRIPTION
## 背景

Closes #652

依赖阶段 A（#650）、阶段 B（#651），均已合并。总体设计见 `docs/knowledge-base.md`。

把报刊文章接进知识库流水线：给一个文章 URL，用 trafilatura 抽正文当"转录"，下游（摘要、生词标注、造卡）全部复用现有 podcast_episodes 管线，零改动。

## 改动

- **新模块 `knowledge/article.py`**
  - `normalize_url(url)`：剥掉 `utm_*`/`fbclid`/`gclid` 等跟踪参数（及 fragment），作为 `podcast_episodes.video_id` 去重键——同一篇文章从不同渠道分享过来会归一到同一行
  - `fetch_article(url) -> {title, text, site, published_at}`：用 `trafilatura` 下载+抽取正文；正文少于 200 字或下载失败一律抛 `ArticleExtractionError`，**绝不存垃圾文本冒充正文**；正文超过 15000 字截断（上下文窗口护栏，非省钱）
  - `fetch_transcript(video)`：与 `knowledge.youtube.fetch_captions` 签名兼容的 `podcast.fetch_transcript` 分流入口，供重试/未来邮件收件（#655）等没有预存正文的场景兜底用

- **`routes/knowledge.py`**：`POST /api/knowledge/add` 原来「不是 YouTube 就 400」的分支改为走文章路径（`_add_article`）。与 YouTube 不同，文章没有 oEmbed 这种廉价的"只要标题"接口——拿标题和拿正文是同一次下载，所以直接在 add 时同步抓取+存入 `transcript_zh`（`kind='article'`，`channel_id`=站点域名，`transcript_source='article'`），落入 `_process_episode` 已有的"复用已存转录"快速路径，用户点"处理"时无需二次抓取

- **`podcast.py`**：`fetch_transcript()` 加 `kind == 'article'` 分支（对称于已有的 `kind == 'video'` 分支），调用 `knowledge.article.fetch_transcript`

- **`schema.sql`**：`transcript_source` 列注释补全 `'youtube_captions'`（#651 遗漏）、`'article'`（#652）

- **`requirements.txt`**：新增 `trafilatura>=2.2,<3.0`

## 与施工图的差异说明

施工图建议 YouTube 式"add 时只拿元数据，process 时才抓正文"的懒加载对称设计。但文章没有 YouTube oEmbed 那种廉价元数据端点——拿标题必须下载整页，这和拿正文是同一次网络请求。因此改为在 `/api/knowledge/add` 里**同步**完成完整抽取并立即存入 `transcript_zh`，避免同一篇文章被下载两次；`podcast.fetch_transcript` 里仍然加了对称的 `article` 分支，作为 retry / 未来邮件收件路径的兜底（尚未有存量转录时会被用到）。已在 `knowledge/article.py` 和 `routes/knowledge.py` 的模块/函数文档字符串里写清楚这个理由。

## 测试

- `tests/test_knowledge_article.py`（16 个用例，全部打桩 `trafilatura`，不联网）：
  - `normalize_url`：剥离 `utm_*`/`fbclid`/`gclid`、保留真实查询参数、剥 fragment、幂等、**不同分享链接归一到同一 key**
  - `fetch_article`：下载失败报错、**正文过短报错**、成功抽取返回 title/text/site/published_at、无标题时退回 URL、超长正文截断、下载异常原样传播
  - `fetch_transcript`：返回 (text, meta)、`video_id` 兜底、抽取失败异常传播
- `pytest tests/` 全绿：**267 passed, 4 skipped**（4 个 skip 与本次改动无关，pre-existing）
- 手动验证（sandbox 环境实测联网）：
  - `tagesschau.de` 真实文章：`fetch_url` 502288 字节 → `extract` 4681 字正文，`extract_metadata` 正确给出德语标题/日期/站点
  - BBC 中文（`bbc.com/zhongwen`）真实文章：同样干净抽取出正文（含少量导览/作者信息前缀，非付费墙失败）

## 待 Daniel 手动验证

- [ ] 在知识页粘贴一篇 tagesschau.de 或类似文章 URL，走通"加 → 抽正文 → 中文摘要 → 生词标注"全链路
- [ ] 找一篇有付费墙的文章确认返回的错误信息可读、不会生成空白摘要