### PR TITLE
登录改为 HTML 表单 + 长期 Cookie，让 iOS 钥匙串能自动填密码

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,12 @@ Daniel 在中国需要 VPN 访问 GitHub。`gh` 命令报 `EOF` 错误时（`cur
 
 ## 生产环境（2026-07-07 上线）
 
-系统运行在一台 Linux VPS 上，Daniel 通过手机/电脑浏览器访问 `https://powerdaniel3000.duckdns.org`（HTTP Basic Auth 保护；凭据不入库——仓库是公开的）。
+系统运行在一台 Linux VPS 上，Daniel 通过手机/电脑浏览器访问 `https://powerdaniel3000.duckdns.org`（登录保护；凭据不入库——仓库是公开的）。
+
+- **登录是 HTML 表单 + 长期签名 Cookie（#666）**，不是 HTTP Basic Auth：iOS 钥匙串只保存**表单**登录，原生 Basic 弹窗它一律不存也不自动填，Daniel 每次进都要手打密码。`GET/POST /login`（`static/login.html`，两个输入框必须带 `autocomplete="username"` / `current-password`，这正是钥匙串识别的前提）→ 校验通过下发 `anki_session` Cookie（HMAC 签名，含过期时间戳，有效期一年，HttpOnly/SameSite=Lax，HTTPS 下 Secure）。签名密钥由 `AUTH_USERNAME`+`AUTH_PASSWORD` 派生 —— 改密码即自动作废全部旧会话，无需存密钥
+- **Basic Auth 保留作回退**（curl/脚本），中间件顺序是 Cookie → Basic → 拒绝
+- **未认证时 `/api/*` 必须返回 401 JSON，不能重定向**：给 `fetch()` 一个 200 的 HTML 登录页会让所有前端请求"成功"拿到垃圾。页面路径才 303 跳 `/login`；`app.js` 的 `api()` 收到 401 自动跳登录页
+- Caddy 反代后应用自己收到的是明文 HTTP，Cookie 的 `secure` 标志按 `X-Forwarded-Proto` 判断
 
 - **唯一生产数据库在服务器上**（`/home/anki/AnkiAdvanced/data/srs.db`）。本地开发只用 `run.dev.sh` + `data/dev.db`。**本地的 `data/srs.db` 已过时，绝不要把它当作现状或复制回服务器。**
 - **自动部署：** 服务器 cron 每 2 分钟运行 `deploy/deploy.sh`——**PR 合并到 main ≈ 2 分钟后自动上线**（拉取、装依赖、重启 systemd 服务 `ankiadvanced`）
@@ -459,7 +464,7 @@ python main.py status [--deck X]     # 显示每个牌组/类别的到期数量
 | `PORT` | `8000` | 服务监听端口（`run.offline.sh` 用 8001） |
 | `LOG_LEVEL` | `INFO` | 日志级别（`DEBUG` 输出详细日志） |
 | `DEV_CLEAR_DB` | `` | 设为任意值启动时清空数据库——生产环境绝不要设置 |
-| `AUTH_USERNAME` / `AUTH_PASSWORD` | 可选 | 两者都设置时启用 HTTP Basic Auth（保护所有路径） |
+| `AUTH_USERNAME` / `AUTH_PASSWORD` | 可选 | 两者都设置时启用登录保护（保护所有路径，`/login` 除外）。主流程是 HTML 表单登录 + 一年期签名 Cookie（#666），Basic Auth 保留作 curl/脚本的回退 |
 | `SMTP_HOST` / `SMTP_PORT` / `SMTP_USERNAME` / `SMTP_PASSWORD` / `SMTP_FROM` | 可选 | 播客爬虫（#479）邮件通知用；`SMTP_PORT` 默认 587（STARTTLS）；未配置时跳过发信，记日志，不算失败 |
 | `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` | 可选 | 播客爬虫用 Spotify Web API 搜索单集链接；未配置时退化为 Spotify 搜索链接 |
 | `PUBLIC_BASE_URL` | `https://powerdaniel3000.duckdns.org` | 播客邮件/Signal 通知里转录页链接的域名前缀 |

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import os
+import pathlib
 import sys
 
 
@@ -184,12 +185,16 @@ def main():
 try:
     import base64
     import binascii
+    import hashlib
+    import hmac
     import secrets
     import time
     from contextlib import asynccontextmanager
-    from fastapi import FastAPI, Request
+    from fastapi import FastAPI, Form, Request
     from fastapi.staticfiles import StaticFiles
