### PR TITLE
版本角标按德国时间显示部署时间（#706）

### DIFF
--- a/main.py
+++ b/main.py
@@ -487,8 +487,13 @@ try:
             return {"commit": "unknown", "message": "", "commit_date": "", "branch": "unknown"}
 
     from datetime import datetime as _dt
+    # astimezone() attaches the server's real UTC offset (#706). A naive
+    # isoformat() loses it, and the browser then parses the string as *its own*
+    # local time — the production server runs on Asia/Shanghai, so the badge
+    # showed Shanghai's digits no matter where it was read. Without the offset
+    # no amount of client-side formatting can recover the actual instant.
     _version_info = {**_read_version(),
-                     "deployed_at": _dt.now().isoformat(timespec="seconds")}
+                     "deployed_at": _dt.now().astimezone().isoformat(timespec="seconds")}
 
     @app.get("/api/version")
     def get_version():

--- a/static/app.js
+++ b/static/app.js
@@ -10720,20 +10720,29 @@ async function _restartServer() {
 // ── Running-version badge (issue #450) ──────────────────────────────────────
 // Bottom-right corner: branch@commit · deploy time. Hover shows the commit
 // message (title); a click/tap toggles it inline for mobile.
+// Deploy time is always shown in Daniel's own timezone (#706), same rule as
+// podcast episode dates (#532) — the server runs on Asia/Shanghai and the
+// phone travels, so neither of those is the timezone the badge is read in.
+// Intl does the conversion; hand-rolling it from getHours() would just read
+// back whatever timezone the browser happens to be in.
+function _formatBerlin(iso) {
+  const d = new Date(iso);
+  if (isNaN(d)) return '';
+  return new Intl.DateTimeFormat('de-DE', {
+    day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit',
+    timeZone: 'Europe/Berlin',
+  }).format(d);
+}
+
 async function _loadVersionBadge() {
   try {
     const v = await api('GET', '/api/version');
     const el = document.getElementById('version-badge');
     if (!el || !v.commit) return;
-    let when = '';
-    if (v.deployed_at) {
-      const d = new Date(v.deployed_at);
-      const p = n => String(n).padStart(2, '0');
-      when = ` · ${p(d.getDate())}.${p(d.getMonth() + 1)}. ${p(d.getHours())}:${p(d.getMinutes())}`;
-    }
-    const short = `${v.branch}@${v.commit}${when}`;
+    const when = v.deployed_at ? _formatBerlin(v.deployed_at) : '';
+    const short = `${v.branch}@${v.commit}${when ? ` · ${when}` : ''}`;
     el.textContent = short;
-    el.title = v.message ? `${v.message}\n(deployed ${v.deployed_at})` : '';
+    el.title = v.message ? `${v.message}\n(deployed ${when || v.deployed_at})` : '';
     el.onclick = () => {
       const expanded = el.classList.toggle('expanded');
       el.textContent = expanded && v.message ? `${short} — ${v.message}` : short;

--- a/tests/test_version_badge.py
+++ b/tests/test_version_badge.py
@@ -1,0 +1,36 @@
+"""Tests for the version badge's deploy timestamp (issue #706).
+
+The badge showed the production server's Asia/Shanghai clock digits no matter
+where it was read, because `deployed_at` carried no UTC offset and the browser
+parses an offset-less ISO date-time as *its own* local time. The offset is the
+root fix — without it no client-side formatting can recover the real instant.
+"""
+import pathlib
+import re
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+import main
+
+
+def test_deployed_at_carries_a_utc_offset():
+    resp = TestClient(main.app).get("/api/version")
+    assert resp.status_code == 200
+    deployed_at = resp.json()["deployed_at"]
+    # Parsing an offset-less string yields a naive datetime — exactly the bug.
+    assert datetime.fromisoformat(deployed_at).tzinfo is not None, deployed_at
+
+
+def test_badge_renders_in_berlin_regardless_of_browser_timezone():
+    """The server travels (Asia/Shanghai) and so does the phone, so neither of
+    those is the timezone the badge should be read in — pin it like podcast
+    episode dates (#532)."""
+    app_js = pathlib.Path("static/app.js").read_text(encoding="utf-8")
+    fn = re.search(r"function _formatBerlin\(iso\) \{.*?\n\}", app_js, re.S)
+    assert fn, "_formatBerlin() is gone — the badge would fall back to browser-local time"
+    assert "timeZone: 'Europe/Berlin'" in fn.group(0)
+    # getHours()/getDate() read the browser's timezone back out, which is what
+    # made the badge wrong in the first place.
+    badge = re.search(r"async function _loadVersionBadge\(\) \{.*?\n\}", app_js, re.S).group(0)
+    assert "getHours()" not in badge and "getDate()" not in badge


### PR DESCRIPTION
## 问题

界面右下角的版本角标显示的时间比德国当地**早 6 小时** —— 它显示的是生产服务器（`Asia/Shanghai`）的时钟数字。

## 根因

在后端，不在前端：

```python
"deployed_at": _dt.now().isoformat(timespec="seconds")   # → "2026-08-11T21:28:56"
```

字符串里**没有时区标记**。浏览器按 ECMAScript 规范会把不带偏移的 date-time 解析成**自己的**本地时间，`getHours()` 再转回本地 —— 数字原样透传，看起来"没坏"，但换个时区读就全错。偏移一旦丢掉，前端再怎么格式化都救不回真实时刻。

## 改动

| 文件 | 改动 |
|------|------|
| `main.py` | `_dt.now().astimezone().isoformat(...)` —— 带上服务器真实偏移（`+08:00`） |
| `static/app.js` | 新增 `_formatBerlin()`，用 `Intl.DateTimeFormat` 固定 `timeZone: "Europe/Berlin"` 渲染角标与 tooltip；删掉手工拼的 `getDate()`/`getHours()` |
| `tests/test_version_badge.py` | 新增 2 条测试 |

**为什么固定柏林而不是跟随浏览器**：服务器在上海、手机会跟着人走，两者都不是读这个角标的时区。与播客单集日期的既有做法一致（#532）。

## 怎么测试

后端返回带偏移：

```
"deployed_at": "2026-08-12T10:24:42+07:00"
```

换算实测（node）：

```
上海 21:28  →  柏林显示: 11.08., 15:28
UTC 参照: 2026-08-11T13:28:56.000Z
```

- `pytest tests/test_version_badge.py` → 2 passed（断言 `deployed_at` 解析出的 `tzinfo` 非 None；断言角标渲染里不再出现 `getHours()`/`getDate()`）
- 全套 `pytest tests/` → 418 passed, 4 skipped
- 时间戳无法解析时 `_formatBerlin()` 返回空串，角标退化成 `branch@commit` —— 角标是 best-effort，绝不能拖垮应用

Closes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)