### PR TITLE
加星句子链回生成它的提示词；knowledge 模式补上真实 prompt_text（#697）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,6 +355,9 @@ FSRS 用毕业评分播种初始 stability/difficulty：默认权重下 **Good �
 - `story_sentences.starred` / `starred_at` 两列，**不新建表**：加星是句子的属性，多一张表只是多一次 JOIN
 - **Again 重生成的句子自动通吃**：它们本来就是 `story_sentences` 行（存在 sentinel category `again` 下，见 `store_again_sentence`），无需特例 —— 而新生成的句子恰恰最需要被评判
 - **列表必须带出生成上下文**：`get_starred_sentences()` 从 `stories.gen_params` 解出 `mode`/`model`/`episode_id`，再带上牌组名与 `source_title`/`source_url`。一句脱离了"是哪个提示词生成的"的好句子，对改提示词毫无用处
+- **提示词只链接不复制**（#697）：提示词已经在 `stories.prompt_text` 里，列表只带 `story_id` + `has_prompt`，全文由 `GET /api/story-prompt/{id}` 按需取。**绝不内联全文** —— 一份 knowledge 提示词含上万字转录，500 行列表会变成几十 MB
+  - `knowledge` 模式原来存的是占位符 `"knowledge mode — item N (kind=video)"`，正在调的那个模式恰恰读不回提示词。现在 `ai.generate_podcast_sentences()` 返回 `(sentences, prompt)`（与本模块其它生成函数一致），存的是**实际发出去的**提示词并跨轮拼接 —— 补漏轮带 `extra_hint`，事后重建的版本并不是写出这些句子的那一份
+  - **提示词为空是正常状态**，不是错误：旧故事早于该列，且离线快照会主动清空它（`scripts/offline_sync_server.py`）。界面必须说明原因，不能显示空白框
 - **前端是独立渲染分支**：Browse 其余所有过滤（`_filteredBrowseWords()`）都是**按词**过滤的，加星是**句子**级实体，塞不进那条链。切到任何按词的过滤/搜索/排序时用 `_leaveStarredView()` 自动退出，免得标签高亮和列表内容说两套话
 - 复习时的加星是**乐观更新**：复习途中按钮卡住比星标没存上更打断节奏；失败回滚并报错
 - 没有句子的卡（还没生成故事，正面只显示单词）不显示该按钮
@@ -428,7 +431,9 @@ GET  /api/tts-file ；POST /api/preload ；POST /api/preload-session/{deck_id}/{
 GET  /api/tts-progress/{deck_id}/{category} ；GET /api/story-progress/{deck_id}/{category}
 GET  /api/news/status                                → 当日新闻缓存状态 {cached, count}（briefing 模式设置弹窗仍在用；旧 news 模式已移除，#512）
 POST /api/story-sentence/{id}/star                   → 给句子加星/取消，body {starred: bool}（#692）；句子不存在 404
-GET  /api/starred-sentences[?lang=&limit=]           → 全部加星句子，附生成模式/模型/episode_id/牌组/来源（#692）
+GET  /api/starred-sentences[?lang=&limit=]           → 全部加星句子，附生成模式/模型/episode_id/牌组/来源 + story_id/has_prompt（#692、#697）
+GET  /api/story-prompt/{story_id}                    → 生成该故事的完整提示词（#697）；故事不存在 404
+                                                       **不能**写成 /api/story/{id}/prompt——GET /api/story/{deck_id}/{category} 注册在前会把它当 category='prompt' 吃掉
 
 # 知识库（播客爬虫 #479 泛化，#650–#655；详见「知识库」节）
 POST /api/knowledge/add                               → body {url} → 新素材 {episode_id}；已存在 {status:"already_exists", episode_id}；不转录不摘要，前端拿 id 后另调 .../process

--- a/ai.py
+++ b/ai.py
@@ -2223,7 +2223,7 @@ def generate_podcast_sentences(
     attempt_label: str = "",
     source_url: str | None = None,
     source_title: str | None = None,
-) -> list[dict]:
+) -> tuple[list[dict], str]:
     """Podcast/knowledge mode rework (issue #561) — a lean single-purpose
     pipeline that replaces reuse of the briefing machinery (originally #482).
 
@@ -2252,9 +2252,14 @@ def generate_podcast_sentences(
     attempt_label: chunk marker like " (2/3)" appended to every progress
     message — the route batches cards by MAX_NEWS_BATCH and calls this once
     per chunk (same convention as generate_briefing_sentences).
+
+    Returns (sentences, prompt) like the other generators in this module. The
+    prompt is what was *actually sent*, joined across rounds — retry rounds add
+    an extra_hint, so a prompt rebuilt afterwards would not be the one that
+    produced these sentences, which is the whole point of keeping it (#697).
     """
     if not cards or not material.strip():