-    from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse
+    from fastapi.responses import (
+        FileResponse, HTMLResponse, JSONResponse, PlainTextResponse, RedirectResponse,
+    )
     from starlette.middleware.gzip import GZipMiddleware
     import uvicorn
 
@@ -231,41 +236,118 @@ try:
 
     ui_logger = logging.getLogger("ui")
 
-    # Optional single-user HTTP Basic Auth — enabled only when both
-    # AUTH_USERNAME and AUTH_PASSWORD are set (issue #419). If either is
-    # missing, this middleware is a no-op — local dev behavior unchanged.
+    # Optional single-user auth — enabled only when both AUTH_USERNAME and
+    # AUTH_PASSWORD are set (issue #419). If either is missing, this middleware
+    # is a no-op — local dev behavior unchanged.
+    #
+    # Primary flow is a plain HTML login form + a long-lived signed cookie
+    # (#666): iOS Keychain only ever saves *form* logins, so the original
+    # HTTP-Basic-only version meant retyping the password on every visit from
+    # Daniel's iPhone. Basic Auth stays supported as a fallback for curl and
+    # scripts.
     _AUTH_USERNAME = os.environ.get("AUTH_USERNAME", "")
     _AUTH_PASSWORD = os.environ.get("AUTH_PASSWORD", "")
     _AUTH_ENABLED = bool(_AUTH_USERNAME and _AUTH_PASSWORD)
+    _SESSION_COOKIE = "anki_session"
+    _SESSION_MAX_AGE = 365 * 24 * 3600  # a year — this is a single-user app
+    # Signing key derived from the credentials, so changing the password
+    # invalidates every outstanding session for free (no key to store).
+    _SESSION_KEY = hashlib.sha256(
+        f"{_AUTH_USERNAME}:{_AUTH_PASSWORD}".encode("utf-8")
+    ).digest()
 
-    def _unauthorized() -> JSONResponse:
-        return JSONResponse(
-            status_code=401,
-            content={"detail": "Unauthorized"},
-            headers={"WWW-Authenticate": 'Basic realm="AnkiAdvanced"'},
-        )
+    def _make_session_cookie() -> str:
+        expires = str(int(time.time()) + _SESSION_MAX_AGE)
+        sig = hmac.new(_SESSION_KEY, expires.encode("utf-8"), hashlib.sha256).hexdigest()
+        return f"{expires}.{sig}"
 
-    @app.middleware("http")
-    async def basic_auth(request: Request, call_next):
-        if not _AUTH_ENABLED:
-            return await call_next(request)
-
-        header = request.headers.get("authorization", "")
-        if not header.startswith("Basic "):
-            return _unauthorized()
-
+    def _session_cookie_valid(value: str) -> bool:
+        expires, _, sig = value.partition(".")
+        if not sig:
+            return False
+        expected = hmac.new(_SESSION_KEY, expires.encode("utf-8"), hashlib.sha256).hexdigest()
+        if not secrets.compare_digest(sig, expected):
+            return False
         try:
-            decoded = base64.b64decode(header[6:]).decode("utf-8")
-            username, _, password = decoded.partition(":")
-        except (ValueError, UnicodeDecodeError, binascii.Error):
-            return _unauthorized()
+            return int(expires) > time.time()
+        except ValueError:
+            return False
 
+    def _credentials_ok(username: str, password: str) -> bool:
+        # Both comparisons always run — no short-circuit that would leak which
+        # half was wrong through timing.
         user_ok = secrets.compare_digest(username.encode("utf-8"), _AUTH_USERNAME.encode("utf-8"))
         pass_ok = secrets.compare_digest(password.encode("utf-8"), _AUTH_PASSWORD.encode("utf-8"))
-        if not (user_ok and pass_ok):
-            return _unauthorized()
+        return user_ok and pass_ok
 
