### PR TITLE
独立的素材收藏页 /save：粘链接或文章正文，可存 iPhone 主屏

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,6 +370,7 @@ FSRS 用毕业评分播种初始 stability/difficulty：默认权重下 **Good �
 - **`knowledge/` 包，`ingest.py` 是唯一入库管线**：`ingest_url()` 判断 YouTube 链接走 `youtube.py`（oEmbed 拿标题 + `youtube-transcript-api` 拿字幕，语言优先级 zh-Hans→zh-CN→zh→zh-TW→de→en，找不到任何字幕轨直接 `no_transcript`，**不跑 Whisper**；**YouTube 封锁云服务商 IP，所以服务器上字幕 API 恒返回 `RequestBlocked`，实际走的是 NotebookLM 兜底**，见下条），否则当文章走 `article.py`（`trafilatura` 抽正文，不足 200 字视为失败并抛 `ArticleExtractionError`——付费墙/登录墙/JS 页面绝不能存进库冒充正文，见其 docstring）。界面「粘贴 URL」框（`POST /api/knowledge/add`）和邮件收件（`mailbox.py`）**共用这一个函数**——理由同 #643 加词单一入口：两条平行管线迟早会让修好的坑在另一条上复活
 - **邮件收件（`knowledge/mailbox.py`，#655）**：IMAP 轮询 UNSEEN 邮件，标题+正文都扫 URL（手机分享到邮件，链接位置因 App 而异）。`KNOWLEDGE_MAIL_ALLOWED_SENDERS` 未配置时**整个邮箱检查被跳过，不读取也不标已读**——这是防止任何知道邮箱地址的人远程触发付费 AI 调用的唯一防线；处理失败的邮件同样不标已读，留给下一轮重试（`ingest_url()` 对已入库 URL 幂等返回 `already_exists`，重试安全）
 - **前端：播客页 → 知识页**（#653，`static/app.js`）：🎙️/📺/📄 三个子标签，播客管理页原有的 RSS 源/详情/生词表格逻辑全部保留，只是按 `?kind=` 过滤。**旧的 `#podcast-<id>` hash 链接永久保留**——已发出去的邮件/Signal 消息里全是这种链接；播客条目仍生成旧格式 hash，只有视频/文章条目用新的 `#knowledge-<id>`
+- **独立收藏页 `/save`（#681）**：`/add` 的素材版 —— 可收藏的网址，🔗 Link / 📋 Text 两个标签，粘链接或粘正文，同样**不加载 `app.js`**（手机上从别的 App 分享文章时秒开）。入库逻辑抽到 `shared.js` 的 `ingestKnowledge()`，应用的知识页和本页共用一份；`knowledgeTitleFor()` 统一"标题留空则取首行"的规则。**两处都不许直接调 `/api/knowledge/add*`**，有测试守着
 - **`GET /api/podcast/episodes` 加 `?kind=` 过滤**，`POST /api/knowledge/add` 只负责入库，**不在请求里做转录/摘要**——前端拿到 `episode_id` 后照常调用既有的 `POST /api/podcast/episodes/{id}/process`，造卡侧（`routes/story.py` 的 `knowledge` 模式，见上）几乎零改动就能吃到播客以外的素材
 - **YouTube 字幕在服务器上必须走 NotebookLM（#681）**：YouTube 整片封锁云服务商 IP，Contabo 的服务器调字幕 API 永远得到 `RequestBlocked`。而 `RequestBlocked`/`IpBlocked`/`PoTokenRequired`/`AgeRestricted` **全是 `CouldNotRetrieveTranscript` 的子类** —— 原来只 `except` 基类，于是"被 YouTube 拒绝"被静默写成 `no_transcript`，一个有 9833 字中文字幕的视频在界面上显示"没有字幕"。现在拒绝类异常必须在基类**之前**捕获（`_blocked_error_types()`），先转 `podcast.transcribe_url_via_notebooklm()`（`sources.add_url()` 自动识别 YouTube 链接，由 Google 自己去取，绕开我们的出口 IP，免费、不下音频），兜底也空则抛 `CaptionsUnavailable` → `status='error'` + 可读原因。**真没字幕的视频不进兜底**，仍走廉价的 `no_transcript`，不浪费几分钟的 NotebookLM 轮次
   - **代价**：NotebookLM 不能指定字幕语言，返回的是视频原声轨（那条视频拿回来的是英文 32633 字，不是本地能拿到的中文翻译轨 9833 字）。摘要提示词本来就容忍任意输入语言，所以功能通；要中文轨只能给字幕 API 配付费代理（`WebshareProxyConfig`），暂不做
