### PR TITLE
加词只进 ★ List：撤掉三处界面的 Today/Tomorrow（#715）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,9 +234,11 @@ bash sync_offline.sh push    # 只推不拉，推完归档本地库
 
 导入机制本身仍然存在（`importer.py`、`POST /api/import`、`python main.py import`，读取 `imports/<Source>/*.yaml`）：需要批量导入新词汇时，重新创建该目录放入 YAML 即可。日常添加单个词条：界面顶栏 `＋` 按钮（见下），或 `de-zh-bot` 技能生成 YAML 后导入。
 
-### 界面内添加生词（#627、#636、#643）
+### 界面内添加生词（#627、#636、#643、#715）
 
-顶栏 `＋` → 输入中文词 → 回车或点"加" → 后台 DeepSeek 生成完整词条 → 进 `Daily::<今天|明天>`，当天到期。
+顶栏 `＋` → 输入中文词 → 回车或点"加" → 后台 DeepSeek 生成完整词条 → 进 **★ List**（`Saved` 牌组，挂起，不进任何复习队列）。
+
+> **界面上只有 ★ List 这一个去处（#715，Daniel 2026-08-12 决定）**：顶栏 ＋、知识库详情页的生词表格、`/add` 页面三处的 Today/Tomorrow 按钮全部撤掉，一律 `day='list'`。新词先攒着，之后在 Browse 的 saved 视图主动提升（那个「→ Add to Daily」按钮**保留**——★ List 是暂存区，总得有出口）。**后端 `day` 参数照旧支持 `today|tomorrow|list`**：Daniel 已有的 iOS 快捷指令 `/add?word=X&day=today` 不该突然改行为，而且以后想恢复某个按钮只是加回一个按钮。`/add` 因此仍尊重 URL 里的 `day`，只是无参数时默认 `list`。
 
 - `ai.generate_word_entry_yaml()` 把 `de-zh-bot` 技能的中文词条规则移植成服务端提示词，输出 **YAML** 而不是 JSON —— 这样能直接交给 `importer.import_yaml_content()`，例句/量词/同义反义词/汉字分解/词源全部复用既有下游逻辑，**没有一行特例建卡代码**。这也意味着卡片与手工导入的词条完全一致（`importer._create_cards` 的 due 就是 `anki_today()`，`_make_leaf_decks` 建的子牌组名与 `get_or_create_category_decks` 相同）
 - 模型没返回 YAML 列表项时抛 `ValueError`；导入数为 0 的"完成"任务前端也报错 —— **绝不把垃圾内容悄悄写进库，也不假装成功**
@@ -251,7 +253,7 @@ bash sync_offline.sh push    # 只推不拉，推完归档本地库
   - **挂起靠 `state`，不靠 `due`**：`cards.due` 是 `NOT NULL DEFAULT date('now')`，写 NULL 直接违反约束。停留在 `Saved` 的卡照样有 due 值，是 `state='suspended'` 把它挡在队列外
   - 停放**不清空** FSRS 字段（挂起已经够了；真要激活时 `promote_saved_word` 会重置），所以 `reviews_discarded` 返回 0 —— 与上面的 `reset` 不同，这不是破坏性操作
   - Browse 的 saved 行只在词条**没有释义**时才显示 "✨ Generate"，★ List 进来的词内容已齐全，再生成纯烧钱
