### PR TITLE
修复：遗留清理代码删除新加的视频（#688）

### DIFF
--- a/database/core.py
+++ b/database/core.py
@@ -654,23 +654,44 @@ def init_db() -> None:
             conn.execute("ALTER TABLE podcast_episodes ADD COLUMN title_en TEXT")
         conn.commit()
 
-        # Purge stale legacy YouTube rows (#497): yt-dlp is retired, so any
-        # row that never got a transcript is now permanently stuck (it can
-        # never be retried successfully) and would just keep eating the
-        # auto-retry pass's budget forever. YouTube video ids are always
-        # exactly 11 chars of [A-Za-z0-9_-]; RSS guids never match that
-        # (ximalaya uses "xmly_track_<digits>", fireside uses UUIDs) so this
-        # is a safe, precise filter. Summarized rows are always kept — they
-        # have a real transcript worth preserving even though the source is
-        # dead. These episodes will re-enter cleanly via the new RSS feeds.
+
+    # Purge stale legacy YouTube rows (#497): yt-dlp is retired, so any row
+    # that never got a transcript is now permanently stuck (it can never be
+    # retried successfully) and would just keep eating the auto-retry pass's
+    # budget forever. YouTube video ids are always exactly 11 chars of
+    # [A-Za-z0-9_-]; RSS guids never match that (ximalaya uses
+    # "xmly_track_<digits>", fireside uses UUIDs) so this is a safe, precise
+    # filter. Summarized rows are always kept — they have a real transcript
+    # worth preserving even though the source is dead. These episodes will
+    # re-enter cleanly via the new RSS feeds.
+    #
+    # TWO guards, both added in #688 after this deleted Daniel's freshly added
+    # videos: the knowledge base (#651) writes the very same 11-char YouTube
+    # video_id, so every newly ingested video sat in this filter's crosshairs
+    # until it reached 'summarized' — and since NotebookLM transcription takes
+    # minutes while production redeploys (and thus restarts, and thus re-runs
+    # init_db) every 2 minutes, they were reliably deleted mid-processing.
+    #   1. kind = 'podcast' — the legacy rows all predate the kind column and
+    #      carry its 'podcast' default; video/article rows are never touched.
+    #   2. a one-shot marker — a data-destroying cleanup has no business
+    #      running on every single startup forever.
+    # Deliberately outside the "podcast_episodes existed before" migration
+    # block above: a brand-new database must set the marker too, so the
+    # cleanup can never fire on rows created later in its life.
+    already_purged = conn.execute(
+        "SELECT value FROM app_settings WHERE key = 'purged_legacy_youtube_rows'"
+    ).fetchone()
+    if not already_purged:
         stale = conn.execute(
-            "SELECT id, video_id FROM podcast_episodes WHERE status != 'summarized'"
+            "SELECT id, video_id FROM podcast_episodes WHERE status != 'summarized' AND kind = 'podcast'"
         ).fetchall()
         stale_ids = [r["id"] for r in stale if re.fullmatch(r"[A-Za-z0-9_-]{11}", r["video_id"] or "")]
         if stale_ids:
             conn.executemany(
                 "DELETE FROM podcast_episodes WHERE id = ?", [(i,) for i in stale_ids])
-            conn.commit()
+        conn.execute(
+            "INSERT OR REPLACE INTO app_settings (key, value) VALUES ('purged_legacy_youtube_rows', '1')")
+        conn.commit()
 
     # One-time transcript normalization (#500): NotebookLM ASR output stored
     # before the fix is Traditional Chinese with per-character spacing —

