### PR TITLE
再次添加已学过的词时，重置为新卡并移到今天/明天的牌组

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,7 +239,10 @@ bash sync_offline.sh push    # 只推不拉，推完归档本地库
 
 - `ai.generate_word_entry_yaml()` 把 `de-zh-bot` 技能的中文词条规则移植成服务端提示词，输出 **YAML** 而不是 JSON —— 这样能直接交给 `importer.import_yaml_content()`，例句/量词/同义反义词/汉字分解/词源全部复用既有下游逻辑，**没有一行特例建卡代码**。这也意味着卡片与手工导入的词条完全一致（`importer._create_cards` 的 due 就是 `anki_today()`，`_make_leaf_decks` 建的子牌组名与 `get_or_create_category_decks` 相同）
 - 模型没返回 YAML 列表项时抛 `ValueError`；导入数为 0 的"完成"任务前端也报错 —— **绝不把垃圾内容悄悄写进库，也不假装成功**
-- **已有的词不能"再加到今天"**：`cards` 有 `UNIQUE(word_id, category)`，一个词终身只有三张卡，`insert_card` 对它是静默无效果的。所以只有卡片仅存在于 `Saved` 牌组（没有调度进度可丢）时才 `promote_saved_word` 到今天；否则如实返回 `already_exists` 和所在牌组名，不去重置人家的 FSRS 状态。同理已有词**不调 AI**（重新生成的内容会被 importer 当重复丢掉，纯烧钱）
+- **已有的词是"移动"不是"新增"**：`cards` 有 `UNIQUE(word_id, category)`，一个词终身只有三张卡，`insert_card` 对它是静默无效果的 —— 不存在"再加一张到今天"。已有词**不调 AI**（重新生成的内容会被 importer 当重复丢掉，纯烧钱）
+- **再次添加已学过的词 = 重置为新卡**（#675，Daniel 2026-08-10 明确要求，此前是拒绝并返回 `already_exists`）：`database.reset_word_to_new(word_id, leaf_decks, due, from_deck_id=None)` 把该词的三张卡搬进今天/明天的 Daily 叶子牌组并清空全部调度状态。`promote_saved_word` 现在只是它 `from_deck_id=Saved` 的一层薄封装
+  - **这是不可撤销的破坏性操作**：stability/difficulty/interval/lapses 是这个词的全部 FSRS 记忆模型。所以接口返回 `status="reset"` + `previous_decks` + `reviews_discarded`，前端如实显示"↺ reset from X → Y, N reviews discarded"，**不报一句平淡的成功**。卡片原本只在 `Saved`（没有进度可丢）时返回 `status="promoted"`，措辞不同
+  - `review_log` 的历史记录不删，所以统计不受影响
 - 生成约 30 秒，所以走后台线程 + `job_id` 轮询（复用 `_import_jobs` 机制）
 - 只接受中文输入：德/英输入需要 AI 反问是哪个意思（`de-zh-bot` 就是这么做的），一个无交互的输入框做不到，猜错会静默存进一个错词
 - **今天/明天可选**（#636）：`day` 参数同时决定 Daily 牌组、`promote_saved_word` 的 due 和 `importer.import_yaml_content(due_offset_days=)`。**牌组和 due 必须一起后移** —— 未来日期的 Daily 牌组被 `parse_daily_deck_date` 锁住不可复习，卡片若还 due 今天就永远够不到

