### PR TITLE
手机顶栏改双行布局，＋ 按钮不再被挤出屏幕

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AnkiAdvanced</title>
-  <link rel="stylesheet" href="/static/style.css?v=14">
+  <link rel="stylesheet" href="/static/style.css?v=15">
 </head>
 <body>
 

--- a/static/style.css
+++ b/static/style.css
@@ -5328,3 +5328,54 @@ table.fsrs-table td.ivl { font-weight: 700; }
   font-size: 13px;
   color: var(--muted);
 }
+
+/* ── Phone header (#679) ─────────────────────────────────
+   The header is a 1fr/auto/1fr grid. During review the middle column carries
+   the counts, the retention/time badges and the Undo + Session buttons, which
+   on a ~390px screen is far wider than the viewport — so the whole header
+   overflowed and the action buttons (＋ above all) sat off-screen to the
+   right, reachable only by scrolling sideways. On phones the counts move to
+   their own second row instead, so title and buttons always stay visible. */
+@media (max-width: 560px) {
+  header {
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas:
+      "left  right"
+      "counts counts";
+    padding: 8px 12px;
+    row-gap: 6px;
+  }
+  .header-left  { grid-area: left; min-width: 0; }
+  .header-right { grid-area: right; }
+  .counts-row {
+    grid-area: counts;
+    /* Even one row of its own can overflow (per-category counts + badges +
+       two buttons) — let it scroll inside itself rather than widening the
+       page. justify-content:center would strand the left end when it does. */
+    justify-content: flex-start;
+    gap: 12px;
+    min-width: 0;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .counts-row::-webkit-scrollbar { display: none; }
+  .counts-row > * { flex: none; }
+  header h1 {
+    font-size: 16px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  /* Apple's minimum comfortable touch target is 44px; these were 32px-ish
+     circles/emoji sized for a mouse. */
+  #add-word-btn { width: 40px; height: 40px; font-size: 24px; margin-left: 2px; }
+  #random-words-btn,
+  #header-regen-btn,
+  #sync-btn {
+    min-width: 40px;
+    min-height: 40px;
+    font-size: 20px;
+    padding: 0;
+  }
+  #back-btn { min-width: 40px; min-height: 40px; font-size: 24px; }
+}


### PR DESCRIPTION
Closes #679

## 问题

手机上复习时必须往右滚动很远才能找到顶栏的 ＋ 按钮。

## 原因

`header` 是 `grid-template-columns: 1fr auto 1fr` 的三列网格。复习时中间列装着三个计数、按类别的计数（读/听/创）、留存率徽章、平均用时徽章、Undo、Session —— 在 390px 屏幕上远比视口宽，整个顶栏溢出，右列（⟳ / ＋ / 🎲 / ↺）被挤到屏幕外。

样式表里此前**没有任何针对顶栏的响应式规则** —— 唯一的 `max-width: 560px` 媒体查询只管加词弹窗。

## 改了什么

≤560px 时顶栏改成两行：

- 第一行：标题（超长省略号）+ 操作按钮，**始终可见**
- 第二行：计数独占整行，超宽时**在自己内部**横向滚动，不撑宽页面
- `justify-content` 从 `center` 改 `flex-start` —— 居中的话滚动时左端会够不到
- 操作按钮放大到 40px 触摸目标（原来是 32px 的鼠标尺寸；Apple 建议 44px）
- 媒体查询只作用于 ≤560px，**桌面端布局完全不变**

## 怎么测试的

用 Playwright 在 390×700 视口渲染复习态顶栏实测：

| | `document.scrollWidth` | 视口 | 结果 |
|---|---|---|---|
| 修复前 | **460px** | 390px | 多出 70px，必须横向滚动 |
| 修复后 | **390px** | 390px | 无横向滚动 |

修复后 ＋ 按钮的位置 `x: 290–330`，完整落在 390px 视口内。截图确认标题、＋、🎲 全部可见，计数在第二行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)