### PR TITLE
知识库造卡改用转录全文，摘要仅作降级兜底

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -342,25 +342,29 @@ Return ONLY a numbered list of Chinese sentences, no explanation:
     # stories still call generate_podcast_sentences below, which now looks up
     # this same "knowledge" template — see database/core.py's one-time
     # prompt_presets rename so Daniel's saved custom template keeps applying.
-    "knowledge": """任务：下面是一期播客单集的内容摘要（德语）。请写若干简体中文句子，帮助 HSK 4-5
-学习者复习词汇。这些句子不需要合起来构成一篇摘要——每一句只要"发生在这一集的世界里"就可以。
+    # {summary} 现在多数情况下是中文转录全文而非德语摘要（issue #661），
+    # 措辞已改成不预设语言，占位符名字本身保留不变（见 generate_podcast_sentences
+    # 注释——改名会让已保存的自定义模板失效）。
+    "knowledge": """任务：下面是一期播客/视频/文章素材的内容（可能是原始转录，也可能是内容摘要）。
+请写若干简体中文句子，帮助 HSK 4-5 学习者复习词汇。这些句子不需要合起来构成一篇摘要——
+每一句只要"发生在这份素材的世界里"就可以。
 
 单集标题：{title}
 
-内容摘要（德语）：
+素材内容：
 {summary}
 
 目标词汇（每个词恰好用在一个句子里，以原文形式出现）：
 {words}
 
 【硬性锚点规则，最重要】
-每一句话都必须至少包含一个来自上面摘要的专有名词——人名、公司名、品牌名、产品名或地名
-（例如摘要里出现的公司、创始人、店名、城市）。没有专有名词的句子一律不合格，必须重写。
+每一句话都必须至少包含一个来自上面素材的专有名词——人名、公司名、品牌名、产品名或地名
+（例如素材里出现的公司、创始人、店名、城市）。没有专有名词的句子一律不合格，必须重写。
 
 【就近三档原则】
 对每个目标词，从上往下选第一个能写得自然的档位；写着别扭就往下降一档，
 绝对不要为了写成事实句而生硬拼凑：
-  A档 事实句：这个词正好能表达摘要中的一个事实。
+  A档 事实句：这个词正好能表达素材中的一个事实。
      例：张一鸣承认，公司的AI能力可能会暂时落后。
   B档 评论句：某人对本集内容的反应、评价或愿望。
      例：我真羡慕那些能天天吃和牛的人。
@@ -368,13 +372,13 @@ Return ONLY a numbered list of Chinese sentences, no explanation:
      例：他在抖音上刷视频，顺便就下了单。
 
 【话题覆盖规则】
-摘要里通常有好几个互不相关的话题（例如公司人事、电商、饮食文化）。
-- 把目标词大致平均地分配到这些话题上；摘要里的每一个话题都至少要有一句话
-- 严禁所有句子都围绕同一个话题，也不要只用摘要开头的内容
+素材里通常有好几个互不相关的话题（例如公司人事、电商、饮食文化）。
+- 把目标词大致平均地分配到这些话题上；素材里的每一个话题都至少要有一句话
+- 严禁所有句子都围绕同一个话题，也不要只用素材开头的内容
 - 属于同一话题的句子尽量排在一起，让整篇按话题一块一块地读下来，不要来回跳
 
 【写作步骤】（每个词按顺序思考，把结论写进 reasoning_zh）
-1. 先决定这句话属于摘要里的哪个话题
+1. 先决定这句话属于素材里的哪个话题
 2. 再从该话题里挑一个专有名词做锚点
 3. 然后定档位（A/B/C）和具体情境：谁、在哪、在做什么
 4. 最后写 sentence_zh：把情境浓缩成一句自然的中文，把目标词自然地嵌进去
@@ -383,8 +387,8 @@ Return ONLY a numbered list of Chinese sentences, no explanation:
 - 每句恰好包含一个目标词汇，一个词都不能漏，也不要在一句里塞进两个目标词
 - 除专有名词和目标词外，只用 HSK 1-{max_hsk} 的词汇
 - 每句 10 到 28 个字，用自然的中文口语，标点用中文标点