--- a/database/cards.py
+++ b/database/cards.py
@@ -36,33 +36,47 @@ def insert_card(word_id: int, category: str, deck_id: int,
     return row["id"]
 
 
-def promote_saved_word(word_id: int, target_deck_ids: dict,
-                       saved_deck_id: int, due: str) -> int:
-    """Move a saved word's suspended cards out of the Saved deck into the per-category
-    leaf decks as fresh 'new' cards due on `due`, clearing any scheduling state.
+def reset_word_to_new(word_id: int, target_deck_ids: dict, due: str,
+                      from_deck_id: int | None = None) -> int:
+    """Move a word's cards into the per-category leaf decks as fresh 'new' cards
+    due on `due`, clearing all scheduling state.
 
     target_deck_ids: {"listening": id, "reading": id, "creating": id} — each card is
     routed to the leaf deck matching its category, so due counts and review queues
     (keyed by deck_id, category) pick it up.
 
-    Returns the number of cards promoted.
+    from_deck_id restricts the move to cards currently in that one deck; None
+    takes the word's cards wherever they are. Note what "clearing" costs when
+    the card was actually being studied: stability/difficulty/interval/lapses
+    are the word's entire FSRS memory model and there is no undo. Callers must
+    only pass from_deck_id=None when the user asked for exactly that (#675).
+
+    Returns the number of cards reset.
     """
     conn = get_db()
     count = 0
     for category, target_deck_id in target_deck_ids.items():
-        cur = conn.execute(
-            """UPDATE cards
-               SET deck_id=?, state='new', due=?, step_index=0, interval=0,
-                   ease=2.5, repetitions=0, lapses=0, stability=NULL, difficulty=NULL,
-                   last_review=NULL, learning_again_count=0, is_leech=0,
-                   probation=0, buried_until=NULL, pre_suspend_state=NULL
-               WHERE word_id=? AND deck_id=? AND category=? AND deleted_at IS NULL""",
-            (target_deck_id, due, word_id, saved_deck_id, category),
-        )
-        count += cur.rowcount
+        sql = """UPDATE cards
+                 SET deck_id=?, state='new', due=?, step_index=0, interval=0,
+                     ease=2.5, repetitions=0, lapses=0, stability=NULL, difficulty=NULL,
+                     last_review=NULL, learning_again_count=0, is_leech=0,
+                     probation=0, buried_until=NULL, pre_suspend_state=NULL
+                 WHERE word_id=? AND category=? AND deleted_at IS NULL"""
+        params = [target_deck_id, due, word_id, category]
+        if from_deck_id is not None:
+            sql += " AND deck_id=?"
+            params.append(from_deck_id)
+        count += conn.execute(sql, params).rowcount
     conn.commit()
     conn.close()
     return count
+
+
+def promote_saved_word(word_id: int, target_deck_ids: dict,
+                       saved_deck_id: int, due: str) -> int:
+    """Promote a word staged in the Saved deck — reset_word_to_new limited to
+    cards sitting in Saved (which are suspended and carry no progress)."""
+    return reset_word_to_new(word_id, target_deck_ids, due, from_deck_id=saved_deck_id)
 
 
 def set_card_note(card_id: int, note: str | None) -> None:

--- a/routes/imports.py
+++ b/routes/imports.py
@@ -255,6 +255,19 @@ def _card_deck_ids(entry_id: int) -> set[int]:
     return {r["deck_id"] for r in rows}
 
 
+def _total_repetitions(entry_id: int) -> int:
+    """How many reviews this word's cards have accumulated — reported back when
+    a reset throws that progress away (#675)."""
+    conn = database.get_db()
+    row = conn.execute(
+        "SELECT COALESCE(SUM(repetitions), 0) AS n FROM cards "
+        "WHERE word_id = ? AND deleted_at IS NULL",
+        (entry_id,),
+    ).fetchone()
+    conn.close()
+    return row["n"]
+
+
 @router.post("/api/add-word-ai")
 def add_word_ai(body: dict):
     """Add one Chinese word to a Daily deck with an AI-generated entry.
@@ -283,26 +296,36 @@ def add_word_ai(body: dict):
     deck_id = database.get_or_create_deck_path(deck_path)
 
     # Known word → don't pay for a second generation; the importer would skip
-    # it as a duplicate anyway. What we can do depends on where its cards are:
-    # `cards` has UNIQUE(word_id, category), so a word owns exactly one card per
-    # category for its whole lifetime — there is no "also add it to today".
+    # it as a duplicate anyway. `cards` has UNIQUE(word_id, category), so a word
+    # owns exactly one card per category for its whole lifetime — there is no
+    # "also add it to today", only moving the cards it already has.
+    #
+    # Daniel asked (2026-08-10, #675) for re-adding a known word to reset it to
+    # new and pull it into today's/tomorrow's deck, whatever its progress. That
+    # discards the word's FSRS memory (stability/difficulty/interval/lapses)
+    # irreversibly, so the response says exactly what was thrown away rather
+    # than reporting a bland success.
     existing = database.get_word_by_zh(word_zh)
     if existing:
         card_decks = _card_deck_ids(existing["id"])
         saved_deck_id = database.get_or_create_saved_deck()
-        if card_decks and card_decks <= {saved_deck_id}:
-            # Only staged in Saved — promoting is exactly what the user wants.
-            leaf_decks = database.get_or_create_category_decks(deck_id, target_day)
-            database.promote_saved_word(existing["id"], leaf_decks, saved_deck_id, target_day)
-            return {"status": "promoted", "word_zh": word_zh, "entry_id": existing["id"],
-                    "deck_path": deck_path, "deck_id": deck_id}
-        # Already being studied somewhere. Moving it here would reset its FSRS
-        # state and lose real scheduling progress, so report instead of acting.
+        was_only_saved = bool(card_decks) and card_decks <= {saved_deck_id}
+        # Count the progress about to be dropped *before* the reset clears it.
+        reps = _total_repetitions(existing["id"])
         deck_names = sorted(
             (database.get_deck(d) or {}).get("name") or f"deck {d}" for d in card_decks
         )
-        return {"status": "already_exists", "word_zh": word_zh, "entry_id": existing["id"],
-                "decks": deck_names}
+        leaf_decks = database.get_or_create_category_decks(deck_id, target_day)
+        moved = database.reset_word_to_new(existing["id"], leaf_decks, target_day)
+        return {
+            # Saved cards carry no progress, so that move is a promotion, not a
+            # reset — the frontend words them differently.
+            "status": "promoted" if was_only_saved else "reset",
+            "word_zh": word_zh, "entry_id": existing["id"],
+            "deck_path": deck_path, "deck_id": deck_id,
+            "cards_moved": moved, "previous_decks": deck_names,
+            "reviews_discarded": reps,
+        }
 
     if ai_disabled():
         raise HTTPException(status_code=503,

--- a/static/shared.js
+++ b/static/shared.js
@@ -45,13 +45,18 @@ async function addWordViaAi(wordZh, day, onUpdate) {
 
   // Known words come back finished — no AI call, no job to poll.
   if (!result.job_id) {
-    if (result.status === 'already_exists') {
-      // A word owns one card per category for life, so there is nothing to
-      // add — say where it lives instead of pretending it worked.
-      onUpdate('error', `already in ${result.decks.join(', ')}`);
-      return;
+    if (result.status === 'reset') {
+      // The cards were moved here from somewhere they had real progress
+      // (#675). That progress is gone for good, so name what was thrown away
+      // instead of reporting a bland success.
+      const from = result.previous_decks.join(', ');
+      const lost = result.reviews_discarded
+        ? `, ${result.reviews_discarded} review${result.reviews_discarded === 1 ? '' : 's'} discarded`
+        : '';
+      onUpdate('done', `↺ reset from ${from} → ${result.deck_path}${lost}`, result.deck_path);
+    } else {
+      onUpdate('done', `✓ moved from Saved → ${result.deck_path}`, result.deck_path);
     }
-    onUpdate('done', `✓ moved from Saved → ${result.deck_path}`, result.deck_path);
     refreshDecks();
     return;
   }

--- a/tests/test_add_word.py
+++ b/tests/test_add_word.py
@@ -130,9 +130,11 @@ def test_full_entry_content_is_stored(tmp_db):
     assert detail["notes"] and "Substantiv" in detail["notes"]
 
 
-def test_known_word_is_reported_without_calling_the_ai(tmp_db):
-    """cards has UNIQUE(word_id, category) — a studied word cannot also be
-    added to today, and re-generating it would just burn an API call."""
+def test_known_word_is_reset_into_todays_deck_without_calling_the_ai(tmp_db):
+    """Re-adding a studied word resets its cards to new and pulls them into
+    today's deck (#675). cards has UNIQUE(word_id, category), so this moves the
+    three cards it already owns — it never creates a fourth — and re-generating
+    the entry would just burn an API call."""
     import importer
 
     other_deck = database.get_or_create_deck_path("Kouyu::Test")
@@ -142,22 +144,64 @@ def test_known_word_is_reported_without_calling_the_ai(tmp_db):
         r = client.post("/api/add-word-ai", json={"word_zh": "生态"})
     assert r.status_code == 200, r.text
     body = r.json()
-    assert body["status"] == "already_exists"
-    assert any("Test" in name for name in body["decks"])
+    assert body["status"] == "reset"
+    assert any("Test" in name for name in body["previous_decks"])
 
-    # The bug behind #643: the old /api/quick-add-word answered "✓ added" here
-    # while INSERT OR IGNORE silently dropped every card, so nothing reached the
-    # daily deck. Prove the word really is absent — the honest report above is
-    # only worth something if it matches reality.
+    # The bug behind #643: the old /api/quick-add-word answered "✓ added" while
+    # INSERT OR IGNORE silently dropped every card, so nothing reached the daily
+    # deck. Prove the cards really moved — a success report is only worth
+    # something if it matches reality.
+    today = date.today().isoformat()
+    leaf_ids = set(_today_leaf_decks().values())
     conn = database.get_db()
-    leaf_ids = tuple(_today_leaf_decks().values())
-    placeholders = ",".join("?" * len(leaf_ids))
-    in_daily = conn.execute(
-        f"SELECT COUNT(*) c FROM cards WHERE word_id=? AND deck_id IN ({placeholders})",
-        (body["entry_id"], *leaf_ids),
+    rows = conn.execute(
+        "SELECT deck_id, state, due FROM cards WHERE word_id=? AND deleted_at IS NULL",
+        (body["entry_id"],),
+    ).fetchall()
+    conn.close()
+    assert rows and {r["deck_id"] for r in rows} == leaf_ids
+    assert all(r["state"] == "new" and r["due"] == today for r in rows)
+    assert body["cards_moved"] == len(rows)
+
+
+def test_reset_clears_fsrs_progress_and_reports_what_it_discarded(tmp_db):
+    """The reset is irreversible — stability/difficulty/interval/lapses are the
+    word's whole memory model. The response must name the cost (#675)."""
+    import importer
+
+    other_deck = database.get_or_create_deck_path("Kouyu::Test")
+    importer.import_yaml_content(ENTRY_YAML, other_deck)
+    entry_id = database.get_word_by_zh("生态")["id"]
+
+    conn = database.get_db()
+    conn.execute(
+        """UPDATE cards SET state='review', repetitions=4, lapses=2, interval=30,
+           stability=42.0, difficulty=6.5, last_review='2026-08-01', is_leech=1
+           WHERE word_id=?""",
+        (entry_id,),
+    )
+    conn.commit()
+    n_cards = conn.execute(
+        "SELECT COUNT(*) c FROM cards WHERE word_id=?", (entry_id,)
     ).fetchone()["c"]
     conn.close()
-    assert in_daily == 0
+
+    with patch.object(ai, "_call_api", side_effect=AssertionError("AI was called")):
+        body = client.post("/api/add-word-ai", json={"word_zh": "生态"}).json()
+
+    assert body["status"] == "reset"
+    assert body["reviews_discarded"] == 4 * n_cards
+
+    conn = database.get_db()
+    rows = conn.execute(
+        "SELECT * FROM cards WHERE word_id=? AND deleted_at IS NULL", (entry_id,)
+    ).fetchall()
+    conn.close()
+    for row in rows:
+        assert row["state"] == "new"
+        assert row["stability"] is None and row["difficulty"] is None
+        assert row["repetitions"] == 0 and row["lapses"] == 0 and row["interval"] == 0
+        assert row["last_review"] is None and row["is_leech"] == 0
 
 
 def test_saved_word_is_promoted_into_todays_deck(tmp_db):


### PR DESCRIPTION
Closes #675

## 为什么

通过顶栏 ＋ 或 `/add` 页面添加一个**已经在学**的词时，此前是拒绝：返回 `already_exists` 和所在牌组名，不动调度状态。Daniel（2026-08-10）明确要求改成一律重置为新卡并拉到今天/明天的 Daily 牌组。

代价已经跟他确认过：`stability`/`difficulty`/`interval`/`lapses` 是这个词的全部 FSRS 记忆模型，清空后不可撤销。他确认照做。

## 改了什么

- **`database.reset_word_to_new(word_id, target_deck_ids, due, from_deck_id=None)`** —— 由现有的 `promote_saved_word` 泛化而来，后者现在只是它 `from_deck_id=Saved` 的一层薄封装（Saved 里的卡是挂起的、没有进度可丢）。
- **`POST /api/add-word-ai`** 的已存在分支改为调用它，返回 `status="reset"`，卡片原本只在 `Saved` 时仍返回 `"promoted"`（措辞不同，因为那不是破坏性操作）。
- **响应如实说明代价**：`previous_decks` + `reviews_discarded`（重置前先数好），前端显示 `↺ reset from X → Y, N reviews discarded`，而不是一句平淡的 "✓ added"。这条项目里踩过好几次（#643 的静默丢弃、#627 的假成功）。
- ＋ 按钮和 `/add` 页面共用 `shared.js` 的 `addWordViaAi()`，两处自动生效。
- `review_log` 的历史记录不删，所以统计不受影响。

## 怎么测试的

- 改写了 `test_known_word_is_reported_without_calling_the_ai` —— 行为按需求改了，断言跟着改（不是删断言），现在验证卡片真的落进今天的叶子牌组、state=new、due=今天。
- 新增 `test_reset_clears_fsrs_progress_and_reports_what_it_discarded`：先给卡片灌上 review 状态（repetitions=4、lapses=2、interval=30、stability=42、is_leech=1），重置后逐字段验证清空，并核对 `reviews_discarded` 数字正确。
- 已有词**不调 AI** 的断言保留（`_call_api` 打桩成抛异常）。
- `pytest tests/` 全套 **340 passed, 4 skipped**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)