### PR TITLE
复习收尾提醒：今天的 Again 卡片全部重新到期时发邮件（#701）

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -1,7 +1,7 @@
 import logging
 import sqlite3
-from datetime import date, datetime, timedelta
-from .core import get_db, anki_today
+from datetime import date, datetime, time, timedelta
+from .core import get_db, anki_today, get_day_cutoff_hour
 from .presets import get_preset_for_deck
 from .decks import get_deck, get_locked_deck_ids
 
@@ -1762,6 +1762,62 @@ def count_due_all_decks() -> dict:
         susp_flags[key] = total > 0 and total == suspended
 
     return counts, susp_flags
+
+
+def due_notification_status() -> dict:
+    """Decide whether today's leftover reviews can be finished in one sitting
+    right now — the trigger for the reminder email (issue #701).
+
+    After Daniel clears the queue, the cards he rated Again are still sitting in
+    the learning steps (1m 10m 1d 3d) and come back in batches. Notifying on the
+    first one to return would just send him back for two cards and another wait,
+    so the reminder waits until nothing is pending anymore:
+
+      due_now      learning/relearn cards due right now — the leftovers.
+      later_today  learning/relearn cards coming back before tomorrow's day
+                   cutoff. Any of these pending means "not yet". Cards on the
+                   1d/3d steps are due after the cutoff and are deliberately
+                   excluded — they belong to a later day, and waiting for them
+                   would mean the reminder never fires.
+      other_due    new + review cards still due today. If any are left the queue
+                   never actually hit zero, so there is no session to finish.
+
+    Counts reuse count_due_all_decks(), which already applies the new-card daily
+    limit and zeroes out locked daily decks and disabled reading categories — a
+    hand-rolled COUNT(*) here would disagree with the badges in the UI.
+    """
+    counts, _ = count_due_all_decks()
+    due_now = sum(c["learning"] for c in counts.values())
+    other_due = sum(c["new"] + c["review"] for c in counts.values())
+
+    now = datetime.now().isoformat(timespec="seconds")
+    # Tomorrow's cutoff as a full ISO datetime: cards.due holds datetimes for
+    # learning cards, so comparing against a bare date string would place
+    # everything due between midnight and the cutoff on the wrong day.
+    tomorrow_cutoff = datetime.combine(
+        anki_today() + timedelta(days=1), time(hour=get_day_cutoff_hour())
+    ).isoformat(timespec="seconds")
+
+    lock_clause, lock_params = _locked_exclusion()
+    conn = get_db()
+    row = conn.execute(
+        "SELECT COUNT(*) AS cnt FROM cards WHERE "
+        "state IN ('learning', 'relearn') AND due > ? AND due < ? "
+        "AND deleted_at IS NULL "
+        "AND (buried_until IS NULL OR buried_until < date('now'))"
+        + lock_clause
+        + f" AND NOT {_READING_DISABLED_SQL}",
+        [now, tomorrow_cutoff, *lock_params],
+    ).fetchone()
+    conn.close()
+    later_today = row["cnt"] or 0
+
+    return {
+        "due_now": due_now,
+        "later_today": later_today,
+        "other_due": other_due,
+        "ready": due_now > 0 and later_today == 0 and other_due == 0,
+    }
 
 
 def get_deck_all_suspended(deck_id: int) -> bool:

--- a/podcast.py
+++ b/podcast.py
@@ -1286,22 +1286,45 @@ def _summary_zh_html(summary_zh: str) -> str:
     )
 
 
-def send_email(episode: dict) -> bool:
-    """Send the HTML notification email for a freshly-summarized episode.
-    Returns True if sent, False if skipped (SMTP not configured) — skipping
-    is not an error, callers just don't set email_sent_at."""
+def send_mail(subject: str, body_html: str, *, context: str = "mail") -> bool:
+    """Send one HTML mail to the configured recipient. Returns True if sent,
+    False if skipped because SMTP isn't configured — skipping is not an error,
+    callers just don't record a send. `context` only labels the log line.
+
+    Shared by the podcast/knowledge notifications and the review reminder
+    (#701) so there is one place that knows how this mailbox is reached."""
     host = os.environ.get("SMTP_HOST")
     username = os.environ.get("SMTP_USERNAME")
     password = os.environ.get("SMTP_PASSWORD")
     from_addr = os.environ.get("SMTP_FROM") or username
     if not host or not username or not password or not from_addr:
-        logger.info("podcast: SMTP not configured, skipping email for %s", episode["video_id"])
+        logger.info("podcast: SMTP not configured, skipping email for %s", context)
         return False
 
     port = int(os.environ.get("SMTP_PORT", "587"))
