### PR TITLE
fix: YouTube 拒绝字幕请求时改用 NotebookLM，不再误报「没有字幕」（#681）

### DIFF
--- a/knowledge/youtube.py
+++ b/knowledge/youtube.py
@@ -3,6 +3,12 @@ existing podcast pipeline (podcast.summarize / _process_episode) can consume
 unchanged. No audio download, no Whisper — captions only; a video with no
 caption track at all falls to status='no_transcript' (see podcast.fetch_transcript).
 
+Issue #681: YouTube blocks cloud-provider IPs, so on the production VPS the
+caption API answers `RequestBlocked` for videos that do have captions. That
+case now falls back to NotebookLM (which fetches the video from Google's own
+network) and, failing that, raises CaptionsUnavailable — it must never be
+reported as "this video has no captions".
+
 `youtube-transcript-api` note (checked against 1.2.4, 2026-08): the library
 moved from classmethods to instance methods in 1.0 — `YouTubeTranscriptApi()`
 must be instantiated, then `.list(video_id)` / `.fetch(video_id, languages=)`
@@ -29,6 +35,41 @@ logger = logging.getLogger(__name__)
 _LANGUAGE_PRIORITY = ("zh-Hans", "zh-CN", "zh", "zh-TW", "de", "en")
 
 _OEMBED_URL = "https://www.youtube.com/oembed"
+
+
+class CaptionsUnavailable(Exception):
+    """YouTube refused to hand over the captions AND the NotebookLM fallback
+    couldn't stand in (issue #681). Deliberately an exception, not a
+    (None, meta) return: "YouTube blocked us" is a real error the episode must
+    surface as status='error' with a readable message, while (None, meta)
+    means the far more specific "this video genuinely has no caption track"
+    and lands on status='no_transcript'. Reporting the first as the second is
+    what made a video with a perfectly good Chinese caption track show up as
+    'no captions' on the server, with no way to tell the two apart."""
+
+
+class _CaptionsBlocked(Exception):
+    """Internal marker: the caption request was refused for a reason that has
+    nothing to do with whether captions exist (cloud-provider IP ban, PoToken
+    requirement, age gate, ...) — worth retrying through NotebookLM."""
+
+
+def _blocked_error_types() -> tuple:
+    """The youtube_transcript_api errors that mean "refused", not "absent".
+
+    All of these subclass CouldNotRetrieveTranscript, so they MUST be caught
+    before the base class or they get swallowed as "no captions" — that was
+    the bug. Resolved lazily and defensively (getattr): the library renames
+    error classes across releases, and a missing name here must not crash
+    ingestion."""
+    from youtube_transcript_api import _errors as e
+    names = ("RequestBlocked", "IpBlocked", "PoTokenRequired", "AgeRestricted",
+             "VideoUnplayable", "YouTubeRequestFailed", "YouTubeDataUnparsable")
+    return tuple(t for t in (getattr(e, n, None) for n in names) if t is not None)
+
+
+def _watch_url(video_id: str) -> str:
+    return f"https://www.youtube.com/watch?v={video_id}"
 
 
 def _http_get_json(url: str, timeout: int = 10) -> dict:
@@ -92,31 +133,24 @@ def fetch_metadata(video_id: str) -> dict:
     }
 
 
-def fetch_captions(video_id: str) -> tuple[str | None, dict]:
-    """Fetch a video's caption track and join it into continuous text,
-    signature-compatible with podcast.fetch_transcript's (text, meta) return.
-
-    Tries _LANGUAGE_PRIORITY in order, then falls back to whatever single
-    track exists (any language). Returns (None, meta) — not an exception —
-    when the video has no captions at all (disabled, unavailable, or no
-    track in any language); the caller stores status='no_transcript' for
-    that, same as an un-transcribable podcast episode. This function does
-    NOT fall back to downloading audio for Whisper (out of scope for #651).
-
-    A genuine transport/API error (not "no captions") is left to propagate —
-    the podcast pipeline's outer try/except stores it in episodes.error.
-    """
+def _fetch_captions_via_api(video_id: str) -> tuple[str | None, str | None]:
+    """The youtube-transcript-api half of fetch_captions: returns
+    (text_or_None, language_code). None means this video genuinely has no
+    usable caption track. Raises _CaptionsBlocked when YouTube refused the
+    request instead (see _blocked_error_types)."""
     from youtube_transcript_api import YouTubeTranscriptApi
     from youtube_transcript_api._errors import CouldNotRetrieveTranscript
 
-    meta: dict = {"transcript_source": "youtube_captions", "language_code": None}
+    blocked = _blocked_error_types()
     api = YouTubeTranscriptApi()
 
     try:
         transcript_list = api.list(video_id)
