### PR TITLE
知识库阶段 F：邮件收件（IMAP 轮询，手机分享链接直接入库）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ bash sync_offline.sh push    # 只推不拉，推完归档本地库
 ├── requirements.txt       # Python 依赖清单
 ├── DEPLOY.md              # 服务器从零到上线的部署教程
 ├── deploy/                # systemd 单元、Caddyfile 示例、deploy.sh（自动部署）
-├── scripts/               # morning_pregen.py（早晨预生成故事+TTS）、podcast_check.py（播客爬虫定时脚本）、offline_sync_server.py + offline_tts_manifest.py（离线同步，#612）、fsrs_optimize.py（用 review_log 训练个人 FSRS 权重，#629）+ README
+├── scripts/               # morning_pregen.py（早晨预生成故事+TTS）、podcast_check.py（播客爬虫定时脚本）、knowledge_mail_check.py（知识库邮件收件定时脚本，#655）、offline_sync_server.py + offline_tts_manifest.py（离线同步，#612）、fsrs_optimize.py（用 review_log 训练个人 FSRS 权重，#629）+ README
 ├── docs/yaml-format.md    # YAML 词条格式完整文档
 └── data/
     ├── srs.db             # SQLite 数据库（生产版在服务器上！）
@@ -449,6 +449,9 @@ python main.py status [--deck X]     # 显示每个牌组/类别的到期数量
 | `SIGNAL_ACCOUNT` / `SIGNAL_CLI_PATH` | 可选 | 播客爬虫（#521）Signal 通知用；`SIGNAL_ACCOUNT` 是 Daniel 关联设备所属号码（如 `+49…`），`SIGNAL_CLI_PATH` 默认 `signal-cli`；`SIGNAL_ACCOUNT` 未配置时跳过发送，记日志，不算失败。一次性 signal-cli 安装/扫码关联步骤见 `scripts/README.md` |
 | `ALIBABA_CLOUD_ACCESS_KEY_ID` / `ALIBABA_CLOUD_ACCESS_KEY_SECRET` | 可选 | 播客爬虫（#498）通义听悟（转录主力）用的阿里云 AccessKey；未配置时自动跳过，落到 Whisper/NotebookLM |
 | `TINGWU_APP_KEY` | 可选 | 播客爬虫（#498）通义听悟控制台创建的应用 AppKey；与上面两个 AccessKey 变量任一缺失都会跳过听悟。一次性开通步骤见 `scripts/README.md` |
+| `KNOWLEDGE_IMAP_HOST` / `KNOWLEDGE_IMAP_PORT` | 可选 | 知识库邮件收件（#655）的 IMAP 服务器；端口默认 `993`（SSL） |
+| `KNOWLEDGE_IMAP_USER` / `KNOWLEDGE_IMAP_PASSWORD` | 可选 | 知识库邮件收件（#655）专用邮箱的登录凭据；三者（含上面两个变量）任一未配置时 `scripts/knowledge_mail_check.py` 直接跳过，不连接 |
+| `KNOWLEDGE_MAIL_ALLOWED_SENDERS` | 可选 | 知识库邮件收件（#655）发件人白名单，逗号分隔的邮箱地址（不区分大小写，兼容 `Name <addr@x.de>` 格式）；**留空则整个邮箱检查被跳过，不处理任何邮件**——这是防止任何知道邮箱地址的人往服务器塞 URL 触发 AI 调用的唯一防线 |
 
 注意：uvicorn 直接启动不建表——测试前先手动 `database.init_db()`（`run.sh`/`main.py` 会自动处理）。
 

