### PR TITLE
设置里加开关控制评 Again 后是否重新生成句子（#714）

### DIFF
--- a/routes/review.py
+++ b/routes/review.py
@@ -38,6 +38,17 @@ def _attach_again_sentence(card: dict | None) -> dict | None:
     return card
 
 
+def again_regen_enabled() -> bool:
+    """User switch for the Again → regenerate behaviour (issue #714). Default on,
+    so an untouched install keeps the behaviour it always had.
+
+    Only the *automatic* trigger on a rating is gated. The "New sentence" button
+    (`/api/review/requeue`) asks for a regeneration explicitly and must keep
+    working regardless — a button silently swallowed by a global switch is a
+    broken button."""
+    return database.get_app_setting("again_regen_enabled", "1") == "1"
+
+
 def _spawn_again_regen(card: dict) -> None:
     """Fire-and-forget: regenerate one fresh sentence for this word in the
     background so the card shows something new when it reappears (~1-10 min)."""
@@ -253,8 +264,14 @@ def submit_review(card_id: int, rating: int, user_response: str | None = None,
 
     # Rated Again → regenerate a fresh sentence for this word in the background,
     # so it shows something new when the card reappears in a few minutes.
+    # Switchable (issue #714): off means the card keeps its original sentence,
+    # which is what you want when the sentence was fine and only the recall failed.
     if rating == 1:
-        _spawn_again_regen(card_before)
+        if again_regen_enabled():
+            _spawn_again_regen(card_before)
+        else:
+            logger.debug("again-regen  word=%s — skipped, switch off",
+                         (card_before or {}).get("word_zh"))
 
     # Apply sibling repulsion: push sibling due dates that are too close to today.
     # Only kicks in when the reviewed card has a long enough interval (> sibling_separation),
@@ -425,6 +442,23 @@ def submit_review(card_id: int, rating: int, user_response: str | None = None,
     else:
         logger.info("submit_review: %.0f ms", _elapsed_ms)
     return {"next_card": next_card, "counts": counts, "transition": transition}
+
+
+@router.get("/api/again-regen-enabled")
+def get_again_regen_enabled():
+    """Whether rating Again auto-regenerates the card's sentence (issue #714)."""
+    return {"enabled": again_regen_enabled()}
+
+
+@router.put("/api/again-regen-enabled")
+def put_again_regen_enabled(body: dict):
+    """Set the Again → regenerate switch (issue #714). body: {"enabled": bool}.
+    Stored server-side because the regeneration itself runs there — a browser-only
+    preference would leave the other devices (and the phone) doing something else."""
+    enabled = bool(body.get("enabled"))
+    database.set_app_setting("again_regen_enabled", "1" if enabled else "0")
+    logger.info("again-regen-enabled  set to %s", enabled)
+    return {"ok": True, "enabled": enabled}
 
 
 @router.post("/api/review/requeue")

--- a/static/app.js
+++ b/static/app.js
@@ -2845,6 +2845,33 @@ function openSettings() {
   showView('settings');
   renderSettings();
   _loadDayCutoffHour();
+  _loadAgainRegenEnabled();
+}
+
+// ── Again → new sentence switch (issue #714) ────────────────────────────────
+// Server-side setting, not localStorage: the regeneration runs on the server, so
+// a browser-local preference would have the phone doing the opposite.
+let _againRegenEnabled = true;
+
+async function _loadAgainRegenEnabled() {
+  try {
+    const res = await api('GET', '/api/again-regen-enabled');
+    _againRegenEnabled = res?.enabled !== false;
+    renderSettings();
+  } catch (e) { /* keep default (on) */ }
+}
+
+async function setAgainRegenEnabled(enabled) {
+  const prev = _againRegenEnabled;
+  _againRegenEnabled = enabled;
+  try {
+    const res = await api('PUT', '/api/again-regen-enabled', { enabled });
+    _againRegenEnabled = res?.enabled !== false && enabled;
+  } catch (e) {
+    _againRegenEnabled = prev;
+    showError('Could not save: ' + e.message);
+  }
+  renderSettings();
 }
 
 async function _loadDayCutoffHour() {
@@ -2895,6 +2922,18 @@ function renderSettings() {
       ${msg}
       ${rows}
       <button class="keymap-reset-all" onclick="resetKeymapAll()">Reset all to defaults</button>
+    </div>
+    <div class="keymap-panel">
+      <h2 class="keymap-heading">Again → new sentence</h2>
+      <p class="keymap-hint">Rating a card <b>Again</b> regenerates its sentence in the background, so it looks different when the card comes back. <b>Off</b> = the card keeps its original sentence (and costs no AI call) — better when the sentence was fine and only the recall failed. The <b>New sentence</b> button (${_keyLabel(_key('new-sentence'))}) always regenerates, switch or not.</p>
+      <div class="keymap-row">
+        <span class="keymap-label">Regenerate after Again</span>
+        <label class="switch-wrap">
+          <input type="checkbox" id="again-regen-switch" ${_againRegenEnabled ? 'checked' : ''}
+                 onchange="setAgainRegenEnabled(this.checked)" style="width:18px;height:18px;cursor:pointer">
+          <span>${_againRegenEnabled ? 'On' : 'Off'}</span>
+        </label>
+      </div>
     </div>
     <div class="keymap-panel">
       <h2 class="keymap-heading">News flow</h2>

--- a/tests/test_again_regen_toggle.py
+++ b/tests/test_again_regen_toggle.py
@@ -1,0 +1,92 @@
+"""Tests for the Again → regenerate switch (issue #714).
+
+Rating Again has always regenerated the card's sentence in the background. The
+switch makes that optional; what these tests pin down is the asymmetry that
+makes it safe: only the *automatic* trigger is gated. The "New sentence" button
+asks for a regeneration in so many words, so a global switch must never swallow
+it — that would turn a button into a no-op with no explanation on screen.
+"""
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+from fastapi.testclient import TestClient
+import database
+import database.core
+import main
+from routes import review as review_routes
+
+client = TestClient(main.app)
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    # database.core.DB_PATH，不是 database.DB_PATH —— 见 conftest.py（#615）。
+    monkeypatch.setattr(database.core, "DB_PATH", str(tmp_path / "test.db"))
+    database.init_db()
+    return tmp_path / "test.db"
+
+
+@pytest.fixture
+def spawns(monkeypatch):
+    """Record every background regeneration instead of running one."""
+    calls = []
+    monkeypatch.setattr(review_routes, "_spawn_again_regen",
+                        lambda card: calls.append(card.get("word_zh")))
+    return calls
+
+
+def _card() -> int:
+    deck_id = database.get_or_create_deck("RegenDeck")
+    word_id = database.insert_word({"word_zh": "开关", "definition": "switch"})
+    return database.insert_card(word_id, "listening", deck_id)
+
+
+# --- the setting itself -----------------------------------------------------
+
+def test_defaults_to_on(tmp_db):
+    """An untouched install must behave exactly as it did before #714."""
+    assert review_routes.again_regen_enabled() is True
+    assert client.get("/api/again-regen-enabled").json() == {"enabled": True}
+
+
+def test_switch_round_trips(tmp_db):
+    assert client.put("/api/again-regen-enabled", json={"enabled": False}).json()["enabled"] is False
+    assert review_routes.again_regen_enabled() is False
+    assert client.get("/api/again-regen-enabled").json()["enabled"] is False
+
+    client.put("/api/again-regen-enabled", json={"enabled": True})
+    assert review_routes.again_regen_enabled() is True
+
+
+# --- what the switch gates --------------------------------------------------
+
+def test_again_regenerates_while_on(tmp_db, spawns):
+    card_id = _card()
+    r = client.post(f"/api/review?card_id={card_id}&rating=1")
+    assert r.status_code == 200
+    assert spawns == ["开关"]
+
+
+def test_again_does_not_regenerate_while_off(tmp_db, spawns):
+    client.put("/api/again-regen-enabled", json={"enabled": False})
+    card_id = _card()
+    r = client.post(f"/api/review?card_id={card_id}&rating=1")
+    assert r.status_code == 200
+    assert spawns == []
+
+
+def test_ratings_other_than_again_never_regenerate(tmp_db, spawns):
+    card_id = _card()
+    client.post(f"/api/review?card_id={card_id}&rating=3")
+    assert spawns == []
+
+
+def test_new_sentence_button_ignores_the_switch(tmp_db, spawns):
+    """The requeue button is an explicit request — it regenerates either way."""
+    client.put("/api/again-regen-enabled", json={"enabled": False})
+    card_id = _card()
+    r = client.post(f"/api/review/requeue?card_id={card_id}")
+    assert r.status_code == 200
+    assert spawns == ["开关"]


### PR DESCRIPTION
## 改了什么

评 Again（rating=1）后自动后台重新生成句子的行为，现在可以在设置弹窗里关掉。默认开启，不改变任何现有行为。

- `app_settings.again_regen_enabled`（默认 `"1"`）+ `GET/PUT /api/again-regen-enabled`
- `submit_review()` 的 `rating == 1` 分支读该开关
- 设置弹窗新增 **Again → new sentence** 一栏

## 为什么

每次 Again 都是一次 AI 调用。句子本身没问题、只是自己没记住时，看同一句反而更有助于记牢——现在有得选。

## 关键决定：requeue 不受开关影响

`POST /api/review/requeue`（"New sentence" 按钮 / 键 5）是用户点下去明确要求重生成的。让全局开关把它静默吞掉，会变成一个按了没反应、界面上还不解释原因的按钮。测试专门守住这一点。

判定放服务器端而不是 localStorage：后台线程跑在服务器上，浏览器本地偏好会让手机和电脑各做各的。

## 怎么测试

`tests/test_again_regen_toggle.py`：默认值、开关往返、开时触发、关时不触发、非 Again 评分从不触发、requeue 无视开关。全套 `pytest tests/` 438 passed。

Closes #714