### PR TITLE
/add 支持 URL 参数：?word=生态&day=list，打开即自动加词

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,7 @@ bash sync_offline.sh push    # 只推不拉，推完归档本地库
   - Browse 的 saved 行只在词条**没有释义**时才显示 "✨ Generate"，★ List 进来的词内容已齐全，再生成纯烧钱
 - **今天/明天可选**（#636）：`day` 参数同时决定 Daily 牌组、`promote_saved_word` 的 due 和 `importer.import_yaml_content(due_offset_days=)`。**牌组和 due 必须一起后移** —— 未来日期的 Daily 牌组被 `parse_daily_deck_date` 锁住不可复习，卡片若还 due 今天就永远够不到
 - **不阻塞连续输入**（#636）：提交后立刻清空输入框，每个词进弹窗里的队列各自轮询自己的 job
-- **独立加词页 `/add`（#668）**：可收藏的网址，打开就是输入框（存 iPhone 主屏当图标用）。`static/add.html` 是自包含页面，**故意不加载 `app.js`** —— 5.5 KB vs 完整应用的 77 KB + 491 KB JS，秒开就是这个功能的全部意义。为此把 `addWordViaAi()` 和 `api()` 从 `app.js` 抽到 `static/shared.js` 两页共用，**不复制第二份**（理由同下条；`tests/test_add_word.py` 有一条测试专门守着 `app.js` 里不能再出现这两个定义）
+- **独立加词页 `/add`（#668）+ URL 参数（#686）**：可收藏的网址，打开就是输入框（存 iPhone 主屏当图标用）。`?word=生态`（或 `?w=`）+ 可选 `&day=today|tomorrow|list` → 打开即自动提交，供 iOS 快捷指令在任意 App 里一键加词；`day` 非法值回落 today（词才是重点，不该为此失败）。**提交后必须 `history.replaceState` 抹掉参数** —— 否则刷新或 iOS 恢复标签页会静默再花一次 AI 钱。`static/add.html` 是自包含页面，**故意不加载 `app.js`** —— 5.5 KB vs 完整应用的 77 KB + 491 KB JS，秒开就是这个功能的全部意义。为此把 `addWordViaAi()` 和 `api()` 从 `app.js` 抽到 `static/shared.js` 两页共用，**不复制第二份**（理由同下条；`tests/test_add_word.py` 有一条测试专门守着 `app.js` 里不能再出现这两个定义）
 - **`/api/add-word-ai` 是全应用唯一的加词入口**（#643）：顶栏 ＋、播客单集的 HSK 生词表格、复习界面长按词的菜单、以及 `/add` 页面，全部共用 `shared.js` 的 `addWordViaAi()`。原来播客/长按走的 `/api/quick-add-word` 已删除 —— 它只让 AI 填四个字段（无例句/汉字分解/量词/同义反义词），而且 `added_to_deck` 分支在词已学过时被 `INSERT OR IGNORE` + `UNIQUE(word_id, category)` 全部静默丢弃，却照样返回成功。**加词只能有一条管线**，否则修好的坑会在第二条路上重新出现
 
 - **YAML 格式完整文档：** `docs/yaml-format.md`（中文格式：词性/例句/词源/汉字分解；法语格式：`lang: fr` + `type: word|sentence`，经 `importer._normalize_fr_entry` 适配后复用全部下游逻辑）
@@ -444,7 +444,7 @@ GET  /api/costs/call/{id}                            → {prompt, response}（�
 
 # 其他
 POST /api/import                                     → 触发 YAML 导入
-GET  /add                                            → 独立加词页（#668，可收藏/存主屏；不加载 app.js）
+GET  /add[?word=生态&day=today|tomorrow|list]         → 独立加词页（#668，可收藏/存主屏；不加载 app.js）；带 word 参数时打开即自动提交（#686，供 iOS 快捷指令用），提交后从地址栏抹掉该参数以免刷新重复扣费
 GET  /save                                           → 独立素材收藏页（#681，Link/Text 两个标签；同样不加载 app.js）
 POST /api/add-word-ai                                → 界面内添加生词（#627）；body {word_zh, day?:today|tomorrow|list}（#636、#677）；新词返回 {job_id}，已有词直接返回 {status}。**全应用唯一的加词入口**（#643）：顶栏 ＋、播客生词表格、复习界面长按菜单都走它
 GET  /api/add-word-ai/progress/{job_id}              → 轮询后台生成+导入的结果

--- a/static/add.html
+++ b/static/add.html
@@ -101,15 +101,16 @@
     // stay suspended until promoted from Browse (#677).
     list: 'Parked in your Saved list — not reviewed until you add it to a deck from Browse.',
   };