--- a/knowledge/ingest.py
+++ b/knowledge/ingest.py
@@ -1,0 +1,125 @@
+"""Shared ingestion core for the knowledge base "add a URL" pipeline
+(issue #651/#652, extracted issue #655).
+
+`ingest_url()` is the ONE place that turns an arbitrary URL into a
+podcast_episodes row (kind='video' for YouTube, kind='article' for
+everything else trafilatura can extract a body from). Both
+routes/knowledge.py (POST /api/knowledge/add, the paste-a-URL box in the
+UI) and scripts/knowledge_mail_check.py (IMAP mailbox polling, #655) call
+this function directly — no HTTP-calls-itself loop, no second parallel
+pipeline. This repo has been burned by that exact mistake before (#643:
+two add-word entry points, the bug fixed in one silently came back in the
+other) so there must only ever be one ingestion path here too.
+
+Deliberately framework-free: raises plain `IngestError` instead of
+fastapi.HTTPException so non-HTTP callers (the mailbox script) don't need
+to import fastapi just to catch a failure.
+"""
+import logging
+
+import database
+import knowledge.article
+import knowledge.youtube
+
+logger = logging.getLogger(__name__)
+
+
+class IngestError(Exception):
+    """A URL could not be turned into a podcast_episodes row (bad/unrecognized
+    URL, metadata fetch failed, article extraction failed, ...)."""
+
+
+def ingest_url(url: str) -> dict:
+    """Resolve `url` to a podcast_episodes row and return either
+    {"episode_id": int} (newly created) or {"status": "already_exists",
+    "episode_id": int} (deduped). Raises IngestError on failure."""
+    url = (url or "").strip()
+    if not url:
+        raise IngestError("url is required")
+
+    video_id = knowledge.youtube.parse_video_id(url)
+    if video_id:
+        return _ingest_video(url, video_id)
+    return _ingest_article(url)
+
+
+def _ingest_video(url: str, video_id: str) -> dict:
+    existing = database.get_episode_by_video_id(video_id)
+    if existing:
+        return {"status": "already_exists", "episode_id": existing["id"]}
+
+    try:
+        meta = knowledge.youtube.fetch_metadata(video_id)
+    except Exception as e:
+        logger.warning("knowledge.ingest: oEmbed metadata lookup failed for %s: %s", video_id, e)
+        raise IngestError(f"Could not fetch video metadata: {e}")
+
+    title = meta.get("title") or video_id
+    # translate_title (#651) is one cheap AI call — best-effort, must not
+    # block/fail the ingest if it errors (translate_title itself already
+    # swallows exceptions and returns None in that case).
+    import ai
+    title_en = ai.translate_title(title)
+
+    episode_id = database.create_pending_episode(
+        video_id=video_id,
+        channel_id=meta.get("author_name"),
+        title=title,
+        published_at=None,
+        youtube_url=url,
+        audio_url=None,
+        duration_seconds=None,
+        kind="video",
+    )
+    if title_en:
+        database.update_episode(episode_id, title_en=title_en)
+
+    return {"episode_id": episode_id}
+
+
+def _ingest_article(url: str) -> dict:
+    """Article ingestion (#652): anything that isn't a recognized YouTube
+    URL is treated as an article. normalize_url() (strips utm_*/fbclid/...)
+    is the dedup key, so the same article shared via different links lands
+    on the same row instead of duplicating."""
+    normalized = knowledge.article.normalize_url(url)
+    existing = database.get_episode_by_video_id(normalized)
+    if existing:
+        return {"status": "already_exists", "episode_id": existing["id"]}
+
+    try:
+        article = knowledge.article.fetch_article(url)
+    except knowledge.article.ArticleExtractionError as e:
+        raise IngestError(str(e))
+    except Exception as e:
+        logger.warning("knowledge.ingest: article extraction failed for %s: %s", url, e)
+        raise IngestError(f"Could not fetch article: {e}")
+
+    title = article["title"]
+    # translate_title (#651) is one cheap AI call — best-effort, must not
+    # block/fail the ingest if it errors (translate_title itself already
+    # swallows exceptions and returns None in that case).
+    import ai
+    title_en = ai.translate_title(title)
+
+    episode_id = database.create_pending_episode(
+        video_id=normalized,
+        channel_id=article["site"],
+        title=title,
+        published_at=article.get("published_at"),
+        youtube_url=url,
+        audio_url=None,
+        duration_seconds=None,
+        kind="article",
+    )
+    # Store the body now (fetch_article() already paid for the download —
+    # see its module docstring for why there's no cheap "metadata only"
+    # step to defer this to). This lands in _process_episode's "reuse
+    # existing transcript" fast path when the frontend later calls
+    # POST /api/podcast/episodes/{id}/process.
+    updates = {"transcript_zh": article["text"], "transcript_source": "article"}
+    if title_en:
+        updates["title_en"] = title_en
+    database.update_episode(episode_id, **updates)
+
+    return {"episode_id": episode_id}