-        return []
+        return [], ""
 
     # 模板可被用户自定义覆盖（issue #581）；默认渲染结果与旧内联 f-string 逐字一致。
     # #654: 查的是 "knowledge" 模板——mode='podcast' 的历史故事也走这个函数，
@@ -2278,13 +2283,16 @@ def generate_podcast_sentences(
 
     sentences: list[dict] = []
     remaining = list(cards)
+    prompts_sent: list[str] = []
 
     def _run_round(batch: list[dict], extra_hint: str, label: str) -> None:
         """One AI call for `batch`; moves every word it covered out of `remaining`."""
         # 8192: all-at-once batching (issue #563) can mean 30+ sentences in one
         # response, and the gpt-5 series shares this budget with internal
         # reasoning tokens (same rationale as the briefing call).
-        raw = _call_api(model, [{"role": "user", "content": _build_prompt(batch, extra_hint)}],
+        prompt = _build_prompt(batch, extra_hint)
+        prompts_sent.append(f"── {label} ──\n{prompt}" if prompts_sent else prompt)
+        raw = _call_api(model, [{"role": "user", "content": prompt}],
                          8192, purpose="podcast")
 
         json_start = raw.find("[")
@@ -2384,7 +2392,7 @@ def generate_podcast_sentences(
         })
 
     _fill_translations(sentences, progress_key=progress_key)
-    return sentences
+    return sentences, "\n\n".join(prompts_sent)
 
 
 def summarize_news_items(items: list[dict], model: str = "gpt-5-mini",

--- a/database/stories.py
+++ b/database/stories.py
@@ -186,8 +186,13 @@ def get_starred_sentences(lang: str | None = None, limit: int = 500) -> list[dic
         lang_clause = " AND (s.lang = ? OR (s.lang IS NULL AND ? = 'zh'))"
         params = [lang, lang]
     rows = conn.execute(
+        # has_prompt, not the prompt itself (#697): a knowledge prompt embeds up to
+        # 15000 chars of transcript, so inlining it would make this list response
+        # tens of MB. The full text is fetched per sentence via get_story_prompt().
         f"""SELECT ss.*, s.date AS story_date, s.category AS story_category,
-                   s.gen_params, s.topic, d.name AS deck_name
+                   s.gen_params, s.topic, d.name AS deck_name,
+                   s.id AS story_id,
+                   (s.prompt_text IS NOT NULL AND s.prompt_text != '') AS has_prompt
             FROM story_sentences ss
             JOIN stories s ON s.id = ss.story_id
             LEFT JOIN decks d ON d.id = s.deck_id
@@ -211,6 +216,35 @@ def get_starred_sentences(lang: str | None = None, limit: int = 500) -> list[dic
         result.append(d)
     conn.close()
     return result
+
+
+def get_story_prompt(story_id: int) -> dict | None:
+    """The full prompt that generated one story, for reading back when tuning it (#697).
+
+    `prompt` can legitimately be empty: legacy stories predate the column, and the
+    offline snapshot deliberately clears it (scripts/offline_sync_server.py). Callers
+    must say so rather than showing a blank box — None here means no such story.
+    """
+    conn = get_db()
+    row = conn.execute(
+        "SELECT id, prompt_text, date, category, gen_params FROM stories WHERE id = ?",
+        (story_id,),
+    ).fetchone()
+    conn.close()
+    if row is None:
+        return None
+    try:
+        gp = json.loads(row["gen_params"]) if row["gen_params"] else {}
+    except (ValueError, TypeError):
+        gp = {}
+    return {
+        "story_id": row["id"],
+        "prompt": row["prompt_text"] or "",
+        "date": row["date"],
+        "category": row["category"],
+        "mode": gp.get("mode") or "story",
+        "model": gp.get("model"),
+    }
 
 
 def get_latest_sentence_for_word(word_id: int) -> dict | None:

--- a/routes/story.py
+++ b/routes/story.py
@@ -382,15 +382,23 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
                           else min(len(cards), ai.MAX_PODCAST_BATCH))
             chunks = [cards[i:i + chunk_size] for i in range(0, len(cards), chunk_size)]
             sentences = []
+            chunk_prompts = []
             for idx, chunk in enumerate(chunks):
                 label = f" ({idx + 1}/{len(chunks)})" if len(chunks) > 1 else ""
-                sentences.extend(ai.generate_podcast_sentences(
+                chunk_sentences, chunk_prompt = ai.generate_podcast_sentences(
                     chunk, material, episode.get("title") or "",
                     model=model, max_hsk=max_hsk, progress_key=progress_key,
                     attempt_label=label,
                     source_url=episode.get("youtube_url") or f"/#{kind}-{episode_id}",
-                    source_title=episode.get("title")))
-            prompt_text = f"knowledge mode — item {episode_id} (kind={kind})"
+                    source_title=episode.get("title"))
+                sentences.extend(chunk_sentences)
+                if chunk_prompt:
+                    chunk_prompts.append(
+                        f"══ chunk{label} ══\n{chunk_prompt}" if len(chunks) > 1 else chunk_prompt)
+            # #697: this used to store a placeholder string, so knowledge stories —
+            # the mode being actively tuned — were the one mode whose prompt you
+            # couldn't go back and read.
+            prompt_text = "\n\n".join(chunk_prompts)
         else:
             sentences, prompt_text = _generate_story_sentences(
                 cards, topic=topic, max_hsk=max_hsk, model=model,
@@ -566,7 +574,7 @@ def generate_sentence_for_word(card: dict, gen_params: dict | None) -> dict | No
                 material = _knowledge_material(ep) if ep else ""
                 if material:
                     ep_kind = ep.get("kind") or "podcast"
-                    sentences = ai.generate_podcast_sentences(
+                    sentences, _ = ai.generate_podcast_sentences(
                         [card], material, ep.get("title") or "",
                         model=_validated_model(gp.get("model"), default=ai.DEFAULT_MODEL),
                         max_hsk=gp.get("max_hsk", 3),
@@ -773,6 +781,18 @@ def star_sentence(sentence_id: int, body: dict | None = None):
 @router.get("/api/starred-sentences")
 def list_starred_sentences(lang: str | None = None, limit: int = 500):
     return {"sentences": database.get_starred_sentences(lang=lang, limit=limit)}
+
+
+# NOT /api/story/{story_id}/prompt: GET /api/story/{deck_id}/{category} is
+# registered earlier and would swallow it with category="prompt".
+@router.get("/api/story-prompt/{story_id}")
+def get_story_prompt(story_id: int):
+    """The prompt that generated this story — the point of starring a sentence is
+    being able to go back and read it (#697)."""
+    result = database.get_story_prompt(story_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail=f"No story with id {story_id}")
+    return result
 
 
 # ── 提示词版本库（issue #610；原单份自定义模板见 #581）──────────────────────────

--- a/static/app.js
+++ b/static/app.js
@@ -2295,14 +2295,25 @@ function _starredSentenceRow(s) {
     source,
   ].filter(Boolean).join('<span class="ss-dot">·</span>');
 
+  // The prompt link is the point of the whole feature (#697) — a good sentence
+  // is only actionable next to the prompt that produced it.
+  const promptBtn = s.has_prompt
+    ? `<button class="ss-prompt-btn" title="Show the prompt that generated this sentence"
+               onclick="showStoryPrompt(${s.story_id})">📝 Prompt</button>`
+    : `<button class="ss-prompt-btn" disabled
+               title="No prompt stored for this story (legacy story, or an offline snapshot — it strips prompt_text)">📝 Prompt</button>`;
+
   return `<div class="bw-row ss-row">
     <div class="ss-main">
       <div class="ss-zh">${_escHtml(s.sentence_zh)}</div>
       ${trans ? `<div class="ss-trans">${_escHtml(trans)}</div>` : ''}
       <div class="ss-meta">${meta}</div>
     </div>
-    <button class="ss-unstar" title="Remove the star"
-            onclick="unstarSentence(${s.id}, this)">★</button>
+    <div class="ss-actions">
+      ${promptBtn}
+      <button class="ss-unstar" title="Remove the star"
+              onclick="unstarSentence(${s.id}, this)">★</button>
+    </div>
   </div>`;
 }
 
@@ -3915,7 +3926,10 @@ function toggleCostAction(idx) {
   arrow.innerHTML = open ? '&#9656;' : '&#9662;';
 }
 
-async function showCostPrompt(callId, kind = 'prompt') {
+// Shared monospace text overlay: the cost page's prompt/response viewer and the
+// starred-sentence prompt link (#697) show the same kind of thing, so they use
+// the same box rather than each growing their own.
+function _openPromptOverlay(title) {
   let overlay = document.getElementById('cost-prompt-overlay');
   if (!overlay) {
     overlay = document.createElement('div');
@@ -3933,15 +3947,37 @@ async function showCostPrompt(callId, kind = 'prompt') {
     document.body.appendChild(overlay);
   }
   overlay.style.display = 'flex';
-  const title = kind === 'response' ? 'Response' : 'Prompt';
   document.getElementById('cost-prompt-title').textContent = title;
   const body = document.getElementById('cost-prompt-body');
   body.textContent = 'Loading…';
+  return body;
+}
+
+async function showCostPrompt(callId, kind = 'prompt') {
+  const body = _openPromptOverlay(kind === 'response' ? 'Response' : 'Prompt');
   try {
     const data = await api('GET', `/api/costs/call/${callId}`);
     body.textContent = data[kind] || `(no ${kind} stored)`;
   } catch (e) {
     body.textContent = `Failed to load ${kind}: ` + e.message;
+  }
+}
+
+// The prompt that generated a starred sentence (#697) — the reason for starring
+// it in the first place is being able to come back and read this.
+async function showStoryPrompt(storyId) {
+  const body = _openPromptOverlay('Prompt');
+  try {
+    const d = await api('GET', `/api/story-prompt/${storyId}`);
+    document.getElementById('cost-prompt-title').textContent =
+      `Prompt — ${d.mode}${d.model ? ` · ${d.model}` : ''} · ${d.date}`;
+    // An empty prompt is a normal state (legacy story, or the offline snapshot
+    // strips prompt_text) — say which, don't show an empty box.
+    body.textContent = d.prompt ||
+      '(no prompt stored for this story — either it predates prompt logging, ' +
+      'or this database is an offline snapshot, which clears prompt_text to save space)';
+  } catch (e) {
+    body.textContent = 'Failed to load prompt: ' + e.message;
   }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -2582,6 +2582,12 @@ a.news-source-line:hover {
 .ss-dot    { opacity: 0.45; }
 .ss-source { color: var(--muted); text-decoration: underline; }
 .ss-source:hover { color: var(--primary); }
+.ss-actions { flex: 0 0 auto; display: flex; align-items: center; gap: 4px; }
+.ss-prompt-btn { cursor: pointer; font-size: 11px; padding: 3px 8px;
+                 border: 1px solid var(--border); border-radius: 999px;
+                 background: transparent; color: var(--muted); white-space: nowrap; }
+.ss-prompt-btn:hover:not(:disabled) { color: var(--primary); border-color: var(--primary); }
+.ss-prompt-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 .ss-unstar { flex: 0 0 auto; cursor: pointer; background: transparent;
              border: none; color: #e0a300; font-size: 17px; line-height: 1;
              padding: 2px 4px; }

--- a/tests/test_knowledge_story_mode.py
+++ b/tests/test_knowledge_story_mode.py
@@ -47,11 +47,12 @@ def populated_db(tmp_db, tmp_path):
 
 
 def _fake_podcast_sentences(cards, summary, title, **kwargs):
+    # (sentences, prompt) since #697 — the route stores the prompt on the story.
     return [
         {"word_id": c["word_id"], "sentence_zh": f"{c['word_zh']}出现在这一集里。",
          "sentence_en": "", "target_word": c["word_zh"]}
         for c in cards
-    ]
+    ], f"假提示词：{title}"
 
 
 def test_knowledge_mode_generates_story_from_video_episode(populated_db):
@@ -226,3 +227,26 @@ def test_knowledge_mode_story_generation_falls_back_without_transcript(populated
     assert not r.json().get("error")
     mock_gen.assert_called_once()
     assert seen_material["value"] == "Nur eine deutsche Zusammenfassung."
+
+
+# ── #697: knowledge 故事必须存下真实提示词 ────────────────────────────────────
+
+def test_knowledge_story_stores_the_real_prompt(populated_db):
+    """原来这里存的是占位符 "knowledge mode — item 7 (kind=video)"，于是
+    knowledge——正在调的那个模式——恰恰是唯一读不回提示词的模式。"""
+    deck_id = populated_db
+    episode_id = database.create_pending_episode(
+        "yt697", "https://youtube.com/@x", "一个视频标题", None,
+        "https://youtube.com/watch?v=yt697", kind="video")
+    database.update_episode(episode_id, status="summarized",
+                            transcript_zh="转录正文。", summary_de="Resümee.")
+
+    with patch("ai.generate_podcast_sentences", side_effect=_fake_podcast_sentences):
+        r = client.get(f"/api/story/{deck_id}/listening",
+                       params={"mode": "knowledge", "episode_id": episode_id})
+    assert r.status_code == 200 and not r.json().get("error")
+
+    story = database.get_active_story(database.anki_today().isoformat(), "listening", deck_id)
+    prompt = database.get_story_prompt(story["id"])["prompt"]
+    assert prompt == "假提示词：一个视频标题"
+    assert "knowledge mode — item" not in prompt

--- a/tests/test_podcast_sentences.py
+++ b/tests/test_podcast_sentences.py
@@ -4,6 +4,8 @@ AI 一律打桩在 ai._call_api 上——打在某个提供商的客户端上会
 """
 import json
 
+import pytest
+
 import ai
 
 
@@ -26,7 +28,7 @@ def test_reasoning_is_kept(monkeypatch):
         {"reasoning_zh": "话题：抖音电商。", "sentence_zh": "他在抖音上刷视频，顺便就下了单。",
          "target_word": "顺便"},
     ]))
-    sentences = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
+    sentences, prompt = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
 
     assert [s["reasoning_zh"] for s in sentences] == [
         "话题：字节跳动的AI路线。", "话题：抖音电商。"]
@@ -39,7 +41,7 @@ def test_missing_reasoning_is_not_fatal(monkeypatch):
         {"sentence_zh": "张一鸣承认公司暂时落后。"},
         {"sentence_zh": "他在抖音上刷视频，顺便就下了单。"},
     ]))
-    sentences = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
+    sentences, prompt = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
 
     assert [s["reasoning_zh"] for s in sentences] == ["", ""]
     assert len(sentences) == 2
@@ -57,7 +59,7 @@ def test_skipped_word_is_re_requested(monkeypatch):
         return _reply([{"sentence_zh": "他在抖音上刷视频，顺便就下了单。"}])
 
     monkeypatch.setattr(ai, "_call_api", fake_call)
-    sentences = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
+    sentences, prompt = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
 
     assert len(prompts) == 2
     assert "顺便" in prompts[1] and "补漏轮" in prompts[1]
@@ -68,7 +70,7 @@ def test_skipped_word_is_re_requested(monkeypatch):
 def test_fallback_only_after_all_rounds(monkeypatch):
     """AI 始终不写句子时仍然收敛：每张卡都有句子，且轮数有上限。"""
     monkeypatch.setattr(ai, "_call_api", lambda *a, **kw: _reply([]))
-    sentences = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
+    sentences, prompt = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
 
     assert len(sentences) == 2
     assert all("我学了" in s["sentence_zh"] for s in sentences)
@@ -88,3 +90,46 @@ def test_progress_log_is_recorded(monkeypatch):
     assert any("开始生成播客句子" in line for line in log)
     assert any("还差 0 个词" in line for line in log)
     ai.reset_story_log(key)
+
+
+# ── #697: 返回实际发出去的提示词，供加星句子回看 ──────────────────────────────
+
+def test_returns_the_prompt_actually_sent(monkeypatch):
+    """加星句子要能翻到生成它的提示词，所以这里必须把提示词交出来——
+    而且是真发出去的那份，不是事后重建的。"""
+    sent = []
+
+    def fake_call(model, messages, *a, **kw):
+        sent.append(messages[0]["content"])
+        return _reply([{"sentence_zh": "张一鸣承认公司暂时落后。"},
+                       {"sentence_zh": "他在抖音上刷视频，顺便就下了单。"}])
+
+    monkeypatch.setattr(ai, "_call_api", fake_call)
+    sentences, prompt = ai.generate_podcast_sentences(CARDS, "字节跳动的一集", "标题")
+
+    assert prompt == sent[0]
+    assert "字节跳动的一集" in prompt      # 素材
+    assert "承认" in prompt and "顺便" in prompt   # 目标词
+
+
+def test_prompt_includes_every_retry_round(monkeypatch):
+    """补漏轮带 extra_hint，提示词和第一轮不同——只留第一轮就说不清
+    这些句子到底是被什么提示词写出来的。"""
+    def fake_call(model, messages, *a, **kw):
+        if "补漏轮" not in messages[0]["content"]:
+            return _reply([{"sentence_zh": "张一鸣承认公司暂时落后。"}])
+        return _reply([{"sentence_zh": "他在抖音上刷视频，顺便就下了单。"}])
+
+    monkeypatch.setattr(ai, "_call_api", fake_call)
+    _, prompt = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
+
+    assert "补漏轮" in prompt
+    assert prompt.count("【补漏轮】") == 1
+
+
+def test_no_material_returns_empty_prompt(monkeypatch):
+    """没有素材时不调 AI，也就没有提示词可存。"""
+    monkeypatch.setattr(ai, "_call_api",
+                        lambda *a, **kw: pytest.fail("素材为空时不该调 AI"))
+    sentences, prompt = ai.generate_podcast_sentences(CARDS, "   ", "标题")
+    assert sentences == [] and prompt == ""

--- a/tests/test_starred_sentences.py
+++ b/tests/test_starred_sentences.py
@@ -211,3 +211,83 @@ def test_api_starred_sentences_lang_filter(tmp_db):
 
     body = client.get("/api/starred-sentences?lang=fr").json()["sentences"]
     assert [s["id"] for s in body] == [fr]
+
+
+# ---------------------------------------------------------------------------
+# Linking a starred sentence back to the prompt that made it (#697)
+# ---------------------------------------------------------------------------
+
+def test_starred_list_links_to_its_story_without_inlining_the_prompt(tmp_db):
+    """A knowledge prompt embeds up to 15000 chars of transcript. Inlining it in a
+    500-row list would make the response tens of MB — so the list carries the link
+    (story_id) and a has_prompt flag, and the text is fetched on demand."""
+    story_id, sentence_id = _make_story()
+    conn = database.get_db()
+    conn.execute("UPDATE stories SET prompt_text = ? WHERE id = ?",
+                 ("完整的提示词正文……", story_id))
+    conn.commit()
+    conn.close()
+    database.set_sentence_starred(sentence_id, True)
+
+    s = database.get_starred_sentences()[0]
+    assert s["story_id"] == story_id
+    assert s["has_prompt"] == 1
+    assert "prompt_text" not in s
+    assert "完整的提示词正文" not in str(s)
+
+
+def test_has_prompt_false_when_prompt_was_stripped(tmp_db):
+    """The offline snapshot clears stories.prompt_text (offline_sync_server.py), and
+    legacy stories predate the column — the UI has to be able to say so."""
+    _, sentence_id = _make_story()
+    database.set_sentence_starred(sentence_id, True)
+    assert database.get_starred_sentences()[0]["has_prompt"] == 0
+
+
+def test_get_story_prompt(tmp_db):
+    story_id, _ = _make_story(mode="knowledge")
+    conn = database.get_db()
+    conn.execute("UPDATE stories SET prompt_text = ? WHERE id = ?", ("提示词正文", story_id))
+    conn.commit()
+    conn.close()
+
+    p = database.get_story_prompt(story_id)
+    assert p["prompt"] == "提示词正文"
+    assert p["mode"] == "knowledge"
+    assert p["model"] == "deepseek-chat"
+    assert p["date"] == "2026-08-11"
+
+
+def test_get_story_prompt_missing_story_is_none(tmp_db):
+    assert database.get_story_prompt(99999) is None
+
+
+def test_get_story_prompt_empty_when_stripped(tmp_db):
+    """No prompt is a normal state, not an error — distinct from "no such story"."""
+    story_id, _ = _make_story()
+    assert database.get_story_prompt(story_id)["prompt"] == ""
+
+
+def test_api_story_prompt_round_trip(tmp_db):
+    story_id, _ = _make_story()
+    conn = database.get_db()
+    conn.execute("UPDATE stories SET prompt_text = ? WHERE id = ?", ("提示词正文", story_id))
+    conn.commit()
+    conn.close()
+
+    r = client.get(f"/api/story-prompt/{story_id}")
+    assert r.status_code == 200
+    assert r.json()["prompt"] == "提示词正文"
+
+
+def test_api_story_prompt_404(tmp_db):
+    assert client.get("/api/story-prompt/99999").status_code == 404
+
+
+def test_api_story_prompt_path_does_not_collide_with_story_endpoint(tmp_db):
+    """GET /api/story/{deck_id}/{category} is registered first and would swallow
+    /api/story/{id}/prompt as category='prompt' — hence the separate path."""
+    story_id, _ = _make_story()
+    r = client.get(f"/api/story-prompt/{story_id}")
+    assert r.status_code == 200
+    assert "story_id" in r.json()


### PR DESCRIPTION
Closes #697

接续 #692。提示词已经存在 `stories.prompt_text` 里，所以这里**只链接，不再存第二份**。

## 前置缺陷：knowledge 模式根本没存提示词

`routes/story.py` 原来是：

```python
prompt_text = f"knowledge mode — item {episode_id} (kind={kind})"
```

一句占位符。于是 `knowledge`——正在打磨的那个模式——恰恰是唯一读不回提示词的模式。修了它，"链过去"才有意义。

## 改动

### `ai.generate_podcast_sentences()` → `(sentences, prompt)`
与本模块其它生成函数一致（`generate_story`、`generate_briefing_sentences` 都返回 tuple；`routes/story.py:576` 早就在用这个惯例）。

返回的是**实际发出去的**提示词，跨轮拼接：补漏轮会带 `extra_hint`，事后重建的版本并不是写出这些句子的那一份——而"这些句子是被什么提示词写出来的"正是要回看的东西。多 chunk 时各 chunk 的提示词也都保留。

### 列表只带链接，不内联全文
`get_starred_sentences()` 增加 `story_id` + `has_prompt`。一份 knowledge 提示词内嵌上万字转录，500 行列表内联全文会变成几十 MB，所以全文按需另取。

### `GET /api/story-prompt/{story_id}`
⚠️ **不能**写成 `/api/story/{story_id}/prompt`：`GET /api/story/{deck_id}/{category}` 注册在前，会把它当 `category="prompt"` 吃掉。有一条测试专门守着这个路径。

### 前端
⭐ Sentences 每行加「📝 Prompt」按钮，弹窗显示全文（复用成本页已有的等宽弹窗——抽出 `_openPromptOverlay()` 两处共用，不造第二个）。

**提示词为空是正常状态**，不是错误：旧故事早于该列，且离线快照会主动清空 `prompt_text`（`scripts/offline_sync_server.py`）。这时按钮禁用并在 title 里说明原因，弹窗也给出解释文字，而不是一个空白框。

## 怎么测试的

- 新增：提示词等于实际发送内容、含素材与目标词；多轮时补漏轮的提示词也在；无素材时不调 AI 且提示词为空
- 新增：knowledge 故事的 `prompt_text` 不再是占位符
- 新增：列表带 `story_id`/`has_prompt` 且**不含**提示词全文；`has_prompt` 在被清空时为假
- 新增：`GET /api/story-prompt/{id}` 往返、404、空提示词、路径不与 `/api/story/{deck}/{cat}` 冲突
- 更新了 9 处旧测试桩以匹配新的 tuple 返回（属于契约变化，未删任何断言）
- `pytest tests/` **383 passed, 4 skipped**；`node --check static/app.js` 通过
- 临时实例（8002 端口 + 临时库，未碰 dev.db）实测：列表确认不泄漏提示词全文、提示词接口取回全文、404 正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)