-        return await call_next(request)
+    def _basic_auth_ok(request: Request) -> bool:
+        header = request.headers.get("authorization", "")
+        if not header.startswith("Basic "):
+            return False
+        try:
+            decoded = base64.b64decode(header[6:]).decode("utf-8")
+        except (ValueError, UnicodeDecodeError, binascii.Error):
+            return False
+        username, _, password = decoded.partition(":")
+        return _credentials_ok(username, password)
+
+    def _unauthorized(request: Request):
+        # API callers must get a real 401 — handing fetch() an HTML login page
+        # with status 200 would make every frontend request "succeed" with
+        # garbage. Browsers navigating to a page get sent to the form instead.
+        if request.url.path.startswith("/api/"):
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Unauthorized"},
+                headers={"WWW-Authenticate": 'Basic realm="AnkiAdvanced"'},
+            )
+        return RedirectResponse("/login", status_code=303)
+
+    def _login_page(error: bool) -> HTMLResponse:
+        html = pathlib.Path("static/login.html").read_text(encoding="utf-8")
+        banner = '<p class="error">Wrong username or password.</p>' if error else ""
+        return HTMLResponse(
+            html.replace("<!--ERROR-->", banner),
+            headers={"Cache-Control": "no-store"},
+        )
+
+    @app.get("/login")
+    def login_form(request: Request, error: int = 0):
+        if not _AUTH_ENABLED:
+            return RedirectResponse("/", status_code=303)
+        return _login_page(bool(error))
+
+    @app.post("/login")
+    def login_submit(request: Request, username: str = Form(""), password: str = Form("")):
+        if not _AUTH_ENABLED:
+            return RedirectResponse("/", status_code=303)
+        if not _credentials_ok(username, password):
+            logger.warning("login failed for user %r", username[:40])
+            return RedirectResponse("/login?error=1", status_code=303)
+        response = RedirectResponse("/", status_code=303)
+        response.set_cookie(
+            _SESSION_COOKIE,
+            _make_session_cookie(),
+            max_age=_SESSION_MAX_AGE,
+            httponly=True,
+            samesite="lax",
+            # Behind Caddy the app itself speaks plain HTTP, so trust the
+            # proxy's header; without it a local http:// run could never
+            # keep a session.
+            secure=request.headers.get("x-forwarded-proto", request.url.scheme) == "https",
+        )
+        return response
+
+    @app.middleware("http")
+    async def require_auth(request: Request, call_next):
+        if not _AUTH_ENABLED or request.url.path == "/login":
+            return await call_next(request)
+        cookie = request.cookies.get(_SESSION_COOKIE, "")
+        if cookie and _session_cookie_valid(cookie):
+            return await call_next(request)
+        if _basic_auth_ok(request):
+            return await call_next(request)
+        return _unauthorized(request)
 
     @app.middleware("http")
     async def log_requests(request: Request, call_next):

--- a/static/app.js
+++ b/static/app.js
@@ -797,6 +797,12 @@ async function api(method, path, body) {
     opts.body = JSON.stringify(body);
   }
   const r = await fetch(path, opts);
+  // Session cookie expired or was cleared (#666): send the user to the login
+  // form instead of letting every view fail with an unexplained error.
+  if (r.status === 401) {
+    location.href = '/login';
+    throw new Error(`${method} ${path} → 401 (redirecting to login)`);
+  }
   if (!r.ok) throw new Error(`${method} ${path} → ${r.status}`);
   return r.json();
 }

