### PR TITLE
已认识词库 + 生词表格 ✓ Known 按钮 + 邮件顶部网站链接（#710）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,6 +387,7 @@ FSRS 用毕业评分播种初始 stability/difficulty：默认权重下 **Good �
 - **接入点在 `podcast.summarize()` 的返回处**（`_annotate_summary`）：NotebookLM 和 API 两条摘要路径、`_process_episode` 和 `regenerate_summary` 两个调用方全都经过这里，标注后的文本才写库，邮件/Signal/详情页三处自然一致，也不会各自重跑谷歌翻译
 - **全程吞异常**：HSK 表读不到、jieba 挂了、翻译超时，一律返回原文（翻译失败降级为只有拼音）。少个拼音是小事，为它丢掉整集摘要是荒唐的
 - **`extract_new_words()`（#650）统一了详情页底部生词表格**：原来表格由 AI 在摘要提示词里自己挑词，会漏词、也会挑 Daniel 已学过的词。改成代码从 `summary_zh` + `summary_de` 扫描，和正文括号标注**同源同规则**，两者现在保证一一对应，不再各说各话
+- **已认识词库 `known_words`（#710）**：Daniel 认识但从没进过词库的词。详情页生词表格的 **✓ Known** 按钮 → `POST /api/known-words`（`shared.js` 的 `markWordKnown()`），纯后台请求，行标灰不刷新页面。**判定入口只有 `zh_annotate._known_words()` 一处**：`word_zh_exists(words) | known_words_exists(words)` —— 行内标注、生词表格、德语总结的拼音标注三处因此自动一致，别处不许再写第二份"已知"判定。**不建卡、不进队列**：这是"我认识了，别再给我看"，与加词恰好相反。已存库的摘要文本里的旧标注**不会**消失（生成时就写死了），变的是下一篇
 
 ---
 
@@ -452,6 +453,7 @@ GET  /api/story-prompt/{story_id}                    → 生成该故事的完�
 
 # 知识库（播客爬虫 #479 泛化，#650–#655；详见「知识库」节）
 POST /api/knowledge/add                               → body {url} → 新素材 {episode_id}；已存在 {status:"already_exists", episode_id}；不转录不摘要，前端拿 id 后另调 .../process
+GET/POST /api/known-words ；DELETE /api/known-words/{word} → 已认识词库（#710）：标记后 zh_annotate 不再当生词；不建卡不排程；DELETE 词不在表里返回 404（不假装成功）
 POST /api/podcast/check                              → 跑一轮抓取，返回汇总 {new, summarized, emailed, failed}
 GET  /api/podcast/episodes                            → 列表（不含转录全文；?feed_id= 按源过滤；?kind= 按 podcast/video/article 过滤，#650；手动处理中的单集 status 显示为 processing）
 GET  /api/podcast/episodes/{id}                       → 详情（摘要 + 转录 + HSK 生词）

--- a/database/podcast.py
+++ b/database/podcast.py
@@ -315,3 +315,49 @@ def word_zh_exists(words: list[str]) -> set[str]:
     ).fetchall()
     conn.close()
     return {r["word_zh"] for r in rows}
+
+
+def known_words_exists(words: list[str]) -> set[str]:
+    """Which of these words Daniel has marked as already known (#710).
+
+    The counterpart of word_zh_exists: a word can be known without ever having
+    been studied here. zh_annotate unions the two — see its _known_words()."""
+    if not words:
+        return set()
+    conn = get_db()
+    placeholders = ",".join("?" for _ in words)
+    rows = conn.execute(
+        f"SELECT word_zh FROM known_words WHERE word_zh IN ({placeholders})", words
+    ).fetchall()
+    conn.close()
+    return {r["word_zh"] for r in rows}
+
+
+def add_known_word(word_zh: str) -> None:
+    """Mark a word as already known (#710). Idempotent: marking a word twice
+    is exactly what happens when Daniel meets it in a second episode."""
+    conn = get_db()
+    conn.execute("INSERT OR IGNORE INTO known_words (word_zh) VALUES (?)", (word_zh,))
+    conn.commit()
+    conn.close()
+
+
+def remove_known_word(word_zh: str) -> bool:
+    """Undo add_known_word. Returns whether the word was actually on the list
+    — the caller reports a miss rather than pretending it removed something."""
+    conn = get_db()
+    cur = conn.execute("DELETE FROM known_words WHERE word_zh = ?", (word_zh,))
+    conn.commit()
+    removed = cur.rowcount > 0
+    conn.close()
+    return removed
+
+
+def list_known_words() -> list[dict]:
+    """All words marked as known, newest first."""
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT word_zh, added_at FROM known_words ORDER BY added_at DESC, word_zh"
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]

