### PR TITLE
知识库标签直达链接：/knowledge/videos（#704）

### DIFF
--- a/main.py
+++ b/main.py
@@ -446,6 +446,25 @@ try:
             "Expires": "0",
         })
 
+    # Bookmarkable knowledge-base tab links (#704): /knowledge/videos is the
+    # browsing counterpart to /add and /save — a clean URL for the iPhone home
+    # screen that lands on one sub-tab. Unlike those two this is *not* a
+    # standalone page: browsing needs the full app (detail view, new-word
+    # table, process buttons), so it just redirects into the app's hash route.
+    # Plural and singular both work, and an unrecognized kind falls back to
+    # podcasts rather than 404ing — same reasoning as the `day` parameter in
+    # #686: getting to the knowledge base is the point, don't fail over a typo.
+    _KNOWLEDGE_TAB_KINDS = {
+        "podcast": "podcast", "podcasts": "podcast",
+        "video": "video", "videos": "video",
+        "article": "article", "articles": "article",
+    }
+
+    @app.get("/knowledge/{kind}")
+    def knowledge_tab_page(kind: str):
+        tab = _KNOWLEDGE_TAB_KINDS.get(kind.lower(), "podcast")
+        return RedirectResponse(f"/#knowledge-{tab}", status_code=303)
+
     # Running-version info (issue #450): read the current commit once at
     # startup — deploy.sh restarts the process on every deploy, so process
     # start time ≈ deploy time. Never fails: without git (or outside a