@@ -444,6 +445,7 @@ GET  /api/costs/call/{id}                            → {prompt, response}（�
 # 其他
 POST /api/import                                     → 触发 YAML 导入
 GET  /add                                            → 独立加词页（#668，可收藏/存主屏；不加载 app.js）
+GET  /save                                           → 独立素材收藏页（#681，Link/Text 两个标签；同样不加载 app.js）
 POST /api/add-word-ai                                → 界面内添加生词（#627）；body {word_zh, day?:today|tomorrow|list}（#636、#677）；新词返回 {job_id}，已有词直接返回 {status}。**全应用唯一的加词入口**（#643）：顶栏 ＋、播客生词表格、复习界面长按菜单都走它
 GET  /api/add-word-ai/progress/{job_id}              → 轮询后台生成+导入的结果
 GET  /api/browse                                     → {deck_id?, category?, state?, q?, lang?}

--- a/main.py
+++ b/main.py
@@ -436,6 +436,16 @@ try:
             "Expires": "0",
         })
 
+    # Standalone knowledge-base page (#681): the /add counterpart for material —
+    # paste a link or an article body from the phone without loading the app.
+    @app.get("/save")
+    def save_material_page():
+        return FileResponse("static/save.html", headers={
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            "Pragma": "no-cache",
+            "Expires": "0",
+        })
+
     # Running-version info (issue #450): read the current commit once at
     # startup — deploy.sh restarts the process on every deploy, so process
     # start time ≈ deploy time. Never fails: without git (or outside a

--- a/static/add.html
+++ b/static/add.html
@@ -83,7 +83,7 @@
   <ul id="queue"></ul>
 </main>
 
-<script src="/static/shared.js?v=1"></script>
+<script src="/static/shared.js?v=2"></script>
 <script>
   // Standalone quick-add page (#668). Deliberately does NOT load app.js: the
   // point is a link that opens instantly on the phone. All the real work goes

--- a/static/app.js
+++ b/static/app.js
@@ -3301,7 +3301,7 @@ async function submitKnowledgeUrl() {
   const url = (input?.value || '').trim();
   if (!url) return;
   if (input) { input.value = ''; input.focus(); }
-  await _submitKnowledgeAdd(() => api('POST', '/api/knowledge/add', { url }), msg);
+  await _submitKnowledgeAdd({ url }, msg);
 }
 
 // Paste-text box (article tab only, #668) — for paywalled pieces the server
@@ -3313,28 +3313,24 @@ async function submitKnowledgeText() {
   const msg = document.getElementById('knowledge-add-msg');
   const text = (textInput?.value || '').trim();
   if (!text) return;
-  let title = (titleInput?.value || '').trim();
-  if (!title) title = text.split('\n').map(l => l.trim()).find(l => l) || '';
+  const title = knowledgeTitleFor(titleInput?.value, text);
   if (!title) {
     if (msg) msg.textContent = 'Need a title (or a non-blank first line).';
     return;
   }
   if (titleInput) titleInput.value = '';
   if (textInput) { textInput.value = ''; textInput.focus(); }
-  await _submitKnowledgeAdd(() => api('POST', '/api/knowledge/add-text', { title, text }), msg);
+  await _submitKnowledgeAdd({ title, text }, msg);
 }
 