-- **今天/明天可选**（#636）：`day` 参数同时决定 Daily 牌组、`promote_saved_word` 的 due 和 `importer.import_yaml_content(due_offset_days=)`。**牌组和 due 必须一起后移** —— 未来日期的 Daily 牌组被 `parse_daily_deck_date` 锁住不可复习，卡片若还 due 今天就永远够不到
+- **今天/明天（#636，#715 起界面不再提供，接口保留）**：`day` 参数同时决定 Daily 牌组、`promote_saved_word` 的 due 和 `importer.import_yaml_content(due_offset_days=)`。**牌组和 due 必须一起后移** —— 未来日期的 Daily 牌组被 `parse_daily_deck_date` 锁住不可复习，卡片若还 due 今天就永远够不到
 - **不阻塞连续输入**（#636）：提交后立刻清空输入框，每个词进弹窗里的队列各自轮询自己的 job
 - **独立加词页 `/add`（#668）+ URL 参数（#686）**：可收藏的网址，打开就是输入框（存 iPhone 主屏当图标用）。`?word=生态`（或 `?w=`）+ 可选 `&day=today|tomorrow|list` → 打开即自动提交，供 iOS 快捷指令在任意 App 里一键加词；`day` 非法值回落 today（词才是重点，不该为此失败）。**提交后必须 `history.replaceState` 抹掉参数** —— 否则刷新或 iOS 恢复标签页会静默再花一次 AI 钱。`static/add.html` 是自包含页面，**故意不加载 `app.js`** —— 5.5 KB vs 完整应用的 77 KB + 491 KB JS，秒开就是这个功能的全部意义。为此把 `addWordViaAi()` 和 `api()` 从 `app.js` 抽到 `static/shared.js` 两页共用，**不复制第二份**（理由同下条；`tests/test_add_word.py` 有一条测试专门守着 `app.js` 里不能再出现这两个定义）
 - **`/api/add-word-ai` 是全应用唯一的加词入口**（#643）：顶栏 ＋、播客单集的 HSK 生词表格、复习界面长按词的菜单、以及 `/add` 页面，全部共用 `shared.js` 的 `addWordViaAi()`。原来播客/长按走的 `/api/quick-add-word` 已删除 —— 它只让 AI 填四个字段（无例句/汉字分解/量词/同义反义词），而且 `added_to_deck` 分支在词已学过时被 `INSERT OR IGNORE` + `UNIQUE(word_id, category)` 全部静默丢弃，却照样返回成功。**加词只能有一条管线**，否则修好的坑会在第二条路上重新出现
@@ -482,7 +484,7 @@ GET  /api/costs/call/{id}                            → {prompt, response}（�
 POST /api/import                                     → 触发 YAML 导入
 GET  /add[?word=生态&day=today|tomorrow|list]         → 独立加词页（#668，可收藏/存主屏；不加载 app.js）；带 word 参数时打开即自动提交（#686，供 iOS 快捷指令用），提交后从地址栏抹掉该参数以免刷新重复扣费
 GET  /save                                           → 独立素材收藏页（#681，Link/Text 两个标签；同样不加载 app.js）
-POST /api/add-word-ai                                → 界面内添加生词（#627）；body {word_zh, day?:today|tomorrow|list}（#636、#677）；新词返回 {job_id}，已有词直接返回 {status}。**全应用唯一的加词入口**（#643）：顶栏 ＋、播客生词表格、复习界面长按菜单都走它
+POST /api/add-word-ai                                → 界面内添加生词（#627）；body {word_zh, day?:today|tomorrow|list}（#636、#677；#715 起界面一律传 list，接口三值仍有效）；新词返回 {job_id}，已有词直接返回 {status}。**全应用唯一的加词入口**（#643）：顶栏 ＋、播客生词表格、复习界面长按菜单都走它
 GET  /api/add-word-ai/progress/{job_id}              → 轮询后台生成+导入的结果
 GET  /api/browse                                     → {deck_id?, category?, state?, q?, lang?}
 GET  /api/stats ；/api/retention ；/api/card-evolution（均支持 ?lang=）

--- a/static/add.html
+++ b/static/add.html
@@ -40,12 +40,6 @@
     color: #fff; background: var(--accent); border: 0; border-radius: 10px; cursor: pointer;
   }
   button.go:disabled { opacity: .5; }
