### PR TITLE
复习时给句子打差评 👎 + 一键原因标签（#712）

### DIFF
--- a/database/core.py
+++ b/database/core.py
@@ -249,6 +249,9 @@ def init_db() -> None:
         conn.execute("ALTER TABLE story_sentences ADD COLUMN starred INTEGER NOT NULL DEFAULT 0")
     if "starred_at" not in ss_cols:
         conn.execute("ALTER TABLE story_sentences ADD COLUMN starred_at TEXT")
+    # Thumbs-down ratings reuse `starred` as -1 and record why here (#712).
+    if "bad_reason" not in ss_cols:
+        conn.execute("ALTER TABLE story_sentences ADD COLUMN bad_reason TEXT")
     if "word_id" in ss_cols:
         _migrate_story_sentences_multi_word(conn)
     existing_tables = {r["name"] for r in conn.execute(

--- a/database/stories.py
+++ b/database/stories.py
@@ -147,38 +147,73 @@ def _hydrate_sentence(conn, sent_row) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Starred sentences (#692) — sentences Daniel marked as good during review, kept
-# as positive examples to learn from when tuning the generation prompts.
+# Rated sentences (#692 good, #712 bad) — sentences Daniel judged during review,
+# kept as examples to learn from when tuning the generation prompts. Both
+# directions live in `starred`: 1 = good, -1 = bad, 0 = unrated.
 # ---------------------------------------------------------------------------
 
-def set_sentence_starred(sentence_id: int, starred: bool) -> dict | None:
-    """Star or unstar one story sentence. Returns the new state, or None if no such sentence.
+#: One-tap tags for *why* a sentence is bad (#712). A closed set, not free text:
+#: typing mid-review breaks the rhythm, and fixed values make systematic prompt
+#: problems visible by counting (e.g. half the bad sentences tagged "too_hard").
+BAD_REASONS = ("unnatural", "too_hard", "factual_error", "wrong_word", "grammar", "other")
+
+
+def set_sentence_rating(sentence_id: int, rating: int,
+                        bad_reason: str | None = None) -> dict | None:
+    """Rate one story sentence 1 (good) / -1 (bad) / 0 (unrated).
+
+    Returns the new state, or None if no such sentence.
 
     Works for regenerated "Again" sentences too — those are ordinary
     story_sentences rows under the AGAIN_CATEGORY sentinel (see store_again_sentence).
     """
+    rating = int(rating)
+    if rating not in (1, 0, -1):
+        raise ValueError(f"rating must be 1, 0 or -1, got {rating!r}")
+    # A reason only means anything on a thumbs-down; carrying one over to a good
+    # or cleared rating would leave a stale "too_hard" tag on a sentence Daniel
+    # later decided he liked.
+    if rating != -1:
+        bad_reason = None
+    elif bad_reason is not None and bad_reason not in BAD_REASONS:
+        raise ValueError(f"unknown bad_reason {bad_reason!r}")
+
     conn = get_db()
-    starred_at = datetime.now().isoformat(timespec="seconds") if starred else None
+    rated_at = datetime.now().isoformat(timespec="seconds") if rating else None
     cur = conn.execute(
-        "UPDATE story_sentences SET starred = ?, starred_at = ? WHERE id = ?",
-        (1 if starred else 0, starred_at, sentence_id),
+        "UPDATE story_sentences SET starred = ?, starred_at = ?, bad_reason = ? WHERE id = ?",
+        (rating, rated_at, bad_reason, sentence_id),
     )
     conn.commit()
     if cur.rowcount == 0:
         conn.close()
         return None
     conn.close()
-    return {"id": sentence_id, "starred": 1 if starred else 0, "starred_at": starred_at}
+    # `starred` stays in the response next to `rating`: the front end reads it as
+    # the truthy "has a rating" flag it always was, and it keeps older clients working.
+    return {"id": sentence_id, "rating": rating, "starred": rating,
+            "starred_at": rated_at, "bad_reason": bad_reason}
 
 
-def get_starred_sentences(lang: str | None = None, limit: int = 500) -> list[dict]:
-    """All starred sentences, newest star first, with the context needed to judge them.
+def set_sentence_starred(sentence_id: int, starred: bool) -> dict | None:
+    """Backwards-compatible wrapper for the boolean-only API of #692."""
+    return set_sentence_rating(sentence_id, 1 if starred else 0)
+
+
+def get_starred_sentences(lang: str | None = None, limit: int = 500,
+                          rating: str | None = None) -> list[dict]:
+    """All rated sentences, newest rating first, with the context needed to judge them.
+
+    `rating` filters to "good" or "bad"; anything else (including None) returns both,
+    which is the default because tuning a prompt means reading the positive and
+    negative examples against each other.
 
     Each row carries its story's generation settings (mode / model / episode_id via
     gen_params) and deck name on top of the usual sentence shape — that context is the
-    whole point: a good sentence is only informative if you know which prompt made it.
+    whole point: a sentence is only informative if you know which prompt made it.
     """
     conn = get_db()
+    rating_clause = {"good": " = 1", "bad": " = -1"}.get(rating, " != 0")
     lang_clause = ""
     params: list = []
     if lang:
@@ -196,7 +231,7 @@ def get_starred_sentences(lang: str | None = None, limit: int = 500) -> list[dic
             FROM story_sentences ss
             JOIN stories s ON s.id = ss.story_id
             LEFT JOIN decks d ON d.id = s.deck_id
-            WHERE ss.starred = 1{lang_clause}
+            WHERE ss.starred{rating_clause}{lang_clause}
             ORDER BY ss.starred_at DESC, ss.id DESC
             LIMIT ?""",
         (*params, limit),
@@ -213,6 +248,7 @@ def get_starred_sentences(lang: str | None = None, limit: int = 500) -> list[dic
         d["mode"] = params_dict.get("mode") or "story"
         d["model"] = params_dict.get("model")
         d["episode_id"] = params_dict.get("episode_id")
+        d["rating"] = d.get("starred") or 0
         result.append(d)
     conn.close()
     return result

--- a/routes/story.py
+++ b/routes/story.py
@@ -766,21 +766,34 @@ def regenerate_story(deck_id: int, category: str,
     return result
 
 
-# ── 加星句子（issue #692）────────────────────────────────────────────────────
-# 复习时看到写得好的句子就地加星，之后集中回看，作为改进生成提示词的正例样本。
+# ── 句子评价（好 issue #692 / 差 issue #712）──────────────────────────────────
+# 复习时就地评价句子，之后集中回看，作为改进生成提示词的正例与反例样本。
 
 @router.post("/api/story-sentence/{sentence_id}/star")
 def star_sentence(sentence_id: int, body: dict | None = None):
-    starred = bool((body or {}).get("starred", True))
-    result = database.set_sentence_starred(sentence_id, starred)
+    body = body or {}
+    if "rating" in body:
+        try:
+            rating = int(body["rating"])
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=400, detail=f"Invalid rating {body['rating']!r}")
+    else:
+        # Legacy boolean body from #692 — still accepted so an open tab running
+        # the old app.js keeps working across a deploy.
+        rating = 1 if bool(body.get("starred", True)) else 0
+    try:
+        result = database.set_sentence_rating(sentence_id, rating, body.get("bad_reason"))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     if result is None:
         raise HTTPException(status_code=404, detail=f"No sentence with id {sentence_id}")
     return result
 
 
 @router.get("/api/starred-sentences")
-def list_starred_sentences(lang: str | None = None, limit: int = 500):
-    return {"sentences": database.get_starred_sentences(lang=lang, limit=limit)}
+def list_starred_sentences(lang: str | None = None, limit: int = 500,
+                           rating: str | None = None):
+    return {"sentences": database.get_starred_sentences(lang=lang, limit=limit, rating=rating)}
 
 
 # NOT /api/story/{story_id}/prompt: GET /api/story/{deck_id}/{category} is

--- a/schema.sql
+++ b/schema.sql
@@ -406,9 +406,14 @@ CREATE TABLE IF NOT EXISTS story_sentences (
     context_de  TEXT,
     source_title TEXT,
     source_name TEXT,
-    -- starred during review as a good example to learn from when tuning prompts (#692)
+    -- Rated during review as an example to learn from when tuning prompts:
+    -- 1 = good (#692), -1 = bad, 0 = unrated (#712). The column keeps its old
+    -- name because renaming it would mean rebuilding the table and migrating
+    -- production for no functional gain.
     starred     INTEGER NOT NULL DEFAULT 0,
     starred_at  TEXT,
+    -- Optional one-tap tag saying what was wrong, only set alongside starred = -1 (#712)
+    bad_reason  TEXT,
     UNIQUE(story_id, position)
 );
 

--- a/static/app.js
+++ b/static/app.js
@@ -142,7 +142,7 @@ const KEYMAP_ACTIONS = [
   { id: 'story-modal',  label: 'Open summary (full story)' },
 ];
 // Keys hardcoded elsewhere in the review view — cannot be reassigned to.
-const KEYMAP_RESERVED = ['R','1','2','3','4','e','n','w','f','v','c','C','D','7','L','o','g','Enter','Tab'];
+const KEYMAP_RESERVED = ['R','1','2','3','4','e','n','w','f','v','c','C','D','7','L','o','g','j','h','Enter','Tab'];
 function _loadKeymap() {
   let saved = {};
   try { saved = JSON.parse(localStorage.getItem('reviewKeymap') || '{}'); } catch (e) {}
@@ -2266,24 +2266,52 @@ function renderBrowseWords(words) {
 // context that makes it useful: which mode/model produced it and from which
 // source material. That's what you read when deciding how to change a prompt.
 
+// Good and bad live in one list with a filter rather than two separate views:
+// tuning a prompt means reading the positive and negative examples against
+// each other, not looking at one half at a time.
+let _starredRatingFilter = 'all';   // 'all' | 'good' | 'bad'
+
+function setStarredRatingFilter(f) {
+  _starredRatingFilter = f;
+  renderStarredSentences();
+}
+
+const _BAD_REASON_LABELS = {
+  unnatural: 'unnatural', too_hard: 'too hard', factual_error: 'factual error',
+  wrong_word: 'wrong word', grammar: 'grammar', other: 'other',
+};
+
 async function renderStarredSentences() {
   const list = document.getElementById('browse-list');
   list.innerHTML = '<div class="browse-empty">Loading…</div>';
   let sentences;
   try {
-    const r = await api('GET', `/api/starred-sentences${_langQP('?')}`);
+    const qp = _langQP('?');
+    const sep = qp ? '&' : '?';
+    const filter = _starredRatingFilter === 'all' ? '' : `${sep}rating=${_starredRatingFilter}`;
+    const r = await api('GET', `/api/starred-sentences${qp}${filter}`);
     sentences = r.sentences;
   } catch (e) {
-    list.innerHTML = `<div class="browse-empty">Could not load starred sentences: ${_escHtml(e.message)}</div>`;
+    list.innerHTML = `<div class="browse-empty">Could not load rated sentences: ${_escHtml(e.message)}</div>`;
     return;
   }
   if (_browseCardStatus !== 'starred') return;  // user switched tabs while loading
+
+  const tabs = ['all', 'good', 'bad'].map(f => {
+    const label = { all: 'All', good: '👍 Good', bad: '👎 Bad' }[f];
+    const active = _starredRatingFilter === f ? ' ss-filter-active' : '';
+    return `<button class="ss-filter${active}" onclick="setStarredRatingFilter('${f}')">${label}</button>`;
+  }).join('');
+  const bar = `<div class="ss-filter-bar">${tabs}</div>`;
+
   if (!sentences.length) {
-    list.innerHTML = '<div class="browse-empty">No starred sentences yet — press Shift+F ' +
-                     'or tap ☆ while reviewing to keep a good one.</div>';
+    const empty = _starredRatingFilter === 'bad'
+      ? 'No sentences marked bad yet — press h or tap 👎 while reviewing.'
+      : 'No rated sentences yet — press j (good) or h (bad) while reviewing.';
+    list.innerHTML = `${bar}<div class="browse-empty">${empty}</div>`;
     return;
   }
-  list.innerHTML = `<div class="bw-list">${sentences.map(_starredSentenceRow).join('')}</div>`;
+  list.innerHTML = `${bar}<div class="bw-list">${sentences.map(_starredSentenceRow).join('')}</div>`;
 }
 
 function _starredSentenceRow(s) {
@@ -2293,8 +2321,15 @@ function _starredSentenceRow(s) {
     ? `<a class="ss-source" href="${_escHtml(s.source_url)}" target="_blank" rel="noopener"
           onclick="event.stopPropagation()">${_escHtml(s.source_title || s.source_name || 'source')}</a>`
     : (s.source_title ? `<span class="ss-source">${_escHtml(s.source_title)}</span>` : '');
+  const bad = s.rating === -1;
+  // The reason is the actionable half of a thumbs-down, so it sits in the meta
+  // line rather than behind a hover title.
+  const reason = bad && s.bad_reason
+    ? `<span class="ss-reason">${_escHtml(_BAD_REASON_LABELS[s.bad_reason] || s.bad_reason)}</span>`
+    : '';
   const meta = [
     `<span class="ss-mode">${_escHtml(s.mode || 'story')}</span>`,
+    reason,
     s.story_date ? `<span>${_escHtml(s.story_date)}</span>` : '',
     s.deck_name ? `<span>${_escHtml(s.deck_name)}</span>` : '',
     words ? `<span class="ss-words">${words}</span>` : '',
@@ -2309,7 +2344,7 @@ function _starredSentenceRow(s) {
     : `<button class="ss-prompt-btn" disabled
                title="No prompt stored for this story (legacy story, or an offline snapshot — it strips prompt_text)">📝 Prompt</button>`;
 
-  return `<div class="bw-row ss-row">
+  return `<div class="bw-row ss-row${bad ? ' ss-row-bad' : ''}">
     <div class="ss-main">
       <div class="ss-zh">${_escHtml(s.sentence_zh)}</div>
       ${trans ? `<div class="ss-trans">${_escHtml(trans)}</div>` : ''}
@@ -2317,8 +2352,8 @@ function _starredSentenceRow(s) {
     </div>
     <div class="ss-actions">
       ${promptBtn}
-      <button class="ss-unstar" title="Remove the star"
-              onclick="unstarSentence(${s.id}, this)">★</button>
+      <button class="ss-unstar" title="Remove this rating"
+              onclick="unstarSentence(${s.id}, this)">${bad ? '👎' : '★'}</button>
     </div>
   </div>`;
 }
@@ -2326,12 +2361,12 @@ function _starredSentenceRow(s) {
 async function unstarSentence(sentenceId, btn) {
   btn.disabled = true;
   try {
-    await api('POST', `/api/story-sentence/${sentenceId}/star`, { starred: false });
+    await api('POST', `/api/story-sentence/${sentenceId}/star`, { rating: 0 });
     btn.closest('.ss-row')?.remove();
     if (!document.querySelector('.ss-row')) renderStarredSentences();  // back to empty state
   } catch (e) {
     btn.disabled = false;
-    showError('Unstar failed: ' + e.message);
+    showError('Clearing the rating failed: ' + e.message);
   }
 }
 
@@ -7193,48 +7228,90 @@ function _syncCardToggleBar() {
                        (de?.textContent && de.style.display !== 'none');
   transBtn.classList.toggle('active', !!transVisible);
 
-  // Star: only when this card actually shows a stored story sentence. A card
+  // Rating: only when this card actually shows a stored story sentence. A card
   // with no sentence (no story yet — renderSentence() falls back to the bare
-  // word) has nothing to star, so the button stays hidden rather than failing.
+  // word) has nothing to rate, so the buttons stay hidden rather than failing.
   const starBtn = document.getElementById('toggle-star-btn');
+  const badBtn = document.getElementById('toggle-bad-btn');
   const starAvail = !!sentence?.id;
-  if (starBtn) {
-    starBtn.style.display = starAvail ? '' : 'none';
-    _syncStarBtn();
-  }
+  if (starBtn) starBtn.style.display = starAvail ? '' : 'none';
+  if (badBtn) badBtn.style.display = starAvail ? '' : 'none';
+  _syncStarBtn();
 
   bar.style.display = (pinAvail || transAvail || starAvail) ? '' : 'none';
 }
 
-// ── Starred sentences (#692) ─────────────────────────────────────────────────
+// ── Rated sentences (good #692, bad #712) ────────────────────────────────────
 // While reviewing, a sentence is either good or it isn't — and that judgement is
-// only available in the second you read it. Starring collects those good ones as
-// positive examples for tuning the generation prompts later (Browse → ★).
+// only available in the second you read it. Rating collects both directions as
+// examples for tuning the generation prompts later (Browse → ⭐ Sentences).
+// `sentence.starred` holds the rating: 1 good, -1 bad, 0 none.
 
 function _syncStarBtn() {
-  const btn = document.getElementById('toggle-star-btn');
-  if (!btn) return;
-  const on = !!sentence?.starred;
-  btn.textContent = on ? '★' : '☆';
-  btn.classList.toggle('active', on);
-  btn.title = on ? 'Starred — click to unstar (Shift+F)'
-                 : 'Star this sentence as a good example (Shift+F)';
+  const good = sentence?.starred === 1;
+  const bad = sentence?.starred === -1;
+  const starBtn = document.getElementById('toggle-star-btn');
+  if (starBtn) {
+    starBtn.textContent = good ? '★' : '☆';
+    starBtn.classList.toggle('active', good);
+    starBtn.title = good ? 'Good example — click to clear (j)' : 'Good example (j)';
+  }
+  const badBtn = document.getElementById('toggle-bad-btn');
+  if (badBtn) {
+    badBtn.classList.toggle('active', bad);
+    badBtn.title = bad ? 'Bad example — click to clear (h)' : 'Bad example (h)';
+  }
+  // The reason row belongs to a thumbs-down and nothing else.
+  const bar = document.getElementById('bad-reason-bar');
+  if (bar) {
+    bar.style.display = bad ? '' : 'none';
+    const reason = sentence?.bad_reason || null;
+    bar.querySelectorAll('.bad-reason-btn').forEach(b => {
+      const val = b.getAttribute('onclick')?.match(/'([^']+)'/)?.[1];
+      b.classList.toggle('active', !!reason && val === reason);
+    });
+  }
 }
 
-async function toggleSentenceStar() {
+// Rating the sentence the way it already is clears it, so the same key toggles.
+async function rateSentence(rating) {
   if (!sentence?.id) return;
-  const next = !sentence.starred;
-  // Optimistic: the star is a note to self, and a stalled button mid-review is
-  // more disruptive than a star that turns out not to have saved.
-  sentence.starred = next ? 1 : 0;
+  const next = sentence.starred === rating ? 0 : rating;
+  const prev = { starred: sentence.starred, bad_reason: sentence.bad_reason };
+  // Optimistic: the rating is a note to self, and a stalled button mid-review is
+  // more disruptive than a rating that turns out not to have saved.
+  sentence.starred = next;
+  if (next !== -1) sentence.bad_reason = null;
   _syncStarBtn();
   try {
-    const r = await api('POST', `/api/story-sentence/${sentence.id}/star`, { starred: next });
-    sentence.starred = r.starred;
+    const r = await api('POST', `/api/story-sentence/${sentence.id}/star`, { rating: next });
+    sentence.starred = r.rating;
     sentence.starred_at = r.starred_at;
+    sentence.bad_reason = r.bad_reason;
   } catch (e) {
-    sentence.starred = next ? 0 : 1;
-    showError('Star failed: ' + e.message);
+    sentence.starred = prev.starred;
+    sentence.bad_reason = prev.bad_reason;
+    showError('Rating failed: ' + e.message);
+  }
+  _syncStarBtn();
+}
+
+// Tag *why* the sentence is bad. Optional by design: the thumbs-down is already
+// saved by the time this row appears, so skipping it costs nothing. Tapping the
+// tag that's already set clears it.
+async function setBadReason(reason) {
+  if (!sentence?.id || sentence.starred !== -1) return;
+  const next = sentence.bad_reason === reason ? null : reason;
+  const prev = sentence.bad_reason;
+  sentence.bad_reason = next;
+  _syncStarBtn();
+  try {
+    const r = await api('POST', `/api/story-sentence/${sentence.id}/star`,
+                        { rating: -1, bad_reason: next });
+    sentence.bad_reason = r.bad_reason;
+  } catch (e) {
+    sentence.bad_reason = prev;
+    showError('Reason failed: ' + e.message);
   }
   _syncStarBtn();
 }
@@ -10150,9 +10227,9 @@ document.addEventListener('keydown', async e => {
     return;
   }
 
-  // Shift+F stars/unstars the sentence on the current card (#692)
+  // Shift+F rates the sentence good — the original #692 binding, kept working.
   if (e.key === 'F' && e.shiftKey && !e.ctrlKey && !e.metaKey) {
-    if (!inInput) { e.preventDefault(); toggleSentenceStar(); }
+    if (!inInput) { e.preventDefault(); rateSentence(1); }
     return;
   }
 
@@ -10322,6 +10399,12 @@ document.addEventListener('keydown', async e => {
       } else {
         toggleNewsflowLang();
       }
+    } else if (e.key === 'j' || e.key === 'h') {
+      // Rate the sentence as a good / bad example for prompt tuning (#712).
+      // g was already taken by the reasoning popup and news-flow language flip
+      // (#452) — on exactly the briefing/knowledge cards worth rating.
+      e.preventDefault();
+      rateSentence(e.key === 'j' ? 1 : -1);
     }
     return;
   }

--- a/static/index.html
+++ b/static/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AnkiAdvanced</title>
-  <link rel="stylesheet" href="/static/style.css?v=15">
+  <link rel="stylesheet" href="/static/style.css?v=16">
 </head>
 <body>
 
@@ -229,9 +229,23 @@
             <div class="card-toggle-bar" id="card-toggle-bar" style="display:none">
               <button class="card-toggle-btn" id="toggle-pinyin-btn" onclick="togglePinyin()" style="display:none">拼音</button>
               <button class="card-toggle-btn" id="toggle-trans-btn" onclick="toggleTranslation()" style="display:none">译文</button>
-              <!-- Star a well-written sentence as a positive example for prompt tuning (#692) -->
-              <button class="card-toggle-btn card-star-btn" id="toggle-star-btn" onclick="toggleSentenceStar()"
-                      style="display:none" title="Star this sentence as a good example (Shift+F)">☆</button>
+              <!-- Rate the sentence as a good (#692) or bad (#712) example for prompt tuning -->
+              <button class="card-toggle-btn card-star-btn" id="toggle-star-btn" onclick="rateSentence(1)"
+                      style="display:none" title="Good example (j)">☆</button>
+              <button class="card-toggle-btn card-bad-btn" id="toggle-bad-btn" onclick="rateSentence(-1)"
+                      style="display:none" title="Bad example (h)">👎</button>
+            </div>
+
+            <!-- Why the sentence is bad (#712). Appears after a thumbs-down; one tap
+                 saves the tag, ignoring it still leaves the sentence rated bad. -->
+            <div class="bad-reason-bar" id="bad-reason-bar" style="display:none">
+              <span class="bad-reason-label">What's wrong?</span>
+              <button class="bad-reason-btn" onclick="setBadReason('unnatural')">unnatural</button>
+              <button class="bad-reason-btn" onclick="setBadReason('too_hard')">too hard</button>
+              <button class="bad-reason-btn" onclick="setBadReason('factual_error')">factual error</button>
+              <button class="bad-reason-btn" onclick="setBadReason('wrong_word')">wrong word</button>
+              <button class="bad-reason-btn" onclick="setBadReason('grammar')">grammar</button>
+              <button class="bad-reason-btn" onclick="setBadReason('other')">other</button>
             </div>
 
             <!-- 2. Pinyin row (hidden by default; press p to toggle) -->
@@ -359,9 +373,9 @@
         <button class="bs-status-item" id="bss-leech"     onclick="setBrowseStatusFilter('leech')">Leeched</button>
         <button class="bs-status-item" id="bss-reference" onclick="setBrowseStatusFilter('reference')">Reference</button>
         <button class="bs-status-item" id="bss-saved"     onclick="setBrowseStatusFilter('saved')">★ Saved</button>
-        <!-- Sentence-level view, not a word filter (#692) -->
+        <!-- Sentence-level view, not a word filter (#692, #712) -->
         <button class="bs-status-item" id="bss-starred"   onclick="setBrowseStatusFilter('starred')"
-                title="Sentences you starred while reviewing — good examples for prompt tuning">⭐ Sentences</button>
+                title="Sentences you rated while reviewing — good and bad examples for prompt tuning">⭐ Sentences</button>
       </div>
       <div class="bs-section">
         <div class="bs-section-head">Hanzi</div>
@@ -669,7 +683,7 @@
 
 <div id="word-tip" style="display:none"></div>
 <script src="/static/shared.js?v=2"></script>
-<script src="/static/app.js?v=17"></script>
+<script src="/static/app.js?v=18"></script>
 
 <!-- Edit card modal -->
 <div id="edit-modal-overlay" onclick="closeEditCard()" style="display:none"></div>

--- a/static/style.css
+++ b/static/style.css
@@ -1494,6 +1494,23 @@ main.browse-open {
    the sentence, not a visibility toggle like its neighbours. */
 .card-star-btn { font-size: 14px; padding: 3px 10px; }
 .card-star-btn.active { color: #e0a300; border-color: #e0a300; }
+/* Thumbs-down counterpart (#712) — muted until active so it never competes with
+   the rating buttons for attention while reading the card. */
+.card-bad-btn { font-size: 14px; padding: 3px 10px; filter: grayscale(1); opacity: .55; }
+.card-bad-btn.active { filter: none; opacity: 1; border-color: #d05050; }
+
+/* "What's wrong?" tag row, shown under the toggle bar after a thumbs-down (#712) */
+.bad-reason-bar {
+  display: flex; flex-wrap: wrap; align-items: center; justify-content: center;
+  gap: 5px; margin: 6px 0 2px;
+}
+.bad-reason-label { font-size: 12px; color: var(--muted); margin-right: 2px; }
+.bad-reason-btn {
+  font-size: 12px; padding: 2px 8px; border-radius: 10px; cursor: pointer;
+  border: 1px solid var(--border); background: var(--card); color: var(--muted);
+}
+.bad-reason-btn:hover { color: var(--text); border-color: #d05050; }
+.bad-reason-btn.active { color: #fff; background: #d05050; border-color: #d05050; }
 
 .char-row:last-child { border-bottom: none; }
 .char-row-link  { cursor: pointer; }
@@ -2593,6 +2610,18 @@ a.news-source-line:hover {
              padding: 2px 4px; }
 .ss-unstar:hover:not(:disabled) { opacity: 0.6; }
 .ss-unstar:disabled { opacity: 0.4; cursor: default; }
+
+/* Good / bad filter and thumbs-down rows (#712) */
+.ss-filter-bar { display: flex; gap: 6px; padding: 8px 4px 10px; }
+.ss-filter { cursor: pointer; font-size: 12px; padding: 4px 12px;
+             border: 1px solid var(--border); border-radius: 999px;
+             background: transparent; color: var(--muted); }
+.ss-filter:hover { color: var(--text); }
+.ss-filter-active { color: #fff; background: var(--primary); border-color: var(--primary); }
+/* A red edge makes bad examples scannable in the mixed list without having to
+   read each row's meta line. */
+.ss-row-bad { border-left: 3px solid #d05050; }
+.ss-reason { font-weight: 600; color: #d05050; }
 .bw-row:hover { background: #f8fafc; }
 .bw-left {
   display: flex;

--- a/tests/test_starred_sentences.py
+++ b/tests/test_starred_sentences.py
@@ -75,7 +75,7 @@ def test_migration_adds_columns_to_legacy_db(tmp_path, monkeypatch):
     conn = sqlite3.connect(db_file)
     cols = {r[1] for r in conn.execute("PRAGMA table_info(story_sentences)")}
     conn.close()
-    assert {"starred", "starred_at"} <= cols
+    assert {"starred", "starred_at", "bad_reason"} <= cols
 
 
 def test_existing_sentences_default_to_unstarred(tmp_db):
@@ -291,3 +291,108 @@ def test_api_story_prompt_path_does_not_collide_with_story_endpoint(tmp_db):
     r = client.get(f"/api/story-prompt/{story_id}")
     assert r.status_code == 200
     assert "story_id" in r.json()
+
+
+# ---------------------------------------------------------------------------
+# Thumbs-down ratings (#712)
+#
+# `starred` carries all three states (1 good / 0 none / -1 bad) rather than
+# gaining a sibling column. These tests pin the parts that are easy to get
+# wrong: that a reason never outlives the thumbs-down it belongs to, and that
+# the pre-#712 boolean API still works for clients that haven't reloaded.
+# ---------------------------------------------------------------------------
+
+def test_rating_bad_round_trips_with_reason(tmp_db):
+    _, sentence_id = _make_story()
+
+    result = database.set_sentence_rating(sentence_id, -1, "too_hard")
+    assert result["rating"] == -1
+    assert result["bad_reason"] == "too_hard"
+    assert result["starred_at"]
+
+    [s] = database.get_starred_sentences()
+    assert s["id"] == sentence_id
+    assert s["rating"] == -1
+    assert s["bad_reason"] == "too_hard"
+
+
+def test_rating_filter_separates_good_from_bad(tmp_db):
+    deck_id = database.get_or_create_deck("StarDeck")
+    _, good = _make_story(deck_id)
+    _, bad = _make_story(deck_id, category="listening")
+    database.set_sentence_rating(good, 1)
+    database.set_sentence_rating(bad, -1, "unnatural")
+
+    assert [s["id"] for s in database.get_starred_sentences(rating="good")] == [good]
+    assert [s["id"] for s in database.get_starred_sentences(rating="bad")] == [bad]
+    # Unfiltered returns both — tuning a prompt means reading them against each other.
+    assert {s["id"] for s in database.get_starred_sentences()} == {good, bad}
+
+
+def test_reason_is_cleared_when_rating_leaves_bad(tmp_db):
+    """A stale 'too_hard' tag on a sentence Daniel later liked would be a lie
+    to whoever reads the list while tuning a prompt."""
+    _, sentence_id = _make_story()
+    database.set_sentence_rating(sentence_id, -1, "too_hard")
+
+    assert database.set_sentence_rating(sentence_id, 1)["bad_reason"] is None
+    [s] = database.get_starred_sentences()
+    assert s["rating"] == 1 and s["bad_reason"] is None
+
+    # And clearing the rating entirely drops it too.
+    database.set_sentence_rating(sentence_id, -1, "grammar")
+    assert database.set_sentence_rating(sentence_id, 0)["bad_reason"] is None
+
+
+def test_reason_is_optional_on_a_thumbs_down(tmp_db):
+    """The rating saves on its own — the tag row is a follow-up that may be skipped."""
+    _, sentence_id = _make_story()
+    assert database.set_sentence_rating(sentence_id, -1)["rating"] == -1
+    assert database.get_starred_sentences(rating="bad")[0]["bad_reason"] is None
+
+
+def test_invalid_rating_and_reason_are_rejected(tmp_db):
+    _, sentence_id = _make_story()
+    with pytest.raises(ValueError):
+        database.set_sentence_rating(sentence_id, 5)
+    with pytest.raises(ValueError):
+        database.set_sentence_rating(sentence_id, -1, "not-a-real-reason")
+
+
+def test_legacy_boolean_helper_still_works(tmp_db):
+    _, sentence_id = _make_story()
+    assert database.set_sentence_starred(sentence_id, True)["starred"] == 1
+    assert database.set_sentence_starred(sentence_id, False)["starred"] == 0
+
+
+def test_api_rating_bad_with_reason(tmp_db):
+    _, sentence_id = _make_story()
+
+    r = client.post(f"/api/story-sentence/{sentence_id}/star",
+                    json={"rating": -1, "bad_reason": "factual_error"})
+    assert r.status_code == 200
+    assert r.json()["rating"] == -1
+    assert r.json()["bad_reason"] == "factual_error"
+
+    body = client.get("/api/starred-sentences?rating=bad").json()["sentences"]
+    assert [s["id"] for s in body] == [sentence_id]
+    assert client.get("/api/starred-sentences?rating=good").json()["sentences"] == []
+
+
+def test_api_still_accepts_the_pre_712_boolean_body(tmp_db):
+    """An open tab running the old app.js must keep working across a deploy."""
+    _, sentence_id = _make_story()
+    assert client.post(f"/api/story-sentence/{sentence_id}/star",
+                       json={"starred": True}).json()["starred"] == 1
+    assert client.post(f"/api/story-sentence/{sentence_id}/star",
+                       json={"starred": False}).json()["starred"] == 0
+
+
+def test_api_rejects_invalid_rating_with_400(tmp_db):
+    _, sentence_id = _make_story()
+    assert client.post(f"/api/story-sentence/{sentence_id}/star",
+                       json={"rating": 7}).status_code == 400
+    assert client.post(f"/api/story-sentence/{sentence_id}/star",
+                       json={"rating": -1, "bad_reason": "bogus"}).status_code == 400
+    assert client.post(f"/api/story-sentence/{sentence_id}/star",
+                       json={"rating": "abc"}).status_code == 400


### PR DESCRIPTION
Closes #712

## 改了什么

#692 只能收集**好**句子。改提示词时更有价值的往往是**反例**，所以加上对称的 👎，并顺手记下差在哪。

### 数据层：`starred` 扩展为三态，不新建表

`story_sentences.starred`：`1` = 👍 好 · `0` = 未评价 · `-1` = 👎 差。新增 `bad_reason TEXT` 存一键原因标签。

**列名保持 `starred` 不改** —— 改名要重建表 + 迁移生产库，风险远大于收益（本仓库先例：`word_zh` 对法语存法语词形）。

- `set_sentence_rating()` 是新的三态入口；`set_sentence_starred()` 保留为布尔封装
- **评价离开「差」时强制清空 `bad_reason`**：一条 Daniel 后来改判为好的句子还挂着 `too_hard`，会误导以后读这个列表改提示词的人
- `get_starred_sentences(rating=)` 支持 `good`/`bad` 过滤，**默认返回两者**

### 快捷键 `j` = 👍 / `h` = 👎

⚠️ **`g` 不能用**：它已绑定 kahneman 背景弹窗与新闻流切换语言（#452），恰好就在最需要评价句子的 briefing/knowledge 卡上。`j`/`h` 相邻且都空着，已登记进 `KEYMAP_RESERVED`，防止在设置里被重新绑定造成冲突。`Shift+F` 保留为「好」的旧绑定。

### 交互

打差评后卡背就地弹出原因标签行（不自然 / 太难 / 事实错误 / 与目标词不符 / 语法错误 / 其他）。**评价本身在标签行出现时已经落库**，跳过不填没有代价 —— 复习时打字太打断节奏，所以是固定枚举而非自由文本；固定值还能靠计数看出模型的系统性毛病（比如一半差评都是「太难」= 该收紧提示词的词汇难度上限）。

Browse 的 ⭐ Sentences 加「全部 / 👍 好 / 👎 差」过滤，差评行左侧红边 + 显示原因。**好差同列表而非拆两个视图** —— 改提示词时正反例要对着看。

### 顺带修掉一个真实问题

**bump `app.js?v=18` / `style.css?v=16`。** #692 改了前端却没动版本号，Daniel 的浏览器一直在跑缓存里的旧 `app.js` —— 加星功能上线一天了他根本看不见，这个 PR 就是这么被提出来的。

## 兼容性

`POST /api/story-sentence/{id}/star` 接受 `{rating, bad_reason}`，同时**仍接受旧的 `{starred: bool}`**，部署时开着的旧标签页不会坏。历史加星数据（`starred=1`）原样继续有效。

## 怎么测试的

- `pytest tests/` **441 passed**（#692 原有 17 条测试全绿，新增 12 条）
- 新测试覆盖：三态往返、`good`/`bad` 过滤、**原因不随评价改判而残留**、原因可选、非法 rating/reason 抛错、旧布尔接口兼容、接口 400
- 迁移测试断言旧库补列后含 `bad_reason`，且 `init_db()` 二次运行幂等
- 另在 8099 端口起真实服务器跑通全流程（打好评/差评、按 rating 过滤、旧请求体、非法值 400），**未占用 8000**

## 备注

本分支在隔离 worktree 中从最新 `main` 重建 —— 原分支被另一个并行会话切走并混入了 #710 的提交（#710 已由 PR #713 独立合并）。`schema.sql` / `database/core.py` 的迁移曾在那次撞车中丢失，已恢复并有测试守着。

🤖 Generated with [Claude Code](https://claude.com/claude-code)