--- a/knowledge/mailbox.py
+++ b/knowledge/mailbox.py
@@ -1,0 +1,237 @@
+"""Knowledge base mailbox intake (issue #655): poll a dedicated mailbox via
+IMAP, pull URLs out of UNSEEN mail (phone "share -> mail" is the easiest
+way to get a link onto the server), and feed each one through
+knowledge.ingest.ingest_url() — the exact same pipeline the paste-a-URL
+box in the UI uses (POST /api/knowledge/add). No second/parallel
+"URL -> episode row" implementation here, see knowledge/ingest.py's
+docstring for why that matters in this repo.
+
+Security: this is the one intake channel that lets *anyone who knows the
+mailbox address* trigger a server-side fetch + paid AI call on Daniel's
+account. KNOWLEDGE_MAIL_ALLOWED_SENDERS is mandatory — if it's unset/empty
+the whole mailbox is skipped (nothing is read, nothing is marked seen),
+never "process everything because the allowlist check couldn't run".
+Non-whitelisted senders are skipped individually (their mail is left
+UNSEEN, harmless, and simply ignored every run).
+
+Only stdlib (imaplib/email) is used — no new dependency for this.
+"""
+import email
+import imaplib
+import logging
+import os
+import re
+from email.header import decode_header
+from email.utils import parseaddr
+
+import knowledge.ingest
+
+logger = logging.getLogger(__name__)
+
+# Matches http(s) URLs; trailing punctuation commonly glued on by mail
+# clients/copy-paste (.,;:!?) and closing brackets/quotes are stripped
+# after the match rather than excluded from the character class, so URLs
+# that legitimately end mid-path still match in full.
+_URL_RE = re.compile(r'https?://[^\s<>"\']+')
+_TRAILING_PUNCT = '.,;:!?)]}\'"'
+
+
+def _env_allowed_senders() -> set:
+    raw = os.environ.get("KNOWLEDGE_MAIL_ALLOWED_SENDERS", "")
+    return {addr.strip().lower() for addr in raw.split(",") if addr.strip()}
+
+
+def _decode_header_value(value) -> str:
+    """RFC 2047 header decoding ('=?UTF-8?B?...?=' etc.) — Subject lines
+    from phone mail clients are frequently encoded this way."""
+    if not value:
+        return ""
+    chunks = []
+    for text, enc in decode_header(value):
+        if isinstance(text, bytes):
+            try:
+                chunks.append(text.decode(enc or "utf-8", errors="replace"))
+            except (LookupError, TypeError):
+                chunks.append(text.decode("utf-8", errors="replace"))
+        else:
+            chunks.append(text)
+    return "".join(chunks)
+
+
+def _decode_payload(part) -> str:
+    payload = part.get_payload(decode=True)
+    if payload is None:
+        return ""
+    charset = part.get_content_charset() or "utf-8"
+    try:
+        return payload.decode(charset, errors="replace")
+    except (LookupError, TypeError):
+        return payload.decode("utf-8", errors="replace")
+
+
+def _body_text(msg: email.message.Message) -> str:
+    """Concatenate every text/plain and text/html part. Share-to-mail apps
+    are inconsistent about which MIME type they use, so both are scanned
+    rather than picking one."""
+    parts = []
+    if msg.is_multipart():
+        for part in msg.walk():
+            if "attachment" in str(part.get("Content-Disposition") or ""):
+                continue
+            if part.get_content_type() in ("text/plain", "text/html"):
+                parts.append(_decode_payload(part))
+    elif msg.get_content_type() in ("text/plain", "text/html"):
+        parts.append(_decode_payload(msg))
+    return "\n".join(parts)
+
+
+def extract_urls(text: str) -> list:
+    """Pull URLs out of one string, de-duplicated, order preserved."""
+    if not text:
+        return []
+    seen = set()
+    urls = []
+    for match in _URL_RE.findall(text):
+        url = match.rstrip(_TRAILING_PUNCT)
+        if url and url not in seen:
+            seen.add(url)
+            urls.append(url)
+    return urls
+
+
+def extract_urls_from_message(msg: email.message.Message) -> list:
+    """Subject AND body both get scanned (#655): phone share sheets put
+    the link in one or the other depending on app/OS, and HTML mail wraps
+    it in an <a href> that text/plain extraction would miss."""
+    subject = _decode_header_value(msg.get("Subject"))
+    body = _body_text(msg)
+    seen = set()
+    urls = []
+    for url in extract_urls(subject) + extract_urls(body):
+        if url not in seen:
+            seen.add(url)
+            urls.append(url)
+    return urls
+
+
+def _sender_address(msg: email.message.Message) -> str:
+    """Handles both 'addr@x.de' and 'Name <addr@x.de>' From headers,
+    case-insensitive, comparing only the address part."""
+    _, addr = parseaddr(msg.get("From") or "")
+    return addr.strip().lower()
+
+
+def check_mailbox(imap_factory=None) -> dict:
+    """Poll KNOWLEDGE_IMAP_HOST's INBOX for UNSEEN mail from whitelisted
+    senders, ingest every URL found in each one, and mark the message
+    \\Seen only if every URL in it ingested without error (failures are
+    left UNSEEN so the next run retries them; ingest_url() is idempotent
+    for already-ingested URLs via its existing_exists dedup, so retrying a
+    partially-succeeded message is safe).
+
+    `imap_factory` is injectable for tests: a zero-arg callable returning
+    an object implementing the imaplib.IMAP4_SSL interface (login/select/
+    search/fetch/store/close/logout). Never used for real network I/O in
+    tests.
+    """
+    summary = {
+        "checked": 0, "processed": 0, "skipped": 0, "failed": 0,
+        "ingested": 0, "errors": [],
+    }
+
+    allowed = _env_allowed_senders()
+    if not allowed:
+        logger.warning(
+            "knowledge.mailbox: KNOWLEDGE_MAIL_ALLOWED_SENDERS 未配置，"
+            "拒绝处理任何邮件（不读取、不标已读）"
+        )
+        summary["reason"] = "no_allowed_senders"
+        return summary
+
+    host = os.environ.get("KNOWLEDGE_IMAP_HOST")
+    user = os.environ.get("KNOWLEDGE_IMAP_USER")
+    password = os.environ.get("KNOWLEDGE_IMAP_PASSWORD")
+    port_raw = os.environ.get("KNOWLEDGE_IMAP_PORT", "993")
+    try:
+        port = int(port_raw)
+    except ValueError:
+        port = 993
+
+    if not host or not user or not password:
+        logger.warning(
+            "knowledge.mailbox: IMAP 凭据未完整配置"
+            "（KNOWLEDGE_IMAP_HOST/KNOWLEDGE_IMAP_USER/KNOWLEDGE_IMAP_PASSWORD），跳过"
+        )
+        summary["reason"] = "no_credentials"
+        return summary
+
+    if imap_factory is None:
+        def imap_factory():
+            return imaplib.IMAP4_SSL(host, port)
+
+    conn = imap_factory()
+    try:
+        conn.login(user, password)
+        conn.select("INBOX")
+
+        status, data = conn.search(None, "UNSEEN")
+        if status != "OK":
+            logger.warning("knowledge.mailbox: IMAP SEARCH 失败: %s", status)
+            summary["reason"] = "search_failed"
+            return summary
+
+        msg_ids = data[0].split() if data and data[0] else []
+        summary["checked"] = len(msg_ids)
+
+        for msg_id in msg_ids:
+            status, msg_data = conn.fetch(msg_id, "(RFC822)")
+            if status != "OK" or not msg_data or not msg_data[0]:
+                logger.warning("knowledge.mailbox: 无法读取邮件 %s，本轮跳过（不标已读）", msg_id)
+                summary["failed"] += 1
+                continue
+
+            raw = msg_data[0][1]
+            msg = email.message_from_bytes(raw)
+
+            sender = _sender_address(msg)
+            if sender not in allowed:
+                logger.info("knowledge.mailbox: 发件人 %s 不在白名单，跳过（不标已读）", sender)
+                summary["skipped"] += 1
+                continue
+
+            urls = extract_urls_from_message(msg)
+            if not urls:
+                logger.info("knowledge.mailbox: 邮件 %s（来自 %s）未提取到 URL，跳过（不标已读）", msg_id, sender)
+                summary["skipped"] += 1
+                continue
+
+            all_ok = True
+            for url in urls:
+                try:
+                    result = knowledge.ingest.ingest_url(url)
+                    summary["ingested"] += 1
+                    logger.info("knowledge.mailbox: 已处理 %s -> %s", url, result)
+                except Exception as e:
+                    all_ok = False
+                    logger.warning("knowledge.mailbox: 处理 URL 失败 %s: %s", url, e)
+                    summary["errors"].append(f"{url}: {e}")
+
+            if all_ok:
+                conn.store(msg_id, "+FLAGS", "\\Seen")
+                summary["processed"] += 1
+            else:
+                # 邮件里至少一个 URL 处理失败——整封不标已读，下轮重试。
+                # ingest_url() 对已入库的 URL 返回 already_exists，重试
+                # 部分成功的邮件是安全的，不会重复造行。
+                summary["failed"] += 1
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+        try:
+            conn.logout()
+        except Exception:
+            pass
+
+    return summary

--- a/routes/knowledge.py
+++ b/routes/knowledge.py
@@ -3,24 +3,18 @@ URL into a podcast_episodes row (kind='video' for YouTube, kind='article'
 for everything else that trafilatura can extract a body from) that the
 existing podcast pipeline can transcribe/summarize.
 
