### PR TITLE
复习时给句子加星 ★ + Browse ⭐ Sentences 视图（#692）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,6 +348,17 @@ FSRS 用毕业评分播种初始 stability/difficulty：默认权重下 **Good �
 
 ---
 
+### 加星句子：改进提示词的正例样本（#692）
+
+复习时读到写得好的句子，就地按 **Shift+F** 或点卡背工具条的 ☆ 加星；之后在 Browse 的 **⭐ Sentences** 视图集中回看。判断一句话好不好只有读到它的那一秒才可能，事后翻故事历史回忆不起来 —— 这是这个功能存在的全部理由。
+
+- `story_sentences.starred` / `starred_at` 两列，**不新建表**：加星是句子的属性，多一张表只是多一次 JOIN
+- **Again 重生成的句子自动通吃**：它们本来就是 `story_sentences` 行（存在 sentinel category `again` 下，见 `store_again_sentence`），无需特例 —— 而新生成的句子恰恰最需要被评判
+- **列表必须带出生成上下文**：`get_starred_sentences()` 从 `stories.gen_params` 解出 `mode`/`model`/`episode_id`，再带上牌组名与 `source_title`/`source_url`。一句脱离了"是哪个提示词生成的"的好句子，对改提示词毫无用处
+- **前端是独立渲染分支**：Browse 其余所有过滤（`_filteredBrowseWords()`）都是**按词**过滤的，加星是**句子**级实体，塞不进那条链。切到任何按词的过滤/搜索/排序时用 `_leaveStarredView()` 自动退出，免得标签高亮和列表内容说两套话
+- 复习时的加星是**乐观更新**：复习途中按钮卡住比星标没存上更打断节奏；失败回滚并报错
+- 没有句子的卡（还没生成故事，正面只显示单词）不显示该按钮
+
 ## 生词标注：代码做，不用 AI（`zh_annotate.py`，#638）
 
 #631 靠提示词让模型标 `pinyin/汉字`，模型经常漏（德语总结里出现光秃秃的 `(浙江)`），中文总结更是一个都没标。所有材料仓库里都有，所以改成确定性代码，**零 AI 调用**：`static/hsk_levels.json`（4991 词的 HSK 1-6 表）+ `entries.word_zh`（Daniel 的词库）+ `jieba` + `pypinyin` + `translator.py`。
@@ -415,6 +426,8 @@ POST /api/speak ；POST /api/speak-multi ；GET /api/speak-status ；POST /api/s
 GET  /api/tts-file ；POST /api/preload ；POST /api/preload-session/{deck_id}/{category}
 GET  /api/tts-progress/{deck_id}/{category} ；GET /api/story-progress/{deck_id}/{category}
 GET  /api/news/status                                → 当日新闻缓存状态 {cached, count}（briefing 模式设置弹窗仍在用；旧 news 模式已移除，#512）
+POST /api/story-sentence/{id}/star                   → 给句子加星/取消，body {starred: bool}（#692）；句子不存在 404
+GET  /api/starred-sentences[?lang=&limit=]           → 全部加星句子，附生成模式/模型/episode_id/牌组/来源（#692）
 
 # 知识库（播客爬虫 #479 泛化，#650–#655；详见「知识库」节）
 POST /api/knowledge/add                               → body {url} → 新素材 {episode_id}；已存在 {status:"already_exists", episode_id}；不转录不摘要，前端拿 id 后另调 .../process

--- a/database/core.py
+++ b/database/core.py
@@ -244,6 +244,11 @@ def init_db() -> None:
         conn.execute("ALTER TABLE story_sentences ADD COLUMN source_title TEXT")
     if "source_name" not in ss_cols:
         conn.execute("ALTER TABLE story_sentences ADD COLUMN source_name TEXT")