+    except blocked as e:
+        raise _CaptionsBlocked(f"{type(e).__name__}") from e
     except CouldNotRetrieveTranscript as e:
         logger.info("knowledge.youtube: no caption list for %s: %s", video_id, e)
-        return None, meta
+        return None, None
 
     transcript = None
     try:
@@ -131,25 +165,70 @@ def fetch_captions(video_id: str) -> tuple[str | None, dict]:
 
     if transcript is None:
         logger.info("knowledge.youtube: no transcript track at all for %s", video_id)
-        return None, meta
+        return None, None
 
     try:
         fetched = transcript.fetch()
+    except blocked as e:
+        raise _CaptionsBlocked(f"{type(e).__name__}") from e
     except CouldNotRetrieveTranscript as e:
         logger.warning("knowledge.youtube: fetch failed for %s (%s): %s",
                         video_id, transcript.language_code, e)
-        return None, meta
+        return None, None
 
     text = " ".join(s.text.strip() for s in fetched if (s.text or "").strip())
     if not text.strip():
+        return None, None
+    return text, transcript.language_code
+
+
+def fetch_captions(video_id: str) -> tuple[str | None, dict]:
+    """Fetch a video's caption text, signature-compatible with
+    podcast.fetch_transcript's (text, meta) return.
+
+    Two sources, in this order:
+      1. youtube-transcript-api — free and instant, and the only one that
+         works when the caller's IP isn't blocked (Daniel's laptop).
+      2. NotebookLM (#681) — used only when YouTube *refused* the request.
+         The production server runs on a Contabo VPS and YouTube blocks
+         cloud-provider IPs wholesale (`RequestBlocked`), so on the server
+         this is the normal path, not the exception. NotebookLM fetches the
+         video itself, from Google's own network, so our IP never matters.
+
+    Returns (None, meta) only for a video that genuinely has no caption
+    track — the caller stores status='no_transcript' for that. When YouTube
+    refuses AND NotebookLM can't stand in, raises CaptionsUnavailable so the
+    episode lands on status='error' with a message that says what actually
+    happened. This function does NOT download audio for Whisper (#651).
+    """
+    meta: dict = {"transcript_source": "youtube_captions", "language_code": None}
+
+    try:
+        text, language_code = _fetch_captions_via_api(video_id)
+    except _CaptionsBlocked as e:
+        logger.warning("knowledge.youtube: YouTube refused captions for %s (%s), "
+                       "trying NotebookLM", video_id, e)
+        # Local import: podcast.fetch_transcript dispatches into this module
+        # for kind='video', so podcast can't be imported at module load time.
+        import podcast
+        text = podcast.transcribe_url_via_notebooklm(_watch_url(video_id), video_id)
+        if not text or not text.strip():
+            raise CaptionsUnavailable(
+                f"YouTube refused the caption request ({e}) — the server's IP is "
+                f"likely blocked — and the NotebookLM fallback returned nothing"
+            ) from e
+        meta["transcript_source"] = "notebooklm"
+        return _normalize(text), meta
+
+    if text is None:
         return None, meta
 
-    # Reuse podcast's ASR cleanup (CJK-spacing collapse + Traditional ->
-    # Simplified) — a local import avoids a podcast <-> knowledge import
-    # cycle (podcast.fetch_transcript dispatches into this module for
-    # kind='video', so this module can't import podcast at module load time).
-    from podcast import _normalize_transcript
-    text = _normalize_transcript(text)
+    meta["language_code"] = language_code
+    return _normalize(text), meta
 
-    meta["language_code"] = transcript.language_code
-    return text, meta
+
+def _normalize(text: str) -> str:
+    """Reuse podcast's ASR cleanup (CJK-spacing collapse + Traditional ->
+    Simplified). Local import for the same import-cycle reason as above."""
+    from podcast import _normalize_transcript
+    return _normalize_transcript(text)

--- a/podcast.py
+++ b/podcast.py
@@ -463,6 +463,67 @@ async def _run_notebooklm_transcription(audio_path: str, video_id: str) -> str |
                 logger.warning("podcast: failed to delete NotebookLM source for %s: %s", video_id, e)
 
 