-Mostly thin: for YouTube this route only resolves the URL to metadata and
-inserts the pending row — transcription happens later via the existing
-POST /api/podcast/episodes/{id}/process (background thread + polling,
-#502). Articles are the exception (#652): there is no cheap "metadata
-only" endpoint for an arbitrary URL the way YouTube has oEmbed — getting a
-title reliably requires downloading and parsing the whole page, which is
-the same cost as getting the body — so this route fetches + stores the
-full article body synchronously here rather than deferring it. See
-knowledge/article.py's module docstring for the full reasoning. Either way,
-no new job/polling mechanism is introduced.
+All the actual resolution logic lives in knowledge/ingest.py's
+ingest_url() (extracted issue #655) so the IMAP mailbox script
+(scripts/knowledge_mail_check.py) can call the exact same pipeline instead
+of hitting this HTTP endpoint or reimplementing it — one ingestion path,
+see that module's docstring for why.
 """
 import logging
 
-import database
-import knowledge.article
-import knowledge.youtube
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
+
+import knowledge.ingest
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -32,93 +26,7 @@ class AddKnowledgeRequest(BaseModel):
 
 @router.post("/api/knowledge/add")
 def add_knowledge(body: AddKnowledgeRequest):
-    url = (body.url or "").strip()
-    if not url:
-        raise HTTPException(400, "url is required")
-
-    video_id = knowledge.youtube.parse_video_id(url)
-    if video_id:
-        return _add_video(url, video_id)
-    return _add_article(url)
-
-
-def _add_video(url: str, video_id: str) -> dict:
-    existing = database.get_episode_by_video_id(video_id)
-    if existing:
-        return {"status": "already_exists", "episode_id": existing["id"]}
-
     try:
-        meta = knowledge.youtube.fetch_metadata(video_id)
-    except Exception as e:
-        logger.warning("knowledge.add: oEmbed metadata lookup failed for %s: %s", video_id, e)
-        raise HTTPException(400, f"Could not fetch video metadata: {e}")
-
-    title = meta.get("title") or video_id
-    # translate_title (#651) is one cheap AI call — best-effort, must not
-    # block/fail the add if it errors (translate_title itself already
-    # swallows exceptions and returns None in that case).
-    import ai
-    title_en = ai.translate_title(title)
-
-    episode_id = database.create_pending_episode(
-        video_id=video_id,
-        channel_id=meta.get("author_name"),
-        title=title,
-        published_at=None,
-        youtube_url=url,
-        audio_url=None,
-        duration_seconds=None,
-        kind="video",
-    )
-    if title_en:
-        database.update_episode(episode_id, title_en=title_en)
-
-    return {"episode_id": episode_id}
-
-
-def _add_article(url: str) -> dict:
-    """Article ingestion (#652): anything that isn't a recognized YouTube
-    URL is treated as an article. normalize_url() (strips utm_*/fbclid/...)
-    is the dedup key, so the same article shared via different links lands
-    on the same row instead of duplicating."""
-    normalized = knowledge.article.normalize_url(url)
-    existing = database.get_episode_by_video_id(normalized)
-    if existing:
-        return {"status": "already_exists", "episode_id": existing["id"]}
-
-    try:
-        article = knowledge.article.fetch_article(url)
-    except knowledge.article.ArticleExtractionError as e:
+        return knowledge.ingest.ingest_url(body.url)
+    except knowledge.ingest.IngestError as e:
         raise HTTPException(400, str(e))
-    except Exception as e:
-        logger.warning("knowledge.add: article extraction failed for %s: %s", url, e)
-        raise HTTPException(400, f"Could not fetch article: {e}")
-
-    title = article["title"]
-    # translate_title (#651) is one cheap AI call — best-effort, must not
-    # block/fail the add if it errors (translate_title itself already
-    # swallows exceptions and returns None in that case).
-    import ai
-    title_en = ai.translate_title(title)
-
-    episode_id = database.create_pending_episode(
-        video_id=normalized,
-        channel_id=article["site"],
-        title=title,
-        published_at=article.get("published_at"),
-        youtube_url=url,
-        audio_url=None,
-        duration_seconds=None,
-        kind="article",
-    )
-    # Store the body now (fetch_article() already paid for the download —
-    # see its module docstring for why there's no cheap "metadata only"
-    # step to defer this to). This lands in _process_episode's "reuse
-    # existing transcript" fast path when the frontend later calls
-    # POST /api/podcast/episodes/{id}/process.
-    updates = {"transcript_zh": article["text"], "transcript_source": "article"}
-    if title_en:
-        updates["title_en"] = title_en
-    database.update_episode(episode_id, **updates)
-
-    return {"episode_id": episode_id}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -316,3 +316,63 @@ python scripts/podcast_check.py
 ```cron
 0 * * * * cd /opt/ankiadvanced && /usr/bin/python3 scripts/podcast_check.py >> data/podcast-check.log 2>&1
 ```
+
+---
+
+## knowledge_mail_check.py（issue #655）
+
+知识库邮件收件：手机「分享 → 邮件」把链接发到一个专用邮箱，这个脚本用
+标准库 `imaplib`/`email` 轮询该邮箱的 UNSEEN 邮件，从**主题和正文**
+（`text/plain` + `text/html` 两种 MIME 都扫）里正则提取 URL，每个 URL
+都走 `knowledge.ingest.ingest_url()`——和知识页顶部粘贴 URL（
+`POST /api/knowledge/add`）用的是**同一条入库管线**（YouTube 视频 or
+文章，判定逻辑见 `knowledge/ingest.py`）。
+
+和 `podcast_check.py`/`morning_pregen.py` 不同：这个脚本**不是**对运行
+中的服务器发 HTTP 请求（没有对应的 `/api/knowledge/mail-check` 接口），
+而是直接 `import database` + `database.init_db()` 后在本进程内完成——
+IMAP 轮询和入库都不需要经过网络往返到自己的服务器。SQLite 默认允许多
+进程并发读写，和同时运行的 FastAPI 服务进程不冲突。脚本自带一个 PID
+锁文件（`data/.knowledge_mail_check.lock`）防止 cron 叠跑（处理邮件里的
+URL 可能触发文章抓取/YouTube 字幕下载/AI 翻译标题，慢的话要几十秒）。
+
+一封邮件里的多个 URL 全部处理；**处理成功的邮件才标记已读**——只要有一
+个 URL 失败，整封邮件保持 UNSEEN，下一轮自动重试（`ingest_url()` 对已
+入库的 URL 会走 `already_exists` 分支，重试部分成功的邮件是安全的，不
+会重复造行）。
+
+**安全（#655 的重点）：** `KNOWLEDGE_MAIL_ALLOWED_SENDERS` 是必须项——
+这是唯一挡住"任何知道这个邮箱地址的人都能让服务器抓取任意 URL 并触发
+付费 AI 调用"的防线。**未配置时脚本直接跳过整个邮箱检查，不建立 IMAP
+连接、不读取任何邮件**；已配置时，发件人比对兼容 `Name <addr@x.de>`
+这种带显示名的 `From` 头格式，只比较邮箱地址部分，且不区分大小写。不在
+白名单里的发件人邮件会被单独跳过（保持 UNSEEN，之后每轮都会再看到、
+再跳过，没有副作用）。
+
+凭据（IMAP 主机/端口/账号/密码）只从环境变量读取，绝不写入代码或数据库。
+
+### 环境变量
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `KNOWLEDGE_IMAP_HOST` | 无 | IMAP 服务器地址 |
+| `KNOWLEDGE_IMAP_PORT` | `993` | IMAP 端口（SSL） |
+| `KNOWLEDGE_IMAP_USER` | 无 | 专用邮箱账号 |
+| `KNOWLEDGE_IMAP_PASSWORD` | 无 | 专用邮箱密码（Gmail/Outlook 等一般需要"应用专用密码"，不是登录密码） |
+| `KNOWLEDGE_MAIL_ALLOWED_SENDERS` | 无（**必须配置**） | 逗号分隔的白名单发件人邮箱地址；留空则整个邮箱检查被跳过 |
+| `DB_PATH` | `data/srs.db` | 数据库路径 |
+
+### 用法
+
+```bash
+python scripts/knowledge_mail_check.py
+```
+
+### 服务器 cron：每 5 分钟检查一次
+
+```cron
+*/5 * * * * cd /opt/ankiadvanced && /usr/bin/python3 scripts/knowledge_mail_check.py >> data/knowledge-mail-check.log 2>&1
+```
+
+退出码：跳过（未配置白名单/凭据）或全部成功为 `0`；有失败邮件时为 `1`
+（方便 cron 邮件通知/监控接入）。

--- a/scripts/knowledge_mail_check.py
+++ b/scripts/knowledge_mail_check.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""知识库邮件收件定时脚本（issue #655）。
+
+轮询一个专用邮箱（`imaplib`），把 UNSEEN 邮件主题/正文里的 URL 逐个送进
+`knowledge.ingest.ingest_url()`——和界面「粘贴 URL」用的是同一条管线
+（见 `knowledge/ingest.py`、`knowledge/mailbox.py` 的模块说明）。
+
+和 `scripts/podcast_check.py` 不同：podcast 检查是对**运行中的服务器**
+发一次 HTTP 请求，由服务器进程做实际工作；这个脚本没有对应的 HTTP 接口
+（IMAP 轮询+入库不需要经过网络往返），而是直接 `import database` +
+`database.init_db()` 后在本进程里完成，风格照抄 `scripts/fsrs_optimize.py`
+这类直接触库的脚本。SQLite 允许多进程并发读写（WAL），和同时运行的服务器
+进程不冲突。
+
+并发锁：用一个简单的 PID 锁文件（`data/.knowledge_mail_check.lock`）避免
+cron 每分钟触发时上一轮还没跑完就叠跑——处理邮件里的 URL 可能触发文章抓取
+/YouTube 字幕下载/AI 翻译标题，慢的话能到几十秒。
+
+用法：
+    python scripts/knowledge_mail_check.py
+
+环境变量（见 CLAUDE.md 环境变量表）：
+    KNOWLEDGE_IMAP_HOST              IMAP 服务器
+    KNOWLEDGE_IMAP_PORT              默认 993（SSL）
+    KNOWLEDGE_IMAP_USER / _PASSWORD  凭据
+    KNOWLEDGE_MAIL_ALLOWED_SENDERS   逗号分隔的白名单发件人；留空则整个
+                                      邮箱检查被跳过，不处理任何邮件
+    DB_PATH                          数据库路径，默认 data/srs.db
+"""
+import fcntl
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+LOCK_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data", ".knowledge_mail_check.lock")
+
+
+def _log(msg: str) -> None:
+    ts = time.strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[{ts}] {msg}", flush=True)
+
+
+def main() -> int:
+    os.makedirs(os.path.dirname(LOCK_PATH), exist_ok=True)
+    lock_file = open(LOCK_PATH, "w")
+    try:
+        fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        _log("上一轮知识库邮件检查仍在进行，本轮跳过。")
+        return 0
+
+    try:
+        lock_file.write(str(os.getpid()))
+        lock_file.flush()
+
+        import database
+        database.init_db()
+        import knowledge.mailbox
+
+        _log("知识库邮件检查开始")
+        summary = knowledge.mailbox.check_mailbox()
+
+        reason = summary.get("reason")
+        if reason == "no_allowed_senders":
+            _log("KNOWLEDGE_MAIL_ALLOWED_SENDERS 未配置，跳过（未处理任何邮件）。")
+            return 0
+        if reason == "no_credentials":
+            _log("IMAP 凭据未完整配置，跳过。")
+            return 0
+        if reason == "search_failed":
+            _log("IMAP 搜索失败。")
+            return 1
+
+        _log(
+            f"未读邮件: {summary['checked']}  已处理: {summary['processed']}  "
+            f"跳过: {summary['skipped']}  失败: {summary['failed']}  "
+            f"入库 URL 数: {summary['ingested']}"
+        )
+        for err in summary.get("errors", []):
+            _log(f"错误: {err}")
+
+        return 0 if not summary["failed"] else 1
+    except Exception as e:
+        _log(f"知识库邮件检查异常: {e}")
+        return 1
+    finally:
+        try:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        lock_file.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_knowledge_mailbox.py
+++ b/tests/test_knowledge_mailbox.py
@@ -1,0 +1,351 @@
+"""Tests for knowledge/mailbox.py (issue #655).
+
+IMAP is entirely faked (a stub object matching the imaplib.IMAP4_SSL
+interface, injected via `imap_factory`) — CLAUDE.md is explicit that test
+suites must never reach real network services, and there is no real
+mailbox to poll in CI anyway. knowledge.ingest.ingest_url is monkeypatched
+too, since exercising the real pipeline (YouTube/article fetch + AI) is
+covered by tests/test_knowledge_youtube.py and tests/test_knowledge_article.py.
+"""
+import email
+from email.message import EmailMessage
+
+import pytest
+
+import knowledge.ingest
+import knowledge.mailbox as mailbox
+
+
+# ---------------------------------------------------------------------------
+# URL extraction (pure functions, no IMAP involved)
+# ---------------------------------------------------------------------------
+
+def test_extract_urls_from_plain_text():
+    text = "Schau dir das an: https://example.com/article-123 danke!"
+    assert mailbox.extract_urls(text) == ["https://example.com/article-123"]
+
+
+def test_extract_urls_strips_trailing_punctuation():
+    text = "Video hier (https://youtu.be/abc123)."
+    assert mailbox.extract_urls(text) == ["https://youtu.be/abc123"]
+
+
+def test_extract_urls_multiple_and_dedup():
+    text = "https://a.com/1 und nochmal https://a.com/1 und https://b.com/2"
+    assert mailbox.extract_urls(text) == ["https://a.com/1", "https://b.com/2"]
+
+
+def test_extract_urls_empty():
+    assert mailbox.extract_urls("") == []
+    assert mailbox.extract_urls(None) == []
+
+
+def _make_plain_message(subject: str, body: str, sender: str = "daniel@example.com") -> EmailMessage:
+    msg = EmailMessage()
+    msg["From"] = sender
+    msg["Subject"] = subject
+    msg.set_content(body)
+    return msg
+
+
+def _make_html_message(subject: str, html_body: str, sender: str = "daniel@example.com") -> EmailMessage:
+    msg = EmailMessage()
+    msg["From"] = sender
+    msg["Subject"] = subject
+    msg.set_content("(html only)")
+    msg.add_alternative(html_body, subtype="html")
+    return msg
+
+
+def test_extract_urls_from_message_subject_only():
+    msg = _make_plain_message("Schau: https://example.com/from-subject", "kein Link im Text")
+    assert mailbox.extract_urls_from_message(msg) == ["https://example.com/from-subject"]
+
+
+def test_extract_urls_from_message_body_only():
+    msg = _make_plain_message("Ohne Link", "hier: https://example.com/from-body")
+    assert mailbox.extract_urls_from_message(msg) == ["https://example.com/from-body"]
+
+
+def test_extract_urls_from_message_subject_and_body_multiple():
+    msg = _make_plain_message(
+        "Zwei Links: https://a.com/1",
+        "und noch einer https://b.com/2 und https://c.com/3",
+    )
+    urls = mailbox.extract_urls_from_message(msg)
+    assert urls == ["https://a.com/1", "https://b.com/2", "https://c.com/3"]
+
+
+def test_extract_urls_from_html_body():
+    msg = _make_html_message(
+        "Artikel",
+        '<html><body><p>Schau mal <a href="https://example.com/html-link">hier</a></p></body></html>',
+    )
+    assert mailbox.extract_urls_from_message(msg) == ["https://example.com/html-link"]
+
+
+def test_extract_urls_from_message_none():
+    msg = _make_plain_message("kein link", "auch kein link hier")
+    assert mailbox.extract_urls_from_message(msg) == []
+
+
+def test_sender_address_plain():
+    msg = _make_plain_message("x", "y", sender="daniel@example.com")
+    assert mailbox._sender_address(msg) == "daniel@example.com"
+
+
+def test_sender_address_with_display_name():
+    msg = _make_plain_message("x", "y", sender="Daniel Schreiber <Daniel@Example.COM>")
+    assert mailbox._sender_address(msg) == "daniel@example.com"
+
+
+# ---------------------------------------------------------------------------
+# check_mailbox — fake IMAP connection
+# ---------------------------------------------------------------------------
+
+class FakeImap:
+    """Minimal stand-in for imaplib.IMAP4_SSL covering only what
+    check_mailbox() calls."""
+
+    def __init__(self, messages):
+        # messages: dict[bytes msg_id] -> EmailMessage (or None to simulate
+        # a fetch failure)
+        self._messages = messages
+        self.seen_flagged = []
+        self.logged_in = False
+
+    def login(self, user, password):
+        self.logged_in = True
+        return "OK", [b"logged in"]
+
+    def select(self, mailbox_name):
+        return "OK", [b"1"]
+
+    def search(self, charset, criterion):
+        ids = b" ".join(self._messages.keys())
+        return "OK", [ids]
+
+    def fetch(self, msg_id, parts):
+        msg = self._messages.get(msg_id)
+        if msg is None:
+            return "NO", [None]
+        raw = msg.as_bytes() if hasattr(msg, "as_bytes") else msg
+        return "OK", [(b"1 (RFC822 {123})", raw)]
+
+    def store(self, msg_id, flag_set, flags):
+        self.seen_flagged.append(msg_id)
+        return "OK", [b"done"]
+
+    def close(self):
+        return "OK", [b"closed"]
+
+    def logout(self):
+        return "OK", [b"logged out"]
+
+
+@pytest.fixture(autouse=True)
+def _knowledge_mail_env(monkeypatch):
+    """Ensure a clean env per test — tests set what they need explicitly."""
+    for var in (
+        "KNOWLEDGE_MAIL_ALLOWED_SENDERS", "KNOWLEDGE_IMAP_HOST",
+        "KNOWLEDGE_IMAP_PORT", "KNOWLEDGE_IMAP_USER", "KNOWLEDGE_IMAP_PASSWORD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _configure_env(monkeypatch, allowed="daniel@example.com"):
+    monkeypatch.setenv("KNOWLEDGE_IMAP_HOST", "imap.example.com")
+    monkeypatch.setenv("KNOWLEDGE_IMAP_USER", "kb@example.com")
+    monkeypatch.setenv("KNOWLEDGE_IMAP_PASSWORD", "secret")
+    if allowed is not None:
+        monkeypatch.setenv("KNOWLEDGE_MAIL_ALLOWED_SENDERS", allowed)
+
+
+def test_no_allowed_senders_processes_nothing(monkeypatch):
+    """Security-critical (#655): with the allowlist unset, nothing gets
+    read or marked seen — not even an IMAP connection is opened."""
+    monkeypatch.setenv("KNOWLEDGE_IMAP_HOST", "imap.example.com")
+    monkeypatch.setenv("KNOWLEDGE_IMAP_USER", "kb@example.com")
+    monkeypatch.setenv("KNOWLEDGE_IMAP_PASSWORD", "secret")
+    # KNOWLEDGE_MAIL_ALLOWED_SENDERS deliberately left unset
+
+    called = {"factory": False}
+
+    def factory():
+        called["factory"] = True
+        raise AssertionError("should never connect when allowlist is empty")
+
+    summary = mailbox.check_mailbox(imap_factory=factory)
+
+    assert called["factory"] is False
+    assert summary["reason"] == "no_allowed_senders"
+    assert summary["checked"] == 0
+    assert summary["processed"] == 0
+
+
+def test_missing_credentials_skips(monkeypatch):
+    monkeypatch.setenv("KNOWLEDGE_MAIL_ALLOWED_SENDERS", "daniel@example.com")
+    # host/user/password left unset
+
+    summary = mailbox.check_mailbox(imap_factory=lambda: (_ for _ in ()).throw(
+        AssertionError("should not connect without credentials")
+    ))
+
+    assert summary["reason"] == "no_credentials"
+
+
+def test_url_in_subject_is_ingested(monkeypatch):
+    _configure_env(monkeypatch)
+    msg = _make_plain_message("Schau: https://example.com/subject-link", "kein Text-Link")
+    fake = FakeImap({b"1": msg})
+
+    calls = []
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", lambda url: calls.append(url) or {"episode_id": 1})
+
+    summary = mailbox.check_mailbox(imap_factory=lambda: fake)
+
+    assert calls == ["https://example.com/subject-link"]
+    assert summary["processed"] == 1
+    assert summary["ingested"] == 1
+    assert fake.seen_flagged == [b"1"]
+
+
+def test_url_in_plain_body_is_ingested(monkeypatch):
+    _configure_env(monkeypatch)
+    msg = _make_plain_message("Ohne Link im Betreff", "Link: https://example.com/body-link")
+    fake = FakeImap({b"1": msg})
+
+    calls = []
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", lambda url: calls.append(url) or {"episode_id": 1})
+
+    summary = mailbox.check_mailbox(imap_factory=lambda: fake)
+
+    assert calls == ["https://example.com/body-link"]
+    assert summary["processed"] == 1
+
+
+def test_url_in_html_body_is_ingested(monkeypatch):
+    _configure_env(monkeypatch)
+    msg = _make_html_message(
+        "Artikel geteilt",
+        '<a href="https://example.com/html-share">Link</a>',
+    )
+    fake = FakeImap({b"1": msg})
+
+    calls = []
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", lambda url: calls.append(url) or {"episode_id": 1})
+
+    summary = mailbox.check_mailbox(imap_factory=lambda: fake)
+
+    assert calls == ["https://example.com/html-share"]
+    assert summary["processed"] == 1
+
+
+def test_multiple_urls_in_one_mail_all_processed(monkeypatch):
+    _configure_env(monkeypatch)
+    msg = _make_plain_message(
+        "Mehrere Links",
+        "https://example.com/one und https://example.com/two",
+    )
+    fake = FakeImap({b"1": msg})
+
+    calls = []
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", lambda url: calls.append(url) or {"episode_id": len(calls)})
+
+    summary = mailbox.check_mailbox(imap_factory=lambda: fake)
+
+    assert calls == ["https://example.com/one", "https://example.com/two"]
+    assert summary["ingested"] == 2
+    assert summary["processed"] == 1
+    assert fake.seen_flagged == [b"1"]
+
+
+def test_non_whitelisted_sender_is_skipped(monkeypatch):
+    _configure_env(monkeypatch, allowed="daniel@example.com")
+    msg = _make_plain_message("Spam mit Link", "https://spam.example.com/pitch", sender="stranger@evil.example")
+    fake = FakeImap({b"1": msg})
+
+    called = {"n": 0}
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", lambda url: called.__setitem__("n", called["n"] + 1))
+
+    summary = mailbox.check_mailbox(imap_factory=lambda: fake)
+
+    assert called["n"] == 0
+    assert summary["skipped"] == 1
+    assert summary["processed"] == 0
+    assert fake.seen_flagged == []
+
+
+def test_whitelist_matches_display_name_format_case_insensitive(monkeypatch):
+    _configure_env(monkeypatch, allowed="Daniel@Example.com")
+    msg = _make_plain_message(
+        "Von Handy geteilt",
+        "https://example.com/shared",
+        sender="Daniel Schreiber <daniel@example.com>",
+    )
+    fake = FakeImap({b"1": msg})
+
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", lambda url: {"episode_id": 1})
+
+    summary = mailbox.check_mailbox(imap_factory=lambda: fake)
+
+    assert summary["processed"] == 1
+    assert fake.seen_flagged == [b"1"]
+
+
+def test_ingest_failure_does_not_mark_seen(monkeypatch):
+    """#655 completion criterion: failed processing must not mark the mail
+    read, so the next run retries it."""
+    _configure_env(monkeypatch)
+    msg = _make_plain_message("Kaputter Link", "https://example.com/broken")
+    fake = FakeImap({b"1": msg})
+
+    def failing_ingest(url):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", failing_ingest)
+
+    summary = mailbox.check_mailbox(imap_factory=lambda: fake)
+
+    assert summary["failed"] == 1
+    assert summary["processed"] == 0
+    assert fake.seen_flagged == []
+    assert len(summary["errors"]) == 1
+
+
+def test_partial_failure_in_multi_url_mail_does_not_mark_seen(monkeypatch):
+    _configure_env(monkeypatch)
+    msg = _make_plain_message(
+        "Ein guter, ein kaputter Link",
+        "https://example.com/good https://example.com/bad",
+    )
+    fake = FakeImap({b"1": msg})
+
+    def ingest(url):
+        if url.endswith("/bad"):
+            raise RuntimeError("boom")
+        return {"episode_id": 1}
+
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", ingest)
+
+    summary = mailbox.check_mailbox(imap_factory=lambda: fake)
+
+    assert summary["ingested"] == 1
+    assert summary["failed"] == 1
+    assert summary["processed"] == 0
+    assert fake.seen_flagged == []
+
+
+def test_mail_without_url_is_skipped_not_marked_seen(monkeypatch):
+    _configure_env(monkeypatch)
+    msg = _make_plain_message("Kein Link", "nur Text, kein Link hier")
+    fake = FakeImap({b"1": msg})
+
+    called = {"n": 0}
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", lambda url: called.__setitem__("n", called["n"] + 1))
+
+    summary = mailbox.check_mailbox(imap_factory=lambda: fake)
+
+    assert called["n"] == 0
+    assert summary["skipped"] == 1
+    assert fake.seen_flagged == []


### PR DESCRIPTION
## 概述

实现知识库邮件收件（issue #655）：手机「分享 → 邮件」把链接发到专用邮箱，服务器 cron 轮询取出 URL，走和界面粘贴 URL 完全相同的入库管线。

## 改动

- **`knowledge/ingest.py`（新增，重构）**：把 `routes/knowledge.py` 里"URL → YouTube/文章判定 → 建 `podcast_episodes` 行"的核心逻辑抽成不依赖 FastAPI 的 `ingest_url(url) -> dict`（框架无关，失败抛 `IngestError`）。`routes/knowledge.py` 改为薄封装，对外行为完全不变（已用既有测试验证）。这样邮件脚本和 HTTP 路由共用同一条管线，不重蹈 #643 两条并行加词入口的覆辙。
- **`knowledge/mailbox.py`（新增）**：用标准库 `imaplib` + `email` 轮询 IMAP 邮箱的 UNSEEN 邮件。
  - 从**主题和正文**（`text/plain` + `text/html` 两种 MIME 都扫）用正则提取 URL，一封邮件里的多个 URL 全部处理
  - 发件人白名单比对兼容 `Name <addr@x.de>` 格式，只比较地址部分、不区分大小写
  - **`KNOWLEDGE_MAIL_ALLOWED_SENDERS` 未配置时直接跳过整个邮箱检查**（不建立 IMAP 连接、不处理任何邮件）——这是防止任何知道邮箱地址的人往服务器塞 URL 触发付费 AI 调用的唯一防线
  - 处理成功的邮件才标记 `\Seen`；只要邮件里有一个 URL 处理失败，整封邮件保持 UNSEEN，下轮自动重试（`ingest_url()` 对已入库 URL 走 `already_exists` 分支，重试部分成功的邮件是安全的）
- **`scripts/knowledge_mail_check.py`（新增）**：对应的 cron 定时脚本。和 `podcast_check.py` 不同，这里没有对应的 HTTP 接口，脚本直接 `import database` + `database.init_db()` 在本进程内完成（风格参考 `fsrs_optimize.py`），带 PID 锁文件防止 cron 叠跑。
- **`scripts/README.md`**：补充完整用法、安全说明、cron 配置示例。
- **`CLAUDE.md`**：环境变量表新增 `KNOWLEDGE_IMAP_HOST`/`KNOWLEDGE_IMAP_PORT`/`KNOWLEDGE_IMAP_USER`/`KNOWLEDGE_IMAP_PASSWORD`/`KNOWLEDGE_MAIL_ALLOWED_SENDERS`，项目结构图补 `knowledge_mail_check.py`。
- **`tests/test_knowledge_mailbox.py`（新增，22 个测试）**：IMAP 全部打桩（自定义 `FakeImap`），绝不联网。覆盖：主题里的 URL、正文里的 URL（纯文本 + HTML 两种）、一封邮件多个 URL、白名单未配置时零处理、非白名单发件人跳过、处理失败不标已读（含部分失败场景）、显示名格式+大小写不敏感的发件人比对。

## 与施工图的差异

- 施工图里"抽取入库函数"建议放 `knowledge/ingest.py` 的 `ingest_url(url) -> dict`，与实际实现一致
- `scripts/knowledge_mail_check.py` 没有对应的 HTTP 端点（不像 `podcast_check.py` 打服务器接口），而是直接触库——因为 IMAP 轮询本身不需要经过网络往返回自己的服务器，新增一个 `/api/knowledge/mail-check` 接口反而多一层没必要的间接。已在 PR 描述和 `scripts/README.md` 里说明这个差异。

## 测试

```
pytest tests/ -q
# 289 passed, 4 skipped
```

`4 skipped` 是仓库既有的、与本 PR 无关的跳过用例。

## 手动验证（未做，需要真实邮箱凭据）

- [ ] 给专用邮箱发一封带 YouTube 链接的邮件，配置好四个环境变量后跑 `python scripts/knowledge_mail_check.py`，确认视频出现在知识页且邮件被标记已读

Closes #655