### PR TITLE
修复：Reconstruct 目标词跨分词边界时不被挖空（#699）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -6715,71 +6715,68 @@ function pickExtraBlankWord(zh, excludeWord) {
   return zh.slice(idx, idx + 2);
 }
 
+// ── Word bank: locate the target word inside the sentence ──────────────────
+// Pure function (no DOM/global access) so tests can run it directly — see
+// tests/test_word_bank.py, which extracts this source and runs it in node.
+//
+// Returns the ordered token stream [{type:'char'|'target', char|word}, ...].
+// The target is located by CHARACTER OFFSET in the raw sentence, not by token
+// identity: the tokenizer regularly cuts straight through it (#699 — target
+// 活下 in "TÜV在严格监管中活下来。" is tokenized as …中活/下来…, i.e. the
+// suffix of one token plus the prefix of the next). Matching whole tokens
+// left the target unblanked, printed in plain sight above its own answer box.
+function buildWordBankOrder(zh, tokens, target) {
+  // Separable words like "由...组成" — each part is located independently
+  const targetParts = target.includes('...') ? target.split('...').filter(p => p.length > 0) : [target];
+
+  // Token texts must rejoin into the exact sentence for offsets to line up;
+  // anything else (malformed AI tokens) falls back to per-character tokens.
+  let tokenTexts = (tokens && tokens.length) ? tokens.map(t => t[0]) : null;
+  if (!tokenTexts || tokenTexts.join('') !== zh) tokenTexts = [...zh];
+
+  // Character ranges of the target parts, searched left to right
+  const ranges = [];
+  let searchFrom = 0;
+  for (const part of targetParts) {
+    const idx = zh.indexOf(part, searchFrom);
+    if (idx < 0) break;
+    ranges.push([idx, idx + part.length]);
+    searchFrom = idx + part.length;
+  }
+
+  // Slice the token stream at those ranges
+  const order = [];
+  let pos = 0;
+  for (const text of tokenTexts) {
+    const start = pos;
+    const end = pos + text.length;
+    pos = end;
+    let cur = start;
+    for (const [rs, re] of ranges) {
+      if (re <= cur || rs >= end) continue;
+      if (rs > cur) order.push({ type: 'char', char: zh.slice(cur, rs) });
+      // A target spanning several tokens is emitted once, where it starts
+      if (rs >= start) order.push({ type: 'target', word: zh.slice(rs, re) });
+      cur = Math.min(re, end);
+    }
+    if (cur < end) order.push({ type: 'char', char: zh.slice(cur, end) });
+  }
+
+  // Target (or some of its parts) missing from the sentence — append a blank
+  // for each one so the user is still asked for the word.
+  for (let i = ranges.length; i < targetParts.length; i++) {
+    order.push({ type: 'target', word: targetParts[i] });
+  }
+  return order;
+}
+
 // ── Word bank (creating mode, non-sentence notes) ─────────────────────────
 async function _buildWordBank() {
   const zh = sentence?.sentence_zh;
   // No sentence for this card yet — clear stale state so the previous card's
   // word bank doesn't linger on screen (renderWordBankUI clears the DOM too).
   if (!zh || !card?.word_zh) { wordBankOrder = []; wordBankTokens = []; return; }
-  const target = card.word_zh;
-
-  // Separable words like "由...组成" — split into parts to match independently
-  const targetParts = target.includes('...') ? target.split('...').filter(p => p.length > 0) : null;
-  const isTargetPart = text => targetParts ? targetParts.includes(text) : (text === target);
-  const isTargetEmbedded = text => !targetParts && target.length > 0 && text.includes(target);
-
-  // Build ordered sequence from tokens [[text, word_id_or_null], ...]
-  let order;
-  if (sentence.tokens && sentence.tokens.length) {
-    order = sentence.tokens.flatMap(([text, wid]) => {
-      if (isTargetPart(text)) return [{ type: 'target', word: text }];
-      if (isTargetEmbedded(text)) {
-        // Target is embedded in a larger token — split it out
-        const idx = text.indexOf(target);
-        const parts = [];
-        if (idx > 0) parts.push({ type: 'char', char: text.slice(0, idx) });
-        parts.push({ type: 'target', word: target });
-        if (idx + target.length < text.length) parts.push({ type: 'char', char: text.slice(idx + target.length) });
-        return parts;
-      }
-      return [{ type: 'char', char: text }];
-    });
-  } else {
-    // Fallback: split by target word boundary, then individual chars
-    const rawTokens = [];
-    let i = 0;
-    const tIdx = targetParts ? -1 : zh.indexOf(target);
-    while (i < zh.length) {
-      if (tIdx >= 0 && i === tIdx) { rawTokens.push(target); i += target.length; }
-      else { rawTokens.push(zh[i]); i++; }
-    }
-    order = rawTokens.map(tok =>
-      isTargetPart(tok)
-        ? { type: 'target', word: tok }
-        : { type: 'char', char: tok }
-    );
-  }
-  // Handle case where NLP tokenizer splits the target across consecutive tokens
-  // e.g., "怎么可能" tokenized as ["怎么", "可能"] — merge them into one target token
-  if (!targetParts) {
-    for (let i = 0; i < order.length; i++) {
-      if (order[i].type !== 'char') continue;
-      let acc = '';
-      let j = i;
-      while (j < order.length && order[j].type === 'char') {
-        acc += order[j].char;
-        if (acc === target) { order.splice(i, j - i + 1, { type: 'target', word: target }); break; }
-        if (!target.startsWith(acc)) break;
-        j++;
-      }
-      if (order[i]?.type === 'target') break;
-    }
-  }
-
-  // For separable words, count how many parts were found; for normal words, check if any target found
-  const targetCount = order.filter(it => it.type === 'target').length;
-  const expectedCount = targetParts ? targetParts.length : 1;
-  if (targetCount < expectedCount) order.push({ type: 'target', word: targetParts ? targetParts[targetCount] : target });
+  const order = buildWordBankOrder(zh, sentence.tokens, card.word_zh);
 
   const MAX_TILES = parseInt(document.getElementById('word-bank-slider')?.value ?? _wordBankTileDefault(), 10);
   // Chinese: a "word" tile is any CJK character. French (space-separated tokens):

--- a/tests/test_word_bank.py
+++ b/tests/test_word_bank.py
@@ -1,0 +1,141 @@
+"""Word bank (Reconstruct the sentence) target-word placement — #699.
+
+`buildWordBankOrder()` lives in static/app.js and has no build step, so the
+test extracts that one pure function from the source and runs it in node.
+Skipped when node isn't installed (it is on ubuntu-latest, where CI runs).
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+APP_JS = Path(__file__).resolve().parent.parent / "static" / "app.js"
+FN = "function buildWordBankOrder("
+
+pytestmark = pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+
+
+def _extract_fn(source: str, header: str) -> str:
+    """Return the full text of a top-level function, by brace matching."""
+    start = source.index(header)
+    depth = 0
+    for i in range(source.index("{", start), len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start:i + 1]
+    raise AssertionError(f"unbalanced braces after {header}")
+
+
+def build_order(zh, tokens, target):
+    fn = _extract_fn(APP_JS.read_text(encoding="utf-8"), FN)
+    script = (
+        fn
+        + "\nconst [zh, tokens, target] = JSON.parse(process.argv[1]);"
+        + "\nprocess.stdout.write(JSON.stringify(buildWordBankOrder(zh, tokens, target)));"
+    )
+    out = subprocess.run(
+        ["node", "-e", script, json.dumps([zh, tokens, target])],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(out.stdout)
+
+
+def rejoined(order):
+    """The order must always reproduce the sentence exactly."""
+    return "".join(it.get("char") or it.get("word") for it in order)
+
+
+def targets(order):
+    return [it["word"] for it in order if it["type"] == "target"]
+
+
+def toks(*texts):
+    return [[t, None] for t in texts]
+
+
+def test_target_across_token_boundary():
+    """#699: jieba cuts 活下 into 中活/下来 — offsets must still find it."""
+    zh = "TÜV在严格监管中活下来。"
+    tokens = toks("T", "Ü", "V", "在", "严格", "监管", "中活", "下来", "。")
+    order = build_order(zh, tokens, "活下")
+    assert targets(order) == ["活下"]
+    assert rejoined(order) == zh
+
+
+def test_target_as_suffix_of_previous_token():
+    zh = "他一定能活下。"
+    order = build_order(zh, toks("他", "一定", "能活", "下", "。"), "活下")
+    assert targets(order) == ["活下"]
+    assert rejoined(order) == zh
+
+
+def test_whole_token_match():
+    zh = "我告诉自己一定要冷静活下。"
+    order = build_order(zh, toks("我", "告诉", "自己", "一定", "要", "冷静", "活下", "。"), "活下")
+    assert targets(order) == ["活下"]
+    assert rejoined(order) == zh
+
+
+def test_target_embedded_in_larger_token():
+    zh = "他怎么可能知道。"
+    order = build_order(zh, toks("他", "怎么可能", "知道", "。"), "怎么")
+    assert targets(order) == ["怎么"]
+    assert rejoined(order) == zh
+
+
+def test_target_spanning_several_whole_tokens():
+    zh = "他怎么可能知道。"
+    order = build_order(zh, toks("他", "怎么", "可能", "知道", "。"), "怎么可能")
+    assert targets(order) == ["怎么可能"]
+    assert rejoined(order) == zh
+
+
+def test_separable_word_both_parts():
+    zh = "水由氢和氧组成。"
+    order = build_order(zh, toks("水", "由", "氢", "和", "氧", "组成", "。"), "由...组成")
+    assert targets(order) == ["由", "组成"]
+    assert rejoined(order) == zh
+
+
+def test_missing_target_appended_as_blank():
+    """Word absent from the sentence: still ask for it, at the end."""
+    zh = "今天天气很好。"
+    order = build_order(zh, toks("今天", "天气", "很", "好", "。"), "活下")
+    assert targets(order) == ["活下"]
+    assert rejoined(order) == zh + "活下"
+
+
+def test_missing_separable_part_appended():
+    zh = "水由氢和氧构成。"
+    order = build_order(zh, toks("水", "由", "氢", "和", "氧", "构成", "。"), "由...组成")
+    assert targets(order) == ["由", "组成"]
+    assert rejoined(order) == zh + "组成"
+
+
+def test_no_tokens_falls_back_to_characters():
+    zh = "TÜV在严格监管中活下来。"
+    order = build_order(zh, [], "活下")
+    assert targets(order) == ["活下"]
+    assert rejoined(order) == zh
+
+
+def test_malformed_tokens_fall_back_to_characters():
+    """AI tokens that don't rejoin into the sentence must not shift offsets."""
+    zh = "他一定能活下。"
+    order = build_order(zh, toks("他", "一定"), "活下")
+    assert targets(order) == ["活下"]
+    assert rejoined(order) == zh
+
+
+def test_french_space_separated_tokens_preserved():
+    zh = "Il faut survivre ici."
+    order = build_order(zh, toks("Il", " ", "faut", " ", "survivre", " ", "ici."), "survivre")
+    assert targets(order) == ["survivre"]
+    assert rejoined(order) == zh
+    # Whitespace stays its own token so it can never become an empty tile
+    assert {"type": "char", "char": " "} in order


### PR DESCRIPTION
## 问题

目标词 `活下`、句子 `TÜV在严格监管中活下来。`：jieba 切成 `… 监管 / 中活 / 下来 / 。`，目标词横跨 `中活`|`下来` 的边界。

`_buildWordBank()` 原来的三条匹配规则（整块 === 目标词、目标词整个嵌在一块里、若干**完整**块拼起来等于目标词）都要求目标词与分词边界对齐，跨边界一条都不命中 → `targetCount = 0` → 句子原样全文显示、句尾额外追加一个空格子。界面上目标生词就明晃晃写在它自己的答题框上方。

## 改法

定位改为**按字符位置**：在原句里 `indexOf` 目标词（可分离词逐段、从左往右），得到字符区间后再据此切开词块流——目标词落在任何边界上都能被挖出来。逻辑抽成纯函数 `buildWordBankOrder(zh, tokens, target)`。

顺带修掉的：词块拼不回原句时（AI 给的 tokens 有问题）会静默错位，现在退回按字符切；可分离词只缺一段时原来只补一个空格子。

## 测试

`tests/test_word_bank.py`：提取该函数源码交给 node 执行（本机/CI 的 ubuntu-latest 都有 node，没有则 skip）。11 条用例覆盖跨边界、整块匹配、块内嵌入、多块合并、可分离词、目标词缺失、无 tokens、tokens 拼不回原句、法语空格分词；每条都断言 order 能原样拼回句子。

本地 `pytest tests/`：395 passed, 4 skipped。

Closes #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)