+  function selectDay(d) {
+    if (!DAYS.includes(d)) return;
+    day = d;
+    for (const other of DAYS) {
+      document.getElementById(`day-${other}`).setAttribute('aria-pressed', String(other === d));
+    }
+    document.getElementById('hint').textContent = HINTS[d];
+  }
   for (const d of DAYS) {
-    document.getElementById(`day-${d}`).onclick = () => {
-      day = d;
-      for (const other of DAYS) {
-        document.getElementById(`day-${other}`).setAttribute('aria-pressed', String(other === d));
-      }
-      document.getElementById('hint').textContent = HINTS[d];
-      input.focus();
-    };
+    document.getElementById(`day-${d}`).onclick = () => { selectDay(d); input.focus(); };
   }
 
   function render() {
@@ -148,6 +149,24 @@
 
   document.getElementById('go').onclick = submit;
   input.addEventListener('keydown', e => { if (e.key === 'Enter') submit(); });
+
+  // URL parameters (#686) — /add?word=生态&day=list — so an iOS Shortcut can
+  // add a word straight from any app. `day` is optional and defaults to today;
+  // an unknown value falls back to today rather than failing, since the word
+  // is the part that matters.
+  //
+  // Opening such a link submits immediately and therefore spends an AI call.
+  // That is the whole point of the parameter, but it also means the word is
+  // stripped from the address bar afterwards (history.replaceState): a reload
+  // or a "restore tabs" on the phone would otherwise silently add it again.
+  const params = new URLSearchParams(location.search);
+  const preset = (params.get('word') || params.get('w') || '').trim();
+  selectDay((params.get('day') || 'today').trim());
+  if (preset) {
+    input.value = preset;
+    history.replaceState(null, '', location.pathname);
+    submit();
+  }
 </script>
 </body>
 </html>

--- a/tests/test_add_word.py
+++ b/tests/test_add_word.py
@@ -453,3 +453,17 @@ def test_listed_word_can_be_promoted_into_a_daily_deck(tmp_db):
 def test_invalid_day_still_rejected_and_list_accepted(tmp_db):
     assert client.post("/api/add-word-ai",
                        json={"word_zh": "生态", "day": "nextweek"}).status_code == 400
+
+
+def test_add_page_reads_word_and_day_from_the_url(tmp_db):
+    """/add?word=生态&day=list (#686) — an iOS Shortcut can add a word from any
+    app. Asserted on the page source because the behaviour lives in the page's
+    own script; the browser round trip is covered manually."""
+    import pathlib
+    src = pathlib.Path("static/add.html").read_text(encoding="utf-8")
+    assert "URLSearchParams" in src
+    assert "params.get('word')" in src and "params.get('w')" in src
+    assert "params.get('day')" in src
+    # The word must be stripped from the URL after submitting, or a reload
+    # (or iOS restoring tabs) silently spends another AI call on it.
+    assert "history.replaceState" in src


### PR DESCRIPTION
Closes #686

## 为什么

`/add` 此前必须手动输入。加上参数后，iOS 快捷指令可以在任意 App 里选中一个词就一键加进牌组。

## 用法

```
https://powerdaniel3000.duckdns.org/add?word=生态
https://powerdaniel3000.duckdns.org/add?word=环境&day=list
https://powerdaniel3000.duckdns.org/add?w=经济&day=tomorrow
```

- `word`（也接受简写 `w`）有值时**打开即自动提交**
- `day` 可选：`today`（默认）| `tomorrow` | `list`；非法值回落 `today` —— 词才是重点，不该为一个拼错的 day 整个失败
- 用查询参数而非路径拼接：中文词在路径里要转义，查询参数是标准做法

## 一个必须处理的坑

自动提交意味着**打开链接就花一次 AI 钱**。这正是参数的意义，但也意味着刷新页面、或 iOS 恢复标签页时会**静默再花一次**。所以提交后立刻 `history.replaceState` 把参数从地址栏抹掉。

## 怎么测试的

**Playwright 实机跑了五种情况**（拦截 `POST /api/add-word-ai` 以核对真实请求体，同时避免真的调用 AI）：

| 链接 | 发送的请求体 | 按钮高亮 | 地址栏 |
|---|---|---|---|
| `?word=生态` | `{word_zh:"生态", day:"today"}` | today | 已清空 |
| `?word=环境&day=list` | `{word_zh:"环境", day:"list"}` | list | 已清空 |
| `?w=经济&day=tomorrow` | `{word_zh:"经济", day:"tomorrow"}` | tomorrow | 已清空 |
| `?word=社会&day=nonsense` | `{word_zh:"社会", day:"today"}` | today | 已清空 |
| 无参数 | **未提交**（正确） | today | — |

全程无 JS 错误。另加一条静态测试守住这个契约（尤其是 `history.replaceState` 不能被后人删掉）。`pytest tests/` 全套 **355 passed, 4 skipped**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)