--- a/podcast.py
+++ b/podcast.py
@@ -1345,6 +1345,9 @@ def send_email(episode: dict) -> bool:
     body_html = f"""
     <html><body style="font-family:sans-serif;max-width:640px">
       <h2>{episode['title']}</h2>
+      <p style="margin:0 0 14px">
+        <a href="{transcript_link}" style="font-weight:bold">▸ Auf der Website öffnen</a>
+      </p>
       {_summary_zh_html(episode.get('summary_zh') or '')}
       <div>{episode.get('summary_de') or ''}</div>
       <h3>Neue HSK5+ Vokabeln</h3>

--- a/routes/knowledge.py
+++ b/routes/knowledge.py
@@ -15,6 +15,7 @@ import logging
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+import database
 import knowledge.ingest
 
 logger = logging.getLogger(__name__)
@@ -49,3 +50,37 @@ def add_knowledge_text(body: AddKnowledgeTextRequest):
         return knowledge.ingest.ingest_text(body.title, body.text, source_url=body.source_url)
     except knowledge.ingest.IngestError as e:
         raise HTTPException(400, str(e))
+
+
+# ── Known words (#710) ──────────────────────────────────────────────────────
+# Words Daniel knows without having studied them here. Marking one only
+# widens zh_annotate's "already known" test (see database.known_words_exists)
+# — no card is created and nothing is scheduled, which is the whole point:
+# these are words he does NOT want to see again.
+
+
+class KnownWordRequest(BaseModel):
+    word: str
+
+
+@router.get("/api/known-words")
+def get_known_words():
+    return {"words": database.list_known_words()}
+
+
+@router.post("/api/known-words")
+def add_known_word(body: KnownWordRequest):
+    word = (body.word or "").strip()
+    if not word:
+        raise HTTPException(400, "word required")
+    database.add_known_word(word)
+    return {"status": "ok", "word": word}
+
+
+@router.delete("/api/known-words/{word}")
+def delete_known_word(word: str):
+    """Undo. Reports a miss instead of pretending — a 404 here means the
+    frontend and the database disagree about what is on the list."""
+    if not database.remove_known_word(word.strip()):
+        raise HTTPException(404, "word not on the known list")
+    return {"status": "ok", "word": word}

--- a/schema.sql
+++ b/schema.sql
@@ -614,6 +614,19 @@ CREATE TABLE IF NOT EXISTS app_settings (
 );
 
 -- ---------------------------------------------------------------------------
+-- Words Daniel already knows without ever having studied them here (#710).
+-- Pure marker: no card, no deck, no scheduling — the only thing this table
+-- does is widen zh_annotate's "already known" test, which until now was
+-- "exists in entries.word_zh". Everything downstream (inline annotations in
+-- both summaries, the HSK word table under an episode) follows from that one
+-- test, so a word marked here quietly stops being flagged everywhere at once.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS known_words (
+    word_zh  TEXT PRIMARY KEY,
+    added_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- ---------------------------------------------------------------------------
 -- Podcast crawler (issue #479): discover new episodes from podcast RSS feeds
 -- (#497 — replaced the original YouTube-channel source), transcribe them,
 -- summarize into German, extract HSK5+ vocabulary, and email a notification.

--- a/static/app.js
+++ b/static/app.js
@@ -3538,11 +3538,12 @@ function _renderKnowledgeDetail(ep) {
   // quote/apostrophe escaping issues in word_zh/definition_de text).
   _podcastDetailWords = ep.hsk_words || [];
   _podcastDetailEpisodeId = ep.id;
-  const hskRows = _podcastDetailWords.map((w, idx) => `<tr>
+  const hskRows = _podcastDetailWords.map((w, idx) => `<tr id="podcast-word-row-${idx}">
       <td>${_escHtml(w.word || w.word_zh || '')}</td>
       <td>${_escHtml(w.pinyin || '')}</td>
       <td>${_escHtml(w.definition_de || w.definition || '')}</td>
       <td><button id="podcast-add-word-${idx}" class="btn-secondary" onclick="doPodcastAddWord(${idx})">+ Add</button></td>
+      <td><button id="podcast-known-word-${idx}" class="btn-secondary" onclick="doPodcastKnownWord(${idx})" title="I already know this word — stop flagging it">✓ Known</button></td>
     </tr>`).join('');
   const hskTable = hskRows
     ? `<div id="podcast-add-day" class="add-word-day-row">
@@ -3551,7 +3552,7 @@ function _renderKnowledgeDetail(ep) {
          <button type="button" class="add-word-day-btn" data-day="tomorrow"
                  onclick="setPodcastAddDay('tomorrow')">Tomorrow</button>
        </div>
-       <table class="cost-table"><thead><tr><th>Word</th><th>Pinyin</th><th>German</th><th>Add</th></tr></thead><tbody>${hskRows}</tbody></table>`
+       <table class="cost-table"><thead><tr><th>Word</th><th>Pinyin</th><th>German</th><th>Add</th><th>Known</th></tr></thead><tbody>${hskRows}</tbody></table>`
     : '<p class="keymap-hint">No HSK vocabulary extracted.</p>';
   const links = [
     ep.youtube_url ? `<a href="${_escHtml(ep.youtube_url)}" target="_blank" rel="noopener" class="btn-secondary">${isPodcast ? 'YouTube' : 'Open'} ↗</a>` : '',
@@ -3697,6 +3698,33 @@ function doPodcastAddWord(idx) {
     btn.classList.toggle('podcast-add-error', state === 'error');
     // Only a failure is worth retrying; a finished add is not repeatable.
     if (state === 'error') btn.disabled = false;
+  });
+}
+
+// "✓ Known" in the HSK word table (#710): Daniel already knows this word, it
+// just never made it into the collection. One background POST — no reload, no
+// re-render of the episode, the other rows stay clickable.
+//
+// The row is greyed out immediately rather than removed: the annotations in
+// the summary text above were baked in when it was generated and don't change,
+// so making the row vanish would suggest the word is gone from the page when
+// it plainly isn't. What actually changes is the NEXT summary.
+function doPodcastKnownWord(idx) {
+  const w = _podcastDetailWords[idx];
+  const btn = document.getElementById(`podcast-known-word-${idx}`);
+  if (!w || !btn) return;
+  const wordZh = w.word || w.word_zh || '';
+  if (!wordZh) return;
+
+  btn.disabled = true;
+  btn.textContent = '…';
+  markWordKnown(wordZh).then(() => {
+    btn.textContent = '✓ known';
+    document.getElementById(`podcast-word-row-${idx}`)?.classList.add('podcast-word-known');
+  }).catch(e => {
+    btn.textContent = e.message || 'failed';
+    btn.classList.add('podcast-add-error');
+    btn.disabled = false;  // only a failure is worth retrying
   });
 }
 

--- a/static/shared.js
+++ b/static/shared.js
@@ -120,3 +120,15 @@ function knowledgeTitleFor(title, text) {
   if (title) return title;
   return (text || '').split('\n').map(l => l.trim()).find(l => l) || '';
 }
+
+// Mark a word as already known (#710) so zh_annotate stops flagging it in
+// future summaries. Shared by the HSK word table and the in-text word menu
+// (#711) for the same reason as addWordViaAi above: one client-side path.
+//
+// Deliberately NOT a card: this is the "I know this, stop showing it to me"
+// action, the opposite of adding it to a deck. Fire-and-await — the caller
+// updates its own UI optimistically and reports a rejected promise as an
+// error rather than silently leaving a wrong ✓ on screen.
+async function markWordKnown(word) {
+  return api('POST', '/api/known-words', { word });
+}

--- a/static/style.css
+++ b/static/style.css
@@ -5185,6 +5185,9 @@ table.fsrs-table td.ivl { font-weight: 700; }
   flex: 0 0 auto;
   min-width: 96px;
 }
+/* A word marked "✓ Known" (#710) — kept in the table but visibly settled, so
+   it's obvious which rows still need a decision. */
+.podcast-word-known { opacity: 0.45; }
 /* A failed add stays clickable to retry, so it must not look like success */
 .podcast-add-error {
   color: var(--again);

--- a/tests/test_known_words.py
+++ b/tests/test_known_words.py
@@ -1,0 +1,102 @@
+"""Tests for the "already known" word list (#710).
+
+Daniel knows plenty of words that never entered the collection; marking one
+here is what stops zh_annotate from flagging it in every future summary. The
+central claim under test is that this list and entries.word_zh are consulted
+through ONE function (zh_annotate._known_words) — that union is why a marked
+word disappears from the inline annotations and the HSK table at the same time.
+"""
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+from fastapi.testclient import TestClient
+import database
+import main
+import zh_annotate
+
+client = TestClient(main.app)
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    """Fresh temp database. Patch database.core.DB_PATH, not database.DB_PATH
+    — the latter is only a copy of the name (issue #615)."""
+    monkeypatch.setattr(database.core, "DB_PATH", str(tmp_path / "test.db"))
+    database.init_db()
+
+
+# --- database layer ---------------------------------------------------------
+
+def test_add_and_query_known_word(tmp_db):
+    database.add_known_word("经济衰退")
+    assert database.known_words_exists(["经济衰退", "供应链"]) == {"经济衰退"}
+
+
+def test_adding_twice_is_idempotent(tmp_db):
+    """Meeting the same word in a second episode must not blow up."""
+    database.add_known_word("经济衰退")
+    database.add_known_word("经济衰退")
+    assert [w["word_zh"] for w in database.list_known_words()] == ["经济衰退"]
+
+
+def test_remove_known_word_reports_whether_it_was_there(tmp_db):
+    database.add_known_word("经济衰退")
+    assert database.remove_known_word("经济衰退") is True
+    assert database.remove_known_word("经济衰退") is False
+    assert database.list_known_words() == []
+
+
+def test_known_words_exists_on_empty_input(tmp_db):
+    assert database.known_words_exists([]) == set()
+
+
+# --- the union that makes it work -------------------------------------------
+
+def test_known_words_unions_collection_and_marked_list(monkeypatch):
+    """The one place that answers "does Daniel know this word" must consult
+    both sources — a word in either is known."""
+    monkeypatch.setattr(database, "word_zh_exists", lambda words: {"就业"})
+    monkeypatch.setattr(database, "known_words_exists", lambda words: {"供应链"})
+    assert zh_annotate._known_words(["就业", "供应链", "衰退"]) == {"就业", "供应链"}
+
+
+def test_marked_word_is_no_longer_annotated(tmp_db, monkeypatch):
+    """End to end: mark a word, and the inline annotation stops appearing."""
+    monkeypatch.setattr(zh_annotate, "_gloss_de", lambda w: f"DE:{w}")
+    text = "经济衰退的风险"
+    assert "经济衰退（" in zh_annotate.annotate_zh_summary(text)
+
+    database.add_known_word("经济衰退")
+    assert "经济衰退（" not in zh_annotate.annotate_zh_summary(text)
+
+
+def test_marked_word_drops_out_of_the_word_table(tmp_db, monkeypatch):
+    """extract_new_words feeds the HSK table under an episode — it reuses the
+    same test, so the table and the annotations can't disagree."""
+    monkeypatch.setattr(zh_annotate, "_gloss_de", lambda w: f"DE:{w}")
+    database.add_known_word("经济衰退")
+    words = [w["word"] for w in zh_annotate.extract_new_words("经济衰退的风险")]
+    assert "经济衰退" not in words
+
+
+# --- API --------------------------------------------------------------------
+
+def test_api_add_list_and_delete(tmp_db):
+    assert client.post("/api/known-words", json={"word": "经济衰退"}).status_code == 200
+    listed = client.get("/api/known-words").json()["words"]
+    assert [w["word_zh"] for w in listed] == ["经济衰退"]
+
+    assert client.delete("/api/known-words/经济衰退").status_code == 200
+    assert client.get("/api/known-words").json()["words"] == []
+
+
+def test_api_rejects_empty_word(tmp_db):
+    assert client.post("/api/known-words", json={"word": "  "}).status_code == 400
+
+
+def test_api_delete_reports_a_miss(tmp_db):
+    """A 404 means the frontend and the database disagree about the list —
+    worth surfacing rather than answering "ok" to a no-op."""
+    assert client.delete("/api/known-words/没有这个词").status_code == 404

--- a/tests/test_podcast.py
+++ b/tests/test_podcast.py
@@ -135,6 +135,15 @@ def test_email_body_leads_with_chinese_summary(monkeypatch):
     assert body.index("这集讨论") < body.index("Es geht um KI")
 
 
+def test_email_links_to_the_website_above_the_summary(monkeypatch):
+    """#710: the website link has to be reachable before reading, not only in
+    the footer — it's how Daniel gets to the page where he can add the words."""
+    body = _email_body(_send_email_capture(monkeypatch, EPISODE, "中文播客秀"))
+    link = "/#podcast-7"
+    assert link in body
+    assert body.index(link) < body.index("这集讨论")
+
+
 def test_email_without_chinese_summary_renders_nothing_extra(monkeypatch):
     ep = dict(EPISODE, summary_zh="")
     body = _email_body(_send_email_capture(monkeypatch, ep, "中文播客秀"))

--- a/zh_annotate.py
+++ b/zh_annotate.py
@@ -88,13 +88,20 @@ def _char_levels() -> dict[str, int]:
 
 
 def _known_words(words: list[str]) -> set[str]:
-    """Which of these words are already in Daniel's collection. Queried per
-    call (the collection grows daily, and it is one indexed IN query)."""
+    """Which of these words Daniel already knows: either studied here
+    (entries.word_zh) or marked as known without ever studying it (#710,
+    known_words). Queried per call (both lists grow daily, and it is two
+    indexed IN queries).
+
+    This union is the ONE place that answers "does Daniel know this word".
+    Inline annotations in both summaries and the HSK word table under an
+    episode all come through here, which is why marking a word known makes it
+    disappear from all of them at once."""
     if not words:
         return set()
     try:
         import database
-        return database.word_zh_exists(words)
+        return database.word_zh_exists(words) | database.known_words_exists(words)
     except Exception as e:
         logger.warning("zh_annotate: collection lookup failed — %s", e)
         return set()


### PR DESCRIPTION
## 改了什么

Daniel 认识很多从没进过词库的词——它们每次都被当生词标注，噪音越积越多。

1. **新表 `known_words`**（`word_zh` 主键 + `added_at`，写在 `schema.sql`，生产库重启自动建）。纯标记：**不建卡、不进任何队列**——这是「我认识了，别再给我看」，与加词恰好相反。
2. **判定入口仍然只有一处**：`zh_annotate._known_words()` 改成 `database.word_zh_exists(words) | database.known_words_exists(words)`。行内标注、底部生词表格、德语总结的拼音标注全都经过它，所以标记一个词，三处同时不再显示——没有第二份「已知」判定。
3. **接口**：`GET/POST /api/known-words`、`DELETE /api/known-words/{word}`（词不在表里返回 404，不假装成功）。
4. **前端**：详情页生词表格加一列 **✓ Known**。点击只发一个后台 POST，**不刷新页面、不重新加载条目**，其它行照常可点；成功后该行标灰（不移除——正文里的旧标注还在，让行凭空消失会造成误会）。`markWordKnown()` 放进 `shared.js`，#711 的正文菜单直接共用。
5. **邮件顶部加「▸ Auf der Website öffnen」链接**：原来只有页脚一处，读到一半想去网站加词得先滚到底。

## 一个需要知道的限制

已经存进库的摘要文本里的括号标注**不会**因此消失——那是生成时就写死的文本。点掉后变的是**下一篇**摘要。为一个词重跑整篇标注（谷歌翻译 + 分词）不值得。

## 怎么测的

- `pytest tests/` → 432 passed, 4 skipped
- 新增 `tests/test_known_words.py`（10 条）：并集判定、标记后标注消失、标记后生词表格也不再出现（两者同源）、增删幂等、`DELETE` 报 404、空词 400
- 新增邮件测试：网站链接必须出现在中文总结**之前**

Closes #710
