### PR TITLE
知识库阶段 E：故事的播客模式改造成知识库模式（#654）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -337,7 +337,12 @@ Rules:
 Return ONLY a numbered list of Chinese sentences, no explanation:
 1. ...
 2. ...""",
-    "podcast": """任务：下面是一期播客单集的内容摘要（德语）。请写若干简体中文句子，帮助 HSK 4-5
+    # Renamed from "podcast" to "knowledge" (issue #654) — episodes now cover
+    # podcast/video/article sources, not just podcasts. Old mode='podcast'
+    # stories still call generate_podcast_sentences below, which now looks up
+    # this same "knowledge" template — see database/core.py's one-time
+    # prompt_presets rename so Daniel's saved custom template keeps applying.
+    "knowledge": """任务：下面是一期播客单集的内容摘要（德语）。请写若干简体中文句子，帮助 HSK 4-5
 学习者复习词汇。这些句子不需要合起来构成一篇摘要——每一句只要"发生在这一集的世界里"就可以。
 
 单集标题：{title}
@@ -401,7 +406,7 @@ PROMPT_TEMPLATE_VARIABLES: dict[str, list[str]] = {
     "story": ["words", "max_hsk", "grammar_block", "topic_block"],
     "qa": ["words", "max_hsk", "grammar_block", "topic"],
     "expository": ["words", "max_hsk", "grammar_block", "topic"],
-    "podcast": ["words", "summary", "title", "max_hsk", "extra_hint"],
+    "knowledge": ["words", "summary", "title", "max_hsk", "extra_hint"],
 }
 
 
@@ -2242,7 +2247,9 @@ def generate_podcast_sentences(
         return []
 
     # 模板可被用户自定义覆盖（issue #581）；默认渲染结果与旧内联 f-string 逐字一致。
-    tpl = _story_prompt_template("podcast")
+    # #654: 查的是 "knowledge" 模板——mode='podcast' 的历史故事也走这个函数，
+    # 迁移后它们的自定义模板同样存在 mode='knowledge' 下（见 database/core.py）。
+    tpl = _story_prompt_template("knowledge")
 
     def _build_prompt(batch: list[dict], extra_hint: str = "") -> str:
         word_list = "\n".join(

--- a/database/core.py
+++ b/database/core.py
@@ -717,6 +717,16 @@ def init_db() -> None:
         )
     conn.commit()
 
+    # One-time migration (issue #654): the story mode identifier "podcast" was
+    # renamed to "knowledge" (episodes now cover podcast/video/article sources).
+    # Rename any saved prompt_presets rows so Daniel's custom podcast-mode
+    # templates keep applying under the new mode name. Idempotent: after the
+    # first run there are no more mode='podcast' rows left to rename, so this
+    # is a no-op on every subsequent init_db() call (deploy.sh runs it every
+    # ~2 minutes on the server).
+    conn.execute("UPDATE prompt_presets SET mode = 'knowledge' WHERE mode = 'podcast'")
+    conn.commit()
+
     conn.close()
 
     # Seed the day-cutoff cache now that app_settings is guaranteed present

--- a/routes/story.py
+++ b/routes/story.py
@@ -26,7 +26,11 @@ MAX_KAHNEMAN_BATCH = 10
 # Again 单句重生成的成本动作标签（issue #578）——按故事模式区分；
 # get_api_costs 会把相邻的同标签 "… Again Sentences" 动作合并成一行。
 _AGAIN_ACTION_LABELS = {
+    # mode="podcast" kept alongside "knowledge" (issue #654 renamed the
+    # identifier for *new* stories; historical mode='podcast' stories still
+    # regenerate single sentences through generate_sentence_for_word below).
     "podcast": "Podcast Again Sentences",
+    "knowledge": "Knowledge Again Sentences",
     "kahneman": "Kahneman Again Sentences",
     "news": "News Again Sentences",
     "briefing": "News Again Sentences",
@@ -243,8 +247,8 @@ def _action_label_for_story(mode: str, deck_id: int) -> str:
         return "Generate Kahneman Story"
     if mode == "paste":
         return "Generate Paste Story"
-    if mode == "podcast":
-        return "Generate Podcast Review"
+    if mode == "knowledge":
+        return "Generate Knowledge Review"
     deck = database.get_deck(deck_id)
     deck_name = deck["name"] if deck else str(deck_id)
     return f"Generate Story: {deck_name}"
@@ -255,6 +259,7 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
                              chapter_ids, articles, progress_key, lang: str,
                              origin: str | None, episode_id: int | None,
                              batch_size: int | None = None) -> dict | None:
+    kind = None  # knowledge mode's source kind (podcast/video/article, issue #654)
     try:
         if mode == "news":
             # Issue #512: the old auto-fetch-only "news" mode has been removed
@@ -264,7 +269,15 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
             # generate_sentence_for_word below), only *new* full-story
             # generation with this mode is rejected.
             raise ValueError("mode 'news' has been removed — use 'briefing' instead")
-        if lang != "zh" and mode in ("kahneman", "paste", "briefing", "podcast"):
+        if mode == "podcast":
+            # Issue #654: the podcast-only story mode was renamed "knowledge"
+            # (episodes now cover podcast/video/article sources uniformly).
+            # Old mode='podcast' stories still display fine and their per-word
+            # Again regeneration still works (see generate_sentence_for_word
+            # below), only *new* full-story generation with this identifier
+            # is rejected — same pattern as the #512 removal of mode='news'.
+            raise ValueError("mode 'podcast' has been renamed — use 'knowledge' instead")
+        if lang != "zh" and mode in ("kahneman", "paste", "briefing", "knowledge"):
             raise ValueError(f"mode '{mode}' is only available for Chinese decks")
         if mode == "kahneman":
             parsed_chapter_ids = [int(x) for x in chapter_ids.split(",") if x.strip()] if chapter_ids else []
@@ -302,29 +315,34 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
                 cards, articles, model=model, progress_key=progress_key,
                 max_hsk=max_hsk, generic=(mode == "paste"),
                 include_context=True, batch_size=batch_size)
-        elif mode == "podcast":
-            # Podcast mode rework (issue #561): drops the briefing pipeline —
-            # only the episode's German summary is sent (detailed enough since
-            # #541, never the full transcript), one lean call per batch of
-            # MAX_NEWS_BATCH words plus missing-word top-ups, no fact-check.
-            # The model is the user's dropdown pick, no longer locked to
-            # BRIEFING_MODEL. Default is ai.DEFAULT_MODEL (DeepSeek) since #640
-            # — the gpt-5-mini default was inherited from the news path, whose
-            # reason (DeepSeek censors news content) doesn't apply here: the
-            # input is a German episode summary, and kahneman has always run on
-            # DeepSeek. If an episode's topic does trip DeepSeek's filter, the
-            # per-word fallback sentences make it obvious and the dropdown
-            # switches back to GPT without a code change.
+        elif mode == "knowledge":
+            # Knowledge mode (issue #654, renamed from "podcast" #482/#561):
+            # after the knowledge-base generalization (#650) podcast_episodes
+            # covers podcast/video/article sources uniformly, so this path
+            # needs zero changes beyond the identifier — database.get_episode()
+            # already returns any kind. Drops the briefing pipeline — only the
+            # item's German summary is sent (detailed enough since #541, never
+            # the full transcript), one lean call per batch of MAX_NEWS_BATCH
+            # words plus missing-word top-ups, no fact-check. The model is the
+            # user's dropdown pick, no longer locked to BRIEFING_MODEL. Default
+            # is ai.DEFAULT_MODEL (DeepSeek) since #640 — the gpt-5-mini default
+            # was inherited from the news path, whose reason (DeepSeek censors
+            # news content) doesn't apply here: the input is a German summary,
+            # and kahneman has always run on DeepSeek. If an item's topic does
+            # trip DeepSeek's filter, the per-word fallback sentences make it
+            # obvious and the dropdown switches back to GPT without a code change.
             if not episode_id:
-                raise ValueError("Podcast mode requires selecting an episode.")
+                raise ValueError("Knowledge mode requires selecting a source item.")
             episode = database.get_episode(episode_id)
             if not episode:
-                raise ValueError(f"Podcast episode {episode_id} not found.")
+                raise ValueError(f"Knowledge item {episode_id} not found.")
             summary = (episode.get("summary_de") or "").strip()
             if not summary:
-                raise ValueError("Selected podcast episode has no summary yet.")
+                raise ValueError("Selected item has no summary yet.")
+            kind = episode.get("kind") or "podcast"
             model = _validated_model(model, default=ai.DEFAULT_MODEL)
-            logger.info("story  podcast model in use: %s batch_size=%s", model, batch_size)
+            logger.info("story  knowledge model in use: %s kind=%s batch_size=%s",
+                        model, kind, batch_size)
             # batch_size (issue #563): user-controlled words-per-call from the
             # setup modal; empty/0 = one single call, capped at MAX_PODCAST_BATCH
             # (#634). Spreading the words over the summary's topics only works if
@@ -340,9 +358,9 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
                     chunk, summary, episode.get("title") or "",
                     model=model, max_hsk=max_hsk, progress_key=progress_key,
                     attempt_label=label,
-                    source_url=episode.get("youtube_url") or f"/#podcast-{episode_id}",
+                    source_url=episode.get("youtube_url") or f"/#{kind}-{episode_id}",
                     source_title=episode.get("title")))
-            prompt_text = f"podcast mode — episode {episode_id}"
+            prompt_text = f"knowledge mode — item {episode_id} (kind={kind})"
         else:
             sentences, prompt_text = _generate_story_sentences(
                 cards, topic=topic, max_hsk=max_hsk, model=model,
@@ -355,7 +373,7 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
             topic=topic, max_hsk=max_hsk, model=model,
             grammar_focus=grammar_focus, grammar_pct=grammar_pct,
             mode=mode, chapter_ids=chapter_ids, articles=articles, lang=lang,
-            origin=origin, episode_id=episode_id, batch_size=batch_size)
+            origin=origin, episode_id=episode_id, batch_size=batch_size, kind=kind)
         database.create_story(today, category, deck_id, sentences, prompt_text, topic, gen_params, lang=lang)
         story = database.get_active_story(today, category, deck_id, lang=lang)
     except Exception as e:
@@ -411,7 +429,8 @@ def _start_background_generation(deck_id: int, category: str, today: str, cards:
 
 def _gen_params_dict(*, topic, max_hsk, model, grammar_focus, grammar_pct,
                      mode, chapter_ids, articles=None, lang="zh",
-                     origin=None, episode_id=None, batch_size=None) -> dict:
+                     origin=None, episode_id=None, batch_size=None,
+                     kind=None) -> dict:
     """Bundle the story generation settings persisted on each story row, so the
     Again regeneration can reproduce the same style (see generate_sentence_for_word).
 