+async def _run_notebooklm_url_source(url: str, video_id: str) -> str | None:
+    """Same round-trip as _run_notebooklm_transcription, but the source is a
+    URL NotebookLM fetches itself instead of a file we upload. add_url()
+    detects YouTube links and adds them as video sources (notebooklm-py
+    _sources.py), so the captions come back through Google's own access to
+    YouTube — which is the entire point for #681."""
+    import notebooklm
+
+    async with notebooklm.NotebookLMClient.from_storage() as client:
+        notebook_id = await _get_or_create_notebooklm_notebook(client)
+        source = await client.sources.add_url(
+            notebook_id, url, wait=True, wait_timeout=_NOTEBOOKLM_INDEX_TIMEOUT,
+        )
+        try:
+            fulltext = await client.sources.get_fulltext(notebook_id, source.id)
+            return fulltext.content or None
+        finally:
+            # Same cleanup contract as the file-upload path: the notebook must
+            # not grow unbounded, and a delete failure must not mask a
+            # successful fetch.
+            try:
+                await client.sources.delete(notebook_id, source.id)
+            except Exception as e:
+                logger.warning("podcast: failed to delete NotebookLM source for %s: %s", video_id, e)
+
+
+def transcribe_url_via_notebooklm(url: str, video_id: str) -> str | None:
+    """Free transcript path for a URL NotebookLM can open itself (#681):
+    used as the YouTube-captions fallback when YouTube blocks our server's
+    (cloud provider) IP — see knowledge/youtube.py.
+
+    Failure contract is deliberately identical to _transcribe_via_notebooklm:
+    an unofficial, undocumented API that can break at any time logs and
+    returns None rather than raising. The *caller* decides what a None means
+    here — knowledge.youtube turns it into a hard error rather than a silent
+    'no captions', which is the whole bug #681 fixes.
+    """
+    try:
+        import notebooklm  # noqa: F401 (import-only availability check)
+    except ImportError:
+        logger.info("podcast: notebooklm-py not installed, skipping NotebookLM URL source for %s", video_id)
+        return None
+
+    try:
+        text = asyncio.run(asyncio.wait_for(
+            _run_notebooklm_url_source(url, video_id),
+            timeout=_NOTEBOOKLM_RUN_TIMEOUT,
+        ))
+    except FileNotFoundError:
+        # No credentials file — `notebooklm login` was never run here.
+        logger.info("podcast: NotebookLM not authenticated, skipping URL source for %s", video_id)
+        return None
+    except Exception as e:
+        logger.warning("podcast: NotebookLM URL source failed for %s: %s", video_id, e)
+        return None
+
+    if text:
+        logger.info("podcast: NotebookLM returned %d chars for %s", len(text), video_id)
+    return text
+
+
 def _normalize_transcript(text: str) -> str:
     """Clean up ASR output before storing/summarizing (#500). NotebookLM's
     speech recognition emits Traditional Chinese with a space between every

--- a/tests/test_knowledge_youtube.py
+++ b/tests/test_knowledge_youtube.py
@@ -4,8 +4,14 @@ parse_video_id is pure (no I/O). fetch_metadata and fetch_captions both make
 real network/API calls in production, so every test here stubs them out —
 CLAUDE.md is explicit that this suite must never actually reach YouTube.
 """
+import pytest
+
 import knowledge.youtube as ky