-// Shared tail end of both paste boxes: kick off processing for a freshly
-// ingested item, then refresh the currently-shown list if we're still on it.
-async function _submitKnowledgeAdd(doAdd, msg) {
+// Shared tail end of both paste boxes: ingest (shared.js kicks off processing),
+// then refresh the currently-shown list if we're still on it.
+async function _submitKnowledgeAdd(payload, msg) {
   if (msg) msg.textContent = 'Adding…';
   try {
-    const res = await doAdd();
-    const id = res?.episode_id;
+    const res = await ingestKnowledge(payload);
     if (res?.status === 'already_exists') {
       if (msg) msg.textContent = 'Already in your library.';
-    } else if (id != null) {
-      api('POST', `/api/podcast/episodes/${id}/process`).catch(() => {});
     }
     if (_knowledgeListKind === _knowledgeTab) {
       const episodes = await api('GET', `/api/podcast/episodes?kind=${_knowledgeTab}&limit=1000`);

--- a/static/index.html
+++ b/static/index.html
@@ -662,8 +662,8 @@
 </div>
 
 <div id="word-tip" style="display:none"></div>
-<script src="/static/shared.js?v=1"></script>
-<script src="/static/app.js?v=16"></script>
+<script src="/static/shared.js?v=2"></script>
+<script src="/static/app.js?v=17"></script>
 
 <!-- Edit card modal -->
 <div id="edit-modal-overlay" onclick="closeEditCard()" style="display:none"></div>

--- a/static/save.html
+++ b/static/save.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Save material</title>
+<!-- Saved to the iPhone home screen this opens without Safari's chrome (#681). -->
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-title" content="Save">
+<meta name="theme-color" content="#6366f1">
+<style>
+  :root { color-scheme: light dark; --bg:#f4f5f7; --card:#fff; --fg:#1c1e21; --muted:#6b7075;
+          --line:#d7d9dd; --accent:#6366f1; --ok:#1f7a44; --err:#a3232b;
+          --ok-bg:#e6f4ec; --err-bg:#fdecee; }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg:#16181c; --card:#232629; --fg:#e6e6e6; --muted:#9aa0a6;
+            --line:#3a3d42; --ok:#6ed49b; --err:#ff9ba1;
+            --ok-bg:#1d3328; --err-bg:#3a2326; }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh; padding: 1.5rem 1rem calc(1.5rem + env(safe-area-inset-bottom));
+    font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: var(--bg); color: var(--fg);
+  }
+  main { max-width: 480px; margin: 0 auto; }
+  header { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 1.25rem; }
+  h1 { margin: 0; font-size: 1.15rem; }
+  header a { color: var(--muted); font-size: .85rem; text-decoration: none; }
+  .card { padding: 1rem; border-radius: 14px; background: var(--card); }
+  .tabs { display: flex; gap: .4rem; margin-bottom: .9rem; }
+  .tabs button {
+    flex: 1; padding: .55rem; font-size: .95rem; color: var(--muted);
+    background: transparent; border: 1px solid var(--line); border-radius: 8px; cursor: pointer;
+  }
+  .tabs button[aria-pressed=true] { color: #fff; background: var(--accent); border-color: var(--accent); }
+  input[type=text], textarea {
+    display: block; width: 100%; padding: .75rem;
+    /* iOS zooms the page in when a focused field is under 16px */
+    font: inherit; font-size: 1rem; color: inherit;
+    border: 1px solid var(--line); border-radius: 10px; background: var(--bg);
+  }
+  input[type=text]:focus, textarea:focus { outline: 2px solid var(--accent); outline-offset: -1px; border-color: var(--accent); }
+  textarea { min-height: 9rem; resize: vertical; margin-top: .5rem; }
+  button.go {
+    width: 100%; padding: .8rem; margin-top: .6rem;
+    font-size: 1.05rem; font-weight: 600;
+    color: #fff; background: var(--accent); border: 0; border-radius: 10px; cursor: pointer;
+  }
+  button.go:active { filter: brightness(.92); }
+  ul { list-style: none; margin: 1rem 0 0; padding: 0; }
+  li {
+    padding: .6rem .8rem; margin-bottom: .4rem; border-radius: 10px;
+    background: var(--card); font-size: .9rem;
+  }
+  li .what { display: block; font-weight: 600; overflow-wrap: anywhere; }
+  li .msg { color: var(--muted); overflow-wrap: anywhere; }
+  li.done { background: var(--ok-bg); } li.done .msg { color: var(--ok); }
+  li.error { background: var(--err-bg); } li.error .msg { color: var(--err); }
+  .hint { margin: .8rem 0 0; font-size: .8rem; color: var(--muted); }
+</style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>Save material</h1>
+    <a href="/">← app</a>
+  </header>
+
+  <div class="card">
+    <div class="tabs">
+      <button id="tab-link" aria-pressed="true">🔗 Link</button>
+      <button id="tab-text" aria-pressed="false">📋 Text</button>
+    </div>
+
+    <div id="pane-link">
+      <input type="text" id="url" placeholder="Paste an article or YouTube link…"
+             inputmode="url" autocomplete="off" autocapitalize="none"
+             autocorrect="off" spellcheck="false" enterkeyhint="done" autofocus>
+      <button class="go" id="go-link">Add</button>
+    </div>
+
+    <div id="pane-text" style="display:none">
+      <input type="text" id="title" placeholder="Title (optional — first line is used)" autocomplete="off">
+      <textarea id="text" placeholder="Paste the article body…"></textarea>
+      <button class="go" id="go-text">Add</button>
+    </div>
+
+    <p class="hint" id="hint">Transcription and the Chinese + German summary run on the
+      server — you can close this page, it keeps going.</p>
+  </div>
+
+  <ul id="queue"></ul>
+</main>
+
+<script src="/static/shared.js?v=2"></script>
+<script>
+  // Standalone knowledge-base page (#681), the /add counterpart for material.
+  // Deliberately does NOT load app.js — the point is a link that opens
+  // instantly on the phone when sharing an article from another app. All the
+  // real work goes through ingestKnowledge() in shared.js, so this page and
+  // the app's Knowledge tab can never drift apart.
+  const items = [];   // newest first
+  const queue = document.getElementById('queue');
+  const url = document.getElementById('url');
+  const title = document.getElementById('title');
+  const text = document.getElementById('text');
+
+  for (const t of ['link', 'text']) {
+    document.getElementById(`tab-${t}`).onclick = () => {
+      for (const other of ['link', 'text']) {
+        document.getElementById(`tab-${other}`).setAttribute('aria-pressed', String(other === t));
+        document.getElementById(`pane-${other}`).style.display = other === t ? '' : 'none';
+      }
+      (t === 'link' ? url : text).focus();
+    };
+  }
+
+  function render() {
+    queue.replaceChildren(...items.map(it => {
+      const li = document.createElement('li');
+      li.className = it.state;
+      const w = document.createElement('span');
+      w.className = 'what';
+      w.textContent = it.what;
+      const m = document.createElement('span');
+      m.className = 'msg';
+      m.textContent = it.text;
+      li.append(w, m);
+      return li;
+    }));
+  }
+
+  async function submit(payload, what) {
+    // Clear immediately — the next link can be pasted while this one runs.
+    const item = { what, state: 'running', text: 'Adding…' };
+    items.unshift(item);
+    render();
+    try {
+      const res = await ingestKnowledge(payload);
+      item.state = 'done';
+      item.text = res?.status === 'already_exists'
+        ? 'Already in your library.'
+        : '✓ added — processing on the server';
+    } catch (e) {
+      // Paywalled/JS-only pages fail extraction on purpose rather than storing
+      // a stub; the Text tab is the way out, so point at it.
+      item.state = 'error';
+      item.text = (e.message || 'Failed') + ' — try the 📋 Text tab.';
+    }
+    render();
+  }
+
+  document.getElementById('go-link').onclick = () => {
+    const v = url.value.trim();
+    if (!v) return;
+    url.value = '';
+    url.focus();
+    submit({ url: v }, v);
+  };
+  url.addEventListener('keydown', e => {
+    if (e.key === 'Enter') document.getElementById('go-link').click();
+  });
+
+  document.getElementById('go-text').onclick = () => {
+    const body = text.value.trim();
+    if (!body) return;
+    const t = knowledgeTitleFor(title.value, body);
+    if (!t) return;
+    title.value = '';
+    text.value = '';
+    text.focus();
+    submit({ title: t, text: body }, t);
+  };
+</script>
+</body>
+</html>

--- a/static/shared.js
+++ b/static/shared.js
@@ -90,3 +90,29 @@ async function addWordViaAi(wordZh, day, onUpdate) {
   };
   setTimeout(poll, 1500);
 }
+
+// Knowledge-base ingestion, shared by the app's Knowledge tab and the
+// standalone /save page (#681). Same reasoning as addWordViaAi above: one
+// client-side path, so a fix lands in both places at once.
+//
+// payload is either {url} or {title, text}. Returns the server's response
+// ({episode_id} or {status:'already_exists', episode_id}) and, for anything
+// newly ingested, kicks off transcription/summarising in the background —
+// POST /api/knowledge/add deliberately only stores the row.
+async function ingestKnowledge(payload) {
+  const path = payload.url ? '/api/knowledge/add' : '/api/knowledge/add-text';
+  const res = await api('POST', path, payload);
+  if (res?.status !== 'already_exists' && res?.episode_id != null) {
+    api('POST', `/api/podcast/episodes/${res.episode_id}/process`).catch(() => {});
+  }
+  return res;
+}
+
+// Title for a pasted body: the caller's own title, else the first non-blank
+// line. Returns '' when neither exists — the server requires a title, and
+// submitting an empty one just produces an untitled row.
+function knowledgeTitleFor(title, text) {
+  title = (title || '').trim();
+  if (title) return title;
+  return (text || '').split('\n').map(l => l.trim()).find(l => l) || '';
+}

--- a/tests/test_knowledge_ingest_text.py
+++ b/tests/test_knowledge_ingest_text.py
@@ -179,3 +179,34 @@ def test_add_text_endpoint_accepts_optional_source_url(client):
     assert resp.status_code == 200
     episode = database.get_episode(resp.json()["episode_id"])
     assert episode["youtube_url"] == "https://example.com/x"
+
+
+# ---------------------------------------------------------------------------
+# Standalone /save page (#681)
+# ---------------------------------------------------------------------------
+
+def test_save_page_is_served_without_the_app_bundle():
+    """Like /add (#668): the point is opening instantly on the phone when
+    sharing an article, so it must not pull in the ~9000-line app.js."""
+    from fastapi.testclient import TestClient
+    import main
+    body = TestClient(main.app).get("/save").text
+    assert 'id="url"' in body and 'id="text"' in body
+    assert "/static/shared.js" in body
+    assert "/static/app.js" not in body
+
+
+def test_knowledge_ingest_is_not_duplicated_in_app_js():
+    """One client-side ingestion path shared by the app and /save — a second
+    copy would drift and every fix would have to be made twice."""
+    import pathlib
+    app_js = pathlib.Path("static/app.js").read_text(encoding="utf-8")
+    shared_js = pathlib.Path("static/shared.js").read_text(encoding="utf-8")
+    save_html = pathlib.Path("static/save.html").read_text(encoding="utf-8")
+
+    assert "async function ingestKnowledge(" in shared_js
+    assert "async function ingestKnowledge(" not in app_js
+    # Neither caller may talk to the endpoints directly.
+    for source in (app_js, save_html):
+        assert "/api/knowledge/add" not in source
+        assert "ingestKnowledge(" in source


### PR DESCRIPTION
Closes #684

## 为什么

知识库的「粘贴链接 / 粘贴正文」此前只在应用内的知识页里，必须先加载整个应用（`app.js` 约 491 KB）。Daniel 想要一个和 `/add`（#669）同样的独立网址，尤其是用来粘**文章正文或链接**的 —— 手机上从别的 App 分享文章时秒开。

## 改了什么

- **`GET /save` → `static/save.html`**：自包含轻量页面，🔗 Link / 📋 Text 两个标签 + 结果队列，深色模式适配，带 `apple-mobile-web-app-capable`（存主屏后无 Safari 界面）。**不加载 `app.js`**。
- **入库逻辑不复制第二份**：`ingestKnowledge()`（POST `add`/`add-text`，再触发 `.../process`）和 `knowledgeTitleFor()`（标题留空取首行）抽到 `static/shared.js`，应用的知识页改为调用同一份。理由同 #643 / #668 —— 两条平行管线迟早让修好的坑在另一条上复活。
- **链接抽取失败时的提示指向 📋 Text 标签**：付费墙/JS 页面会抛 `ArticleExtractionError`（`article.py` 故意不存半截正文），Text 标签正是这种情况的出路。

## 怎么测试的

- 新增 2 条测试：`/save` 正常提供且不引用 `app.js`；`ingestKnowledge` 只在 `shared.js` 里定义，且 `app.js` 和 `save.html` **都不直接调** `/api/knowledge/add*`。
- **Playwright 实机走了一遍**（390×780 视口）：切到 Text 标签 → 填标题和正文 → 点 Add → 队列显示 `✓ added — processing on the server`，页面无 JS 错误，无横向溢出（390 = 390）。再查 `GET /api/podcast/episodes?kind=article` 确认条目真的进了库（`1 | 德国新能源政策 | article | pending`）—— 界面报成功而库里没有，正是这个项目踩过的坑。
- `pytest tests/` 全套 **354 passed, 4 skipped**；`node --check` 通过。

## 上线后

打开 `https://powerdaniel3000.duckdns.org/save` → Safari 分享按钮 → 添加到主屏幕。

🤖 Generated with [Claude Code](https://claude.com/claude-code)