@@ -420,11 +439,16 @@ def _gen_params_dict(*, topic, max_hsk, model, grammar_focus, grammar_pct,
     origin: "pregen" when the story was created by the morning pregen —
     get_recent_story_keys skips those rows so pregen only ever reproduces
     user-initiated generations instead of feeding on its own output (issue #468).
-    episode_id: podcast mode's selected episode (issue #482, summary-only
-    pipeline since #561) — Again-regen re-fetches the episode's summary_de by
-    this id rather than reusing `articles` (podcast stories don't store any).
+    episode_id: knowledge mode's selected source item (issue #482, renamed
+    from "podcast" mode in #654; summary-only pipeline since #561) —
+    Again-regen re-fetches the item's summary_de by this id rather than
+    reusing `articles` (knowledge stories don't store any).
+    kind: the selected item's source kind (podcast/video/article, issue #654)
+    at generation time — purely informational (regen re-derives it from the
+    episode row via episode_id), kept here so the frontend can show what kind
+    of source a knowledge story came from without an extra lookup.
     batch_size: user-chosen words-per-AI-call (issue #563 podcast-only, #574 all
-    modes); None/0 = each mode's default chunking (podcast: all at once; story
+    modes); None/0 = each mode's default chunking (knowledge: all at once; story
     family: CHUNK_SIZE; kahneman: per-chapter split capped at MAX_KAHNEMAN_BATCH;
     briefing/paste: MAX_NEWS_BATCH). Stored for handoff/reproducibility only —
     Again-regen is single-card.
@@ -442,6 +466,7 @@ def _gen_params_dict(*, topic, max_hsk, model, grammar_focus, grammar_pct,
         "origin": origin,
         "episode_id": episode_id,
         "batch_size": batch_size,
+        "kind": kind,
     }
 
 
@@ -495,19 +520,24 @@ def generate_sentence_for_word(card: dict, gen_params: dict | None) -> dict | No
                     sentences = ai.generate_kahneman_sentences([card], chapter, model=model)
                 else:  # book data missing → fall back to a plain sentence
                     sentences, _ = ai.generate_story([card], model=model, lang=lang)
-            elif mode == "podcast":
-                # Podcast Again-regen (issue #561): same lean pipeline, one card +
-                # the episode summary, honoring the story's stored user-picked
-                # model (old stories stored gpt-5.1, which is not whitelisted, so
-                # _validated_model falls back). No summary → plain sentence.
+            elif mode in ("knowledge", "podcast"):
+                # Knowledge Again-regen (issue #561, renamed from "podcast" in
+                # #654): same lean pipeline, one card + the item's summary,
+                # honoring the story's stored user-picked model (old stories
+                # stored gpt-5.1, which is not whitelisted, so _validated_model
+                # falls back). mode="podcast" here means a *historical* story
+                # (new stories are generated with mode="knowledge" — #654
+                # rejects "podcast" at generation time, but old stories must
+                # keep regenerating). No summary → plain sentence.
                 ep = database.get_episode(gp["episode_id"]) if gp.get("episode_id") else None
                 summary = ((ep or {}).get("summary_de") or "").strip()
                 if summary:
+                    ep_kind = ep.get("kind") or "podcast"
                     sentences = ai.generate_podcast_sentences(
                         [card], summary, ep.get("title") or "",
                         model=_validated_model(gp.get("model"), default=ai.DEFAULT_MODEL),
                         max_hsk=gp.get("max_hsk", 3),
-                        source_url=ep.get("youtube_url") or f"/#podcast-{ep['id']}",
+                        source_url=ep.get("youtube_url") or f"/#{ep_kind}-{ep['id']}",
                         source_title=ep.get("title"))
                 else:
                     sentences, _ = ai.generate_story([card], model=model, lang=lang)

--- a/routes/story.py
+++ b/routes/story.py
@@ -689,10 +689,13 @@ def regenerate_story(deck_id: int, category: str,
     """Regenerate today's story. body (optional JSON): {"articles": [{"url", "title", "text"}]}
     — pasted texts for mode="paste" (too long to fit in a query string).
     mode="briefing" ignores pasted articles and auto-fetches today's news (issue #387);
-    mode="paste" with no articles is an error (issue #396); mode="podcast" uses the
-    episode_id's German summary directly, no articles involved (reworked #561).
-    mode="news" (the old auto-fetch-only mode) has been removed (issue #512) and
-    is rejected."""
+    mode="paste" with no articles is an error (issue #396); mode="knowledge" (renamed
+    from "podcast" in #654) uses the episode_id's German summary directly, no
+    articles involved (reworked #561).
+    mode="news" (the old auto-fetch-only mode) has been removed (issue #512), and
+    mode="podcast" (renamed to "knowledge" in #654) has likewise been removed —
+    both are rejected for *new* generation, but stories already stored with either
+    identifier still display and still support per-word Again regeneration."""
     if ai_disabled():
         return None
     chosen_model = _validated_model(model)

--- a/static/app.js
+++ b/static/app.js
@@ -719,7 +719,9 @@ function _updateStoryInfoRow() {
     const pos = `Sentence ${sentence.position + 1} / ${story.sentences.length}`;
     // News flow / news / paste / kahneman: show the mode name + story date to the
     // right of the counter (issue #452). Plain stories keep the topic.
-    const modeName = { kahneman: 'Kahneman', news: 'News', briefing: 'News flow', paste: 'Paste', podcast: 'Podcast' }[_activeStoryMode()];
+    // podcast kept alongside knowledge (issue #654 renamed the mode identifier
+    // going forward, but historical mode='podcast' stories still display fine).
+    const modeName = { kahneman: 'Kahneman', news: 'News', briefing: 'News flow', paste: 'Paste', podcast: 'Podcast', knowledge: 'Knowledge' }[_activeStoryMode()];
     const parts = [pos];
     if (modeName) {
       const date = String(story.date || story.generated_at || '').slice(0, 10);
@@ -7376,7 +7378,7 @@ function updateSetupMode() {
   // zh decks only (fr uses the built-in language-neutral prompt path).
   const editPromptBtn = document.getElementById('setup-edit-prompt-btn');
   if (editPromptBtn) {
-    const editable = ['story', 'qa', 'expository', 'podcast'].includes(mode)
+    const editable = ['story', 'qa', 'expository', 'knowledge'].includes(mode)
       && (_deckLangById[deckId] || 'zh') === 'zh';
     editPromptBtn.style.display = editable ? '' : 'none';
   }
@@ -7416,11 +7418,11 @@ function updateSetupMode() {
     pasteSection.style.display = 'block';
     btn.textContent = 'Generate summary';
     if (!document.getElementById('setup-paste-blocks').children.length) addPasteBlock();
-  } else if (mode === 'podcast') {
+  } else if (mode === 'knowledge') {
     topicLabel.style.display = 'none';
     kahnemanSection.style.display = 'none';
     if (podcastSection) podcastSection.style.display = 'block';
-    btn.textContent = 'Generate podcast summary';
+    btn.textContent = 'Generate from source';
     _loadPodcastEpisodesForSetup();
   } else if (mode === 'vocab') {
     topicLabel.style.display = 'none';
@@ -7441,16 +7443,16 @@ function updateSetupMode() {
 // BRIEFING_MODEL (DeepSeek censors news content, so it's OpenAI-only).
 // Switching to one of them locks the dropdown to a "Server: BRIEFING_MODEL"
 // placeholder and remembers the previous model; switching back restores it.
-// podcast (issue #561 rework) is no longer part of this lock — it picks its
-// own model, remembered per-mode via localStorage (see MODE_MODEL_DEFAULTS
-// below) instead of sharing BRIEFING_MODEL.
+// knowledge mode (issue #561 rework, renamed from podcast in #654) is no
+// longer part of this lock — it picks its own model, remembered per-mode via
+// localStorage (see MODE_MODEL_DEFAULTS below) instead of sharing BRIEFING_MODEL.
 let _modelBeforeNewsMode = null;
 
-// Per-mode remembered model (issue #561): podcast has its own first-time
-// default, then remembers whatever the user picked last. Since #640 that
-// default is DeepSeek (like kahneman) rather than gpt-5-mini — must stay in
-// sync with ai.DEFAULT_MODEL, which is the backend-side default.
-const MODE_MODEL_DEFAULTS = { podcast: 'deepseek-v4-flash' };
+// Per-mode remembered model (issue #561): knowledge mode has its own
+// first-time default, then remembers whatever the user picked last. Since
+// #640 that default is DeepSeek (like kahneman) rather than gpt-5-mini — must
+// stay in sync with ai.DEFAULT_MODEL, which is the backend-side default.
+const MODE_MODEL_DEFAULTS = { knowledge: 'deepseek-v4-flash' };
 let _modelSelMode = 'story';   // mode the model dropdown's current value belongs to
 
 function _autoSwitchModelForMode(mode) {
@@ -7829,23 +7831,36 @@ function randomKahnemanChapters() {
   _updateKahnemanCount();
 }
 
-// ── Podcast episode picker (issue #482, feed filter added in #561) —
+// ── Knowledge item picker (issue #482, feed filter #561, kind filter #654) —
 // single-select, template copied from the kahneman chapter selector above
-// but radio-style (one episode per story).
+// but radio-style (one item per story). Renamed from podcast-only to
+// knowledge (podcast/video/article) in #654 — element ids kept as
+// setup-podcast-* to minimize churn (they're internal, not user-facing).
 let _setupPodcastFeeds = null;              // null = not loaded yet
-let _setupPodcastEpisodesByFeed = {};       // key '' (all) or feed_id → episodes array
+// key `${kind}|${feedId}` ('' feedId = all podcasts, only meaningful for kind=podcast) → episodes array
+let _setupPodcastEpisodesByFeed = {};
+let _setupKnowledgeKind = localStorage.getItem('setupKnowledgeKind') || 'podcast';
 // Words per AI call (issue #563 podcast-only, #574 all modes): persisted per
 // mode like setupModel. null = the mode's default chunking. Read by
 // _storyParams for every generation URL.
 function _savedBatchSize(mode) {
   return parseInt(localStorage.getItem('setupBatch:' + mode), 10) || null;
 }
-// One-time migration from the podcast-only #563 key.
+// One-time migrations: the podcast-only #563 key, then the #654 mode rename
+// (podcast -> knowledge) so an existing per-mode batch size still applies.
 (() => {
   const old = localStorage.getItem('podcastBatchSize');
   if (old) {
     localStorage.setItem('setupBatch:podcast', old);
     localStorage.removeItem('podcastBatchSize');
+  }
+  const oldPodcastBatch = localStorage.getItem('setupBatch:podcast');
+  if (oldPodcastBatch && !localStorage.getItem('setupBatch:knowledge')) {
+    localStorage.setItem('setupBatch:knowledge', oldPodcastBatch);
+  }
+  const oldPodcastModel = localStorage.getItem('setupModel:podcast');
+  if (oldPodcastModel && !localStorage.getItem('setupModel:knowledge')) {
+    localStorage.setItem('setupModel:knowledge', oldPodcastModel);
   }
 })();
 
@@ -7853,7 +7868,15 @@ async function _loadPodcastEpisodesForSetup() {
   const container = document.getElementById('setup-podcast-episodes');
   const loading = document.getElementById('setup-podcast-loading');
   const feedSel = document.getElementById('setup-podcast-feed');
+  const kindSel = document.getElementById('setup-knowledge-kind');
   if (!container) return;
+  if (kindSel) {
+    kindSel.value = _setupKnowledgeKind;
+    kindSel.onchange = _onKnowledgeKindChange;
+  }
+  // The feed filter dropdown only makes sense for the podcast kind — videos
+  // and articles aren't grouped by RSS feed (issue #654).
+  if (feedSel) feedSel.style.display = _setupKnowledgeKind === 'podcast' ? '' : 'none';
   if (_setupPodcastFeeds === null) {
     try {
       const feeds = await api('GET', '/api/podcast/feeds');
@@ -7871,6 +7894,19 @@ async function _loadPodcastEpisodesForSetup() {
   await _loadPodcastEpisodesForCurrentFeed();
 }
 
+// Source-type switch (🎙️ podcast | 📺 video | 📄 article, issue #654) —
+// re-renders the episode list for the newly selected kind.
+function _onKnowledgeKindChange() {
+  const kindSel = document.getElementById('setup-knowledge-kind');
+  _setupKnowledgeKind = (kindSel && kindSel.value) || 'podcast';
+  localStorage.setItem('setupKnowledgeKind', _setupKnowledgeKind);
+  const feedSel = document.getElementById('setup-podcast-feed');
+  if (feedSel) feedSel.style.display = _setupKnowledgeKind === 'podcast' ? '' : 'none';
+  // Selecting a new item clears any previous radio pick — the episode ids
+  // aren't comparable across kinds.
+  _loadPodcastEpisodesForCurrentFeed();
+}
+
 function _onPodcastFeedFilterChange() {
   _loadPodcastEpisodesForCurrentFeed();
 }
@@ -7880,29 +7916,35 @@ async function _loadPodcastEpisodesForCurrentFeed() {
   const loading = document.getElementById('setup-podcast-loading');
   const feedSel = document.getElementById('setup-podcast-feed');
   if (!container) return;
-  const feedId = feedSel ? feedSel.value : '';
-  if (_setupPodcastEpisodesByFeed[feedId]) { _renderPodcastEpisodes(feedId); return; }
+  const kind = _setupKnowledgeKind || 'podcast';
+  const feedId = (kind === 'podcast' && feedSel) ? feedSel.value : '';
+  const cacheKey = `${kind}|${feedId}`;
+  if (_setupPodcastEpisodesByFeed[cacheKey]) { _renderPodcastEpisodes(cacheKey); return; }
   container.style.display = 'none';
   if (loading) loading.style.display = 'block';
   try {
-    const url = '/api/podcast/episodes?limit=1000' + (feedId ? `&feed_id=${feedId}` : '');
+    // kind=podcast keeps the existing feed_id filter; video/article ignore it
+    // and just list every item of that kind (issue #654 — /api/podcast/episodes
+    // already supports ?kind= since #651).
+    const url = '/api/podcast/episodes?limit=1000&kind=' + encodeURIComponent(kind) +
+      (feedId ? `&feed_id=${feedId}` : '');
     const data = await api('GET', url);
-    // Only episodes with a finished summary can seed a story (issue #482).
-    _setupPodcastEpisodesByFeed[feedId] = (data || []).filter(ep => ep.status === 'summarized');
+    // Only items with a finished summary can seed a story (issue #482).
+    _setupPodcastEpisodesByFeed[cacheKey] = (data || []).filter(ep => ep.status === 'summarized');
     if (loading) loading.style.display = 'none';
     container.style.display = 'block';
-    _renderPodcastEpisodes(feedId);
+    _renderPodcastEpisodes(cacheKey);
   } catch (e) {
-    if (loading) loading.textContent = 'Failed to load episodes.';
+    if (loading) loading.textContent = 'Failed to load items.';
   }
 }
 
-function _renderPodcastEpisodes(feedId) {
+function _renderPodcastEpisodes(cacheKey) {
   const container = document.getElementById('setup-podcast-episodes');
-  const episodes = _setupPodcastEpisodesByFeed[feedId];
+  const episodes = _setupPodcastEpisodesByFeed[cacheKey];
   if (!container || !episodes) return;
   if (!episodes.length) {
-    container.innerHTML = '<div style="padding:12px;text-align:center;color:var(--muted,#888);font-size:13px">No summarized episodes yet.</div>';
+    container.innerHTML = '<div style="padding:12px;text-align:center;color:var(--muted,#888);font-size:13px">No summarized items yet.</div>';
     return;
   }
   const esc = s => String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
@@ -7942,16 +7984,16 @@ function confirmStorySetup() {
   if (model && model !== 'briefing-server') localStorage.setItem('setupModel:' + mode, model);
   const chapterIds  = mode === 'kahneman' ? _getSelectedChapterIds() : null;
   const articles    = mode === 'paste' ? _collectPastedContents() : null;
-  const episodeId   = mode === 'podcast' ? _getSelectedEpisodeId() : null;
+  const episodeId   = mode === 'knowledge' ? _getSelectedEpisodeId() : null;
   // News mode never sends articles: today's news is auto-fetched server-side
   // (issue #387). Paste mode requires at least one non-empty text (issue #396).
   if (mode === 'paste' && !articles.length) {
     showError('Paste mode needs at least one text — paste some content first.');
     return;
   }
-  // Podcast mode requires picking exactly one episode (issue #482).
-  if (mode === 'podcast' && !episodeId) {
-    showError('Podcast mode needs an episode — select one first.');
+  // Knowledge mode requires picking exactly one source item (issue #482/#654).
+  if (mode === 'knowledge' && !episodeId) {
+    showError('Knowledge mode needs a source — select one first.');
     return;
   }
   // Words per AI call (issue #563 podcast-only, #574 all modes): empty input

--- a/static/index.html
+++ b/static/index.html
@@ -717,11 +717,11 @@
         <option value="kahneman" class="setup-mode-zh-only">🧠 Kahneman — cognitive bias style</option>
         <option value="briefing" class="setup-mode-zh-only">🗞️ News flow — summary with German context</option>
         <option value="paste" class="setup-mode-zh-only">📋 Paste content — summarize anything</option>
-        <option value="podcast" class="setup-mode-zh-only">🎙️ Podcast — summarize an episode</option>
+        <option value="knowledge" class="setup-mode-zh-only">🧠 Knowledge — build cards from a saved source</option>
         <option value="vocab">🔤 Words only — no story, single vocab</option>
       </select>
     </label>
-    <!-- Prompt template editor entry (issue #581) — story/qa/expository/podcast, zh only -->
+    <!-- Prompt template editor entry (issue #581) — story/qa/expository/knowledge, zh only -->
     <button type="button" class="edit-cancel-btn" id="setup-edit-prompt-btn"
             style="display:none;padding:3px 10px;font-size:12px;align-self:flex-start"
             onclick="openPromptEditor()">✎ Edit prompt</button>
@@ -750,15 +750,21 @@
       <div id="setup-paste-blocks"></div>
       <button class="edit-cancel-btn" style="padding:4px 10px;font-size:12px;margin-top:6px" onclick="addPasteBlock()">+ Add text</button>
     </div>
-    <!-- Podcast episode selector (shown only in podcast mode, issue #482) -->
+    <!-- Knowledge source selector (shown only in knowledge mode, issue #482/#654) -->
     <div id="setup-podcast-section" style="display:none">
-      <label class="edit-label" style="margin:0">Episode</label>
+      <label class="edit-label" style="margin:0">Source type</label>
+      <select class="edit-input" id="setup-knowledge-kind" style="margin-bottom:6px">
+        <option value="podcast">🎙️ Podcast</option>
+        <option value="video">📺 Video</option>
+        <option value="article">📄 Article</option>
+      </select>
+      <label class="edit-label" style="margin:0">Item</label>
       <div style="font-size:12px;color:var(--muted,#888);margin:2px 0 6px">
-        Pick one summarized episode — the sentences will summarize its content (no context sentences).
+        Pick one summarized item — the sentences will be built from its content (no context sentences).
       </div>
       <select class="edit-input" id="setup-podcast-feed" style="margin-bottom:6px"></select>
       <div id="setup-podcast-episodes" style="max-height:220px;overflow-y:auto;border:1px solid var(--border,#ddd);border-radius:6px;padding:4px 0"></div>
-      <div id="setup-podcast-loading" style="display:none;padding:12px;text-align:center;color:var(--muted,#888);font-size:13px">Loading episodes…</div>
+      <div id="setup-podcast-loading" style="display:none;padding:12px;text-align:center;color:var(--muted,#888);font-size:13px">Loading items…</div>
     </div>
     <label class="edit-label" id="setup-topic-label">Topic <span style="font-weight:400;text-transform:none">(optional)</span>
       <input class="edit-input" id="setup-topic" type="text" placeholder="e.g. a day at a coffee shop" onkeydown="if(event.key==='Enter')confirmStorySetup()">

--- a/tests/test_knowledge_story_mode.py
+++ b/tests/test_knowledge_story_mode.py
@@ -1,0 +1,142 @@
+"""知识库故事模式测试（issue #654）：podcast 模式的故事生成 → knowledge 模式。
+
+核心保证：
+- mode='knowledge' 的新故事能按视频/文章素材正常生成（走既有的
+  ai.generate_podcast_sentences 管线，episode_id 指向任意 kind）。
+- 新故事生成拒绝旧标识符 mode='podcast'（照 #512 移除旧 news 模式的做法）。
+- mode='podcast' 的历史故事仍能通过 GET /api/story 正常展示（读取路径不拒绝），
+  且 Again 单句重生成（generate_sentence_for_word）仍能工作。
+"""
+import pytest
+from unittest.mock import patch
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+from fastapi.testclient import TestClient
+import database
+import importer
+import main
+import routes.story as story_routes
+
+client = TestClient(main.app)
+
+ENTRY_你好 = {"type": "vocabulary", "simplified": "你好", "pinyin": "nǐ hǎo",
+               "english": "hello", "pos": "intj", "hsk": "1"}
+
+
+def write_yaml(tmp_path, name, entries):
+    import yaml
+    d = tmp_path / "Kouyu"
+    d.mkdir(exist_ok=True)
+    (d / name).write_text(yaml.dump({"entries": entries}, allow_unicode=True))
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setattr(database.core, "DB_PATH", str(db_file))
+    database.init_db()
+    return db_file
+
+
+@pytest.fixture
+def populated_db(tmp_db, tmp_path):
+    write_yaml(tmp_path, "words.yaml", [ENTRY_你好])
+    importer.import_all(str(tmp_path))
+    return next(d["id"] for d in database.get_all_decks() if d["name"] == "Kouyu")
+
+
+def _fake_podcast_sentences(cards, summary, title, **kwargs):
+    return [
+        {"word_id": c["word_id"], "sentence_zh": f"{c['word_zh']}出现在这一集里。",
+         "sentence_en": "", "target_word": c["word_zh"]}
+        for c in cards
+    ]
+
+
+def test_knowledge_mode_generates_story_from_video_episode(populated_db):
+    """kind='video' 的素材走同一条 knowledge 生成管线（阶段 A 之后 get_episode
+    对三种 kind 一视同仁）。"""
+    deck_id = populated_db
+    episode_id = database.create_pending_episode(
+        "yt123", "https://youtube.com/@x", "一个视频标题", None,
+        "https://youtube.com/watch?v=yt123", kind="video")
+    database.update_episode(episode_id, status="summarized",
+                            summary_de="Ein deutsches Resümee.", summary_zh="中文摘要")
+
+    with patch("ai.generate_podcast_sentences", side_effect=_fake_podcast_sentences) as mock_gen:
+        r = client.get(f"/api/story/{deck_id}/listening",
+                       params={"mode": "knowledge", "episode_id": episode_id})
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body is not None and not body.get("error")
+    assert len(body["sentences"]) == 1
+    mock_gen.assert_called_once()
+
+    story = database.get_active_story(database.anki_today().isoformat(), "listening", deck_id)
+    gen_params = __import__("json").loads(story["gen_params"])
+    assert gen_params["mode"] == "knowledge"
+    assert gen_params["episode_id"] == episode_id
+    assert gen_params["kind"] == "video"  # #654: kind recorded alongside episode_id
+
+
+def test_new_story_rejects_old_podcast_mode_identifier(populated_db):
+    """#654（照 #512 先例）：新故事生成拒绝旧标识符 mode='podcast'，只接受
+    'knowledge'。"""
+    deck_id = populated_db
+    episode_id = database.create_pending_episode(
+        "pc123", "https://example.com/feed.xml", "一期播客", None,
+        "https://example.com/ep1", kind="podcast")
+    database.update_episode(episode_id, status="summarized", summary_de="Zusammenfassung.")
+
+    r = client.get(f"/api/story/{deck_id}/listening",
+                   params={"mode": "podcast", "episode_id": episode_id})
+    assert r.status_code == 200  # error is returned as a JSON error dict, not an HTTP error
+    body = r.json()
+    assert body["error"] is True
+    assert "podcast" in body["reason"] and "knowledge" in body["reason"]
+
+
+def test_historical_podcast_story_still_displays(populated_db):
+    """mode='podcast' 的历史故事必须继续能被 GET /api/story 正常读取展示——
+    读取路径不做任何拒绝，只有新生成才拒绝旧标识符。"""
+    deck_id = populated_db
+    card = story_routes._get_cards_for_story(deck_id, "listening")[0]
+    today = database.anki_today().isoformat()
+    database.create_story(
+        today, "listening", deck_id,
+        [{"position": 0, "sentence_zh": "你好出现在这一集里。", "sentence_en": "",
+          "word_ids": [card["word_id"]]}],
+        prompt_text="podcast mode — episode 1",
+        gen_params={"mode": "podcast", "episode_id": 1, "max_hsk": 3, "model": None,
+                   "topic": None, "grammar_focus": None, "grammar_pct": 75,
+                   "chapter_ids": None, "articles": None, "lang": "zh",
+                   "origin": None, "batch_size": None},
+        lang="zh")
+
+    r = client.get(f"/api/story/{deck_id}/listening")
+    assert r.status_code == 200
+    body = r.json()
+    assert body is not None
+    assert len(body["sentences"]) == 1
+    assert body["sentences"][0]["sentence_zh"] == "你好出现在这一集里。"
+
+
+def test_historical_podcast_story_again_regen_still_works(populated_db):
+    """Again 单句重生成（generate_sentence_for_word）对历史 mode='podcast'
+    故事仍要工作，走 ai.generate_podcast_sentences 同一条管线。"""
+    deck_id = populated_db
+    card = story_routes._get_cards_for_story(deck_id, "listening")[0]
+    episode_id = database.create_pending_episode(
+        "pc999", "https://example.com/feed.xml", "旧单集", None,
+        "https://example.com/ep-old", kind="podcast")
+    database.update_episode(episode_id, status="summarized", summary_de="Alte Zusammenfassung.")
+
+    gen_params = {"mode": "podcast", "episode_id": episode_id, "max_hsk": 3, "model": None}
+    with patch("ai.generate_podcast_sentences", side_effect=_fake_podcast_sentences) as mock_gen:
+        result = story_routes.generate_sentence_for_word(card, gen_params)
+
+    assert result is not None
+    assert result["sentence_zh"]
+    mock_gen.assert_called_once()

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -70,8 +70,9 @@ def test_story_template_matches_old_prompt_with_topic_and_grammar():
     assert _render_story(wl, 5, grammar, "咖啡店") == _old_story_prompt(wl, 5, grammar, "咖啡店")
 
 
-def test_podcast_template_keeps_json_example_braces():
-    rendered = ai._render_prompt(ai.DEFAULT_PROMPT_TEMPLATES["podcast"], {
+def test_knowledge_template_keeps_json_example_braces():
+    """issue #654: 模板键从 "podcast" 改名为 "knowledge"（故事模式标识符同步改名）。"""
+    rendered = ai._render_prompt(ai.DEFAULT_PROMPT_TEMPLATES["knowledge"], {
         "title": "T", "summary": "S", "words": "1. 蘑菇（mógū）— mushroom",
         "max_hsk": "3", "extra_hint": "",
     })
@@ -80,8 +81,30 @@ def test_podcast_template_keeps_json_example_braces():
             '"target_word": "词汇"}') in rendered
     assert "T" in rendered and "S" in rendered and "HSK 1-3" in rendered
     # 所有记号都已被替换
-    for var in ai.PROMPT_TEMPLATE_VARIABLES["podcast"]:
+    for var in ai.PROMPT_TEMPLATE_VARIABLES["knowledge"]:
         assert "{" + var + "}" not in rendered
+
+
+def test_podcast_prompt_presets_migrate_to_knowledge(db):
+    """issue #654: prompt_presets 里 mode='podcast' 的自定义版本要迁移到
+    'knowledge'，且迁移必须幂等（生产库每 2 分钟自动跑一次 init_db）。"""
+    conn = database.get_db()
+    conn.execute(
+        """INSERT INTO prompt_presets (mode, name, template, is_active, updated_at)
+           VALUES ('podcast', 'Saved', 'MY PODCAST TEMPLATE {words}', 1, datetime('now'))"""
+    )
+    conn.commit()
+    conn.close()
+
+    database.init_db()  # re-run the migration (simulates deploy.sh's 2-minute cron)
+
+    assert database.get_prompt_template("podcast") is None
+    assert database.get_prompt_template("knowledge") == "MY PODCAST TEMPLATE {words}"
+
+    # Idempotent: running init_db() again must not error or duplicate rows.
+    database.init_db()
+    presets = database.list_prompt_presets("knowledge")
+    assert len(presets) == 1
 
 
 def test_custom_template_roundtrip(db):


### PR DESCRIPTION
## 背景

依赖阶段 A（#650）和 D（#653）。故事生成的 `podcast` 模式（#482）原来只能选播客单集；阶段 A 之后视频/文章也在同一张 `podcast_episodes` 表里，这条路本来就能用，只需把模式标识符和入口泛化。

## 改动

### 后端
- `routes/story.py`：故事模式标识符 `podcast` → `knowledge`
  - 新故事生成拒绝旧标识符 `mode='podcast'`（照 #512 移除旧 `news` 模式的先例），报清晰错误
  - **读取路径不拒绝**：`GET /api/story` 对历史 `mode='podcast'` 故事照常返回、展示
  - `generate_sentence_for_word`（Again 单句重生成）同时支持 `"knowledge"` 和历史 `"podcast"`，历史故事仍能重生成单句
  - `gen_params` 新增 `kind` 字段（podcast/video/article），随 episode 一起记录，供前端/重生成显示素材类型
  - `source_url` 回退链接按 `kind` 生成对应哈希（`#podcast-N` / `#video-N` / `#article-N`），knowledge 浏览页两种哈希都认
- `ai.py`：`DEFAULT_PROMPT_TEMPLATES`/`PROMPT_TEMPLATE_VARIABLES` 的 `"podcast"` 键改名为 `"knowledge"`；`generate_podcast_sentences` 内部改查 `"knowledge"` 模板（历史 `podcast` 故事的 Again 重生成走同一个函数，因此也读到迁移后的自定义模板）
- `database/core.py`：`init_db()` 里新增一次性迁移，把 `prompt_presets` 表中 `mode='podcast'` 的行改成 `mode='knowledge'`，保留 Daniel 存过的自定义提示词版本。**迁移是幂等的**（简单 `UPDATE … WHERE mode='podcast'`，第二次运行时已无匹配行，测试 `test_podcast_prompt_presets_migrate_to_knowledge` 验证了幂等性）——生产环境每 2 分钟自动部署会反复跑 `init_db()`

### 前端
- `static/index.html`：设置弹窗模式下拉的 `podcast` 选项改为 `knowledge`，文案改成「🧠 Knowledge — build cards from a saved source」；`#setup-podcast-section` 内新增素材类型选择（🎙️ Podcast / 📺 Video / 📄 Article），播客类型下继续保留原有的按源筛选下拉，视频/文章类型直接按 `kind` 拉取列表
- `static/app.js`：
  - `updateSetupMode()`、`MODE_MODEL_DEFAULTS`、prompt 编辑器可见性判断等处的模式标识符同步改为 `knowledge`
  - 单集选择器改为按 `kind` 查询 `/api/podcast/episodes?kind=&limit=1000&...`（`kind` 过滤已在 #651 实现），只列 `status='summarized'` 的素材
  - `_updateStoryInfoRow` 的模式名映射同时保留 `podcast`（历史故事展示用）和新增 `knowledge`
  - 一次性迁移 `localStorage` 里按模式记的 model/batch-size 选择（`setupModel:podcast` → `setupModel:knowledge` 等），避免用户之前调过的参数丢失

## 与施工图的差异

- 施工图提到"素材正文用 `transcript_zh`（截断 15000 字）"，但实际 podcast 模式在 #561 已重构为只发送 `summary_de`（详见 `episode.get("summary_de")`），不发送 `transcript_zh`。本 PR 沿用现状（重命名而非改动管线），未改动这部分逻辑——这与 issue 目标"改动很小，只改标识符"是一致的，只是 issue 描述的管线细节与当前代码有出入，以代码为准。

## 测试

- `pytest tests/` 全绿：256 passed, 4 skipped
- 新增 `tests/test_knowledge_story_mode.py`：
  - `mode='knowledge'` 能用 `kind='video'` 的素材生成新故事，`gen_params.kind` 正确记录
  - 新故事生成拒绝 `mode='podcast'`
  - 历史 `mode='podcast'` 故事仍能被 `GET /api/story` 正常展示
  - 历史故事的 Again 单句重生成仍能工作
- `tests/test_prompt_templates.py` 新增 `test_podcast_prompt_presets_migrate_to_knowledge`，验证迁移正确且幂等
- 本地未在 8000 端口起测试服务器（用 `data/dev.db` + `PORT=8002` 验证 `init_db()`）

Closes #654