-  .days { display: flex; gap: .4rem; margin-top: .75rem; }
-  .days button {
-    flex: 1; padding: .5rem; font-size: .9rem; color: var(--muted);
-    background: transparent; border: 1px solid var(--line); border-radius: 8px; cursor: pointer;
-  }
-  .days button[aria-pressed=true] { color: #fff; background: var(--accent); border-color: var(--accent); }
   ul { list-style: none; margin: 1rem 0 0; padding: 0; }
   li {
     display: flex; align-items: baseline; gap: .6rem;
@@ -72,12 +66,7 @@
              autocapitalize="none" autocorrect="off" spellcheck="false" enterkeyhint="done" autofocus>
       <button class="go" id="go">加</button>
     </div>
-    <div class="days">
-      <button id="day-today" aria-pressed="true">Today</button>
-      <button id="day-tomorrow" aria-pressed="false">Tomorrow</button>
-      <button id="day-list" aria-pressed="false">★ List</button>
-    </div>
-    <p class="hint" id="hint">Chinese input only. Generation takes ~30s — you can keep typing the next word meanwhile.</p>
+    <p class="hint" id="hint">Parked in your ★ List — generated in full, but not reviewed until you add it to a deck from Browse.</p>
   </div>
 
   <ul id="queue"></ul>
@@ -88,30 +77,19 @@
   // Standalone quick-add page (#668). Deliberately does NOT load app.js: the
   // point is a link that opens instantly on the phone. All the real work goes
   // through addWordViaAi() in shared.js — the single add-word pipeline (#643).
-  let day = 'today';
+  // Where an added word goes (#715): the ★ List, always. Adding a word no
+  // longer drops it straight into a review queue — it is staged in Saved
+  // (suspended) and activated later from Browse, deliberately.
+  //
+  // The day is still a parameter of the API and of this page's URL, so the
+  // iOS Shortcuts Daniel already built (/add?word=X&day=today) keep behaving
+  // the way they did. There is simply no button for it any more.
+  let day = 'list';
   const items = [];   // newest first
   const input = document.getElementById('word');
   const queue = document.getElementById('queue');
 
   const DAYS = ['today', 'tomorrow', 'list'];
-  const HINTS = {
-    today: 'Chinese input only. Generation takes ~30s — you can keep typing the next word meanwhile.',
-    tomorrow: 'Chinese input only. Generation takes ~30s — you can keep typing the next word meanwhile.',
-    // ★ List = the Saved deck: the entry is generated in full, but the cards
-    // stay suspended until promoted from Browse (#677).
-    list: 'Parked in your Saved list — not reviewed until you add it to a deck from Browse.',
-  };
-  function selectDay(d) {
-    if (!DAYS.includes(d)) return;
-    day = d;
-    for (const other of DAYS) {
-      document.getElementById(`day-${other}`).setAttribute('aria-pressed', String(other === d));
-    }
-    document.getElementById('hint').textContent = HINTS[d];
-  }
-  for (const d of DAYS) {
-    document.getElementById(`day-${d}`).onclick = () => { selectDay(d); input.focus(); };
-  }
 
   function render() {
     queue.replaceChildren(...items.map(it => {
@@ -150,10 +128,10 @@
   document.getElementById('go').onclick = submit;
   input.addEventListener('keydown', e => { if (e.key === 'Enter') submit(); });
 
-  // URL parameters (#686) — /add?word=生态&day=list — so an iOS Shortcut can
-  // add a word straight from any app. `day` is optional and defaults to today;
-  // an unknown value falls back to today rather than failing, since the word
-  // is the part that matters.
+  // URL parameters (#686) — /add?word=生态&day=today — so an iOS Shortcut can
+  // add a word straight from any app. `day` is optional and defaults to the
+  // ★ List (#715); an unknown value falls back to it rather than failing,
+  // since the word is the part that matters.
   //
   // Opening such a link submits immediately and therefore spends an AI call.
   // That is the whole point of the parameter, but it also means the word is
@@ -161,7 +139,8 @@
   // or a "restore tabs" on the phone would otherwise silently add it again.
   const params = new URLSearchParams(location.search);
   const preset = (params.get('word') || params.get('w') || '').trim();
-  selectDay((params.get('day') || 'today').trim());
+  const dayParam = (params.get('day') || '').trim();
+  if (DAYS.includes(dayParam)) day = dayParam;
   if (preset) {
     input.value = preset;
     history.replaceState(null, '', location.pathname);

--- a/static/app.js
+++ b/static/app.js
@@ -3542,17 +3542,11 @@ function _renderKnowledgeDetail(ep) {
       <td>${_escHtml(w.word || w.word_zh || '')}</td>
       <td>${_escHtml(w.pinyin || '')}</td>
       <td>${_escHtml(w.definition_de || w.definition || '')}</td>
-      <td><button id="podcast-add-word-${idx}" class="btn-secondary" onclick="doPodcastAddWord(${idx})">+ Add</button></td>
+      <td><button id="podcast-add-word-${idx}" class="btn-secondary" onclick="doPodcastAddWord(${idx})">★ List</button></td>
       <td><button id="podcast-known-word-${idx}" class="btn-secondary" onclick="doPodcastKnownWord(${idx})" title="I already know this word — stop flagging it">✓ Known</button></td>
     </tr>`).join('');
   const hskTable = hskRows
-    ? `<div id="podcast-add-day" class="add-word-day-row">
-         <button type="button" class="add-word-day-btn" data-day="today"
-                 onclick="setPodcastAddDay('today')">Today</button>
-         <button type="button" class="add-word-day-btn" data-day="tomorrow"
-                 onclick="setPodcastAddDay('tomorrow')">Tomorrow</button>
-       </div>
-       <table class="cost-table"><thead><tr><th>Word</th><th>Pinyin</th><th>German</th><th>Add</th><th>Known</th></tr></thead><tbody>${hskRows}</tbody></table>`
+    ? `<table class="cost-table"><thead><tr><th>Word</th><th>Pinyin</th><th>German</th><th>Save</th><th>Known</th></tr></thead><tbody>${hskRows}</tbody></table>`
     : '<p class="keymap-hint">No HSK vocabulary extracted.</p>';
   const links = [
     ep.youtube_url ? `<a href="${_escHtml(ep.youtube_url)}" target="_blank" rel="noopener" class="btn-secondary">${isPodcast ? 'YouTube' : 'Open'} ↗</a>` : '',
@@ -3593,7 +3587,6 @@ function _renderKnowledgeDetail(ep) {
       <h2 class="keymap-heading">${contentLabel}</h2>
       ${transcript || `<p class="keymap-hint">No ${contentLabel.toLowerCase()} available.</p>`}
     </div>`;
-  setPodcastAddDay(_podcastAddDay);  // highlights the active day button
 }
 
 function _togglePodcastTranscript() {
@@ -3671,17 +3664,6 @@ async function doPodcastNotify(channel) {
   }
 }
 
-// Which day the podcast vocabulary table adds to. Podcasts are usually
-// listened to in the evening, so tomorrow stays the default (#643).
-let _podcastAddDay = 'tomorrow';
-
-function setPodcastAddDay(day) {
-  _podcastAddDay = day === 'today' ? 'today' : 'tomorrow';
-  for (const btn of document.querySelectorAll('#podcast-add-day .add-word-day-btn')) {
-    btn.classList.toggle('active', btn.dataset.day === _podcastAddDay);
-  }
-}
-
 function doPodcastAddWord(idx) {
   const w = _podcastDetailWords[idx];
   const btn = document.getElementById(`podcast-add-word-${idx}`);
@@ -3693,7 +3675,11 @@ function doPodcastAddWord(idx) {
   btn.textContent = '…';
   // Generation takes ~30s in the background — the other rows stay clickable,
   // so several words can be queued up at once.
-  addWordViaAi(wordZh, _podcastAddDay, (state, text) => {
+  //
+  // Always the ★ List (#715): a word met while reading goes to the staging
+  // area, never straight into today's or tomorrow's review queue. Activating
+  // it is a separate, deliberate step in Browse's saved view.
+  addWordViaAi(wordZh, 'list', (state, text) => {
     btn.textContent = text;
     btn.classList.toggle('podcast-add-error', state === 'error');
     // Only a failure is worth retrying; a finished add is not repeatable.
@@ -6441,14 +6427,12 @@ function showQuickAddBanner(msg, isInfo) {
 // Generation takes ~30s but the request returns a job id immediately, so the
 // input never blocks: each submitted word becomes a queue entry that polls its
 // own job while the user types the next one (#636).
-let _addWordDay = 'today';          // 'today' | 'tomorrow'
 let _addWordQueue = [];             // [{key, wordZh, state, text}]
 let _addWordSeq = 0;
 
 function openAddWordModal() {
   document.getElementById('add-word-overlay').style.display = 'block';
   document.getElementById('add-word-modal').style.display = 'block';
-  setAddWordDay(_addWordDay);
   const input = document.getElementById('add-word-input');
   input.value = '';
   input.disabled = false;
@@ -6466,25 +6450,6 @@ function closeAddWordModal() {
   // date; closing only hides the list. Drop finished rows so reopening the
   // modal shows a clean slate.
   _addWordQueue = _addWordQueue.filter(item => item.state === 'running');
-}
-
-function setAddWordDay(day) {
-  _addWordDay = ['tomorrow', 'list'].includes(day) ? day : 'today';
-  for (const btn of document.querySelectorAll('.add-word-day-btn')) {
-    btn.classList.toggle('active', btn.dataset.day === _addWordDay);
-  }
-  const label = document.getElementById('add-word-deck');
-  if (_addWordDay === 'list') {
-    // ★ List parks the word in the Saved deck, suspended (#677) — say so,
-    // because "Saved" alone reads like a deck it will be reviewed from.
-    label.textContent = 'Saved (not reviewed until promoted)';
-  } else {
-    const d = new Date();
-    if (_addWordDay === 'tomorrow') d.setDate(d.getDate() + 1);
-    label.textContent =
-      'Daily::' + `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-  }
-  document.getElementById('add-word-input').focus();
 }
 
 function _renderAddWordQueue() {
@@ -6525,7 +6490,9 @@ function submitAddWord() {
   _addWordQueue.unshift(item);
   _renderAddWordQueue();
 
-  addWordViaAi(wordZh, _addWordDay, (state, text, deckPath) => {
+  // Always the ★ List (#715): every add-word entry point parks the word in
+  // Saved, suspended, and activating it is a separate step in Browse.
+  addWordViaAi(wordZh, 'list', (state, text, deckPath) => {
     _setAddWordItem(item, state, text);
     // The modal may already be closed; the banner is how the user finds out.
     if (state === 'done' &&

--- a/static/index.html
+++ b/static/index.html
@@ -936,14 +936,6 @@
     <button class="edit-modal-close" onclick="closeAddWordModal()">✕</button>
   </div>
   <div id="add-word-body">
-    <div id="add-word-day">
-      <button type="button" class="add-word-day-btn active" data-day="today"
-              onclick="setAddWordDay('today')">Today</button>
-      <button type="button" class="add-word-day-btn" data-day="tomorrow"
-              onclick="setAddWordDay('tomorrow')">Tomorrow</button>
-      <button type="button" class="add-word-day-btn" data-day="list"
-              onclick="setAddWordDay('list')" title="Park in the Saved list — not reviewed until promoted from Browse">★ List</button>
-    </div>
     <div id="add-word-row">
       <input id="add-word-input" type="text" placeholder="新词…" autocomplete="off"
              onkeydown="if (event.key === 'Enter') submitAddWord()">
@@ -951,7 +943,8 @@
     </div>
     <div id="add-word-hint">
       Enter a Chinese word — DeepSeek writes the full entry (definitions,
-      examples, character breakdown) into <b id="add-word-deck">today's deck</b>.
+      examples, character breakdown) into your <b id="add-word-deck">★ List</b>
+      (Saved, not reviewed until promoted from Browse).
       Generation runs in the background, so you can keep typing the next word.
     </div>
     <div id="add-word-status"></div>

--- a/static/style.css
+++ b/static/style.css
@@ -5166,25 +5166,6 @@ table.fsrs-table td.ivl { font-weight: 700; }
   padding: 16px;
 }
 
-/* Today / Tomorrow segmented control — shared with the podcast vocabulary
-   table's Add buttons (#643) */
-#add-word-day,
-.add-word-day-row {
-  display: flex;
-  gap: 4px;
-  padding: 4px;
-  margin-bottom: 12px;
-  background: var(--bg);
-  border-radius: 12px;
-}
-/* In the podcast panel it sits above a wide table — keep it compact */
-.add-word-day-row {
-  width: fit-content;
-}
-.add-word-day-row .add-word-day-btn {
-  flex: 0 0 auto;
-  min-width: 96px;
-}
 /* A word marked "✓ Known" (#710) — kept in the table but visibly settled, so
    it's obvious which rows still need a decision. */
 .podcast-word-known { opacity: 0.45; }
@@ -5193,25 +5174,6 @@ table.fsrs-table td.ivl { font-weight: 700; }
   color: var(--again);
   border-color: var(--again);
 }
-.add-word-day-btn {
-  flex: 1;
-  padding: 10px 12px;
-  min-height: 44px;
-  font-size: 15px;
-  font-weight: 600;
-  background: none;
-  color: var(--muted);
-  border: none;
-  border-radius: 9px;
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s;
-}
-.add-word-day-btn.active {
-  background: var(--card);
-  color: var(--primary);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
-}
-
 #add-word-row {
   display: flex;
   gap: 8px;

--- a/tests/test_add_word.py
+++ b/tests/test_add_word.py
@@ -478,3 +478,36 @@ def test_add_page_reads_word_and_day_from_the_url(tmp_db):
     # The word must be stripped from the URL after submitting, or a reload
     # (or iOS restoring tabs) silently spends another AI call on it.
     assert "history.replaceState" in src
+
+
+# --- ★ List is the only destination the UI offers (#715) --------------------
+# The API still accepts day=today|tomorrow (old iOS Shortcut links must keep
+# working), so what these tests guard is the *interface*: no entry point may
+# put a freshly added word straight into a review queue again.
+
+def _static(name):
+    import pathlib
+    return pathlib.Path(f"static/{name}").read_text(encoding="utf-8")
+
+
+def test_no_ui_entry_point_offers_today_or_tomorrow():
+    """All three add-word entry points (top-bar ＋, the knowledge item's HSK
+    table, and /add) stage the word instead of scheduling it."""
+    for name in ("index.html", "add.html", "app.js"):
+        assert "add-word-day-btn" not in _static(name), f"day selector left in {name}"
+
+
+def test_add_word_calls_pass_the_list_destination():
+    app_js = _static("app.js")
+    assert "addWordViaAi(wordZh, 'list'" in app_js
+    # The mutable day state behind the old selector must be gone, not merely
+    # unused — a stale 'today' default is exactly how this would come back.
+    assert "_addWordDay" not in app_js
+    assert "_podcastAddDay" not in app_js
+
+
+def test_add_page_defaults_to_the_list():
+    src = _static("add.html")
+    assert "let day = 'list'" in src
+    # …but an explicit ?day= from an existing Shortcut is still honoured.
+    assert "params.get('day')" in src


### PR DESCRIPTION
## 改了什么

加词的三处入口一律送进 **★ List**（`Saved` 牌组、挂起、不进任何复习队列），Today/Tomorrow 按钮全部撤掉：

1. **顶栏 ＋ 弹窗**（`index.html` + `app.js`）：去掉三个 day 按钮和 `_addWordDay`/`setAddWordDay`，提示语改成「进你的 ★ List（Saved，提升前不复习）」。
2. **知识库详情页的 HSK 生词表格**：去掉表格上方的 Today/Tomorrow 切换行和 `_podcastAddDay`/`setPodcastAddDay`，`+ Add` 按钮改为 **★ List**，表头 `Add` → `Save`。
3. **独立加词页 `/add`**：去掉三个 day 按钮，`day` 固定 `list`。
4. 两处只服务于 day 选择器的 CSS（`style.css` 的 `.add-word-day-*`、`add.html` 内联的 `.days`）一并删掉——留着就是下次误用的种子。

## 明确没改的（都是刻意的）

- **后端 `POST /api/add-word-ai` 的 `day` 仍接受 `today|tomorrow|list`**。Daniel 已有的 iOS 快捷指令 `/add?word=X&day=today` 不该突然改行为；而且以后想恢复某个按钮，只是加回一个按钮。`/add` 因此仍尊重 URL 里的 `day`，无参数时默认 `list`。
- **Browse 的 saved 视图里「→ Add to Daily」提升按钮保留**。★ List 是暂存区，总得有出口把词真正放进复习队列——本次限制的是「加词时的去处」，不是「永远不能进 Daily」。

## 怎么测的

- `pytest tests/` → 435 passed, 4 skipped
- 新增 3 条测试守住约定：三处静态文件里都不能再出现 `add-word-day-btn`；`app.js` 里不能再有 `_addWordDay`/`_podcastAddDay`（残留的 `'today'` 默认值正是这功能倒退回来的方式）；`/add` 默认 `list` 但仍读 `?day=`

Closes #715
