### PR TITLE
fix: 加词后台完成不再把用户踢回主页（#695）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1176,8 +1176,11 @@ async function _pollSyncProgress() {
 
 
 // ── Deck list ───────────────────────────────────────────────────────────────
-async function loadDecks() {
-  setLoading('Loading decks…');
+// keepView: refresh the deck data in place without switching to the home view.
+// Background work (adding a word during a review, #695) needs the due counts
+// updated, but must never yank the user out of whatever they are doing.
+async function loadDecks({ keepView = false } = {}) {
+  if (!keepView) setLoading('Loading decks…');
   try {
     const [langs, mode] = await Promise.all([
       api('GET', '/api/langs').catch(() => ['zh']),
@@ -1204,8 +1207,11 @@ async function loadDecks() {
       if (d.id != null) _deckLangById[d.id] = d.lang || 'zh';
     }
     renderDecks(decks);
-    showView('decks');
+    if (!keepView) showView('decks');
   } catch (e) {
+    // A background refresh failing is not worth an error screen — the user
+    // never asked for it, and the banner already reports the word's outcome.
+    if (keepView) { console.warn('background deck refresh failed', e); return; }
     showError('Could not load decks: ' + e.message);
     showView('decks');
   }

--- a/static/shared.js
+++ b/static/shared.js
@@ -41,7 +41,11 @@ async function addWordViaAi(wordZh, day, onUpdate) {
   }
 
   // The deck list only exists in the full app; /add has nothing to refresh.
-  const refreshDecks = () => { if (typeof loadDecks === 'function') loadDecks(); };
+  // keepView (#695): generation finishes ~30s later, quite possibly mid-review
+  // — refresh the due counts, never switch the view out from under the user.
+  const refreshDecks = () => {
+    if (typeof loadDecks === 'function') loadDecks({ keepView: true });
+  };
 
   // Known words come back finished — no AI call, no job to poll.
   if (!result.job_id) {

--- a/tests/test_add_word.py
+++ b/tests/test_add_word.py
@@ -337,6 +337,17 @@ def test_add_word_pipeline_is_not_duplicated_in_app_js():
     assert "async function api(" not in app_js
 
 
+def test_background_deck_refresh_keeps_the_current_view():
+    """#695: generation finishes ~30s later, often mid-review. loadDecks() ends
+    in showView('decks'), so refreshing the due counts must pass keepView —
+    otherwise finishing a word throws the user back to the home screen."""
+    import pathlib
+    shared_js = pathlib.Path("static/shared.js").read_text(encoding="utf-8")
+    app_js = pathlib.Path("static/app.js").read_text(encoding="utf-8")
+    assert "loadDecks({ keepView: true })" in shared_js
+    assert "if (!keepView) showView('decks');" in app_js
+
+
 def test_add_page_uses_the_shared_endpoint():
     """Guards against the page growing its own add-word call."""
     import pathlib


### PR DESCRIPTION
## 问题

复习途中加生词，约 30 秒后生成完成，界面突然跳回牌组主页，复习被打断。

## 原因

`shared.js` 的 `addWordViaAi()` 完成后调 `refreshDecks()` → `loadDecks()`，而 `loadDecks()` 结尾无条件 `showView('decks')`。它是主页的加载入口，被复用为"刷新牌组数据"时把视图也切走了。

## 改动

- `loadDecks({ keepView })`：跳过 `setLoading` 和 `showView`，只重新拉取数据并 `renderDecks`（渲染隐藏的主页视图无副作用，到期计数照常更新）。默认参数为 false，所有既有调用行为完全不变
- 后台刷新失败只 `console.warn`，不再弹 `showError` 盖住复习界面——用户没主动要求这次刷新，加词结果本来就由横幅报告
- `shared.js` 的 `refreshDecks()` 传 `keepView: true`；顶栏 ＋、复习长按菜单、知识页生词表格、`/add` 页四处共用这一条路径，一次改全

## 测试

- `pytest tests/` 371 passed
- 新增 `test_background_deck_refresh_keeps_the_current_view` 守住这两处（JS 无测试运行器，沿用本文件既有的静态断言做法）

Closes #695