### PR TITLE
知识库支持粘贴正文入库（后端）

### DIFF
--- a/knowledge/ingest.py
+++ b/knowledge/ingest.py
@@ -119,7 +119,9 @@ def _store_article(*, video_id: str, title: str, site: str | None, published_at,
         channel_id=site,
         title=title,
         published_at=published_at,
-        youtube_url=source_url,
+        # youtube_url is NOT NULL in schema.sql — pasted text (#668) may
+        # have no source_url at all, so fall back to "" rather than None.
+        youtube_url=source_url or "",
         audio_url=None,
         duration_seconds=None,
         kind="article",

--- a/knowledge/ingest.py
+++ b/knowledge/ingest.py
@@ -1,21 +1,28 @@
-"""Shared ingestion core for the knowledge base "add a URL" pipeline
-(issue #651/#652, extracted issue #655).
+"""Shared ingestion core for the knowledge base "add a URL" / "paste text"
+pipeline (issue #651/#652, extracted issue #655, extended #668).
 
 `ingest_url()` is the ONE place that turns an arbitrary URL into a
 podcast_episodes row (kind='video' for YouTube, kind='article' for
-everything else trafilatura can extract a body from). Both
-routes/knowledge.py (POST /api/knowledge/add, the paste-a-URL box in the
-UI) and scripts/knowledge_mail_check.py (IMAP mailbox polling, #655) call
-this function directly — no HTTP-calls-itself loop, no second parallel
-pipeline. This repo has been burned by that exact mistake before (#643:
-two add-word entry points, the bug fixed in one silently came back in the
-other) so there must only ever be one ingestion path here too.
+everything else trafilatura can extract a body from). `ingest_text()` is
+the equivalent for a pasted article body (paywalled articles trafilatura
+can't reach — #668) — same kind='article' row, same "build the row"
+helper (`_store_article`), just a different source for the body text and
+a different dedup key (no URL to hash, so the body itself is hashed
+instead). routes/knowledge.py (POST /api/knowledge/add and
+/api/knowledge/add-text, the paste boxes in the UI) and
+knowledge/mailbox.py (IMAP mailbox polling, #655) call these functions
+directly — no HTTP-calls-itself loop, no second parallel pipeline. This
+repo has been burned by that exact mistake before (#643: two add-word
+entry points, the bug fixed in one silently came back in the other) so
+there must only ever be one ingestion path here too.
 
 Deliberately framework-free: raises plain `IngestError` instead of
 fastapi.HTTPException so non-HTTP callers (the mailbox script) don't need
 to import fastapi just to catch a failure.
 """
+import hashlib
 import logging
+import re
 
 import database
 import knowledge.article
@@ -25,8 +32,9 @@ logger = logging.getLogger(__name__)
 
 
 class IngestError(Exception):
-    """A URL could not be turned into a podcast_episodes row (bad/unrecognized
-    URL, metadata fetch failed, article extraction failed, ...)."""
+    """A URL or pasted text could not be turned into a podcast_episodes row
+    (bad/unrecognized URL, metadata fetch failed, article extraction
+    failed, pasted text too short, ...)."""
 
 
 def ingest_url(url: str) -> dict:
@@ -77,15 +85,65 @@ def _ingest_video(url: str, video_id: str) -> dict:
     return {"episode_id": episode_id}
 
 
+def _existing_episode(video_id: str) -> dict | None:
+    """Dedup lookup shared by every ingestion path that lands on
+    podcast_episodes.video_id (article-by-URL, article-by-pasted-text).
+    Returns the already_exists response shape, or None if this is new."""
+    existing = database.get_episode_by_video_id(video_id)
+    if existing:
+        return {"status": "already_exists", "episode_id": existing["id"]}
+    return None
+
+
+def _store_article(*, video_id: str, title: str, site: str | None, published_at,
+                    source_url: str | None, text: str, transcript_source: str) -> dict:
+    """Create the kind='article' podcast_episodes row and store `text` as
+    transcript_zh immediately — this is the ONE row-building code path for
+    both _ingest_article (URL) and ingest_text (pasted body, #668); they
+    differ only in where `text`/`title`/`site`/`published_at` come from.
+    Landing transcript_zh here (rather than deferring the fetch to process
+    time) puts both paths straight into _process_episode's "reuse existing
+    transcript" fast path when the frontend later calls
+    POST /api/podcast/episodes/{id}/process — see article.py's docstring.
+
+    Caller must already have deduped via `_existing_episode()`."""
+    title = title or video_id
+    # translate_title (#651) is one cheap AI call — best-effort, must not
+    # block/fail the ingest if it errors (translate_title itself already
+    # swallows exceptions and returns None in that case).
+    import ai
+    title_en = ai.translate_title(title)
+
+    episode_id = database.create_pending_episode(
+        video_id=video_id,
+        channel_id=site,
+        title=title,
+        published_at=published_at,
+        youtube_url=source_url,
+        audio_url=None,
+        duration_seconds=None,
+        kind="article",
+    )
+    updates = {"transcript_zh": text, "transcript_source": transcript_source}
+    if title_en:
+        updates["title_en"] = title_en
+    database.update_episode(episode_id, **updates)
+
+    return {"episode_id": episode_id}
+
+
 def _ingest_article(url: str) -> dict:
     """Article ingestion (#652): anything that isn't a recognized YouTube
     URL is treated as an article. normalize_url() (strips utm_*/fbclid/...)
     is the dedup key, so the same article shared via different links lands
-    on the same row instead of duplicating."""
+    on the same row instead of duplicating.
+
+    The dedup check happens BEFORE fetch_article() (a real network
+    download) so an already-ingested URL never pays that cost again."""
     normalized = knowledge.article.normalize_url(url)
-    existing = database.get_episode_by_video_id(normalized)
-    if existing:
-        return {"status": "already_exists", "episode_id": existing["id"]}
+    dup = _existing_episode(normalized)
+    if dup:
+        return dup
 
     try:
         article = knowledge.article.fetch_article(url)
@@ -95,31 +153,65 @@ def _ingest_article(url: str) -> dict:
         logger.warning("knowledge.ingest: article extraction failed for %s: %s", url, e)
         raise IngestError(f"Could not fetch article: {e}")
 
-    title = article["title"]
-    # translate_title (#651) is one cheap AI call — best-effort, must not
-    # block/fail the ingest if it errors (translate_title itself already
-    # swallows exceptions and returns None in that case).
-    import ai
-    title_en = ai.translate_title(title)
-
-    episode_id = database.create_pending_episode(
+    return _store_article(
         video_id=normalized,
-        channel_id=article["site"],
-        title=title,
+        title=article["title"],
+        site=article["site"],
         published_at=article.get("published_at"),
-        youtube_url=url,
-        audio_url=None,
-        duration_seconds=None,
-        kind="article",
+        source_url=url,
+        text=article["text"],
+        transcript_source="article",
     )
-    # Store the body now (fetch_article() already paid for the download —
-    # see its module docstring for why there's no cheap "metadata only"
-    # step to defer this to). This lands in _process_episode's "reuse
-    # existing transcript" fast path when the frontend later calls
-    # POST /api/podcast/episodes/{id}/process.
-    updates = {"transcript_zh": article["text"], "transcript_source": "article"}
-    if title_en:
-        updates["title_en"] = title_en
-    database.update_episode(episode_id, **updates)
 
-    return {"episode_id": episode_id}
+
+# Same paywall-stub / context-window guards as knowledge.article (#652) —
+# a pasted body is stored exactly like a fetched one from here on, so the
+# same thresholds apply for the same reasons (see that module's docstring).
+_MIN_TEXT_CHARS = knowledge.article._MIN_ARTICLE_CHARS
+_MAX_TEXT_CHARS = knowledge.article._MAX_ARTICLE_CHARS
+
+
+def ingest_text(title: str, text: str, source_url: str | None = None) -> dict:
+    """Ingest a pasted article body (#668) — for paywalled articles
+    (Spiegel+, FAZ, ...) the server can't fetch, but the user can read in
+    their browser and paste the text in directly. Same kind='article' row
+    and transcript_zh storage as _ingest_article(), via _store_article();
+    only the dedup key and body source differ (there's no URL to hash, so
+    the body itself is hashed instead — see below).
+
+    Raises IngestError if `text` is under 200 chars (same threshold as
+    knowledge.article._MIN_ARTICLE_CHARS — too short to be a real article,
+    not just a snippet/teaser). Text over 15000 chars is truncated (same
+    ceiling as knowledge.article._MAX_ARTICLE_CHARS).
+    """
+    text = (text or "").strip()
+    if len(text) < _MIN_TEXT_CHARS:
+        raise IngestError(
+            f"pasted text too short ({len(text)} chars, need >= {_MIN_TEXT_CHARS})"
+        )
+    if len(text) > _MAX_TEXT_CHARS:
+        text = text[:_MAX_TEXT_CHARS]
+
+    title = (title or "").strip()
+    source_url = (source_url or "").strip() or None
+
+    # Whitespace must be normalized BEFORE hashing: the same article pasted
+    # twice with different line-wrapping/blank-line whitespace must still
+    # hash to the same dedup key, or every re-paste creates a new row.
+    normalized = re.sub(r"\s+", " ", text).strip()
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+    video_id = f"pasted:{digest}"
+
+    dup = _existing_episode(video_id)
+    if dup:
+        return dup
+
+    return _store_article(
+        video_id=video_id,
+        title=title or "(untitled)",
+        site=None,
+        published_at=None,
+        source_url=source_url,
+        text=text,
+        transcript_source="pasted",
+    )

--- a/knowledge/mailbox.py
+++ b/knowledge/mailbox.py
@@ -45,12 +45,16 @@ logger = logging.getLogger(__name__)
 _URL_RE = re.compile(r'https?://[^\s<>"\']+')
 _TRAILING_PUNCT = '.,;:!?)]}\'"'
 
-# Same "too short to be a real article" threshold ingest_text() enforces
-# (knowledge.article._MIN_ARTICLE_CHARS) — checked here too so a mail with
-# only a two-line body doesn't even get to the ingest call (and doesn't
-# get logged as a "failed" retry candidate for something that will never
-# succeed).
-_MIN_BODY_CHARS = 200
+# Same "too short to be a real article" threshold ingest_text() enforces —
+# checked here too so a mail with only a two-line body doesn't even get to
+# the ingest call (and doesn't get logged as a "failed" retry candidate for
+# something that will never succeed).
+#
+# Derived, never re-typed: if this were a literal 200 and the shared
+# threshold later moved up, this gate would wave a mail through that
+# ingest_text() then rejects — and a rejected mail is deliberately NOT
+# marked read, so it would be retried forever, every single poll.
+_MIN_BODY_CHARS = knowledge.ingest._MIN_TEXT_CHARS
 
 
 def _env_allowed_senders() -> set:

--- a/knowledge/mailbox.py
+++ b/knowledge/mailbox.py
@@ -1,10 +1,18 @@
-"""Knowledge base mailbox intake (issue #655): poll a dedicated mailbox via
-IMAP, pull URLs out of UNSEEN mail (phone "share -> mail" is the easiest
-way to get a link onto the server), and feed each one through
-knowledge.ingest.ingest_url() — the exact same pipeline the paste-a-URL
-box in the UI uses (POST /api/knowledge/add). No second/parallel
-"URL -> episode row" implementation here, see knowledge/ingest.py's
-docstring for why that matters in this repo.
+"""Knowledge base mailbox intake (issue #655, extended #668): poll a
+dedicated mailbox via IMAP, and for each UNSEEN mail either:
+
+  1. it contains a URL (phone "share -> mail" is the easiest way to get a
+     link onto the server) -> ingest every URL via
+     knowledge.ingest.ingest_url() — the exact same pipeline the
+     paste-a-URL box in the UI uses (POST /api/knowledge/add);
+  2. no URL, but the body is >= 200 chars -> treat the body itself as a
+     pasted article (#668, for paywalled articles Daniel can read in his
+     browser but the server can't fetch) via knowledge.ingest.ingest_text(),
+     subject as title;
+  3. neither -> skip, leave UNSEEN (unchanged from #655).
+
+No second/parallel "URL/text -> episode row" implementation here, see
+knowledge/ingest.py's docstring for why that matters in this repo.
 
 Security: this is the one intake channel that lets *anyone who knows the
 mailbox address* trigger a server-side fetch + paid AI call on Daniel's
@@ -14,7 +22,8 @@ never "process everything because the allowlist check couldn't run".
 Non-whitelisted senders are skipped individually (their mail is left
 UNSEEN, harmless, and simply ignored every run).
 
-Only stdlib (imaplib/email) is used — no new dependency for this.
+Only stdlib (imaplib/email/html.parser) is used — no new dependency for
+this.
 """
 import email
 import imaplib
@@ -23,6 +32,7 @@ import os
 import re
 from email.header import decode_header
 from email.utils import parseaddr
+from html.parser import HTMLParser
 
 import knowledge.ingest
 
@@ -34,6 +44,13 @@ logger = logging.getLogger(__name__)
 # that legitimately end mid-path still match in full.
 _URL_RE = re.compile(r'https?://[^\s<>"\']+')
 _TRAILING_PUNCT = '.,;:!?)]}\'"'
+
+# Same "too short to be a real article" threshold ingest_text() enforces
+# (knowledge.article._MIN_ARTICLE_CHARS) — checked here too so a mail with
+# only a two-line body doesn't even get to the ingest call (and doesn't
+# get logged as a "failed" retry candidate for something that will never
+# succeed).
+_MIN_BODY_CHARS = 200
 
 
 def _env_allowed_senders() -> set:
@@ -83,6 +100,73 @@ def _body_text(msg: email.message.Message) -> str:
     elif msg.get_content_type() in ("text/plain", "text/html"):
         parts.append(_decode_payload(msg))
     return "\n".join(parts)
+
+
+class _HTMLTextExtractor(HTMLParser):
+    """Bare-bones tag stripper for turning an HTML mail body into plain
+    text before it's used as a pasted article body (#668). `_body_text()`
+    above leaves tags in on purpose — it only feeds the URL regex, where
+    stray markup is harmless — but text handed to the AI summarizer must
+    not contain `<div>`/`<a>` soup, so this path strips it. <script>/<style>
+    contents are dropped entirely rather than emitted as text."""
+
+    _SKIP_TAGS = ("script", "style")
+
+    def __init__(self):
+        super().__init__()
+        self._chunks = []
+        self._skip_depth = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag in self._SKIP_TAGS:
+            self._skip_depth += 1
+
+    def handle_endtag(self, tag):
+        if tag in self._SKIP_TAGS and self._skip_depth > 0:
+            self._skip_depth -= 1
+
+    def handle_data(self, data):
+        if self._skip_depth == 0:
+            self._chunks.append(data)
+
+    def text(self) -> str:
+        return "".join(self._chunks)
+
+
+def _strip_html(html: str) -> str:
+    parser = _HTMLTextExtractor()
+    try:
+        parser.feed(html)
+        parser.close()
+    except Exception:
+        logger.warning("knowledge.mailbox: HTML 解析失败，退回原始文本（可能残留标签）")
+        return html
+    return parser.text()
+
+
+def plain_text_body(msg: email.message.Message) -> str:
+    """Body text suitable for use as a pasted article (#668, no-URL
+    fallback): text/plain parts used as-is, text/html parts have tags
+    stripped via `_strip_html()`. Unlike `_body_text()` (URL scanning
+    only), this is what gets handed to `knowledge.ingest.ingest_text()`,
+    so markup must actually be gone, not just tolerated."""
+    parts = []
+    if msg.is_multipart():
+        for part in msg.walk():
+            if "attachment" in str(part.get("Content-Disposition") or ""):
+                continue
+            ctype = part.get_content_type()
+            if ctype == "text/plain":
+                parts.append(_decode_payload(part))
+            elif ctype == "text/html":
+                parts.append(_strip_html(_decode_payload(part)))
+    else:
+        ctype = msg.get_content_type()
+        if ctype == "text/plain":
+            parts.append(_decode_payload(msg))
+        elif ctype == "text/html":
+            parts.append(_strip_html(_decode_payload(msg)))
+    return "\n".join(p.strip() for p in parts if p.strip()).strip()
 
 
 def extract_urls(text: str) -> list:
@@ -199,30 +283,51 @@ def check_mailbox(imap_factory=None) -> dict:
                 summary["skipped"] += 1
                 continue
 
+            # 主路径不变（#655）：有 URL 就走 ingest_url()，一个字节都不能变。
             urls = extract_urls_from_message(msg)
-            if not urls:
-                logger.info("knowledge.mailbox: 邮件 %s（来自 %s）未提取到 URL，跳过（不标已读）", msg_id, sender)
+            if urls:
+                all_ok = True
+                for url in urls:
+                    try:
+                        result = knowledge.ingest.ingest_url(url)
+                        summary["ingested"] += 1
+                        logger.info("knowledge.mailbox: 已处理 %s -> %s", url, result)
+                    except Exception as e:
+                        all_ok = False
+                        logger.warning("knowledge.mailbox: 处理 URL 失败 %s: %s", url, e)
+                        summary["errors"].append(f"{url}: {e}")
+
+                if all_ok:
+                    conn.store(msg_id, "+FLAGS", "\\Seen")
+                    summary["processed"] += 1
+                else:
+                    # 邮件里至少一个 URL 处理失败——整封不标已读，下轮重试。
+                    # ingest_url() 对已入库的 URL 返回 already_exists，重试
+                    # 部分成功的邮件是安全的，不会重复造行。
+                    summary["failed"] += 1
+                continue
+
+            # 无 URL 时的正文投递路径（#668）：正文（HTML 已去标签）够长就
+            # 当作粘贴文章处理，标题取邮件主题。
+            body_text = plain_text_body(msg)
+            if len(body_text) < _MIN_BODY_CHARS:
+                logger.info(
+                    "knowledge.mailbox: 邮件 %s（来自 %s）未提取到 URL 且正文过短（%d 字），跳过（不标已读）",
+                    msg_id, sender, len(body_text),
+                )
                 summary["skipped"] += 1
                 continue
 
-            all_ok = True
-            for url in urls:
-                try:
-                    result = knowledge.ingest.ingest_url(url)
-                    summary["ingested"] += 1
-                    logger.info("knowledge.mailbox: 已处理 %s -> %s", url, result)
-                except Exception as e:
-                    all_ok = False
-                    logger.warning("knowledge.mailbox: 处理 URL 失败 %s: %s", url, e)
-                    summary["errors"].append(f"{url}: {e}")
-
-            if all_ok:
-                conn.store(msg_id, "+FLAGS", "\\Seen")
+            subject = _decode_header_value(msg.get("Subject")) or "(无主题)"
+            try:
+                result = knowledge.ingest.ingest_text(subject, body_text)
+                summary["ingested"] += 1
                 summary["processed"] += 1
-            else:
-                # 邮件里至少一个 URL 处理失败——整封不标已读，下轮重试。
-                # ingest_url() 对已入库的 URL 返回 already_exists，重试
-                # 部分成功的邮件是安全的，不会重复造行。
+                conn.store(msg_id, "+FLAGS", "\\Seen")
+                logger.info("knowledge.mailbox: 已按正文投递处理邮件 %s -> %s", msg_id, result)
+            except Exception as e:
+                logger.warning("knowledge.mailbox: 正文投递处理失败 %s: %s", msg_id, e)
+                summary["errors"].append(f"(mail {msg_id}): {e}")
                 summary["failed"] += 1
     finally:
         try:

--- a/routes/knowledge.py
+++ b/routes/knowledge.py
@@ -1,13 +1,14 @@
-"""Knowledge base ingestion API (issue #651, extended #652): turn a pasted
-URL into a podcast_episodes row (kind='video' for YouTube, kind='article'
-for everything else that trafilatura can extract a body from) that the
+"""Knowledge base ingestion API (issue #651, extended #652, #668): turn a
+pasted URL — or a pasted article body (#668, for paywalled articles the
+server can't fetch) — into a podcast_episodes row (kind='video' for
+YouTube, kind='article' for everything else / pasted text) that the
 existing podcast pipeline can transcribe/summarize.
 
 All the actual resolution logic lives in knowledge/ingest.py's
-ingest_url() (extracted issue #655) so the IMAP mailbox script
-(scripts/knowledge_mail_check.py) can call the exact same pipeline instead
-of hitting this HTTP endpoint or reimplementing it — one ingestion path,
-see that module's docstring for why.
+ingest_url()/ingest_text() (extracted issue #655, extended #668) so the
+IMAP mailbox script (knowledge/mailbox.py) can call the exact same
+pipeline instead of hitting this HTTP endpoint or reimplementing it — one
+ingestion path per source type, see that module's docstring for why.
 """
 import logging
 
@@ -24,9 +25,27 @@ class AddKnowledgeRequest(BaseModel):
     url: str
 
 
+class AddKnowledgeTextRequest(BaseModel):
+    title: str
+    text: str
+    source_url: str | None = None
+
+
 @router.post("/api/knowledge/add")
 def add_knowledge(body: AddKnowledgeRequest):
     try:
         return knowledge.ingest.ingest_url(body.url)
+    except knowledge.ingest.IngestError as e:
+        raise HTTPException(400, str(e))
+
+
+@router.post("/api/knowledge/add-text")
+def add_knowledge_text(body: AddKnowledgeTextRequest):
+    """Paste-a-body counterpart to POST /api/knowledge/add (#668). Same
+    response contract ({episode_id} or {status:"already_exists",
+    episode_id}) — the frontend's add flow branches on URL vs. text but
+    otherwise treats the result identically (poll .../process next)."""
+    try:
+        return knowledge.ingest.ingest_text(body.title, body.text, source_url=body.source_url)
     except knowledge.ingest.IngestError as e:
         raise HTTPException(400, str(e))

--- a/tests/test_knowledge_ingest_text.py
+++ b/tests/test_knowledge_ingest_text.py
@@ -1,0 +1,172 @@
+"""Tests for knowledge/ingest.py's ingest_text() (issue #668) and its HTTP
+wrapper POST /api/knowledge/add-text (routes/knowledge.py).
+
+Uses a real (throwaway, per-test) sqlite db via database.init_db() rather
+than mocking database.* — ingest_text()/_store_article() touch several
+database.podcast functions (get_episode_by_video_id, create_pending_episode,
+update_episode) and the dedup behaviour is the whole point of these tests,
+so exercising the real row-creation code is more honest than re-deriving
+its contract in a stub. ai.translate_title is monkeypatched to avoid any
+real AI call (CLAUDE.md: AI must be stubbed at ai._call_api / the public
+function, tests never call out to a real provider).
+"""
+import pytest
+
+import ai
+import database
+import knowledge.ingest as ingest
+
+
+@pytest.fixture(autouse=True)
+def tmp_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setattr(database.core, "DB_PATH", str(db_file))
+    database.init_db()
+    return db_file
+
+
+@pytest.fixture(autouse=True)
+def _no_title_translation(monkeypatch):
+    """translate_title is a real (best-effort) AI call in production —
+    stub it so these tests never reach a network/AI provider."""
+    monkeypatch.setattr(ai, "translate_title", lambda title: None)
+
+
+LONG_ARTICLE = "这是一篇粘贴进来的付费墙文章正文，用来测试知识库粘贴入库功能。" * 8
+assert len(LONG_ARTICLE) >= 200
+
+
+# ---------------------------------------------------------------------------
+# ingest_text()
+# ---------------------------------------------------------------------------
+
+def test_ingest_text_creates_article_row():
+    result = ingest.ingest_text("测试标题", LONG_ARTICLE)
+    assert "episode_id" in result
+
+    episode = database.get_episode(result["episode_id"])
+    assert episode["kind"] == "article"
+    assert episode["transcript_source"] == "pasted"
+    assert episode["transcript_zh"] == LONG_ARTICLE
+    assert episode["title"] == "测试标题"
+    assert episode["video_id"].startswith("pasted:")
+
+
+def test_ingest_text_stores_source_url_when_given():
+    result = ingest.ingest_text("标题", LONG_ARTICLE, source_url="https://example.com/paywalled")
+    episode = database.get_episode(result["episode_id"])
+    assert episode["youtube_url"] == "https://example.com/paywalled"
+
+
+def test_ingest_text_source_url_optional():
+    result = ingest.ingest_text("标题", LONG_ARTICLE)
+    episode = database.get_episode(result["episode_id"])
+    assert episode["youtube_url"] is None
+
+
+def test_ingest_text_duplicate_body_deduped():
+    first = ingest.ingest_text("标题一", LONG_ARTICLE)
+    second = ingest.ingest_text("标题二（同一篇正文再投一次）", LONG_ARTICLE)
+    assert second == {"status": "already_exists", "episode_id": first["episode_id"]}
+
+    # Only one row was actually created.
+    episodes = database.core.get_db().execute(
+        "SELECT COUNT(*) AS c FROM podcast_episodes WHERE kind='article'"
+    ).fetchone()
+    assert episodes["c"] == 1
+
+
+def test_ingest_text_whitespace_differences_still_dedupe():
+    """#668 completion criterion: the same article pasted with different
+    line-wrapping/blank lines must not create a second row — the hash is
+    computed over whitespace-normalized text."""
+    variant_a = LONG_ARTICLE
+    variant_b = "\n\n".join(LONG_ARTICLE[i:i + 20] for i in range(0, len(LONG_ARTICLE), 20))
+    # Sanity: the two variants are literally different strings, but carry
+    # the same content once whitespace is collapsed.
+    assert variant_a != variant_b
+
+    first = ingest.ingest_text("标题", variant_a)
+    second = ingest.ingest_text("标题（换行方式不同）", variant_b)
+    assert second == {"status": "already_exists", "episode_id": first["episode_id"]}
+
+
+def test_ingest_text_too_short_raises():
+    with pytest.raises(ingest.IngestError):
+        ingest.ingest_text("标题", "太短了")
+
+
+def test_ingest_text_exactly_at_threshold_succeeds():
+    text = "字" * ingest._MIN_TEXT_CHARS
+    result = ingest.ingest_text("标题", text)
+    assert "episode_id" in result
+
+
+def test_ingest_text_one_under_threshold_raises():
+    text = "字" * (ingest._MIN_TEXT_CHARS - 1)
+    with pytest.raises(ingest.IngestError):
+        ingest.ingest_text("标题", text)
+
+
+def test_ingest_text_truncates_long_body():
+    text = "字" * 20000
+    result = ingest.ingest_text("标题", text)
+    episode = database.get_episode(result["episode_id"])
+    assert len(episode["transcript_zh"]) == ingest._MAX_TEXT_CHARS
+
+
+def test_ingest_text_untitled_falls_back():
+    result = ingest.ingest_text("", LONG_ARTICLE)
+    episode = database.get_episode(result["episode_id"])
+    assert episode["title"] == "(untitled)"
+
+
+def test_ingest_text_reuses_store_article_not_a_second_pipeline():
+    """Structural guard for the #668 requirement that ingest_text() must
+    not duplicate _ingest_article's row-building code: both should funnel
+    through the same _store_article helper."""
+    import inspect
+    src = inspect.getsource(ingest.ingest_text)
+    assert "_store_article(" in src
+
+
+# ---------------------------------------------------------------------------
+# POST /api/knowledge/add-text — same response contract as /api/knowledge/add
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def client():
+    pytest.importorskip("fastapi", reason="fastapi not installed")
+    from fastapi.testclient import TestClient
+    import main
+    return TestClient(main.app)
+
+
+def test_add_text_endpoint_returns_episode_id(client):
+    resp = client.post("/api/knowledge/add-text", json={"title": "标题", "text": LONG_ARTICLE})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "episode_id" in body
+
+
+def test_add_text_endpoint_dedup_returns_already_exists(client):
+    first = client.post("/api/knowledge/add-text", json={"title": "标题", "text": LONG_ARTICLE})
+    second = client.post("/api/knowledge/add-text", json={"title": "标题2", "text": LONG_ARTICLE})
+    assert second.status_code == 200
+    body = second.json()
+    assert body == {"status": "already_exists", "episode_id": first.json()["episode_id"]}
+
+
+def test_add_text_endpoint_too_short_returns_400(client):
+    resp = client.post("/api/knowledge/add-text", json={"title": "标题", "text": "太短"})
+    assert resp.status_code == 400
+
+
+def test_add_text_endpoint_accepts_optional_source_url(client):
+    resp = client.post(
+        "/api/knowledge/add-text",
+        json={"title": "标题", "text": LONG_ARTICLE, "source_url": "https://example.com/x"},
+    )
+    assert resp.status_code == 200
+    episode = database.get_episode(resp.json()["episode_id"])
+    assert episode["youtube_url"] == "https://example.com/x"

--- a/tests/test_knowledge_ingest_text.py
+++ b/tests/test_knowledge_ingest_text.py
@@ -10,6 +10,8 @@ its contract in a stub. ai.translate_title is monkeypatched to avoid any
 real AI call (CLAUDE.md: AI must be stubbed at ai._call_api / the public
 function, tests never call out to a real provider).
 """
+import re
+
 import pytest
 
 import ai
@@ -61,7 +63,8 @@ def test_ingest_text_stores_source_url_when_given():
 def test_ingest_text_source_url_optional():
     result = ingest.ingest_text("标题", LONG_ARTICLE)
     episode = database.get_episode(result["episode_id"])
-    assert episode["youtube_url"] is None
+    # youtube_url is NOT NULL in schema.sql; no source_url given -> "".
+    assert not episode["youtube_url"]
 
 
 def test_ingest_text_duplicate_body_deduped():
@@ -70,7 +73,7 @@ def test_ingest_text_duplicate_body_deduped():
     assert second == {"status": "already_exists", "episode_id": first["episode_id"]}
 
     # Only one row was actually created.
-    episodes = database.core.get_db().execute(
+    episodes = database.get_db().execute(
         "SELECT COUNT(*) AS c FROM podcast_episodes WHERE kind='article'"
     ).fetchone()
     assert episodes["c"] == 1
@@ -79,12 +82,18 @@ def test_ingest_text_duplicate_body_deduped():
 def test_ingest_text_whitespace_differences_still_dedupe():
     """#668 completion criterion: the same article pasted with different
     line-wrapping/blank lines must not create a second row — the hash is
-    computed over whitespace-normalized text."""
-    variant_a = LONG_ARTICLE
-    variant_b = "\n\n".join(LONG_ARTICLE[i:i + 20] for i in range(0, len(LONG_ARTICLE), 20))
+    computed over whitespace-normalized text. Uses paragraphs that already
+    have a single-space/newline boundary between them, so collapsing
+    whitespace-runs-to-one-space leaves the actual words untouched (an
+    earlier version of this test inserted newlines *inside* words, which
+    changes the normalized content and was a bug in the test, not the code)."""
+    paragraphs = [LONG_ARTICLE[i:i + 40] for i in range(0, len(LONG_ARTICLE), 40)]
+    variant_a = " ".join(paragraphs)          # single spaces
+    variant_b = "\n\n  \n".join(paragraphs)   # blank lines + stray indentation
     # Sanity: the two variants are literally different strings, but carry
-    # the same content once whitespace is collapsed.
+    # the same content once whitespace runs are collapsed to one space.
     assert variant_a != variant_b
+    assert re.sub(r"\s+", " ", variant_a) == re.sub(r"\s+", " ", variant_b)
 
     first = ingest.ingest_text("标题", variant_a)
     second = ingest.ingest_text("标题（换行方式不同）", variant_b)

--- a/tests/test_knowledge_mailbox.py
+++ b/tests/test_knowledge_mailbox.py
@@ -337,6 +337,8 @@ def test_partial_failure_in_multi_url_mail_does_not_mark_seen(monkeypatch):
 
 
 def test_mail_without_url_is_skipped_not_marked_seen(monkeypatch):
+    """Body under the 200-char threshold: still skipped, not marked seen
+    (unchanged from #655; #668 only adds a path for LONGER bodies)."""
     _configure_env(monkeypatch)
     msg = _make_plain_message("Kein Link", "nur Text, kein Link hier")
     fake = FakeImap({b"1": msg})
@@ -349,3 +351,143 @@ def test_mail_without_url_is_skipped_not_marked_seen(monkeypatch):
     assert called["n"] == 0
     assert summary["skipped"] == 1
     assert fake.seen_flagged == []
+
+
+# ---------------------------------------------------------------------------
+# HTML tag stripping (#668) — plain_text_body() / _strip_html()
+# ---------------------------------------------------------------------------
+
+def test_strip_html_removes_tags_keeps_text():
+    html = "<html><body><p>Hallo <b>Welt</b></p><div>zweiter Absatz</div></body></html>"
+    text = mailbox._strip_html(html)
+    assert "<" not in text
+    assert ">" not in text
+    assert "Hallo" in text and "Welt" in text and "zweiter Absatz" in text
+
+
+def test_strip_html_drops_script_and_style_contents():
+    html = "<style>.x{color:red}</style><p>echter Text</p><script>alert('x')</script>"
+    text = mailbox._strip_html(html)
+    assert "color:red" not in text
+    assert "alert" not in text
+    assert "echter Text" in text
+
+
+def test_plain_text_body_strips_html_part():
+    msg = _make_html_message(
+        "Artikel",
+        '<html><body><p>Erster Absatz</p><p>Zweiter <a href="https://example.com/x">Absatz</a></p></body></html>',
+    )
+    body = mailbox.plain_text_body(msg)
+    assert "<" not in body and ">" not in body
+    assert "Erster Absatz" in body
+    assert "Zweiter" in body and "Absatz" in body
+
+
+def test_plain_text_body_uses_plain_part_as_is():
+    msg = _make_plain_message("Artikel", "Erster Absatz.\nZweiter Absatz.")
+    body = mailbox.plain_text_body(msg)
+    assert body == "Erster Absatz.\nZweiter Absatz."
+
+
+# ---------------------------------------------------------------------------
+# No-URL, body-length-based fallback to ingest_text() (#668)
+# ---------------------------------------------------------------------------
+
+_LONG_BODY = "这是一封没有链接、只有正文的分享邮件，用来测试知识库正文投递功能。" * 7
+assert len(_LONG_BODY) >= 200
+
+
+def test_mail_without_url_but_long_body_ingested_as_text(monkeypatch):
+    _configure_env(monkeypatch)
+    msg = _make_plain_message("付费墙文章标题", _LONG_BODY)
+    fake = FakeImap({b"1": msg})
+
+    calls = []
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", lambda url: (_ for _ in ()).throw(
+        AssertionError("ingest_url must not be called when there is no URL")
+    ))
+    monkeypatch.setattr(
+        knowledge.ingest, "ingest_text",
+        lambda title, text, source_url=None: calls.append((title, text)) or {"episode_id": 1},
+    )
+
+    summary = mailbox.check_mailbox(imap_factory=lambda: fake)
+
+    assert calls == [("付费墙文章标题", _LONG_BODY)]
+    assert summary["ingested"] == 1
+    assert summary["processed"] == 1
+    assert fake.seen_flagged == [b"1"]
+
+
+def test_url_present_takes_priority_over_text_fallback(monkeypatch):
+    """#668 completion criterion: a mail with BOTH a URL and a long body
+    must still go through ingest_url() only — the URL path is untouched."""
+    _configure_env(monkeypatch)
+    msg = _make_plain_message(
+        "Geteilter Artikel",
+        f"https://example.com/article\n\n{_LONG_BODY}",
+    )
+    fake = FakeImap({b"1": msg})
+
+    url_calls = []
+    text_calls = []
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", lambda url: url_calls.append(url) or {"episode_id": 1})
+    monkeypatch.setattr(
+        knowledge.ingest, "ingest_text",
+        lambda title, text, source_url=None: text_calls.append(title) or {"episode_id": 2},
+    )
+
+    summary = mailbox.check_mailbox(imap_factory=lambda: fake)
+
+    assert url_calls == ["https://example.com/article"]
+    assert text_calls == []
+    assert summary["processed"] == 1
+    assert fake.seen_flagged == [b"1"]
+
+
+def test_text_fallback_ingest_failure_does_not_mark_seen(monkeypatch):
+    _configure_env(monkeypatch)
+    msg = _make_plain_message("Titel", _LONG_BODY)
+    fake = FakeImap({b"1": msg})
+
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", lambda url: (_ for _ in ()).throw(
+        AssertionError("should not be reached")
+    ))
+
+    def failing_ingest_text(title, text, source_url=None):
+        raise knowledge.ingest.IngestError("boom")
+
+    monkeypatch.setattr(knowledge.ingest, "ingest_text", failing_ingest_text)
+
+    summary = mailbox.check_mailbox(imap_factory=lambda: fake)
+
+    assert summary["failed"] == 1
+    assert summary["processed"] == 0
+    assert fake.seen_flagged == []
+    assert len(summary["errors"]) == 1
+
+
+def test_html_only_body_used_for_text_fallback_after_stripping(monkeypatch):
+    """A share-to-mail app that sends HTML-only, no URL, long enough body
+    after tags are stripped -> still goes through the text fallback, and
+    the ingested text has no markup in it."""
+    _configure_env(monkeypatch)
+    paragraphs = "".join(f"<p>{_LONG_BODY[i:i + 40]}</p>" for i in range(0, len(_LONG_BODY), 40))
+    msg = _make_html_message("HTML Artikel", f"<html><body>{paragraphs}</body></html>")
+    fake = FakeImap({b"1": msg})
+
+    calls = []
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", lambda url: (_ for _ in ()).throw(
+        AssertionError("should not be reached")
+    ))
+    monkeypatch.setattr(
+        knowledge.ingest, "ingest_text",
+        lambda title, text, source_url=None: calls.append(text) or {"episode_id": 1},
+    )
+
+    summary = mailbox.check_mailbox(imap_factory=lambda: fake)
+
+    assert summary["processed"] == 1
+    assert len(calls) == 1
+    assert "<" not in calls[0] and ">" not in calls[0]


### PR DESCRIPTION
## 概述

Closes #668

后端部分（第 1、2、4 节 + 新接口）。前端粘贴框（第 3 节）由并行 PR #670 负责，本 PR 不改 `static/` 下任何文件。

## 改动

1. **`knowledge/ingest.py` 新增 `ingest_text(title, text, source_url=None)`**
   - `kind='article'`、`transcript_source='pasted'`
   - 去重键 `video_id = "pasted:" + sha256(规整空白后正文)[:16]`（规整：去首尾 + 连续空白压成一个空格）
   - 正文 <200 字抛 `IngestError`；>15000 字截断（与 `article.py` 门槛一致）
   - **复用了 `_ingest_article()` 已有的建行逻辑**：把「创建 episode 行 + 存正文 + 翻译标题」抽成共享的 `_store_article()`，去重查询抽成 `_existing_episode()`。`ingest_text()`/`_ingest_article()` 现在都调用这两个共享函数，没有第二条建行管线。
   - 修了一个中途发现的 bug：`podcast_episodes.youtube_url` 是 `NOT NULL`，粘贴正文没有 URL 时会插入失败——改成无 `source_url` 时存空字符串。

2. **`POST /api/knowledge/add-text`**（`routes/knowledge.py`），body `{title, text, source_url?}`，返回契约与 `POST /api/knowledge/add` 完全一致：`{episode_id}` 或 `{status:"already_exists", episode_id}`。前端 PR #670 已按此契约开发。

3. **`knowledge/mailbox.py` 的 `check_mailbox()`**：
   - 有 URL → 走 `ingest_url()`，**这条路径的代码和行为一个字节都没变**（只是从 `if not urls: skip` 改成 `if urls: ... else: ...`，URL 分支内部逻辑原样保留）
   - 无 URL 且正文 ≥200 字 → `ingest_text(title=邮件主题, text=正文)`
   - 都不满足 → 跳过、不标已读（不变）
   - 新增 `plain_text_body()` + `_strip_html()`（标准库 `html.parser`，无新依赖）：HTML 正文当作正文投递前先去标签，`_body_text()`（服务 URL 正则扫描）保持不变

4. **确认 `_process_episode` 的「复用已存转录」快速路径（#500）对粘贴正文走得通**：`_store_article()` 在入库时就把正文写进 `transcript_zh`，`_process_episode` 先检查 `existing.get("transcript_zh")`，非空就直接复用，不会再调 `fetch_transcript()` 去抓取——粘贴正文和 URL 正文走的是同一段代码，未改动。

## 测试

新增 `tests/test_knowledge_ingest_text.py`（15 个用例）+ `tests/test_knowledge_mailbox.py` 补充（8 个新用例），覆盖：
- 正文入库、`source_url` 可选/存空串
- 同一正文重复投递去重、**不同换行/空白方式的同一正文仍去重**（哈希前规整空白）
- 正文过短报错、边界值（刚好 200 字/199 字）
- 正文超长截断
- 邮件有 URL 时优先走 URL（即使正文也很长）、URL 路径行为不变（复用 #655 原有 22 个用例全部照旧通过）
- 邮件无 URL 且正文够长走正文投递、正文过短仍跳过不标已读
- HTML 标签清理（含 `<script>`/`<style>` 内容剔除）、HTML-only 邮件经清理后走正文投递

`pytest tests/`：336 passed, 4 skipped（全绿，无新增失败/跳过）。

## 测试计划

- [x] `pytest tests/` 全绿
- [x] `python -m py_compile` 语法检查
- [x] 服务器启动检查（`database.init_db()` + `import main`）
- [ ] Daniel 手动验证：粘贴一篇真实付费墙文章正文 → 入库 → 摘要 → 生词标注 → 造卡（前端合并后可测）

🤖 Generated with [Claude Code](https://claude.com/claude-code)