### PR TITLE
知识库文章标签支持粘贴正文（前端部分，#668）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3000,6 +3000,7 @@ let _podcastCurrentFeedId = null;   // layer 2/3 (podcast tab): which feed's epi
 let _podcastPollTimer = null;       // re-poll while any listed item is "processing"
 let _knowledgeTab = localStorage.getItem('knowledgeTab') || 'podcast';  // 'podcast' | 'video' | 'article'
 let _knowledgeListKind = null;      // set while a flat video/article list is showing (layer 1 for those tabs)
+let _knowledgeAddMode = 'link';     // 'link' | 'text' — article tab only (#668); paywalled articles can't be fetched, so pasting the body is the escape hatch
 
 function _clearPodcastPoll() {
   if (_podcastPollTimer) { clearTimeout(_podcastPollTimer); _podcastPollTimer = null; }
@@ -3232,18 +3233,52 @@ function _renderKnowledgeMaterialList() {
   const kindLabel = _knowledgeTab === 'video' ? 'video' : 'article';
   const rows = _podcastEpisodes.map(ep => _knowledgeMaterialRowHtml(ep)).join('') ||
     `<div class="keymap-hint">No ${kindLabel}s yet — paste a link above.</div>`;
+  // Paste-text is an article-only escape hatch for paywalled pieces the server
+  // can't fetch (#668) — video/podcast tabs only ever get a link box.
+  const isArticleTab = _knowledgeTab === 'article';
+  const addBoxHtml = (isArticleTab && _knowledgeAddMode === 'text')
+    ? `<div class="keymap-panel">
+        <div class="keymap-row" style="align-items:flex-start">
+          <div style="flex:1;display:flex;flex-direction:column;gap:6px">
+            <input type="text" class="edit-input" id="knowledge-add-title"
+                   placeholder="Title (leave blank to use the first line)">
+            <textarea class="edit-input" id="knowledge-add-text" rows="10"
+                      placeholder="Paste the full article text here…"
+                      style="width:100%;box-sizing:border-box;resize:vertical"></textarea>
+          </div>
+          <button class="btn-secondary" onclick="submitKnowledgeText()" style="flex-shrink:0">Add</button>
+        </div>
+        <span id="knowledge-add-msg" style="font-size:12px;color:var(--muted)"></span>
+      </div>`
+    : `<div class="keymap-panel">
+        <div class="keymap-row">
+          <input type="text" class="opt-input" id="knowledge-add-url"
+                 placeholder="Paste a ${kindLabel} link…" style="flex:1"
+                 onkeydown="if(event.key==='Enter') submitKnowledgeUrl()">
+          <button class="btn-secondary" onclick="submitKnowledgeUrl()">Add</button>
+        </div>
+        <span id="knowledge-add-msg" style="font-size:12px;color:var(--muted)"></span>
+      </div>`;
   el.innerHTML = `
     ${_knowledgeTabBarHtml()}
-    <div class="keymap-panel">
-      <div class="keymap-row">
-        <input type="text" class="opt-input" id="knowledge-add-url"
-               placeholder="Paste a ${kindLabel} link…" style="flex:1"
-               onkeydown="if(event.key==='Enter') submitKnowledgeUrl()">
-        <button class="btn-secondary" onclick="submitKnowledgeUrl()">Add</button>
-      </div>
-      <span id="knowledge-add-msg" style="font-size:12px;color:var(--muted)"></span>
-    </div>
+    ${isArticleTab ? _knowledgeAddModeBarHtml() : ''}
+    ${addBoxHtml}
     <div class="podcast-list">${rows}</div>`;
+}
+
+// Link/text toggle for the article tab's paste box (#668) — reuses the same
+// hcal-seg segmented-control styling as the kind tab bar just above it.
+function _knowledgeAddModeBarHtml() {
+  const modes = [['link', '🔗 Link'], ['text', '📋 Text']];
+  const btns = modes.map(([id, label]) =>
+    `<button class="hcal-seg-btn ${_knowledgeAddMode === id ? 'active' : ''}" onclick="switchKnowledgeAddMode('${id}')">${label}</button>`
+  ).join('');
+  return `<div class="hcal-seg" style="margin-bottom:12px">${btns}</div>`;
+}
+
+function switchKnowledgeAddMode(mode) {
+  _knowledgeAddMode = mode;
+  _renderKnowledgeMaterialList();
 }
 
 function _knowledgeMaterialRowHtml(ep) {
@@ -3277,9 +3312,35 @@ async function submitKnowledgeUrl() {
   const url = (input?.value || '').trim();
   if (!url) return;
   if (input) { input.value = ''; input.focus(); }
+  await _submitKnowledgeAdd(() => api('POST', '/api/knowledge/add', { url }), msg);
+}
+
+// Paste-text box (article tab only, #668) — for paywalled pieces the server
+// can't fetch. Title falls back to the pasted text's first line rather than
+// silently submitting an empty title (server also requires non-empty text).
+async function submitKnowledgeText() {
+  const titleInput = document.getElementById('knowledge-add-title');
+  const textInput = document.getElementById('knowledge-add-text');
+  const msg = document.getElementById('knowledge-add-msg');
+  const text = (textInput?.value || '').trim();
+  if (!text) return;
+  let title = (titleInput?.value || '').trim();
+  if (!title) title = text.split('\n').map(l => l.trim()).find(l => l) || '';
+  if (!title) {
+    if (msg) msg.textContent = 'Need a title (or a non-blank first line).';
+    return;
+  }
+  if (titleInput) titleInput.value = '';
+  if (textInput) { textInput.value = ''; textInput.focus(); }
+  await _submitKnowledgeAdd(() => api('POST', '/api/knowledge/add-text', { title, text }), msg);
+}
+
+// Shared tail end of both paste boxes: kick off processing for a freshly
+// ingested item, then refresh the currently-shown list if we're still on it.
+async function _submitKnowledgeAdd(doAdd, msg) {
   if (msg) msg.textContent = 'Adding…';
   try {
-    const res = await api('POST', '/api/knowledge/add', { url });
+    const res = await doAdd();
     const id = res?.episode_id;
     if (res?.status === 'already_exists') {
       if (msg) msg.textContent = 'Already in your library.';


### PR DESCRIPTION
## 说明

**这是 #668 的前端部分**，配合并行的后端 PR（`POST /api/knowledge/add-text`）一起完成本功能。**不引用 `Closes #668`** —— 由后端 PR 合并时关闭议题，避免只合一半就把 Issue 关掉。

## 改了什么

`static/app.js`，📄 文章标签的粘贴框：

- 加「🔗 链接 / 📋 正文」切换（复用已有的 `hcal-seg` 分段控件样式，未新增 CSS）
- 选「正文」→ 显示标题输入框 + 多行 `<textarea>`，提交到 `POST /api/knowledge/add-text`，body `{title, text}`
- 拿到 `episode_id` 后复用现有的 `POST /api/podcast/episodes/{id}/process` 触发 + 轮询逻辑 —— 把 `submitKnowledgeUrl` 的尾段抽成 `_submitKnowledgeAdd(doAdd, msg)`，链接框和正文框共用同一份代码，不写第二份
- 标题为空时回退用正文首行；正文首行也为空则提示必填，不静默提交空标题
- 提交后立刻清空输入框，允许连续提交（同 #636/现有链接框的做法）
- 视频/播客标签不受影响，仍只有链接框

## 为什么无法端到端联调

`POST /api/knowledge/add-text` 由并行的后端 PR 实现，尚未合并到本分支。前端严格按 #668 里定死的接口契约编写：

```
POST /api/knowledge/add-text   body {title, text, source_url?}
→ 新素材：{"episode_id": N}
→ 已存在：{"status": "already_exists", "episode_id": N}
```

## 测试计划

- [x] `node --check static/app.js` 通过
- [x] `PORT=8002 DB_PATH=data/dev.db` 起服务器，确认页面/静态资源正常加载（未联调新接口，因后端尚未合并）
- [ ] 后端 PR 合并、本分支 rebase 后手动验证：粘贴正文 → 入库 → 摘要/造卡全链路