-- C档允许虚构日常细节（谁在排队、谁在点菜），但绝不可以编造摘要里没有的数字、
-  结论或事实性主张，也不可以与摘要矛盾
+- C档允许虚构日常细节（谁在排队、谁在点菜），但绝不可以编造素材里没有的数字、
+  结论或事实性主张，也不可以与素材矛盾
 - 严禁空洞句子，例如"这一集很有趣。""他说了很多。"
 - 只用简体中文，绝对不要出现繁体字；不要使用markdown格式
 - 不要给目标词加引号、括号或任何标记，直接写进句子里
@@ -2211,7 +2215,7 @@ def generate_briefing_sentences(
 
 def generate_podcast_sentences(
     cards: list[dict],
-    summary: str,            # the episode's German summary_de (caller ensures non-empty)
+    material: str,            # transcript_zh (preferred) or summary_de fallback; caller ensures non-empty — see routes/story.py's _knowledge_material()
     episode_title: str,
     model: str = DEFAULT_MODEL,     # #640: DeepSeek, same as kahneman
     max_hsk: int = 3,
@@ -2220,8 +2224,8 @@ def generate_podcast_sentences(
     source_url: str | None = None,
     source_title: str | None = None,
 ) -> list[dict]:
-    """Podcast mode rework (issue #561) — a lean single-purpose pipeline that
-    replaces reuse of the briefing machinery (originally #482).
+    """Podcast/knowledge mode rework (issue #561) — a lean single-purpose
+    pipeline that replaces reuse of the briefing machinery (originally #482).
 
     Prompt rewritten in #634: the sentences no longer have to add up to a
     summary of the episode, and no longer have to each state a fact from it —
@@ -2229,26 +2233,34 @@ def generate_podcast_sentences(
     demand only produced contortions and invented facts. Instead each sentence
     just has to happen "in the world of the episode" (kahneman's approach),
     anchored by a hard rule that every sentence names a proper noun from the
-    summary, plus a topic-coverage rule so the sentences don't all pile onto
-    the summary's first topic.
+    material, plus a topic-coverage rule so the sentences don't all pile onto
+    the material's first topic.
 
     One main call + up to 2 missing-word retry rounds + fallback sentences.
-    Deliberately has NO fact-check and NO whole-summary validation retry —
-    those are what make briefing slow and expensive, and podcast summaries
-    (unlike news) are AI-authored to begin with, so there's no external source
-    to fact-check against. The only input is the German episode summary
-    (detailed enough since #541) — the full transcript is never sent.
+    Deliberately has NO fact-check and NO whole-material validation retry —
+    those are what make briefing slow and expensive, and podcast/knowledge
+    content (unlike news) is not something to fact-check against an external
+    source in the same way. `material` is normally the item's full transcript
+    (transcript_zh, truncated to 15000 chars by the caller — issue #661;
+    Daniel explicitly asked for transcript-based cards, #561 had switched to
+    summary_de purely to cut cost/latency, which stopped mattering once cost
+    was confirmed to be ~$0.003/generation) with summary_de as a fallback for
+    rows that only have a summary (old synced-down data, etc.). The prompt
+    template's {summary} placeholder is reused for whichever text is passed
+    in, so custom prompt_presets Daniel already saved keep working unchanged.
 
     attempt_label: chunk marker like " (2/3)" appended to every progress
     message — the route batches cards by MAX_NEWS_BATCH and calls this once
     per chunk (same convention as generate_briefing_sentences).
     """
-    if not cards or not summary.strip():
+    if not cards or not material.strip():
         return []
 
     # 模板可被用户自定义覆盖（issue #581）；默认渲染结果与旧内联 f-string 逐字一致。
     # #654: 查的是 "knowledge" 模板——mode='podcast' 的历史故事也走这个函数，
     # 迁移后它们的自定义模板同样存在 mode='knowledge' 下（见 database/core.py）。
+    # {summary} 占位符名字保留不变（issue #661 起实际传入的多为转录全文而非
+    # 摘要）——改名会让 Daniel 已保存的自定义模板失效。
     tpl = _story_prompt_template("knowledge")
 
     def _build_prompt(batch: list[dict], extra_hint: str = "") -> str:
@@ -2258,7 +2270,7 @@ def generate_podcast_sentences(
         )
         return _render_prompt(tpl, {
             "title": episode_title,
-            "summary": summary,
+            "summary": material,
             "words": word_list,
             "max_hsk": str(max_hsk),
             "extra_hint": extra_hint,
@@ -2334,8 +2346,8 @@ def generate_podcast_sentences(
             # topic" is an instruction that cannot be satisfied.
             hint = (f"\n\n【补漏轮】上一轮你漏掉了这些词：{missing}。"
                     f"这一轮只需要为上面列出的每一个词各写一句话，一个都不能少。"
-                    f"词少的时候不必覆盖摘要里的所有话题，但每句仍然必须包含"
-                    f"一个来自摘要的专有名词。")
+                    f"词少的时候不必覆盖素材里的所有话题，但每句仍然必须包含"
+                    f"一个来自素材的专有名词。")
             msg = f"补漏 {len(remaining)} 个词（第{round_no}轮）…{attempt_label}"
             # Late rounds go one word per call: with only a few words left this
             # is the most reliable shape — the model has no room to "pick the

--- a/routes/story.py
+++ b/routes/story.py
@@ -37,6 +37,28 @@ _AGAIN_ACTION_LABELS = {
     "paste": "Paste Again Sentences",
 }
 
+# 知识库素材正文截断长度（issue #661）——与 knowledge/article.py 的
+# _MAX_ARTICLE_CHARS 一致，是上下文窗口的长度护栏，不是省钱考量
+# （成本已实测约 $0.003/次，见 #661）。
+_KNOWLEDGE_MATERIAL_MAX_CHARS = 15000
+
+
+def _knowledge_material(episode: dict) -> str:
+    """Return the text to feed knowledge-mode story generation for `episode`.
+
+    issue #661: prefer the full transcript (transcript_zh, truncated to
+    _KNOWLEDGE_MATERIAL_MAX_CHARS) — Daniel explicitly asked for this when
+    the feature shipped; #561 switched to summary_de purely to cut cost/
+    latency (skip fact-check + fewer tokens per call), which stopped
+    mattering once the per-generation cost was confirmed to be ~$0.003.
+    Rows synced down before this change (or otherwise missing a transcript)
+    may only have summary_de — fall back to it rather than erroring, so old
+    episodes keep working."""
+    transcript = (episode.get("transcript_zh") or "").strip()
+    if transcript:
+        return transcript[:_KNOWLEDGE_MATERIAL_MAX_CHARS]
+    return (episode.get("summary_de") or "").strip()
+
 # 《思考，快与慢》原书的 5 个部分（Part）—— 按章节号区间划分。
 # 数据文件不存部分信息，统一在此按章节号计算，保证一致性。
 _KAHNEMAN_PARTS = [
@@ -320,34 +342,42 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
             # after the knowledge-base generalization (#650) podcast_episodes
             # covers podcast/video/article sources uniformly, so this path
             # needs zero changes beyond the identifier — database.get_episode()
-            # already returns any kind. Drops the briefing pipeline — only the
-            # item's German summary is sent (detailed enough since #541, never
-            # the full transcript), one lean call per batch of MAX_NEWS_BATCH
-            # words plus missing-word top-ups, no fact-check. The model is the
-            # user's dropdown pick, no longer locked to BRIEFING_MODEL. Default
-            # is ai.DEFAULT_MODEL (DeepSeek) since #640 — the gpt-5-mini default
-            # was inherited from the news path, whose reason (DeepSeek censors
-            # news content) doesn't apply here: the input is a German summary,
-            # and kahneman has always run on DeepSeek. If an item's topic does
+            # already returns any kind. Drops the briefing pipeline (no
+            # fact-check / whole-batch validation retry — see
+            # generate_podcast_sentences' docstring), one lean call per batch
+            # of MAX_NEWS_BATCH words plus missing-word top-ups. The model is
+            # the user's dropdown pick, no longer locked to BRIEFING_MODEL.
+            # Default is ai.DEFAULT_MODEL (DeepSeek) since #640 — the
+            # gpt-5-mini default was inherited from the news path, whose
+            # reason (DeepSeek censors news content) doesn't apply here, and
+            # kahneman has always run on DeepSeek. If an item's topic does
             # trip DeepSeek's filter, the per-word fallback sentences make it
             # obvious and the dropdown switches back to GPT without a code change.
+            #
+            # Material (issue #661): the full transcript (transcript_zh,
+            # truncated to _KNOWLEDGE_MATERIAL_MAX_CHARS) is sent, not the
+            # German summary — #561 sent only summary_de purely to cut cost/
+            # latency, which Daniel confirmed no longer matters at ~$0.003/
+            # generation. See _knowledge_material()'s docstring. Rows without
+            # a transcript (synced-down snapshots, etc.) fall back to
+            # summary_de automatically.
             if not episode_id:
                 raise ValueError("Knowledge mode requires selecting a source item.")
             episode = database.get_episode(episode_id)
             if not episode:
                 raise ValueError(f"Knowledge item {episode_id} not found.")
-            summary = (episode.get("summary_de") or "").strip()
-            if not summary:
-                raise ValueError("Selected item has no summary yet.")
+            material = _knowledge_material(episode)
+            if not material:
+                raise ValueError("Selected item has no transcript or summary yet.")
             kind = episode.get("kind") or "podcast"
             model = _validated_model(model, default=ai.DEFAULT_MODEL)
             logger.info("story  knowledge model in use: %s kind=%s batch_size=%s",
                         model, kind, batch_size)
             # batch_size (issue #563): user-controlled words-per-call from the
             # setup modal; empty/0 = one single call, capped at MAX_PODCAST_BATCH
-            # (#634). Spreading the words over the summary's topics only works if
-            # one call sees them all, so one call stays the default — but past
-            # ~20 words the model starts dropping rules, hence the ceiling.
+            # (#634). Spreading the words over the material's topics only works
+            # if one call sees them all, so one call stays the default — but
+            # past ~20 words the model starts dropping rules, hence the ceiling.
             chunk_size = (batch_size if batch_size and batch_size > 0
                           else min(len(cards), ai.MAX_PODCAST_BATCH))
             chunks = [cards[i:i + chunk_size] for i in range(0, len(cards), chunk_size)]
@@ -355,7 +385,7 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
             for idx, chunk in enumerate(chunks):
                 label = f" ({idx + 1}/{len(chunks)})" if len(chunks) > 1 else ""
                 sentences.extend(ai.generate_podcast_sentences(
-                    chunk, summary, episode.get("title") or "",
+                    chunk, material, episode.get("title") or "",
                     model=model, max_hsk=max_hsk, progress_key=progress_key,
                     attempt_label=label,
                     source_url=episode.get("youtube_url") or f"/#{kind}-{episode_id}",
@@ -440,9 +470,10 @@ def _gen_params_dict(*, topic, max_hsk, model, grammar_focus, grammar_pct,
     get_recent_story_keys skips those rows so pregen only ever reproduces
     user-initiated generations instead of feeding on its own output (issue #468).
     episode_id: knowledge mode's selected source item (issue #482, renamed
-    from "podcast" mode in #654; summary-only pipeline since #561) —
-    Again-regen re-fetches the item's summary_de by this id rather than
-    reusing `articles` (knowledge stories don't store any).
+    from "podcast" mode in #654; lean pipeline since #561, transcript-first
+    material since #661) — Again-regen re-fetches the item's transcript_zh
+    (falling back to summary_de) by this id rather than reusing `articles`
+    (knowledge stories don't store any).
     kind: the selected item's source kind (podcast/video/article, issue #654)
     at generation time — purely informational (regen re-derives it from the
     episode row via episode_id), kept here so the frontend can show what kind
@@ -522,19 +553,21 @@ def generate_sentence_for_word(card: dict, gen_params: dict | None) -> dict | No
                     sentences, _ = ai.generate_story([card], model=model, lang=lang)
             elif mode in ("knowledge", "podcast"):
                 # Knowledge Again-regen (issue #561, renamed from "podcast" in
-                # #654): same lean pipeline, one card + the item's summary,
+                # #654): same lean pipeline, one card + the item's material,
                 # honoring the story's stored user-picked model (old stories
                 # stored gpt-5.1, which is not whitelisted, so _validated_model
                 # falls back). mode="podcast" here means a *historical* story
                 # (new stories are generated with mode="knowledge" — #654
                 # rejects "podcast" at generation time, but old stories must
-                # keep regenerating). No summary → plain sentence.
+                # keep regenerating). Material is transcript_zh with a
+                # summary_de fallback (issue #661, see _knowledge_material());
+                # no material at all → plain sentence.
                 ep = database.get_episode(gp["episode_id"]) if gp.get("episode_id") else None
-                summary = ((ep or {}).get("summary_de") or "").strip()
-                if summary:
+                material = _knowledge_material(ep) if ep else ""
+                if material:
                     ep_kind = ep.get("kind") or "podcast"
                     sentences = ai.generate_podcast_sentences(
-                        [card], summary, ep.get("title") or "",
+                        [card], material, ep.get("title") or "",
                         model=_validated_model(gp.get("model"), default=ai.DEFAULT_MODEL),
                         max_hsk=gp.get("max_hsk", 3),
                         source_url=ep.get("youtube_url") or f"/#{ep_kind}-{ep['id']}",
@@ -690,8 +723,9 @@ def regenerate_story(deck_id: int, category: str,
     — pasted texts for mode="paste" (too long to fit in a query string).
     mode="briefing" ignores pasted articles and auto-fetches today's news (issue #387);
     mode="paste" with no articles is an error (issue #396); mode="knowledge" (renamed
-    from "podcast" in #654) uses the episode_id's German summary directly, no
-    articles involved (reworked #561).
+    from "podcast" in #654) uses the episode_id's transcript_zh directly (falling
+    back to summary_de for rows without one, issue #661), no articles involved
+    (lean pipeline since #561).
     mode="news" (the old auto-fetch-only mode) has been removed (issue #512), and
     mode="podcast" (renamed to "knowledge" in #654) has likewise been removed —
     both are rejected for *new* generation, but stories already stored with either

--- a/tests/test_knowledge_story_mode.py
+++ b/tests/test_knowledge_story_mode.py
@@ -140,3 +140,89 @@ def test_historical_podcast_story_again_regen_still_works(populated_db):
     assert result is not None
     assert result["sentence_zh"]
     mock_gen.assert_called_once()
+
+
+# ── issue #661: knowledge mode material is transcript_zh, summary_de is only
+# a fallback for rows without a transcript (#561 had switched to summary-only
+# purely to cut cost/latency; that stopped mattering once cost was confirmed
+# to be ~$0.003/generation — see routes/story.py's _knowledge_material()). ──
+
+def test_knowledge_material_prefers_transcript():
+    """有 transcript_zh 时用它（截断到 15000 字），不是 summary_de。"""
+    ep = {"transcript_zh": "这是完整的转录正文。" * 5, "summary_de": "Eine Zusammenfassung."}
+    material = story_routes._knowledge_material(ep)
+    assert material == ep["transcript_zh"]
+    assert "Zusammenfassung" not in material
+
+
+def test_knowledge_material_truncates_long_transcript():
+    """转录截断到 _KNOWLEDGE_MATERIAL_MAX_CHARS（issue #661，与 knowledge/article.py
+    的 _MAX_ARTICLE_CHARS 一致），是上下文窗口护栏，不是省钱考量。"""
+    long_transcript = "字" * (story_routes._KNOWLEDGE_MATERIAL_MAX_CHARS + 500)
+    ep = {"transcript_zh": long_transcript, "summary_de": ""}
+    material = story_routes._knowledge_material(ep)
+    assert len(material) == story_routes._KNOWLEDGE_MATERIAL_MAX_CHARS
+
+
+def test_knowledge_material_falls_back_to_summary_without_error():
+    """没有 transcript_zh 的旧行（例如只同步下来摘要）自动退回 summary_de，不报错。"""
+    ep = {"transcript_zh": "", "summary_de": "Nur eine Zusammenfassung."}
+    assert story_routes._knowledge_material(ep) == "Nur eine Zusammenfassung."
+
+    ep_missing_key = {"summary_de": "Nur eine Zusammenfassung."}
+    assert story_routes._knowledge_material(ep_missing_key) == "Nur eine Zusammenfassung."
+
+    assert story_routes._knowledge_material({}) == ""
+
+
+def test_knowledge_mode_story_generation_uses_transcript(populated_db):
+    """新故事生成走 transcript_zh，而不是 summary_de（issue #661）。"""
+    deck_id = populated_db
+    episode_id = database.create_pending_episode(
+        "yt661", "https://youtube.com/@x", "转录素材视频", None,
+        "https://youtube.com/watch?v=yt661", kind="video")
+    database.update_episode(
+        episode_id, status="summarized",
+        transcript_zh="转录正文提到了你好这个词的使用场景。",
+        summary_de="Eine kurze deutsche Zusammenfassung.")
+
+    seen_material = {}
+
+    def _capturing(cards, material, title, **kwargs):
+        seen_material["value"] = material
+        return _fake_podcast_sentences(cards, material, title, **kwargs)
+
+    with patch("ai.generate_podcast_sentences", side_effect=_capturing) as mock_gen:
+        r = client.get(f"/api/story/{deck_id}/listening",
+                       params={"mode": "knowledge", "episode_id": episode_id})
+
+    assert r.status_code == 200
+    assert not r.json().get("error")
+    mock_gen.assert_called_once()
+    assert seen_material["value"] == "转录正文提到了你好这个词的使用场景。"
+    assert "Zusammenfassung" not in seen_material["value"]
+
+
+def test_knowledge_mode_story_generation_falls_back_without_transcript(populated_db):
+    """旧行只有 summary_de 时，新故事生成仍然成功（自动降级，不报错）。"""
+    deck_id = populated_db
+    episode_id = database.create_pending_episode(
+        "yt661b", "https://youtube.com/@x", "只有摘要的旧视频", None,
+        "https://youtube.com/watch?v=yt661b", kind="video")
+    database.update_episode(episode_id, status="summarized",
+                            summary_de="Nur eine deutsche Zusammenfassung.")
+
+    seen_material = {}
+
+    def _capturing(cards, material, title, **kwargs):
+        seen_material["value"] = material
+        return _fake_podcast_sentences(cards, material, title, **kwargs)
+
+    with patch("ai.generate_podcast_sentences", side_effect=_capturing) as mock_gen:
+        r = client.get(f"/api/story/{deck_id}/listening",
+                       params={"mode": "knowledge", "episode_id": episode_id})
+
+    assert r.status_code == 200
+    assert not r.json().get("error")
+    mock_gen.assert_called_once()
+    assert seen_material["value"] == "Nur eine deutsche Zusammenfassung."


### PR DESCRIPTION
## 背景

Closes #661

`mode='knowledge'` 故事生成（原 `podcast` 模式）之前只把单集的 `summary_de`（德语摘要）发给模型造句，转录全文（`transcript_zh`）从不参与，据此造出的句子远离 Daniel 实际听到/读到的内容。

## 对 #561 的调查结论

先读了 #561（原始 issue）、其实现 PR #562，以及后续把 podcast 模式改名为 knowledge 的 #654 / PR #660。

- **#561 把入参从转录改成摘要，理由是纯粹的省时省钱**：原文写"输入只发单集的 summary_de（德语摘要，#541 起已足够详细）+ 目标词列表，不发转录全文"，并在实现里明确注释"deliberately has NO fact-check and NO whole-summary validation retry — those are what make briefing slow and expensive"。这是速度/成本优化，不是硬性技术限制（撑爆上下文窗口、噪音导致质量崩坏等在原始讨论里都没有出现）。
- **#654（PR #660）本应把知识库模式素材换成 `transcript_zh`**（issue 目标里写"素材正文用 `transcript_zh`（截断 15000 字）"），但实现时发现代码沿用了 #561 的 `summary_de` 管线并原样保留——PR #660 的说明里也承认了这个偏差（"与施工图的差异"一节），并非有意为之的技术决策，只是重命名时没有顺手改。
- 结论：**没有发现任何硬性技术原因**（转录长度早就在 `knowledge/article.py` 里以 15000 字截断使用，且这条截断此前一直在其它模式里正常工作）。成本已实测约 $0.003/次生成，Daniel 已确认可接受。因此本 PR 直接把入参换回转录全文，不是"硬改"一个当初有意修好的问题。

## 改动

- `routes/story.py`
  - 新增 `_knowledge_material(episode)`：优先取 `transcript_zh`（截断 `_KNOWLEDGE_MATERIAL_MAX_CHARS=15000`，与 `knowledge/article.py` 的 `_MAX_ARTICLE_CHARS` 一致），没有转录时自动退回 `summary_de`（不报错）
  - 新故事生成路径、Again 单句重生成路径都改用它，不再直接读 `episode.get("summary_de")`
  - 更新相关 docstring/注释（`regenerate_story`、`create_story` 里过时的"uses the episode_id's German summary directly"描述已同步）
- `ai.py`
  - `generate_podcast_sentences` 的入参 `summary` 改名为 `material`（含义已不限于德语摘要），文档字符串同步更新为 #661 的说明
  - 默认 `knowledge` 提示词模板措辞去掉硬编码的"德语摘要"表述，改成语言中立的"素材内容"；`{summary}` 占位符**名字保留不变**，避免 Daniel 已保存的自定义提示词版本失效

## 降级链

没有 `transcript_zh` 的行（旧数据/只同步下来摘要的行）自动退回 `summary_de`，`_knowledge_material` 两者都没有时返回空字符串，调用方按原有逻辑报"素材未生成"错误，不会崩溃。

## 测试

- `pytest tests/`：277 passed, 4 skipped
- `tests/test_knowledge_story_mode.py` 新增 6 个测试：
  - `_knowledge_material` 优先转录 / 截断到 15000 字 / 降级到摘要（含 episode dict 缺 key 的情况）
  - 通过 `/api/story` 端点验证：有转录时实际传给 `ai.generate_podcast_sentences` 的是转录文本，无转录时自动降级为摘要文本，两种情况生成都成功不报错
- 未在 8000 端口起测试服务器；本地用 `DB_PATH=data/dev.db PORT=8002` 起过一次，`/api/decks` 返回 200
- 未做"用一个真实播客单集/YouTube 视频各生成一次故事"的真实 AI 调用验证（sandbox 无外网/无 API key），逻辑已由上面的打桩测试覆盖；建议 Daniel 在生产或本地有 key 的环境里跑一次真实生成确认句子确实更贴近原文细节

## 未改动

- `mode='podcast'` 的历史故事读取路径未动，仍照常展示与 Again 单句重生成（沿用同一条 `_knowledge_material`/`generate_podcast_sentences` 管线）
- 未触碰 `knowledge/mailbox.py`、`knowledge/ingest.py`、`scripts/`、`CLAUDE.md`、`routes/knowledge.py`（另一位代理并行负责的范围）