### PR TITLE
加词时可选 ★ List：生成完整词条但先不复习，之后从 Browse 提升

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,11 @@ bash sync_offline.sh push    # 只推不拉，推完归档本地库
   - `review_log` 的历史记录不删，所以统计不受影响
 - 生成约 30 秒，所以走后台线程 + `job_id` 轮询（复用 `_import_jobs` 机制）
 - 只接受中文输入：德/英输入需要 AI 反问是哪个意思（`de-zh-bot` 就是这么做的），一个无交互的输入框做不到，猜错会静默存进一个错词
+- **第三个去处 ★ List**（#677）：`day="list"` —— 照常花钱生成完整词条，但卡片直接进 `Saved` 牌组并挂起，**不进任何复习队列**，直到在 Browse 的 saved 视图点 "→ Add to Daily" 提升。`database.stage_word_in_saved()` 是 `promote_saved_word` 的逆操作
+  - **导入仍走今天的 Daily 牌组，之后再搬**：直接以 `Saved` 为父牌组导入会建出 `Saved::listening` 等叶子牌组，而 Browse 的 saved 过滤器认的是 `deck_name === 'Saved'`
+  - **挂起靠 `state`，不靠 `due`**：`cards.due` 是 `NOT NULL DEFAULT date('now')`，写 NULL 直接违反约束。停留在 `Saved` 的卡照样有 due 值，是 `state='suspended'` 把它挡在队列外
+  - 停放**不清空** FSRS 字段（挂起已经够了；真要激活时 `promote_saved_word` 会重置），所以 `reviews_discarded` 返回 0 —— 与上面的 `reset` 不同，这不是破坏性操作
+  - Browse 的 saved 行只在词条**没有释义**时才显示 "✨ Generate"，★ List 进来的词内容已齐全，再生成纯烧钱
 - **今天/明天可选**（#636）：`day` 参数同时决定 Daily 牌组、`promote_saved_word` 的 due 和 `importer.import_yaml_content(due_offset_days=)`。**牌组和 due 必须一起后移** —— 未来日期的 Daily 牌组被 `parse_daily_deck_date` 锁住不可复习，卡片若还 due 今天就永远够不到
 - **不阻塞连续输入**（#636）：提交后立刻清空输入框，每个词进弹窗里的队列各自轮询自己的 job
 - **独立加词页 `/add`（#668）**：可收藏的网址，打开就是输入框（存 iPhone 主屏当图标用）。`static/add.html` 是自包含页面，**故意不加载 `app.js`** —— 5.5 KB vs 完整应用的 77 KB + 491 KB JS，秒开就是这个功能的全部意义。为此把 `addWordViaAi()` 和 `api()` 从 `app.js` 抽到 `static/shared.js` 两页共用，**不复制第二份**（理由同下条；`tests/test_add_word.py` 有一条测试专门守着 `app.js` 里不能再出现这两个定义）
@@ -437,7 +442,7 @@ GET  /api/costs/call/{id}                            → {prompt, response}（�
 # 其他
 POST /api/import                                     → 触发 YAML 导入
 GET  /add                                            → 独立加词页（#668，可收藏/存主屏；不加载 app.js）
-POST /api/add-word-ai                                → 界面内添加生词（#627）；body {word_zh, day?:today|tomorrow}（#636）；新词返回 {job_id}，已有词直接返回 {status}。**全应用唯一的加词入口**（#643）：顶栏 ＋、播客生词表格、复习界面长按菜单都走它
+POST /api/add-word-ai                                → 界面内添加生词（#627）；body {word_zh, day?:today|tomorrow|list}（#636、#677）；新词返回 {job_id}，已有词直接返回 {status}。**全应用唯一的加词入口**（#643）：顶栏 ＋、播客生词表格、复习界面长按菜单都走它
 GET  /api/add-word-ai/progress/{job_id}              → 轮询后台生成+导入的结果
 GET  /api/browse                                     → {deck_id?, category?, state?, q?, lang?}
 GET  /api/stats ；/api/retention ；/api/card-evolution（均支持 ?lang=）