+    # Sentences Daniel starred during review as good examples for prompt tuning (#692).
+    if "starred" not in ss_cols:
+        conn.execute("ALTER TABLE story_sentences ADD COLUMN starred INTEGER NOT NULL DEFAULT 0")
+    if "starred_at" not in ss_cols:
+        conn.execute("ALTER TABLE story_sentences ADD COLUMN starred_at TEXT")
     if "word_id" in ss_cols:
         _migrate_story_sentences_multi_word(conn)
     existing_tables = {r["name"] for r in conn.execute(

--- a/database/stories.py
+++ b/database/stories.py
@@ -1,6 +1,6 @@
 import json
 import sqlite3
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from .core import get_db
 
 
@@ -144,6 +144,73 @@ def _hydrate_sentence(conn, sent_row) -> dict:
     raw_tokens = d.get("tokens")
     d["tokens"] = json.loads(raw_tokens) if raw_tokens else []
     return d
+
+
+# ---------------------------------------------------------------------------
+# Starred sentences (#692) — sentences Daniel marked as good during review, kept
+# as positive examples to learn from when tuning the generation prompts.
+# ---------------------------------------------------------------------------
+
+def set_sentence_starred(sentence_id: int, starred: bool) -> dict | None:
+    """Star or unstar one story sentence. Returns the new state, or None if no such sentence.
+
+    Works for regenerated "Again" sentences too — those are ordinary
+    story_sentences rows under the AGAIN_CATEGORY sentinel (see store_again_sentence).
+    """
+    conn = get_db()
+    starred_at = datetime.now().isoformat(timespec="seconds") if starred else None
+    cur = conn.execute(
+        "UPDATE story_sentences SET starred = ?, starred_at = ? WHERE id = ?",
+        (1 if starred else 0, starred_at, sentence_id),
+    )
+    conn.commit()
+    if cur.rowcount == 0:
+        conn.close()
+        return None
+    conn.close()
+    return {"id": sentence_id, "starred": 1 if starred else 0, "starred_at": starred_at}
+
+
+def get_starred_sentences(lang: str | None = None, limit: int = 500) -> list[dict]:
+    """All starred sentences, newest star first, with the context needed to judge them.
+
+    Each row carries its story's generation settings (mode / model / episode_id via
+    gen_params) and deck name on top of the usual sentence shape — that context is the
+    whole point: a good sentence is only informative if you know which prompt made it.
+    """
+    conn = get_db()
+    lang_clause = ""
+    params: list = []
+    if lang:
+        # NULL lang = legacy row from before #436, treated as 'zh'.
+        lang_clause = " AND (s.lang = ? OR (s.lang IS NULL AND ? = 'zh'))"
+        params = [lang, lang]
+    rows = conn.execute(
+        f"""SELECT ss.*, s.date AS story_date, s.category AS story_category,
+                   s.gen_params, s.topic, d.name AS deck_name
+            FROM story_sentences ss
+            JOIN stories s ON s.id = ss.story_id
+            LEFT JOIN decks d ON d.id = s.deck_id
+            WHERE ss.starred = 1{lang_clause}
+            ORDER BY ss.starred_at DESC, ss.id DESC
+            LIMIT ?""",
+        (*params, limit),
+    ).fetchall()
+
+    result = []
+    for row in rows:
+        d = _hydrate_sentence(conn, row)
+        gp = d.pop("gen_params", None)
+        try:
+            params_dict = json.loads(gp) if gp else {}
+        except (ValueError, TypeError):
+            params_dict = {}
+        d["mode"] = params_dict.get("mode") or "story"
+        d["model"] = params_dict.get("model")
+        d["episode_id"] = params_dict.get("episode_id")
+        result.append(d)
+    conn.close()
+    return result
 
 
 def get_latest_sentence_for_word(word_id: int) -> dict | None:

--- a/routes/story.py
+++ b/routes/story.py
@@ -758,6 +758,23 @@ def regenerate_story(deck_id: int, category: str,
     return result
 
 
+# ── 加星句子（issue #692）────────────────────────────────────────────────────
+# 复习时看到写得好的句子就地加星，之后集中回看，作为改进生成提示词的正例样本。
+
+@router.post("/api/story-sentence/{sentence_id}/star")
+def star_sentence(sentence_id: int, body: dict | None = None):
+    starred = bool((body or {}).get("starred", True))
+    result = database.set_sentence_starred(sentence_id, starred)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"No sentence with id {sentence_id}")
+    return result
+
+
+@router.get("/api/starred-sentences")
+def list_starred_sentences(lang: str | None = None, limit: int = 500):
+    return {"sentences": database.get_starred_sentences(lang=lang, limit=limit)}
+
+
 # ── 提示词版本库（issue #610；原单份自定义模板见 #581）──────────────────────────
 
 def _require_editable_mode(mode: str) -> None:

--- a/schema.sql
+++ b/schema.sql
@@ -406,6 +406,9 @@ CREATE TABLE IF NOT EXISTS story_sentences (
     context_de  TEXT,
     source_title TEXT,
     source_name TEXT,
+    -- starred during review as a good example to learn from when tuning prompts (#692)
+    starred     INTEGER NOT NULL DEFAULT 0,
+    starred_at  TEXT,
     UNIQUE(story_id, position)
 );
 

--- a/static/app.js
+++ b/static/app.js
@@ -7037,7 +7037,50 @@ function _syncCardToggleBar() {
                        (de?.textContent && de.style.display !== 'none');
   transBtn.classList.toggle('active', !!transVisible);
 
-  bar.style.display = (pinAvail || transAvail) ? '' : 'none';
+  // Star: only when this card actually shows a stored story sentence. A card
+  // with no sentence (no story yet — renderSentence() falls back to the bare
+  // word) has nothing to star, so the button stays hidden rather than failing.
+  const starBtn = document.getElementById('toggle-star-btn');
+  const starAvail = !!sentence?.id;
+  if (starBtn) {
+    starBtn.style.display = starAvail ? '' : 'none';
+    _syncStarBtn();
+  }
+
+  bar.style.display = (pinAvail || transAvail || starAvail) ? '' : 'none';
+}
+
+// ── Starred sentences (#692) ─────────────────────────────────────────────────
+// While reviewing, a sentence is either good or it isn't — and that judgement is
+// only available in the second you read it. Starring collects those good ones as
+// positive examples for tuning the generation prompts later (Browse → ★).
+
+function _syncStarBtn() {
+  const btn = document.getElementById('toggle-star-btn');
+  if (!btn) return;
+  const on = !!sentence?.starred;
+  btn.textContent = on ? '★' : '☆';
+  btn.classList.toggle('active', on);
+  btn.title = on ? 'Starred — click to unstar (Shift+F)'
+                 : 'Star this sentence as a good example (Shift+F)';
+}
+
+async function toggleSentenceStar() {
+  if (!sentence?.id) return;
+  const next = !sentence.starred;
+  // Optimistic: the star is a note to self, and a stalled button mid-review is
+  // more disruptive than a star that turns out not to have saved.
+  sentence.starred = next ? 1 : 0;
+  _syncStarBtn();
+  try {
+    const r = await api('POST', `/api/story-sentence/${sentence.id}/star`, { starred: next });
+    sentence.starred = r.starred;
+    sentence.starred_at = r.starred_at;
+  } catch (e) {
+    sentence.starred = next ? 0 : 1;
+    showError('Star failed: ' + e.message);
+  }
+  _syncStarBtn();
 }
 
 // ── Translation toggle (German/French sentence translation) ───────────────────
@@ -9935,6 +9978,12 @@ document.addEventListener('keydown', async e => {
 
   if (e.key === 'R' && e.shiftKey && !e.ctrlKey && !e.metaKey) {
     if (!inInput) { e.preventDefault(); _restartServer(); }
+    return;
+  }
+
+  // Shift+F stars/unstars the sentence on the current card (#692)
+  if (e.key === 'F' && e.shiftKey && !e.ctrlKey && !e.metaKey) {
+    if (!inInput) { e.preventDefault(); toggleSentenceStar(); }
     return;
   }
 

--- a/static/app.js
+++ b/static/app.js
@@ -1815,6 +1815,7 @@ function _sortWords(words) {
 
 function onBrowseSort(val) {
   _browseSort = val;
+  _leaveStarredView();  // the sort options are word fields (pinyin/hanzi), #692
   const q = document.getElementById('browse-search').value.trim();
   if (_browseMode === 'hanzi') renderHanziList(_allHanzi, q);
   else if (q) onBrowseSearch(q); else renderBrowseWords(_filteredBrowseWords());
@@ -1853,6 +1854,7 @@ function setBrowseFilter(mode, filter) {
   _browseMode   = mode;
   _browseFilter = filter;
   _browseDeckId = null;
+  _leaveStarredView();
   // Update sidebar active state
   document.querySelectorAll('.bs-item').forEach(el => el.classList.remove('bs-active'));
   const btnId = mode === 'hanzi' ? 'bsf-hanzi' : `bsf-${filter}`;
@@ -1873,10 +1875,23 @@ function setBrowseStatusFilter(status) {
   document.getElementById('browse-search').value = '';
   _browseSelected.clear();
   _updateBrowseActionBar();
+  // 'starred' lists sentences, not words, so it can't go through the word filter
+  // chain in _filteredBrowseWords() — it's its own rendering branch (#692).
+  if (status === 'starred') { renderStarredSentences(); return; }
   if (_browseMode === 'notes') renderBrowseWords(_filteredBrowseWords());
 }
 
+// Any word-level filter action leaves the sentence view: it lists a different
+// kind of thing, so silently keeping its tab highlighted would be a lie (#692).
+function _leaveStarredView() {
+  if (_browseCardStatus !== 'starred') return;
+  _browseCardStatus = 'all';
+  document.querySelectorAll('.bs-status-item').forEach(el => el.classList.remove('bs-active'));
+  document.getElementById('bss-all')?.classList.add('bs-active');
+}
+
 function setBrowseDeckFilter(deckId) {
+  _leaveStarredView();
   if (_browseDeckId === deckId) {
     _browseDeckId = null;
     document.querySelectorAll('.bs-deck-item').forEach(el => el.classList.remove('bs-active'));
@@ -1994,6 +2009,7 @@ function toggleBrowseDeckExpand(deckId) {
 
 function onBrowseSearch(val) {
   clearTimeout(_browseSearchTimer);
+  _leaveStarredView();  // searching is word-level (#692)
   const q = val.trim();
   if (_browseMode === 'hanzi') { renderHanziList(_allHanzi, q); return; }
   if (!q) { renderBrowseWords(_filteredBrowseWords()); return; }
@@ -2237,6 +2253,69 @@ function renderBrowseWords(words) {
     return;
   }
   list.innerHTML = `<div class="bw-list">${_sortWords(words).map(_wordRow).join('')}</div>`;
+}
+
+// ── Starred sentences view (#692) ────────────────────────────────────────────
+// Sentences starred during review, newest first, each with the generation
+// context that makes it useful: which mode/model produced it and from which
+// source material. That's what you read when deciding how to change a prompt.
+
+async function renderStarredSentences() {
+  const list = document.getElementById('browse-list');
+  list.innerHTML = '<div class="browse-empty">Loading…</div>';
+  let sentences;
+  try {
+    const r = await api('GET', `/api/starred-sentences${_langQP('?')}`);
+    sentences = r.sentences;
+  } catch (e) {
+    list.innerHTML = `<div class="browse-empty">Could not load starred sentences: ${_escHtml(e.message)}</div>`;
+    return;
+  }
+  if (_browseCardStatus !== 'starred') return;  // user switched tabs while loading
+  if (!sentences.length) {
+    list.innerHTML = '<div class="browse-empty">No starred sentences yet — press Shift+F ' +
+                     'or tap ☆ while reviewing to keep a good one.</div>';
+    return;
+  }
+  list.innerHTML = `<div class="bw-list">${sentences.map(_starredSentenceRow).join('')}</div>`;
+}
+
+function _starredSentenceRow(s) {
+  const trans = s.sentence_de || s.sentence_fr || s.sentence_en || '';
+  const words = (s.words || []).map(w => _escHtml(w.word_zh)).join('、');
+  const source = s.source_url
+    ? `<a class="ss-source" href="${_escHtml(s.source_url)}" target="_blank" rel="noopener"
+          onclick="event.stopPropagation()">${_escHtml(s.source_title || s.source_name || 'source')}</a>`
+    : (s.source_title ? `<span class="ss-source">${_escHtml(s.source_title)}</span>` : '');
+  const meta = [
+    `<span class="ss-mode">${_escHtml(s.mode || 'story')}</span>`,
+    s.story_date ? `<span>${_escHtml(s.story_date)}</span>` : '',
+    s.deck_name ? `<span>${_escHtml(s.deck_name)}</span>` : '',
+    words ? `<span class="ss-words">${words}</span>` : '',
+    source,
+  ].filter(Boolean).join('<span class="ss-dot">·</span>');
+
+  return `<div class="bw-row ss-row">
+    <div class="ss-main">
+      <div class="ss-zh">${_escHtml(s.sentence_zh)}</div>
+      ${trans ? `<div class="ss-trans">${_escHtml(trans)}</div>` : ''}
+      <div class="ss-meta">${meta}</div>
+    </div>
+    <button class="ss-unstar" title="Remove the star"
+            onclick="unstarSentence(${s.id}, this)">★</button>
+  </div>`;
+}
+
+async function unstarSentence(sentenceId, btn) {
+  btn.disabled = true;
+  try {
+    await api('POST', `/api/story-sentence/${sentenceId}/star`, { starred: false });
+    btn.closest('.ss-row')?.remove();
+    if (!document.querySelector('.ss-row')) renderStarredSentences();  // back to empty state
+  } catch (e) {
+    btn.disabled = false;
+    showError('Unstar failed: ' + e.message);
+  }
 }
 
 function renderBrowseSearchResults(primary, secondary, q) {

--- a/static/index.html
+++ b/static/index.html
@@ -359,6 +359,9 @@
         <button class="bs-status-item" id="bss-leech"     onclick="setBrowseStatusFilter('leech')">Leeched</button>
         <button class="bs-status-item" id="bss-reference" onclick="setBrowseStatusFilter('reference')">Reference</button>
         <button class="bs-status-item" id="bss-saved"     onclick="setBrowseStatusFilter('saved')">★ Saved</button>
+        <!-- Sentence-level view, not a word filter (#692) -->
+        <button class="bs-status-item" id="bss-starred"   onclick="setBrowseStatusFilter('starred')"
+                title="Sentences you starred while reviewing — good examples for prompt tuning">⭐ Sentences</button>
       </div>
       <div class="bs-section">
         <div class="bs-section-head">Hanzi</div>

--- a/static/index.html
+++ b/static/index.html
@@ -229,6 +229,9 @@
             <div class="card-toggle-bar" id="card-toggle-bar" style="display:none">
               <button class="card-toggle-btn" id="toggle-pinyin-btn" onclick="togglePinyin()" style="display:none">拼音</button>
               <button class="card-toggle-btn" id="toggle-trans-btn" onclick="toggleTranslation()" style="display:none">译文</button>
+              <!-- Star a well-written sentence as a positive example for prompt tuning (#692) -->
+              <button class="card-toggle-btn card-star-btn" id="toggle-star-btn" onclick="toggleSentenceStar()"
+                      style="display:none" title="Star this sentence as a good example (Shift+F)">☆</button>
             </div>
 
             <!-- 2. Pinyin row (hidden by default; press p to toggle) -->

--- a/static/style.css
+++ b/static/style.css
@@ -1490,6 +1490,10 @@ main.browse-open {
   color: var(--primary);
   border-color: var(--primary);
 }
+/* Star (#692): gold rather than the primary colour — it marks a judgement about
+   the sentence, not a visibility toggle like its neighbours. */
+.card-star-btn { font-size: 14px; padding: 3px 10px; }
+.card-star-btn.active { color: #e0a300; border-color: #e0a300; }
 
 .char-row:last-child { border-bottom: none; }
 .char-row-link  { cursor: pointer; }

--- a/static/style.css
+++ b/static/style.css
@@ -2568,6 +2568,25 @@ a.news-source-line:hover {
   user-select: none;
 }
 .bw-row:last-child { border-bottom: none; }
+
+/* Starred sentences view (#692) — one starred sentence per row, with the
+   generation context (mode / date / deck / target words / source) beneath it. */
+.ss-row    { cursor: default; align-items: flex-start; }
+.ss-main   { flex: 1 1 auto; min-width: 0; }
+.ss-zh     { font-size: 17px; line-height: 1.5; }
+.ss-trans  { font-size: 13px; color: var(--muted); margin-top: 3px; }
+.ss-meta   { font-size: 11px; color: var(--muted); margin-top: 6px;
+             display: flex; flex-wrap: wrap; align-items: center; gap: 5px; }
+.ss-mode   { font-weight: 600; color: var(--primary); }
+.ss-words  { font-weight: 600; }
+.ss-dot    { opacity: 0.45; }
+.ss-source { color: var(--muted); text-decoration: underline; }
+.ss-source:hover { color: var(--primary); }
+.ss-unstar { flex: 0 0 auto; cursor: pointer; background: transparent;
+             border: none; color: #e0a300; font-size: 17px; line-height: 1;
+             padding: 2px 4px; }
+.ss-unstar:hover:not(:disabled) { opacity: 0.6; }
+.ss-unstar:disabled { opacity: 0.4; cursor: default; }
 .bw-row:hover { background: #f8fafc; }
 .bw-left {
   display: flex;

--- a/tests/test_starred_sentences.py
+++ b/tests/test_starred_sentences.py
@@ -1,0 +1,213 @@
+"""Tests for starring story sentences (issue #692).
+
+Starred sentences are the positive examples Daniel collects while reviewing, to
+feed back into prompt tuning. What matters beyond "the flag round-trips" is that
+a starred sentence still knows *which prompt made it* — mode/model/episode_id
+from the story's gen_params — because that context is the entire point.
+"""
+
+import sqlite3
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+from fastapi.testclient import TestClient
+import database
+import database.core
+import main
+
+client = TestClient(main.app)
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    # database.core.DB_PATH, not database.DB_PATH — see conftest.py (#615).
+    monkeypatch.setattr(database.core, "DB_PATH", str(tmp_path / "test.db"))
+    database.init_db()
+    return tmp_path / "test.db"
+
+
+def _make_story(deck_id=None, *, mode="knowledge", lang="zh", category="reading"):
+    """Create a one-sentence story and return (story_id, sentence_id)."""
+    if deck_id is None:
+        deck_id = database.get_or_create_deck("StarDeck")
+    story_id = database.create_story(
+        "2026-08-11", category, deck_id,
+        [{
+            "position": 0,
+            "sentence_zh": "他把复杂的想法说得很清楚。",
+            "sentence_en": "He explained the complex idea clearly.",
+            "sentence_de": "Er erklärte die komplexe Idee klar.",
+            "source_title": "某播客单集",
+            "source_url": "https://example.com/ep1",
+        }],
+        gen_params={"mode": mode, "model": "deepseek-chat", "episode_id": 7},
+        lang=lang,
+    )
+    sentences = database.get_story_sentences(story_id)
+    return story_id, sentences[0]["id"]
+
+
+# ---------------------------------------------------------------------------
+# Migration
+# ---------------------------------------------------------------------------
+
+def test_migration_adds_columns_to_legacy_db(tmp_path, monkeypatch):
+    """init_db() on a DB whose story_sentences predates #692 adds both columns,
+    and running it a second time is a no-op (not an error)."""
+    db_file = tmp_path / "legacy.db"
+    conn = sqlite3.connect(db_file)
+    conn.execute("""CREATE TABLE story_sentences (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        story_id INTEGER NOT NULL,
+        position INTEGER NOT NULL,
+        sentence_zh TEXT NOT NULL,
+        sentence_en TEXT NOT NULL DEFAULT ''
+    )""")
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(database.core, "DB_PATH", str(db_file))
+    database.init_db()
+    database.init_db()  # idempotent
+
+    conn = sqlite3.connect(db_file)
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(story_sentences)")}
+    conn.close()
+    assert {"starred", "starred_at"} <= cols
+
+
+def test_existing_sentences_default_to_unstarred(tmp_db):
+    _, sentence_id = _make_story()
+    assert database.get_starred_sentences() == []
+
+
+# ---------------------------------------------------------------------------
+# database layer
+# ---------------------------------------------------------------------------
+
+def test_star_and_unstar_round_trip(tmp_db):
+    _, sentence_id = _make_story()
+
+    result = database.set_sentence_starred(sentence_id, True)
+    assert result["starred"] == 1
+    assert result["starred_at"]
+
+    starred = database.get_starred_sentences()
+    assert [s["id"] for s in starred] == [sentence_id]
+
+    result = database.set_sentence_starred(sentence_id, False)
+    assert result["starred"] == 0
+    assert result["starred_at"] is None
+    assert database.get_starred_sentences() == []
+
+
+def test_star_unknown_sentence_returns_none(tmp_db):
+    assert database.set_sentence_starred(99999, True) is None
+
+
+def test_starred_list_carries_generation_context(tmp_db):
+    """Without mode/source, a starred sentence can't tell you which prompt to fix."""
+    _, sentence_id = _make_story(mode="knowledge")
+    database.set_sentence_starred(sentence_id, True)
+
+    s = database.get_starred_sentences()[0]
+    assert s["mode"] == "knowledge"
+    assert s["model"] == "deepseek-chat"
+    assert s["episode_id"] == 7
+    assert s["story_date"] == "2026-08-11"
+    assert s["deck_name"] == "StarDeck"
+    assert s["source_title"] == "某播客单集"
+    assert s["sentence_de"] == "Er erklärte die komplexe Idee klar."
+
+
+def test_starred_list_newest_first(tmp_db):
+    deck_id = database.get_or_create_deck("StarDeck")
+    _, first = _make_story(deck_id)
+    _, second = _make_story(deck_id, category="listening")
+
+    database.set_sentence_starred(first, True)
+    database.set_sentence_starred(second, True)
+    # Same-second timestamps are broken by id DESC, so the later star still wins.
+    assert [s["id"] for s in database.get_starred_sentences()][0] == second
+
+
+def test_starred_list_filters_by_lang(tmp_db):
+    deck_id = database.get_or_create_deck("StarDeck")
+    _, zh = _make_story(deck_id, lang="zh")
+    _, fr = _make_story(deck_id, lang="fr", category="listening")
+    database.set_sentence_starred(zh, True)
+    database.set_sentence_starred(fr, True)
+
+    assert [s["id"] for s in database.get_starred_sentences(lang="fr")] == [fr]
+    assert [s["id"] for s in database.get_starred_sentences(lang="zh")] == [zh]
+    assert len(database.get_starred_sentences()) == 2
+
+
+def test_again_regenerated_sentence_can_be_starred(tmp_db):
+    """Again-regen sentences live under the 'again' sentinel category but are
+    ordinary story_sentences rows — starring must work there too, since that's
+    exactly where a freshly generated sentence gets judged."""
+    deck_id = database.get_or_create_deck("StarDeck")
+    # entries has no insert helper (only the importer writes it) — same approach
+    # as tests/test_offline_sync.py.
+    conn = database.get_db()
+    word_id = conn.execute(
+        "INSERT INTO entries (word_zh, definition) VALUES ('清楚', 'clear')"
+    ).lastrowid
+    conn.commit()
+    conn.close()
+    database.store_again_sentence(
+        deck_id, word_id,
+        {"sentence_zh": "说得很清楚。", "sentence_en": "Said clearly."},
+        "2026-08-11",
+    )
+    again = database.get_again_sentence_for_word(word_id, "2026-08-11")
+
+    assert database.set_sentence_starred(again["id"], True)["starred"] == 1
+    assert [s["id"] for s in database.get_starred_sentences()] == [again["id"]]
+
+
+# ---------------------------------------------------------------------------
+# API
+# ---------------------------------------------------------------------------
+
+def test_api_star_round_trip(tmp_db):
+    _, sentence_id = _make_story()
+
+    r = client.post(f"/api/story-sentence/{sentence_id}/star", json={"starred": True})
+    assert r.status_code == 200
+    assert r.json()["starred"] == 1
+
+    r = client.get("/api/starred-sentences")
+    assert r.status_code == 200
+    body = r.json()["sentences"]
+    assert [s["id"] for s in body] == [sentence_id]
+    assert body[0]["mode"] == "knowledge"
+
+    r = client.post(f"/api/story-sentence/{sentence_id}/star", json={"starred": False})
+    assert r.json()["starred"] == 0
+    assert client.get("/api/starred-sentences").json()["sentences"] == []
+
+
+def test_api_star_defaults_to_starring(tmp_db):
+    _, sentence_id = _make_story()
+    r = client.post(f"/api/story-sentence/{sentence_id}/star", json={})
+    assert r.json()["starred"] == 1
+
+
+def test_api_star_unknown_sentence_404(tmp_db):
+    r = client.post("/api/story-sentence/99999/star", json={"starred": True})
+    assert r.status_code == 404
+
+
+def test_api_starred_sentences_lang_filter(tmp_db):
+    deck_id = database.get_or_create_deck("StarDeck")
+    _, zh = _make_story(deck_id, lang="zh")
+    _, fr = _make_story(deck_id, lang="fr", category="listening")
+    client.post(f"/api/story-sentence/{zh}/star", json={"starred": True})
+    client.post(f"/api/story-sentence/{fr}/star", json={"starred": True})
+
+    body = client.get("/api/starred-sentences?lang=fr").json()["sentences"]
+    assert [s["id"] for s in body] == [fr]


### PR DESCRIPTION
Closes #692

## 改了什么

复习时读到写得好的句子，一键加星；之后在 Browse 的 **⭐ Sentences** 视图集中回看，作为改进生成提示词的正例样本。Daniel 正在打磨 `knowledge` 模式（播客/视频/文章 → 句子），需要这批正例。

判断一句话好不好，只有读到它的那一秒才可能——事后翻故事历史回忆不起来。这是这个功能的全部理由，也是它必须做在复习界面里的原因。

### 数据库
`story_sentences` 加 `starred` / `starred_at` 两列（`schema.sql` + `database/core.py` 幂等迁移）。**不新建表**：加星是句子的属性，多一张表只是多一次 JOIN。

### 数据层（`database/stories.py`）
- `set_sentence_starred(sentence_id, starred)` → 新状态，句子不存在返回 `None`
- `get_starred_sentences(lang=None, limit=500)` → 按加星时间倒序，**带出生成上下文**：从 `stories.gen_params` 解出 `mode` / `model` / `episode_id`，加上牌组名与 `source_title` / `source_url`。一句脱离了「是哪个提示词生成的」的好句子，对改提示词毫无用处。

### 接口（`routes/story.py`）
- `POST /api/story-sentence/{id}/star`，body `{starred}` → 新状态；不存在 404
- `GET /api/starred-sentences[?lang=&limit=]`

### 复习界面
★ 按钮挂在已有的卡背工具条（`card-toggle-bar`）上，手机点按和 **Shift+F** 走同一个入口。没有句子的卡（还没生成故事，正面只显示单词）不显示该按钮。乐观更新——复习途中按钮卡住比星标没存上更打断节奏，失败则回滚并报错。

### Browse ⭐ Sentences 视图
每行：中文句子、译文、模式 / 日期 / 牌组 / 目标词 / 来源链接，以及就地取消星标。

⚠️ 这是**句子级**实体，塞不进 `_filteredBrowseWords()` 那条**按词**的过滤链，所以是独立渲染分支；切到任何按词的过滤 / 搜索 / 排序时 `_leaveStarredView()` 自动退出，免得标签高亮和列表内容说两套话。

## 为什么这么做

- **Again 重生成的句子自动通吃**：它们本来就是 `story_sentences` 行（sentinel category `again`），无需一行特例代码——而新生成的句子恰恰最需要被评判。测试专门守着这条。
- 只做「好」一种标记，不做 👎（Daniel 确认）。

## 怎么测试的

- `tests/test_starred_sentences.py` 12 条：旧库迁移幂等、开关往返（取消时 `starred_at` 置空）、生成上下文带出、时间倒序、按 `lang` 过滤、Again 句子可加星、接口往返与 404
- `pytest tests/` 全套 **367 passed, 4 skipped**
- `node --check static/app.js` 通过
- 起临时实例（8002 端口 + 临时库，未碰 dev.db）实测：`GET /api/starred-sentences` 200、未知 id 加星 404、首页 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)