-    public_base = os.environ.get("PUBLIC_BASE_URL", "https://powerdaniel3000.duckdns.org")
     cfg = database.get_podcast_config()
     to_addr = cfg.get("email_to") or "u82g@outlook.com"
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = subject
+    msg["From"] = from_addr
+    msg["To"] = to_addr
+    msg.attach(MIMEText(body_html, "html", "utf-8"))
+
+    with smtplib.SMTP(host, port, timeout=30) as server:
+        server.starttls()
+        server.login(username, password)
+        server.sendmail(from_addr, [to_addr], msg.as_string())
+
+    logger.info("podcast: email sent for %s to %s", context, to_addr)
+    return True
+
+
+def send_email(episode: dict) -> bool:
+    """Send the HTML notification email for a freshly-summarized episode.
+    Returns True if sent, False if skipped (SMTP not configured) — skipping
+    is not an error, callers just don't set email_sent_at."""
+    public_base = os.environ.get("PUBLIC_BASE_URL", "https://powerdaniel3000.duckdns.org")
 
     transcript_link = f"{public_base}/#podcast-{episode['id']}"
     words_html = _words_table_html(episode.get("hsk_words") or [])
@@ -1323,7 +1346,6 @@ def send_email(episode: dict) -> bool:
     </body></html>
     """
 
-    msg = MIMEMultipart("alternative")
     # Subject = "<podcast name> - <episode title>" (#631). The old
     # "Neue Podcast-Folge:" prefix was identical on every mail and ate the
     # first 20 characters of the inbox list — the podcast name is what
@@ -1331,18 +1353,8 @@ def send_email(episode: dict) -> bool:
     # feed name on record the episode title stands alone; the dead prefix
     # does not come back.
     feed_title = _feed_title(episode)
-    msg["Subject"] = f"{feed_title} - {episode['title']}" if feed_title else episode["title"]
-    msg["From"] = from_addr
-    msg["To"] = to_addr
-    msg.attach(MIMEText(body_html, "html", "utf-8"))
-
-    with smtplib.SMTP(host, port, timeout=30) as server:
-        server.starttls()
-        server.login(username, password)
-        server.sendmail(from_addr, [to_addr], msg.as_string())
-
-    logger.info("podcast: email sent for %s to %s", episode["video_id"], to_addr)
-    return True
+    subject = f"{feed_title} - {episode['title']}" if feed_title else episode["title"]
+    return send_mail(subject, body_html, context=episode["video_id"])
 
 
 def send_signal(episode: dict) -> bool:

--- a/review_notify.py
+++ b/review_notify.py
@@ -1,0 +1,66 @@
+"""复习收尾提醒（议题 #701）。
+
+Daniel 清空当天队列后，被他评为 Again 的卡片还留在学习步骤里（1m 10m 1d 3d），
+分批重新到期。他离开界面就无从知道它们什么时候回来。本模块由服务器 cron
+定期调用：当**今天剩下的复习可以一口气做完**时发一封邮件，且每个 Anki 日
+最多发一次。
+
+判定逻辑全在 database.due_notification_status()，这里只负责去重与发信。
+"""
+
+import logging
+import os
+
+import database
+import podcast
+
+logger = logging.getLogger(__name__)
+
+# 记录上次发送提醒的 Anki 日（ISO 日期），保证每天最多一封。
+LAST_SENT_KEY = "due_notify_last_day"
+
+
+def _build_email_html(status: dict) -> str:
+    base = os.environ.get("PUBLIC_BASE_URL", "https://powerdaniel3000.duckdns.org")
+    count = status["due_now"]
+    return f"""
+    <html><body style="font-family:sans-serif;max-width:640px">
+      <h2>复习收尾：{count} 张卡片等你</h2>
+      <p style="font-size:15px;line-height:1.7">
+        今天你评为 Again 的卡片已经<b>全部</b>重新到期，现在一次就能做完，
+        不会做到一半又要等下一个学习步骤。
+      </p>
+      <p><a href="{base}/">打开复习</a></p>
+    </body></html>
+    """
+
+
+def check_and_notify(force: bool = False) -> dict:
+    """跑一次判定，满足条件就发邮件。返回判定明细 + 本次是否发送。
+
+    force=True 跳过"每天一封"的去重，供手动测试用；仍然要求条件成立。
+    """
+    status = database.due_notification_status()
+    today = database.anki_today().isoformat()
+    already = database.get_app_setting(LAST_SENT_KEY)
+
+    result = {**status, "sent": False, "already_sent_today": already == today}
+
+    if not status["ready"]:
+        logger.info("due-notify: 条件未满足 %s", status)
+        return result
+    if already == today and not force:
+        logger.info("due-notify: 今天（%s）已经发过，跳过", today)
+        return result
+
+    # SMTP 未配置时 send_mail 返回 False —— 那是"跳过"不是失败，所以也不写
+    # 标记：等配置好了当天仍然能收到提醒。
+    sent = podcast.send_mail(
+        f"复习收尾：{status['due_now']} 张卡片已重新到期",
+        _build_email_html(status),
+        context="due-notify",
+    )
+    if sent:
+        database.set_app_setting(LAST_SENT_KEY, today)
+    result["sent"] = sent
+    return result

--- a/routes/review.py
+++ b/routes/review.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from fastapi import APIRouter, HTTPException
 
 import database
+import review_notify
 import srs
 import tts
 from .utils import leaf_ids, queue_mgr as _queue_mgr, ai_disabled
@@ -566,6 +567,15 @@ def get_card_calendar(card_id: int):
 @router.get("/api/cards/{card_id}/timeline")
 def get_card_timeline(card_id: int):
     return database.get_card_timeline_data(card_id)
+
+
+@router.post("/api/review/due-notify-check")
+def due_notify_check(force: bool = False):
+    """Run one review-reminder check (issue #701). Called by cron every few
+    minutes; sends the mail only when today's leftovers are all due at once and
+    nothing was sent yet today. Returns the verdict either way — a check that
+    decides not to send is a normal outcome, not an error."""
+    return review_notify.check_and_notify(force=force)
 
 
 @router.post("/api/session-timelines")

--- a/scripts/due_check.py
+++ b/scripts/due_check.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""复习收尾提醒定时脚本（议题 #701）。
+
+对一台运行中的服务器发送一次 POST /api/review/due-notify-check —— 服务器判断
+「今天评过 Again 的卡片是否已经全部重新到期」，是则发一封提醒邮件（每个 Anki
+日最多一封）。风格照抄 scripts/podcast_check.py：只用标准库，本地/服务器都能跑。
+
+用法：
+    BASE_URL=http://127.0.0.1:8000 python scripts/due_check.py
+
+服务器 cron（每 5 分钟一次；条件不满足时脚本什么都不做，很便宜）：
+    */5 * * * * cd /home/anki/AnkiAdvanced && /home/anki/AnkiAdvanced/venv/bin/python \
+        scripts/due_check.py >> /home/anki/AnkiAdvanced/data/due_check.log 2>&1
+
+环境变量：
+    BASE_URL       服务器地址，默认 http://127.0.0.1:8000
+    AUTH_USERNAME  可选，HTTP Basic 认证用户名
+    AUTH_PASSWORD  可选，HTTP Basic 认证密码
+"""
+
+import base64
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+BASE_URL = os.environ.get("BASE_URL", "http://127.0.0.1:8000").rstrip("/")
+AUTH_USERNAME = os.environ.get("AUTH_USERNAME")
+AUTH_PASSWORD = os.environ.get("AUTH_PASSWORD")
+
+# 判定是几条 SQL + 可能一次 SMTP 发信，30 秒足够。
+CHECK_TIMEOUT_SECONDS = 30
+
+
+def _log(msg: str) -> None:
+    ts = time.strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[{ts}] {msg}", flush=True)
+
+
+def _auth_header() -> dict:
+    if AUTH_USERNAME is not None and AUTH_PASSWORD is not None:
+        token = base64.b64encode(f"{AUTH_USERNAME}:{AUTH_PASSWORD}".encode()).decode()
+        return {"Authorization": f"Basic {token}"}
+    return {}
+
+
+def main() -> int:
+    url = f"{BASE_URL}/api/review/due-notify-check"
+    req = urllib.request.Request(url, data=b"", headers=_auth_header(), method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=CHECK_TIMEOUT_SECONDS) as resp:
+            result = json.loads(resp.read() or b"{}")
+    except urllib.error.URLError as e:
+        _log(f"无法连接服务器 {BASE_URL}: {e}")
+        return 1
+    except Exception as e:
+        _log(f"复习提醒检查请求失败: {e}")
+        return 1
+
+    # 绝大多数轮次都是"条件未满足"，只在真发了信时才写一行日志，免得
+    # 每 5 分钟往日志里灌一条毫无信息量的记录。
+    if result.get("sent"):
+        _log(f"已发送复习提醒：{result.get('due_now')} 张卡片到期")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_due_notify.py
+++ b/tests/test_due_notify.py
@@ -1,0 +1,188 @@
+"""复习收尾提醒的测试（议题 #701）。
+
+这个功能的价值全在「什么时候**不**发」：分批到期时发信等于把 Daniel 叫回来
+做两张卡再干等十分钟，那还不如不提醒。所以下面每条否定用例都和肯定用例同等
+重要。
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+import database
+import database.core
+import review_notify
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    # database.core.DB_PATH，不是 database.DB_PATH —— 见 conftest.py（#615）。
+    monkeypatch.setattr(database.core, "DB_PATH", str(tmp_path / "test.db"))
+    database.init_db()
+    return tmp_path / "test.db"
+
+
+@pytest.fixture
+def mail(monkeypatch):
+    """拦住 SMTP，记录每次发信。"""
+    sent = []
+
+    def _fake_send_mail(subject, body_html, *, context="mail"):
+        sent.append({"subject": subject, "body": body_html, "context": context})
+        return True
+
+    monkeypatch.setattr(review_notify.podcast, "send_mail", _fake_send_mail)
+    return sent
+
+
+def _deck() -> int:
+    return database.get_or_create_deck("NotifyDeck")
+
+
+def _card(deck_id: int, word: str, state: str, due: str) -> int:
+    """建一张指定状态与到期时刻的卡片。"""
+    word_id = database.insert_word({"word_zh": word, "definition": word})
+    card_id = database.insert_card(word_id, "listening", deck_id, state=state, due=due)
+    conn = database.get_db()
+    conn.execute("UPDATE cards SET state = ?, due = ? WHERE id = ?", (state, due, card_id))
+    conn.commit()
+    conn.close()
+    return card_id
+
+
+def _now_minus(minutes: int) -> str:
+    return (datetime.now() - timedelta(minutes=minutes)).isoformat(timespec="seconds")
+
+
+def _now_plus(minutes: int) -> str:
+    return (datetime.now() + timedelta(minutes=minutes)).isoformat(timespec="seconds")
+
+
+# ---------------------------------------------------------------------------
+# 判定逻辑
+# ---------------------------------------------------------------------------
+
+def test_ready_when_all_leftovers_are_due(tmp_db):
+    """队列空过、Again 的卡全部重新到期 → 该发。"""
+    deck = _deck()
+    _card(deck, "词一", "learning", _now_minus(5))
+    _card(deck, "词二", "relearn", _now_minus(1))
+
+    status = database.due_notification_status()
+    assert status["due_now"] == 2
+    assert status["later_today"] == 0
+    assert status["other_due"] == 0
+    assert status["ready"] is True
+
+
+def test_not_ready_while_another_card_is_still_waiting(tmp_db):
+    """还有一张卡十分钟后才回来 → 不发。这是本功能的核心条件。"""
+    deck = _deck()
+    _card(deck, "词一", "learning", _now_minus(5))
+    _card(deck, "词二", "learning", _now_plus(10))
+
+    status = database.due_notification_status()
+    assert status["due_now"] == 1
+    assert status["later_today"] == 1
+    assert status["ready"] is False
+
+
+def test_cards_on_the_1d_step_do_not_block(tmp_db):
+    """1d/3d 学习步骤的卡到期在明天日界之后，属于别的一天，不该拦住今天的提醒
+    —— 否则等它们就永远发不出去。"""
+    deck = _deck()
+    _card(deck, "词一", "learning", _now_minus(5))
+    _card(deck, "词二", "learning",
+          (datetime.now() + timedelta(days=1)).isoformat(timespec="seconds"))
+
+    status = database.due_notification_status()
+    assert status["later_today"] == 0
+    assert status["ready"] is True
+
+
+def test_not_ready_when_the_queue_never_emptied(tmp_db):
+    """还有普通到期卡没复习 → 队列根本没空过，没有"收尾"可言。"""
+    deck = _deck()
+    _card(deck, "词一", "learning", _now_minus(5))
+    _card(deck, "词二", "review", database.anki_today().isoformat())
+
+    status = database.due_notification_status()
+    assert status["other_due"] == 1
+    assert status["ready"] is False
+
+
+def test_not_ready_with_nothing_due(tmp_db):
+    """一张到期的收尾卡都没有 → 没什么可提醒的。"""
+    deck = _deck()
+    _card(deck, "词一", "learning", _now_plus(10))
+
+    status = database.due_notification_status()
+    assert status["due_now"] == 0
+    assert status["ready"] is False
+
+
+def test_suspended_and_deleted_cards_are_ignored(tmp_db):
+    """挂起/删除的卡既不触发提醒，也不拦住提醒。"""
+    deck = _deck()
+    _card(deck, "词一", "learning", _now_minus(5))
+    _card(deck, "词二", "suspended", _now_plus(10))
+    deleted = _card(deck, "词三", "learning", _now_plus(10))
+    conn = database.get_db()
+    conn.execute("UPDATE cards SET deleted_at = datetime('now') WHERE id = ?", (deleted,))
+    conn.commit()
+    conn.close()
+
+    status = database.due_notification_status()
+    assert status["later_today"] == 0
+    assert status["ready"] is True
+
+
+# ---------------------------------------------------------------------------
+# 发信与去重
+# ---------------------------------------------------------------------------
+
+def test_sends_once_per_anki_day(tmp_db, mail):
+    deck = _deck()
+    _card(deck, "词一", "learning", _now_minus(5))
+
+    first = review_notify.check_and_notify()
+    assert first["sent"] is True
+    assert len(mail) == 1
+    assert "1" in mail[0]["subject"]
+
+    second = review_notify.check_and_notify()
+    assert second["sent"] is False
+    assert second["already_sent_today"] is True
+    assert len(mail) == 1
+
+
+def test_force_bypasses_the_daily_dedup(tmp_db, mail):
+    deck = _deck()
+    _card(deck, "词一", "learning", _now_minus(5))
+
+    review_notify.check_and_notify()
+    review_notify.check_and_notify(force=True)
+    assert len(mail) == 2
+
+
+def test_force_still_respects_the_condition(tmp_db, mail):
+    """force 只跳过去重，条件不成立照样不发。"""
+    deck = _deck()
+    _card(deck, "词一", "learning", _now_plus(10))
+
+    result = review_notify.check_and_notify(force=True)
+    assert result["sent"] is False
+    assert mail == []
+
+
+def test_no_mark_written_when_smtp_is_unconfigured(tmp_db, monkeypatch):
+    """SMTP 没配置是"跳过"不是"已发送"：不能写标记，否则配好之后当天再也收不到。"""
+    deck = _deck()
+    _card(deck, "词一", "learning", _now_minus(5))
+    monkeypatch.setattr(review_notify.podcast, "send_mail", lambda *a, **k: False)
+
+    result = review_notify.check_and_notify()
+    assert result["sent"] is False
+    assert database.get_app_setting(review_notify.LAST_SENT_KEY) is None


### PR DESCRIPTION
Closes #701

## 改了什么

复习完队列（0 open cards）后，评过 Again 的卡片还留在学习步骤里分批回来。现在服务器定时检查，当**今天剩下的复习可以一口气做完**时发一封提醒邮件，每个 Anki 日最多一封。

判定要求三条同时成立（`database.due_notification_status()`）：

| 字段 | 含义 | 为什么 |
|---|---|---|
| `due_now > 0` | 此刻已到期的 learning/relearn 卡 | 有东西可做 |
| `later_today == 0` | 现在 → 明天日界点之间没有还在等的学习卡 | 核心条件：分批到期时通知，等于做两张卡再干等十分钟 |
| `other_due == 0` | new + review 到期卡已清零 | 队列确实空过，否则"收尾"无从谈起 |

1d/3d 学习步骤的卡到期在明天日界之后，**刻意不参与判断**——等它们就永远发不出去。

## 为什么这么写

- **计数复用 `count_due_all_decks()`**，不手写 COUNT(*)：它已经处理了新卡每日上限、锁定的未来 Daily 牌组、禁用的 reading 类别。自己写一份迟早和界面上的角标说两套话
- **"明天日界点"算成完整 ISO datetime**（用 `get_day_cutoff_hour()`）：`cards.due` 对 learning 卡存的是 datetime，拿日期字符串比会把凌晨 0–5 点的卡算成明天
- **`podcast.send_mail()` 从 `send_email()` 抽出**，两处共用一份 SMTP 逻辑，播客邮件行为不变（16 条原有测试全绿）
- **SMTP 未配置 = 跳过不是失败**，且此时**不写**已发送标记——否则等配置好了，当天再也收不到提醒

## 怎么测试

`tests/test_due_notify.py` 10 条，全套 405 passed / 4 skipped。否定用例和肯定用例同等重要：分批到期不发、队列没空过不发、无卡不发、挂起/删除的卡既不触发也不阻塞、`force` 只跳过去重不跳过条件。

手动验证：`curl -X POST 'http://127.0.0.1:8000/api/review/due-notify-check?force=true'` 返回判定明细。

## 启用方式

服务器加一行 cron（脚本头部有完整命令）：

```
*/5 * * * * cd /home/anki/AnkiAdvanced && venv/bin/python scripts/due_check.py >> data/due_check.log 2>&1
```

条件不满足时脚本什么都不做，也不写日志。

🤖 Generated with [Claude Code](https://claude.com/claude-code)