--- a/database/cards.py
+++ b/database/cards.py
@@ -72,6 +72,29 @@ def reset_word_to_new(word_id: int, target_deck_ids: dict, due: str,
     return count
 
 
+def stage_word_in_saved(word_id: int, saved_deck_id: int) -> int:
+    """Park all of a word's cards in the Saved deck as suspended — the "add it
+    to my list, I'm not studying it yet" case (#677).
+
+    The inverse of promote_saved_word. Scheduling fields are deliberately left
+    alone: state='suspended' is what keeps a card out of every queue (`due` is
+    NOT NULL and stays whatever it was), and promote_saved_word resets them
+    anyway if the word is ever activated — so parking a word costs nothing that
+    promoting wouldn't cost later.
+
+    Returns the number of cards staged.
+    """
+    conn = get_db()
+    cur = conn.execute(
+        """UPDATE cards SET deck_id=?, state='suspended', buried_until=NULL
+           WHERE word_id=? AND deleted_at IS NULL""",
+        (saved_deck_id, word_id),
+    )
+    conn.commit()
+    conn.close()
+    return cur.rowcount
+
+
 def promote_saved_word(word_id: int, target_deck_ids: dict,
                        saved_deck_id: int, due: str) -> int:
     """Promote a word staged in the Saved deck — reset_word_to_new limited to

--- a/routes/imports.py
+++ b/routes/imports.py
@@ -270,9 +270,13 @@ def _total_repetitions(entry_id: int) -> int:
 
 @router.post("/api/add-word-ai")
 def add_word_ai(body: dict):
-    """Add one Chinese word to a Daily deck with an AI-generated entry.
+    """Add one Chinese word with an AI-generated entry.
 
-    Body: { word_zh, day?: "today"|"tomorrow" }
+    Body: { word_zh, day?: "today"|"tomorrow"|"list" }
+      today/tomorrow → cards go into that day's Daily deck, due then.
+      list (#677)    → the entry is generated in full but its cards are parked
+                       suspended in the Saved deck, so the word enters no review
+                       queue until it is promoted from Browse.
     Returns either {job_id, deck_path} — generation runs in the background,
     poll /api/add-word-ai/progress/{job_id} — or, when the word is already in
     the database, a finished {status, ...} with no AI call at all.
@@ -285,15 +289,23 @@ def add_word_ai(body: dict):
                             detail="Please enter the word in Chinese characters")
 
     day = (body.get("day") or "today").strip()
-    if day not in ("today", "tomorrow"):
-        raise HTTPException(status_code=400, detail="day must be 'today' or 'tomorrow'")
+    if day not in ("today", "tomorrow", "list"):
+        raise HTTPException(status_code=400,
+                            detail="day must be 'today', 'tomorrow' or 'list'")
+    # 'list' (#677) = generate the full entry now but park it in the Saved deck
+    # as suspended cards, so the word enters no queue until it is promoted from
+    # Browse. The import itself still runs against today's Daily deck — that is
+    # the one code path that builds a complete entry — and the cards are moved
+    # afterwards. Importing straight into Saved would create Saved::listening
+    # etc. leaf decks, and Browse's saved filter matches on deck_name == 'Saved'.
+    to_list = day == "list"
     # A daily deck dated in the future is locked until its date arrives
     # (database.parse_daily_deck_date), which is exactly the "stage it for
     # tomorrow" semantics — the cards just have to be due then too (#636).
     due_offset_days = 1 if day == "tomorrow" else 0
     target_day = (date.today() + timedelta(days=due_offset_days)).isoformat()
-    deck_path = f"Daily::{target_day}"
-    deck_id = database.get_or_create_deck_path(deck_path)
+    deck_path = "Saved" if to_list else f"Daily::{target_day}"
+    deck_id = database.get_or_create_deck_path(f"Daily::{target_day}")
 
     # Known word → don't pay for a second generation; the importer would skip
     # it as a duplicate anyway. `cards` has UNIQUE(word_id, category), so a word
@@ -315,12 +327,20 @@ def add_word_ai(body: dict):
         deck_names = sorted(
             (database.get_deck(d) or {}).get("name") or f"deck {d}" for d in card_decks
         )
-        leaf_decks = database.get_or_create_category_decks(deck_id, target_day)
-        moved = database.reset_word_to_new(existing["id"], leaf_decks, target_day)
-        return {
+        if to_list:
+            # Parking suspends the cards but leaves their scheduling alone, so
+            # nothing is discarded here — promoting later is what resets them.
+            moved = database.stage_word_in_saved(existing["id"], saved_deck_id)
+            status = "already_listed" if was_only_saved else "listed"
+            reps = 0
+        else:
+            leaf_decks = database.get_or_create_category_decks(deck_id, target_day)
+            moved = database.reset_word_to_new(existing["id"], leaf_decks, target_day)
             # Saved cards carry no progress, so that move is a promotion, not a
             # reset — the frontend words them differently.
-            "status": "promoted" if was_only_saved else "reset",
+            status = "promoted" if was_only_saved else "reset"
+        return {
+            "status": status,
             "word_zh": word_zh, "entry_id": existing["id"],
             "deck_path": deck_path, "deck_id": deck_id,
             "cards_moved": moved, "previous_decks": deck_names,
@@ -348,6 +368,12 @@ def add_word_ai(body: dict):
             if result.get("yaml_error"):
                 raise ValueError(
                     f"AI returned invalid YAML: {result['yaml_error'].get('problem', 'parse error')}")
+            if to_list and result.get("imported"):
+                # Only now do the freshly created cards exist to move (#677).
+                entry = database.get_word_by_zh(word_zh)
+                if entry:
+                    database.stage_word_in_saved(
+                        entry["id"], database.get_or_create_saved_deck())
             with _import_jobs_lock:
                 started_at = _import_jobs[job_id]["started_at"]
                 _import_jobs[job_id] = {

--- a/static/add.html
+++ b/static/add.html
@@ -75,8 +75,9 @@
     <div class="days">
       <button id="day-today" aria-pressed="true">Today</button>
       <button id="day-tomorrow" aria-pressed="false">Tomorrow</button>
+      <button id="day-list" aria-pressed="false">★ List</button>
     </div>
-    <p class="hint">Chinese input only. Generation takes ~30s — you can keep typing the next word meanwhile.</p>
+    <p class="hint" id="hint">Chinese input only. Generation takes ~30s — you can keep typing the next word meanwhile.</p>
   </div>
 
   <ul id="queue"></ul>
@@ -92,11 +93,21 @@
   const input = document.getElementById('word');
   const queue = document.getElementById('queue');
 
-  for (const d of ['today', 'tomorrow']) {
+  const DAYS = ['today', 'tomorrow', 'list'];
+  const HINTS = {
+    today: 'Chinese input only. Generation takes ~30s — you can keep typing the next word meanwhile.',
+    tomorrow: 'Chinese input only. Generation takes ~30s — you can keep typing the next word meanwhile.',
+    // ★ List = the Saved deck: the entry is generated in full, but the cards
+    // stay suspended until promoted from Browse (#677).
+    list: 'Parked in your Saved list — not reviewed until you add it to a deck from Browse.',
+  };
+  for (const d of DAYS) {
     document.getElementById(`day-${d}`).onclick = () => {
       day = d;
-      document.getElementById('day-today').setAttribute('aria-pressed', String(d === 'today'));
-      document.getElementById('day-tomorrow').setAttribute('aria-pressed', String(d === 'tomorrow'));
+      for (const other of DAYS) {
+        document.getElementById(`day-${other}`).setAttribute('aria-pressed', String(other === d));
+      }
+      document.getElementById('hint').textContent = HINTS[d];
       input.focus();
     };
   }

--- a/static/app.js
+++ b/static/app.js
@@ -2015,8 +2015,11 @@ function _wordRow(w) {
   const sel = _browseSelected.has(w.id) ? ' bw-row-selected' : '';
   let rightHtml;
   if (_browseCardStatus === 'saved') {
+    // Words parked via ★ List (#677) already carry a full entry — offering
+    // "Generate" there would just burn an API call to re-produce it.
     rightHtml =
-      `<button class="bw-saved-btn" onclick="event.stopPropagation();savedGenerate(${w.id},this)" title="Generate content with AI">✨ Generate</button>` +
+      (w.definition ? '' :
+        `<button class="bw-saved-btn" onclick="event.stopPropagation();savedGenerate(${w.id},this)" title="Generate content with AI">✨ Generate</button>`) +
       `<button class="bw-saved-btn bw-saved-promote" onclick="event.stopPropagation();savedPromote(${w.id},this)" title="Add to tomorrow's Daily deck">→ Add to Daily</button>`;
   } else if (_browseCardStatus === 'leech' && w.cards.some(c => c.is_leech)) {
     rightHtml =
@@ -6311,14 +6314,21 @@ function closeAddWordModal() {
 }
 
 function setAddWordDay(day) {
-  _addWordDay = day === 'tomorrow' ? 'tomorrow' : 'today';
+  _addWordDay = ['tomorrow', 'list'].includes(day) ? day : 'today';
   for (const btn of document.querySelectorAll('.add-word-day-btn')) {
     btn.classList.toggle('active', btn.dataset.day === _addWordDay);
   }
-  const d = new Date();
-  if (_addWordDay === 'tomorrow') d.setDate(d.getDate() + 1);
-  document.getElementById('add-word-deck').textContent =
-    'Daily::' + `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  const label = document.getElementById('add-word-deck');
+  if (_addWordDay === 'list') {
+    // ★ List parks the word in the Saved deck, suspended (#677) — say so,
+    // because "Saved" alone reads like a deck it will be reviewed from.
+    label.textContent = 'Saved (not reviewed until promoted)';
+  } else {
+    const d = new Date();
+    if (_addWordDay === 'tomorrow') d.setDate(d.getDate() + 1);
+    label.textContent =
+      'Daily::' + `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  }
   document.getElementById('add-word-input').focus();
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -935,6 +935,8 @@
               onclick="setAddWordDay('today')">Today</button>
       <button type="button" class="add-word-day-btn" data-day="tomorrow"
               onclick="setAddWordDay('tomorrow')">Tomorrow</button>
+      <button type="button" class="add-word-day-btn" data-day="list"
+              onclick="setAddWordDay('list')" title="Park in the Saved list — not reviewed until promoted from Browse">★ List</button>
     </div>
     <div id="add-word-row">
       <input id="add-word-input" type="text" placeholder="新词…" autocomplete="off"

--- a/static/shared.js
+++ b/static/shared.js
@@ -45,7 +45,13 @@ async function addWordViaAi(wordZh, day, onUpdate) {
 
   // Known words come back finished — no AI call, no job to poll.
   if (!result.job_id) {
-    if (result.status === 'reset') {
+    if (result.status === 'already_listed') {
+      onUpdate('done', '★ already on your list', result.deck_path);
+    } else if (result.status === 'listed') {
+      // Parked from a real deck: suspended, so it stops coming up for review.
+      onUpdate('done', `★ moved to list from ${result.previous_decks.join(', ')}`,
+               result.deck_path);
+    } else if (result.status === 'reset') {
       // The cards were moved here from somewhere they had real progress
       // (#675). That progress is gone for good, so name what was thrown away
       // instead of reporting a bland success.
@@ -78,7 +84,8 @@ async function addWordViaAi(wordZh, day, onUpdate) {
       onUpdate('error', 'could not be imported — check the logs');
       return;
     }
-    onUpdate('done', `✓ ${result.deck_path}`, result.deck_path);
+    onUpdate('done', day === 'list' ? '★ added to your list' : `✓ ${result.deck_path}`,
+             result.deck_path);
     refreshDecks();
   };
   setTimeout(poll, 1500);

--- a/tests/test_add_word.py
+++ b/tests/test_add_word.py
@@ -343,3 +343,113 @@ def test_add_page_uses_the_shared_endpoint():
     add_html = pathlib.Path("static/add.html").read_text(encoding="utf-8")
     assert "addWordViaAi(" in add_html
     assert "/api/add-word-ai" not in add_html
+
+
+# ---------------------------------------------------------------------------
+# ★ List: park a word in the Saved deck instead of a Daily deck (#677)
+# ---------------------------------------------------------------------------
+
+def _saved_deck_id():
+    return database.get_or_create_saved_deck()
+
+
+def test_list_generates_the_full_entry_but_parks_it_suspended(tmp_db):
+    """day='list' still pays for a complete de-zh-bot entry — the word is just
+    kept out of every review queue until promoted."""
+    result = _run_add_word("生态", day="list")
+    assert result["job"]["status"] == "done", result["job"]
+    assert result["deck_path"] == "Saved"
+
+    entry = database.get_word_by_zh("生态")
+    conn = database.get_db()
+    cards = conn.execute(
+        "SELECT deck_id, state, due FROM cards WHERE word_id=? AND deleted_at IS NULL",
+        (entry["id"],),
+    ).fetchall()
+    examples = conn.execute(
+        "SELECT COUNT(*) c FROM entry_examples WHERE word_id=?", (entry["id"],)
+    ).fetchone()["c"]
+    conn.close()
+
+    assert cards, "no cards were created"
+    assert {c["deck_id"] for c in cards} == {_saved_deck_id()}
+    # `due` is NOT NULL in the schema — state='suspended' is what keeps a card
+    # out of the queues, not its due date.
+    assert all(c["state"] == "suspended" for c in cards)
+    assert examples > 0, "list mode must still produce the full entry"
+
+
+def test_listed_word_is_invisible_to_the_review_queue(tmp_db):
+    """The whole point: a listed word must not turn up for review anywhere."""
+    _run_add_word("生态", day="list")
+    today_deck = database.get_or_create_deck_path(f"Daily::{date.today().isoformat()}")
+    for category in ("reading", "listening", "creating"):
+        r = client.get(f"/api/today/{today_deck}/{category}")
+        assert r.status_code == 200
+        assert r.json().get("card") is None
+
+
+def test_listing_a_studied_word_suspends_it_without_discarding_progress(tmp_db):
+    """Parking is not a reset: suspending already keeps the card out of every
+    queue, and promoting later resets it anyway (#677)."""
+    import importer
+
+    other_deck = database.get_or_create_deck_path("Kouyu::Test")
+    importer.import_yaml_content(ENTRY_YAML, other_deck)
+    entry_id = database.get_word_by_zh("生态")["id"]
+    conn = database.get_db()
+    conn.execute(
+        "UPDATE cards SET state='review', repetitions=3, stability=20.0 WHERE word_id=?",
+        (entry_id,),
+    )
+    conn.commit()
+    conn.close()
+
+    with patch.object(ai, "_call_api", side_effect=AssertionError("AI was called")):
+        body = client.post("/api/add-word-ai", json={"word_zh": "生态", "day": "list"}).json()
+
+    assert body["status"] == "listed"
+    assert body["reviews_discarded"] == 0
+    conn = database.get_db()
+    rows = conn.execute(
+        "SELECT deck_id, state, stability FROM cards WHERE word_id=? AND deleted_at IS NULL",
+        (entry_id,),
+    ).fetchall()
+    conn.close()
+    assert {r["deck_id"] for r in rows} == {_saved_deck_id()}
+    assert all(r["state"] == "suspended" for r in rows)
+    assert all(r["stability"] == 20.0 for r in rows), "parking must not wipe FSRS state"
+
+
+def test_listing_an_already_listed_word_is_reported_as_such(tmp_db):
+    r = client.post("/api/save-word", json={"word_zh": "生态", "pinyin": "shēngtài"})
+    assert r.json()["status"] == "saved"
+    with patch.object(ai, "_call_api", side_effect=AssertionError("AI was called")):
+        body = client.post("/api/add-word-ai", json={"word_zh": "生态", "day": "list"}).json()
+    assert body["status"] == "already_listed"
+
+
+def test_listed_word_can_be_promoted_into_a_daily_deck(tmp_db):
+    """Browse's '→ Add to Daily' button must work on words added via ★ List —
+    that round trip is the reason the feature exists."""
+    _run_add_word("生态", day="list")
+    entry_id = database.get_word_by_zh("生态")["id"]
+
+    r = client.post(f"/api/saved/{entry_id}/promote")
+    assert r.status_code == 200, r.text
+    tomorrow = (date.today() + timedelta(days=1)).isoformat()
+    assert r.json()["deck_path"] == f"Daily::{tomorrow}"
+
+    conn = database.get_db()
+    rows = conn.execute(
+        "SELECT deck_id, state, due FROM cards WHERE word_id=? AND deleted_at IS NULL",
+        (entry_id,),
+    ).fetchall()
+    conn.close()
+    assert {r["deck_id"] for r in rows} == set(_daily_leaf_decks(tomorrow).values())
+    assert all(r["state"] == "new" and r["due"] == tomorrow for r in rows)
+
+
+def test_invalid_day_still_rejected_and_list_accepted(tmp_db):
+    assert client.post("/api/add-word-ai",
+                       json={"word_zh": "生态", "day": "nextweek"}).status_code == 400


### PR DESCRIPTION
Closes #677

## 为什么

加词只能选今天或明天，加完立刻进复习队列。Daniel 想要第三个去处：把生词放进一个列表暂时不复习，之后在 Browse 里打开这个列表，再决定加进复习牌组。

两头的地基都已存在（`Saved` 牌组、Browse 的 saved 过滤器和 `→ Add to Daily` 按钮），缺的只是加词界面的第三个选项和「生成完整词条但停在 Saved」这条路径 —— 现有的 `/api/save-word` 只存词形，不生成内容。

## 改了什么

- **`POST /api/add-word-ai` 接受 `day="list"`**：照常花钱生成完整词条（例句、汉字分解、量词、同义反义词），导入后把三张卡搬进 `Saved` 并挂起。
- **导入仍走今天的 Daily 牌组再搬** —— 直接以 `Saved` 为父牌组导入会建出 `Saved::listening` 等叶子牌组，而 Browse 的 saved 过滤器认的是 `deck_name === "Saved"`。
- **`database.stage_word_in_saved()`** —— `promote_saved_word` 的逆操作。两个细节：
  - 挂起靠 `state` 不靠 `due`：`cards.due` 是 `NOT NULL DEFAULT date("now")`，写 NULL 直接违反约束（第一版就是这么挂的）。
  - **不清空 FSRS 字段**：挂起已经足以退出所有队列，真要激活时 `promote_saved_word` 会重置。所以 `reviews_discarded` 返回 0 —— 与 #675 的 `reset` 不同，停放不是破坏性操作。
- **`/add` 页面和 ＋ 弹窗各加一个 `★ List` 按钮**，逻辑共用 `shared.js`（只写一份）。`/add` 选中 List 时提示语也跟着换，说明它不会被复习。
- **Browse 的 saved 行只在词条没有释义时才显示 `✨ Generate`** —— ★ List 进来的词内容已齐全，再点就是白烧一次 API。

## 怎么测试的

新增 6 条测试：
- `day="list"` 生成的词条**内容齐全**（断言 `entry_examples` 非空），卡片在 `Saved` 且 `state=suspended`
- 该词在三个类别的复习队列里**都取不到**（这是功能的全部意义）
- 已学过的词选 List → 搬进 Saved 挂起，`stability` 原封不动、`reviews_discarded == 0`
- 已在列表里的词返回 `already_listed`，且**不调 AI**
- 从 Browse 走 `/api/saved/{id}/promote` 能正常提升为新卡、due 明天 —— 这个往返是功能存在的理由
- 非法 `day` 仍返回 400

`pytest tests/` 全套 **346 passed, 4 skipped**；`node --check` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)