--- a/static/login.html
+++ b/static/login.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>AnkiAdvanced — Login</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    margin: 0; min-height: 100vh;
+    display: flex; align-items: center; justify-content: center;
+    font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: #f4f5f7; color: #1c1e21;
+  }
+  .card {
+    width: min(360px, calc(100vw - 3rem));
+    padding: 2rem; border-radius: 14px;
+    background: #fff; box-shadow: 0 4px 24px rgba(0,0,0,.08);
+  }
+  h1 { margin: 0 0 1.5rem; font-size: 1.25rem; text-align: center; }
+  label { display: block; margin-bottom: 1rem; font-size: .85rem; color: #666; }
+  input {
+    display: block; width: 100%; box-sizing: border-box;
+    margin-top: .35rem; padding: .7rem .8rem;
+    font-size: 1rem; color: inherit;
+    border: 1px solid #ccc; border-radius: 8px; background: #fff;
+  }
+  input:focus { outline: 2px solid #4a90d9; outline-offset: -1px; border-color: #4a90d9; }
+  button {
+    width: 100%; padding: .75rem; margin-top: .5rem;
+    font-size: 1rem; font-weight: 600; color: #fff;
+    background: #4a90d9; border: 0; border-radius: 8px; cursor: pointer;
+  }
+  button:active { background: #3b76b3; }
+  .error {
+    margin: 0 0 1rem; padding: .6rem .8rem; border-radius: 8px;
+    font-size: .85rem; color: #a3232b; background: #fdecee;
+  }
+  @media (prefers-color-scheme: dark) {
+    body { background: #16181c; color: #e6e6e6; }
+    .card { background: #232629; box-shadow: none; }
+    label { color: #9aa0a6; }
+    input { background: #1a1c1f; border-color: #3a3d42; }
+    .error { color: #ff9ba1; background: #3a2326; }
+  }
+</style>
+</head>
+<body>
+  <main class="card">
+    <h1>AnkiAdvanced</h1>
+    <!-- Rendered server-side: the placeholder below is replaced with an error
+         banner when ?error=1, and removed otherwise (see main.py). -->
+    <!--ERROR-->
+    <!-- Both fields with explicit autocomplete tokens are what makes iOS
+         Keychain / Safari offer to save and later autofill the password —
+         the whole reason this form exists instead of HTTP Basic Auth (#666). -->
+    <form method="post" action="/login">
+      <label>Username
+        <input type="text" name="username" autocomplete="username"
+               autocapitalize="none" autocorrect="off" spellcheck="false" required autofocus>
+      </label>
+      <label>Password
+        <input type="password" name="password" autocomplete="current-password" required>
+      </label>
+      <button type="submit">Sign in</button>
+    </form>
+  </main>
+</body>
+</html>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,125 @@
+"""
+Tests for the form login + signed session cookie (#666).
+
+The auth globals are read at call time inside main's middleware, so enabling
+auth for a test is just monkeypatching them — no reimport of main needed.
+"""
+
+import base64
+import hashlib
+import hmac
+import time
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+from fastapi.testclient import TestClient
+import main
+
+USER = "daniel"
+PASSWORD = "geheim123"
+
+
+@pytest.fixture
+def auth_client(monkeypatch):
+    monkeypatch.setattr(main, "_AUTH_USERNAME", USER)
+    monkeypatch.setattr(main, "_AUTH_PASSWORD", PASSWORD)
+    monkeypatch.setattr(main, "_AUTH_ENABLED", True)
+    monkeypatch.setattr(
+        main, "_SESSION_KEY",
+        hashlib.sha256(f"{USER}:{PASSWORD}".encode("utf-8")).digest(),
+    )
+    with TestClient(main.app, follow_redirects=False) as c:
+        yield c
+
+
+def _sign(expires, key=None):
+    key = key or hashlib.sha256(f"{USER}:{PASSWORD}".encode("utf-8")).digest()
+    sig = hmac.new(key, str(expires).encode("utf-8"), hashlib.sha256).hexdigest()
+    return f"{expires}.{sig}"
+
+
+# --- login form ------------------------------------------------------------
+
+def test_login_page_has_autofill_fields(auth_client):
+    """The autocomplete tokens are the whole point: without them iOS Keychain
+    never offers to save the password (which is why Basic Auth was replaced)."""
+    body = auth_client.get("/login").text
+    assert 'autocomplete="username"' in body
+    assert 'autocomplete="current-password"' in body
+    assert 'action="/login"' in body
+
+
+def test_login_page_shows_error_only_when_requested(auth_client):
+    assert "Wrong username or password" not in auth_client.get("/login").text
+    assert "Wrong username or password" in auth_client.get("/login?error=1").text
+
+
+def test_login_success_sets_session_cookie(auth_client):
+    r = auth_client.post("/login", data={"username": USER, "password": PASSWORD})
+    assert r.status_code == 303
+    assert r.headers["location"] == "/"
+    cookie = r.cookies.get("anki_session")
+    assert cookie and main._session_cookie_valid(cookie)
+
+
+def test_login_failure_redirects_back_without_cookie(auth_client):
+    r = auth_client.post("/login", data={"username": USER, "password": "wrong"})
+    assert r.status_code == 303
+    assert r.headers["location"] == "/login?error=1"
+    assert "anki_session" not in r.cookies
+
+
+# --- middleware ------------------------------------------------------------
+
+def test_unauthenticated_api_gets_401_not_a_redirect(auth_client):
+    """fetch() must see a real failure — an HTML login page with status 200
+    would look like a successful response carrying garbage."""
+    r = auth_client.get("/api/version")
+    assert r.status_code == 401
+
+
+def test_unauthenticated_page_redirects_to_login(auth_client):
+    r = auth_client.get("/")
+    assert r.status_code == 303
+    assert r.headers["location"] == "/login"
+
+
+def test_valid_cookie_grants_access(auth_client):
+    auth_client.cookies.set("anki_session", _sign(int(time.time()) + 600))
+    assert auth_client.get("/api/version").status_code == 200
+
+
+@pytest.mark.parametrize("cookie", [
+    "nonsense",
+    "9999999999.deadbeef",                                  # forged signature
+    _sign(int(time.time()) - 10),                           # expired
+    _sign("later", hashlib.sha256(b"other:creds").digest()),  # wrong key
+])
+def test_bad_cookies_rejected(auth_client, cookie):
+    auth_client.cookies.set("anki_session", cookie)
+    assert auth_client.get("/api/version").status_code == 401
+
+
+def test_basic_auth_still_works(auth_client):
+    """Kept as a fallback for curl and scripts."""
+    token = base64.b64encode(f"{USER}:{PASSWORD}".encode()).decode()
+    r = auth_client.get("/api/version", headers={"Authorization": f"Basic {token}"})
+    assert r.status_code == 200
+    bad = base64.b64encode(f"{USER}:nope".encode()).decode()
+    assert auth_client.get("/api/version", headers={"Authorization": f"Basic {bad}"}).status_code == 401
+
+
+def test_password_change_invalidates_old_sessions(auth_client, monkeypatch):
+    old = _sign(int(time.time()) + 600)
+    monkeypatch.setattr(main, "_SESSION_KEY", hashlib.sha256(b"daniel:neues").digest())
+    auth_client.cookies.set("anki_session", old)
+    assert auth_client.get("/api/version").status_code == 401
+
+
+def test_auth_disabled_is_a_noop():
+    """AUTH_* unset (CI, local dev) must behave exactly as before."""
+    with TestClient(main.app, follow_redirects=False) as c:
+        assert c.get("/api/version").status_code == 200
+        assert c.get("/login").status_code == 303


### PR DESCRIPTION
Closes #666

## 问题

iOS 的密码钥匙串只保存 **HTML 表单**登录，对浏览器原生的 HTTP Basic Auth 弹窗一概不保存、不自动填。所以 Daniel 每次在 iPhone Safari 上打开应用都要手打密码。这不是 bug，是 Basic Auth 的固有限制，只能换认证方式。

## 改了什么

- **`static/login.html`** —— 自包含登录页（内联样式，适配深色模式）。两个输入框分别带 `autocomplete="username"` 和 `autocomplete="current-password"`，这正是 Safari/钥匙串识别并保存密码的前提。
- **`GET /login` / `POST /login`**（`main.py`）—— 校验通过下发 `anki_session` Cookie：HMAC 签名 + 过期时间戳，有效期一年，HttpOnly、SameSite=Lax，`Secure` 按 `X-Forwarded-Proto` 判断（Caddy 反代后应用收到的是明文 HTTP）。密码错误跳回 `/login?error=1`。
- **签名密钥由 `AUTH_USERNAME`+`AUTH_PASSWORD` 派生** —— 改密码即自动作废全部旧会话，不需要额外存密钥。
- **中间件顺序：Cookie → Basic → 拒绝。** Basic Auth 保留作 curl/脚本的回退。
- **未认证时 `/api/*` 返回 401 JSON，不重定向** —— 给 `fetch()` 一个 200 的 HTML 登录页会让所有前端请求"成功"拿到垃圾。只有页面路径才 303 跳 `/login`。
- **`app.js` 的 `api()` 收到 401 自动跳登录页**，避免一年后会话过期时页面静默坏掉。
- `AUTH_*` 未配置时（CI、本地开发）整个中间件仍是空操作，行为不变。

## 怎么测试的

- 新增 `tests/test_auth.py`，14 项：登录页含自动填写属性、错误提示只在 `?error=1` 时出现、登录成功/失败、有效 Cookie 放行、伪造签名/过期/换密钥的 Cookie 被拒、Basic Auth 仍可用、API 401 vs 页面 303、未配置 AUTH_* 时空操作。
- `pytest tests/` 全套 **313 passed, 4 skipped**。
- 实机端到端跑了一遍：未登录访问 `/` → 303 到登录页 → 提交表单 → 拿到 Cookie → `/api/version` 200。

## 上线后 Daniel 要做的

部署后在 iPhone Safari 上会看到新的登录页，输入一次用户名和密码，Safari 会提示"存储密码"，之后一年内不再需要登录。（旧的 Basic Auth 凭据如果已存在 Safari 里，可能需要在 设置 → App → Safari 里清一下自动填充记录。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)