--- a/tests/test_legacy_purge.py
+++ b/tests/test_legacy_purge.py
@@ -1,0 +1,89 @@
+"""Regression tests for the #497 legacy-YouTube-row purge in database.core
+(issue #688).
+
+That purge deletes podcast_episodes rows whose video_id looks like a YouTube
+id (11 chars) and which never reached 'summarized'. The knowledge base (#651)
+stores exactly that video_id shape for every video it ingests, and init_db()
+runs on every startup — so freshly added videos were deleted mid-processing,
+every couple of minutes, on the production server. These tests pin down both
+guards: kind-scoping and the one-shot marker.
+"""
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    """A fresh initialized database at a throwaway path."""
+    import database.core
+
+    monkeypatch.setattr(database.core, "DB_PATH", str(tmp_path / "purge.db"))
+    database.core.init_db()
+    return database.core
+
+
+def _insert(db, *, video_id, kind, status):
+    conn = db.get_db()
+    conn.execute(
+        """INSERT INTO podcast_episodes (video_id, title, youtube_url, status, kind)
+           VALUES (?, ?, ?, ?, ?)""",
+        (video_id, "T", f"https://example.com/{video_id}", status, kind),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _video_ids(db):
+    conn = db.get_db()
+    ids = {r["video_id"] for r in conn.execute("SELECT video_id FROM podcast_episodes")}
+    conn.close()
+    return ids
+
+
+def test_pending_video_survives_restart(db):
+    """The actual #688 bug: a knowledge-base video still being transcribed
+    must not be deleted by the next init_db()."""
+    _insert(db, video_id="dQw4w9WgXcQ", kind="video", status="pending")
+    db.init_db()
+    assert "dQw4w9WgXcQ" in _video_ids(db)
+
+
+def test_article_and_summarized_rows_survive_restart(db):
+    _insert(db, video_id="abcdefghijk", kind="article", status="error")
+    _insert(db, video_id="lmnopqrstuv", kind="video", status="summarized")
+    db.init_db()
+    assert {"abcdefghijk", "lmnopqrstuv"} <= _video_ids(db)
+
+
+def test_purge_runs_only_once(db):
+    """The legacy cleanup already ran during the fixture's init_db(), so a
+    podcast row inserted afterwards is never purged — a destructive cleanup
+    must not keep firing on every startup."""
+    _insert(db, video_id="ABCDEFGHIJK", kind="podcast", status="error")
+    db.init_db()
+    assert "ABCDEFGHIJK" in _video_ids(db)
+
+
+def test_legacy_podcast_row_is_purged_on_first_run(tmp_path, monkeypatch):
+    """The original #497 behavior still works on a database that has not been
+    purged yet: a stuck legacy YouTube row (kind='podcast') is removed."""
+    import database.core as core
+
+    monkeypatch.setattr(core, "DB_PATH", str(tmp_path / "legacy.db"))
+    core.init_db()
+    conn = core.get_db()
+    conn.execute("DELETE FROM app_settings WHERE key = 'purged_legacy_youtube_rows'")
+    conn.execute(
+        """INSERT INTO podcast_episodes (video_id, title, youtube_url, status, kind)
+           VALUES ('ZYXWVUTSRQP', 'legacy', 'https://y/ZYXWVUTSRQP', 'error', 'podcast')""")
+    conn.commit()
+    conn.close()
+
+    core.init_db()
+
+    conn = core.get_db()
+    remaining = {r["video_id"] for r in conn.execute("SELECT video_id FROM podcast_episodes")}
+    conn.close()
+    assert "ZYXWVUTSRQP" not in remaining


### PR DESCRIPTION
## 问题

在知识库 Videos 标签加入的视频，PROCESSING 途中从列表里彻底消失。

## 原因

`database/core.py` 里 #497 写的 YouTube 遗留行清理：

- 判据 = `video_id` 是 11 位字符 **且** `status != 'summarized'`；
- 知识库（#651）摄取 YouTube 视频时存的正是这个 11 位 `video_id`；
- 清理没有一次性保护，**每次 `init_db()`（即每次启动）都跑**，而生产环境 cron 每 2 分钟跑一次 deploy.sh 重启服务。

NotebookLM 转录要几分钟，所以每个新视频在到达 `summarized` 之前几乎必然被删除。已摘要的旧视频不受影响 —— 与观察到的现象完全一致。

## 改动

1. 清理只作用于 `kind = 'podcast'`（遗留行都早于 `kind` 列，取的是默认值），video/article 永不触碰；
2. 加 `app_settings.purged_legacy_youtube_rows` 一次性标记 —— 破坏性清理不该每次启动都执行；
3. 标记写入移出"表已存在"的迁移块，全新数据库首次启动也会写入，清理不可能在其后创建的行上触发。

## 测试

新增 `tests/test_legacy_purge.py`（4 条）：pending 视频经重启存活、article/summarized 行存活、标记后不再清理、首次运行仍能清掉真正的遗留 podcast 行。全套 359 passed。

Closes #688