--- a/static/app.js
+++ b/static/app.js
@@ -3058,9 +3058,13 @@ async function savePregenConfig() {
 //
 // Hash routes (the bare "podcast" prefix is kept working forever — episode
 // links already went out in podcast notification emails/Signal messages):
-//   #knowledge                          -> top level (sub-tab remembered in localStorage)
+//   #knowledge-podcast|video|article    -> top level, one sub-tab (#704; the
+//                                          target of the /knowledge/<kind>
+//                                          redirect, and bookmarkable)
 //   #podcast-feed-<id> / #knowledge-feed-<id> -> layer 2: one feed's episodes
 //   #podcast-<id>      / #knowledge-<id>       -> layer 3: item detail
+// The tab form is letters-only and the other two are digits-only, so they can
+// never collide.
 // Settings: GET/PUT /api/podcast/config (detail_level only — feeds/auto now
 // live in the podcast_feeds table via /api/podcast/feeds).
 const PODCAST_STATUS_LABEL = {
@@ -3095,7 +3099,7 @@ function _clearPodcastPoll() {
 
 async function openKnowledge(tab) {
   if (tab) { _knowledgeTab = tab; localStorage.setItem('knowledgeTab', tab); }
-  location.hash = 'knowledge';
+  location.hash = `knowledge-${_knowledgeTab}`;
   _clearPodcastPoll();
   _podcastCurrentFeedId = null;
   setLoading('Loading…');
@@ -3107,7 +3111,7 @@ async function openKnowledge(tab) {
 async function switchKnowledgeTab(tab) {
   _knowledgeTab = tab;
   localStorage.setItem('knowledgeTab', tab);
-  location.hash = 'knowledge';
+  location.hash = `knowledge-${tab}`;
   await _loadKnowledgeTab();
 }
 
@@ -3708,7 +3712,13 @@ function _openKnowledgeFromHash() {
   const feedMatch = /^#(?:podcast|knowledge)-feed-(\d+)$/.exec(location.hash);
   if (feedMatch) { openPodcastFeed(parseInt(feedMatch[1])); return; }
   const m = /^#(?:podcast|knowledge)-(\d+)$/.exec(location.hash);
-  if (m) openKnowledgeItem(parseInt(m[1]));
+  if (m) { openKnowledgeItem(parseInt(m[1])); return; }
+  // Tab link (#704): #knowledge-video etc. — the letters-only form, which the
+  // digits-only patterns above can never match. This is what /knowledge/videos
+  // redirects to, and also what the tab bar writes into the address bar, so
+  // reloading a bookmarked tab stays on that tab.
+  const tabMatch = /^#knowledge-(podcast|video|article)$/.exec(location.hash);
+  if (tabMatch) openKnowledge(tabMatch[1]);
 }
 
 function startKeyCapture(id) {
@@ -10739,7 +10749,9 @@ async function _loadVersionBadge() {
 // feed-id form must be checked first — it also matches the plain item-detail
 // form's prefix. Both the legacy #podcast-* and new #knowledge-* hash shapes
 // are recognized (see _openKnowledgeFromHash).
-if (/^#(?:podcast|knowledge)-feed-\d+$/.test(location.hash) || /^#(?:podcast|knowledge)-\d+$/.test(location.hash)) {
+if (/^#(?:podcast|knowledge)-feed-\d+$/.test(location.hash)
+    || /^#(?:podcast|knowledge)-\d+$/.test(location.hash)
+    || /^#knowledge-(?:podcast|video|article)$/.test(location.hash)) {
   _openKnowledgeFromHash();
 } else {
   loadDecks();

--- a/tests/test_knowledge_tab_link.py
+++ b/tests/test_knowledge_tab_link.py
@@ -1,0 +1,84 @@
+"""Tests for the bookmarkable knowledge-tab links (issue #704).
+
+/knowledge/videos is the browsing counterpart to /add (#668) and /save (#681):
+a clean URL for the phone's home screen that lands on one sub-tab. Unlike those
+two it is not a standalone page — it redirects into the app's hash route, so
+these tests cover both halves: the server redirect and the client-side hash
+patterns in app.js that have to recognize the target.
+"""
+import pathlib
+import re
+
+import pytest
+from fastapi.testclient import TestClient
+
+import main
+
+
+@pytest.fixture(scope="module")
+def client():
+    return TestClient(main.app)
+
+
+@pytest.mark.parametrize("path,tab", [
+    ("/knowledge/videos", "video"),
+    ("/knowledge/video", "video"),
+    ("/knowledge/articles", "article"),
+    ("/knowledge/article", "article"),
+    ("/knowledge/podcasts", "podcast"),
+    ("/knowledge/podcast", "podcast"),
+    ("/knowledge/VIDEOS", "video"),
+])
+def test_tab_link_redirects_to_the_matching_hash(client, path, tab):
+    resp = client.get(path, follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == f"/#knowledge-{tab}"
+
+
+def test_unknown_kind_falls_back_instead_of_404ing(client):
+    """Same reasoning as the `day` parameter in #686: reaching the knowledge
+    base is the point — a typo in the URL must not turn into a dead end."""
+    resp = client.get("/knowledge/videoss", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/#knowledge-podcast"
+
+
+# ---------------------------------------------------------------------------
+# Client side: app.js must recognize what the redirect points at
+# ---------------------------------------------------------------------------
+
+APP_JS = pathlib.Path("static/app.js").read_text(encoding="utf-8")
+
+# Every hash pattern app.js tests at boot / in _openKnowledgeFromHash.
+HASH_PATTERNS = [
+    re.compile(r"^#(?:podcast|knowledge)-feed-\d+$"),
+    re.compile(r"^#(?:podcast|knowledge)-\d+$"),
+    re.compile(r"^#knowledge-(?:podcast|video|article)$"),
+]
+
+
+def test_app_js_declares_the_tab_hash_pattern():
+    """The boot branch decides between "open the knowledge view" and "load the
+    deck list"; if it doesn't know the tab form, a bookmarked tab link opens
+    the deck list instead."""
+    assert APP_JS.count("#knowledge-(?:podcast|video|article)$") == 1
+    assert "/^#knowledge-(podcast|video|article)$/" in APP_JS
+
+
+def test_tab_hash_is_matched_by_exactly_one_pattern():
+    """The tab form is letters-only and the item/feed forms are digits-only,
+    so an item link can never be mistaken for a tab link or vice versa."""
+    for tab in ("podcast", "video", "article"):
+        matched = [p for p in HASH_PATTERNS if p.match(f"#knowledge-{tab}")]
+        assert len(matched) == 1, tab
+    # The legacy links that already went out in podcast emails/Signal messages.
+    for legacy in ("#podcast-12", "#knowledge-12", "#podcast-feed-3", "#knowledge-feed-3"):
+        assert len([p for p in HASH_PATTERNS if p.match(legacy)]) == 1, legacy
+
+
+def test_tab_switch_writes_the_tab_into_the_hash():
+    """A bare "#knowledge" is recognized by nothing, so reloading such a URL
+    used to drop back to the deck list. The tab bar must write the full form."""
+    assert "location.hash = 'knowledge';" not in APP_JS
+    assert APP_JS.count("location.hash = `knowledge-${tab}`;") == 1
+    assert APP_JS.count("location.hash = `knowledge-${_knowledgeTab}`;") == 1


### PR DESCRIPTION
## 改了什么

像 `/add`（#668）和 `/save`（#681）那样可存 iPhone 主屏的网址，打开即停在指定子标签：

```
https://powerdaniel3000.duckdns.org/knowledge/videos
```

| 文件 | 改动 |
|------|------|
| `main.py` | `GET /knowledge/{kind}` → 303 重定向到 `/#knowledge-<kind>`。`videos`/`video`、`articles`/`article`、`podcasts`/`podcast` 都接受，大小写不敏感 |
| `static/app.js` | boot 分支 + `_openKnowledgeFromHash()` 识别纯字母形式 `#knowledge-podcast\|video\|article` |
| `static/app.js` | `openKnowledge()` / `switchKnowledgeTab()` 的 hash 从 `knowledge` 改为 `knowledge-<标签>` |
| `tests/test_knowledge_tab_link.py` | 新增 11 条测试 |

## 为什么

`/add` 和 `/save` 解决了"往里放东西"，但"看"知识库列表只能打开主应用 → 点 🧠 Knowledge → 点 📺 Videos。

第三条改动是必须的：切标签写入的 `location.hash = "knowledge"` **不被任何路由识别**，用这个地址刷新会掉回牌组列表。现在地址栏始终反映当前标签，刷新/iOS 恢复标签页都保持不变。

无法识别的 kind **回落到 podcast 而不是 404** —— 照 #686 的先例（`day` 非法值回落 today）：进知识库才是重点，不该为一个拼写错误变成死路。

## 为什么不做独立轻量页面

`/add` 和 `/save` 故意不加载 `app.js`（5.5 KB vs 77 KB + 491 KB）是因为它们只是一个输入框。浏览列表本来就需要完整应用——详情页、生词表格、Process/Regenerate 按钮全在里面，再造一份是重复。

## 怎么测试

- `pytest tests/test_knowledge_tab_link.py` → 11 passed
- 全套 `pytest tests/` → 416 passed, 4 skipped
- 测试覆盖：各 kind 的重定向目标、单复数、大小写、非法值回落；app.js 三个 hash 正则**互不重叠**（旧的 `#podcast-<id>` / `#knowledge-feed-<id>` 链接不受影响——已发出去的邮件/Signal 消息里全是这种链接）；hash 里不再出现光秃秃的 `knowledge`

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)