-from youtube_transcript_api._errors import CouldNotRetrieveTranscript
+from youtube_transcript_api._errors import (
+    CouldNotRetrieveTranscript,
+    RequestBlocked,
+    TranscriptsDisabled,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -193,6 +199,91 @@ def test_fetch_captions_fetch_failure_returns_none(monkeypatch):
 
     text, meta = ky.fetch_captions("vid4")
     assert text is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_captions — YouTube refusing the request (#681)
+# ---------------------------------------------------------------------------
+
+def _patch_notebooklm(monkeypatch, result):
+    """Stub podcast.transcribe_url_via_notebooklm; returns the list of
+    (url, video_id) calls it received so tests can assert it actually ran."""
+    import podcast
+    calls = []
+
+    def fake(url, video_id):
+        calls.append((url, video_id))
+        return result
+
+    monkeypatch.setattr(podcast, "transcribe_url_via_notebooklm", fake)
+    return calls
+
+
+def test_blocked_request_falls_back_to_notebooklm(monkeypatch):
+    """RequestBlocked (the production server's cloud IP being banned) must NOT
+    be reported as 'no captions' — it goes to NotebookLM instead."""
+    _patch_api(monkeypatch, _FakeApi(list_raises=RequestBlocked("vid6")))
+    calls = _patch_notebooklm(monkeypatch, "大家好 欢迎收听")
+
+    text, meta = ky.fetch_captions("vid6")
+    assert text == "大家好欢迎收听"  # normalized like every other transcript
+    assert meta["transcript_source"] == "notebooklm"
+    assert calls == [("https://www.youtube.com/watch?v=vid6", "vid6")]
+
+
+def test_blocked_during_fetch_also_falls_back(monkeypatch):
+    """The block can hit on the track fetch rather than the listing."""
+    transcripts = _FakeTranscriptList([
+        _FakeTranscript("zh-Hans", [], fetch_raises=RequestBlocked("vid7")),
+    ])
+    _patch_api(monkeypatch, _FakeApi(transcript_list=transcripts))
+    calls = _patch_notebooklm(monkeypatch, "内容")
+
+    text, meta = ky.fetch_captions("vid7")
+    assert text == "内容"
+    assert meta["transcript_source"] == "notebooklm"
+    assert len(calls) == 1
+
+
+def test_blocked_with_failing_fallback_raises(monkeypatch):
+    """Both sources failed: this is an error the episode must surface
+    (status='error'), never a silent 'no_transcript'."""
+    _patch_api(monkeypatch, _FakeApi(list_raises=RequestBlocked("vid8")))
+    _patch_notebooklm(monkeypatch, None)
+
+    with pytest.raises(ky.CaptionsUnavailable) as excinfo:
+        ky.fetch_captions("vid8")
+    assert "RequestBlocked" in str(excinfo.value)
+
+
+def test_blocked_with_blank_fallback_raises(monkeypatch):
+    """A whitespace-only NotebookLM result is no transcript at all."""
+    _patch_api(monkeypatch, _FakeApi(list_raises=RequestBlocked("vid9")))
+    _patch_notebooklm(monkeypatch, "   \n ")
+
+    with pytest.raises(ky.CaptionsUnavailable):
+        ky.fetch_captions("vid9")
+
+
+def test_missing_captions_never_calls_notebooklm(monkeypatch):
+    """A video that truly has no caption track stays a cheap 'no_transcript' —
+    it must not spend a ~minutes-long NotebookLM round on the way there."""
+    _patch_api(monkeypatch, _FakeApi(list_raises=TranscriptsDisabled("vid10")))
+    calls = _patch_notebooklm(monkeypatch, "should not be used")
+
+    text, _ = ky.fetch_captions("vid10")
+    assert text is None
+    assert calls == []
+
+
+def test_blocked_error_types_are_transcript_error_subclasses():
+    """Guards the exact bug: these all subclass CouldNotRetrieveTranscript, so
+    catching the base class first swallows them as 'no captions'. If a future
+    library version renames one, _blocked_error_types() drops it silently —
+    this asserts the ones we rely on are still resolvable."""
+    types = ky._blocked_error_types()
+    assert RequestBlocked in types
+    assert all(issubclass(t, CouldNotRetrieveTranscript) for t in types)
 
 
 def test_fetch_captions_joins_and_normalizes_chinese_text(monkeypatch):


### PR DESCRIPTION
Closes #681

## 问题

Daniel 加入的视频 `rvYRifKrS24` 明明有 9833 字的简体中文人工字幕轨，界面却说没有字幕。实测：

| 环境 | 结果 |
|---|---|
| Daniel 的笔记本 | ✅ `zh-Hans`，9833 字 |
| 生产服务器（Contabo VPS） | ❌ `RequestBlocked`（YouTube 封锁云服务商 IP） |

`knowledge/youtube.py` 捕获的是 `CouldNotRetrieveTranscript` **基类**，而 `RequestBlocked` 是它的子类 —— "YouTube 拒绝了我们" 被静默写成 `status='no_transcript'`。用户看到的信息与事实相反。

## 改了什么

1. **区分两类失败**。`_blocked_error_types()`（`RequestBlocked`/`IpBlocked`/`PoTokenRequired`/`AgeRestricted`/`VideoUnplayable`/…）**必须在基类之前捕获**，否则又被吞掉；这些是"拒绝"，不是"没有"。库改名时用 `getattr` 容错，不因缺一个类名就崩掉摄取。
2. **NotebookLM 兜底**（Daniel 的提议）。`podcast.transcribe_url_via_notebooklm()` 用 `sources.add_url()` —— notebooklm-py 会自动识别 YouTube 链接并作为视频源添加，由 Google 自己去取字幕，**完全绕开我们的出口 IP**。免费、不下音频、不用 ffmpeg。复用既有的 `_get_or_create_notebooklm_notebook` 和"用完删除源"的 finally 清理。服务器上凭据已就绪（播客链一直在用）。
3. **兜底也失败 → 抛 `CaptionsUnavailable`** → `_process_episode` 存 `status='error'` + 可读原因。再也不冒充 `no_transcript`。
4. **真没字幕的视频不受影响**：仍走原来的廉价路径直接 `no_transcript`，不浪费一轮几分钟的 NotebookLM。

顺序是 API 优先（笔记本上免费秒回）→ 被拒才用 NotebookLM（服务器上的常态路径）。

## 测试

`tests/test_knowledge_youtube.py` 新增 6 条（26 通过）：被拒→兜底成功、fetch 阶段被拒→兜底、兜底返回 None/空白→抛错、真没字幕→不调用 NotebookLM、以及一条守住"这些异常都是基类子类"的回归断言。全套 352 通过。

合并后我会在服务器上用 `rvYRifKrS24` 端到端验证一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)