### PR TITLE
递增 app.js 缓存版本号，让 #714 的设置面板真正上线（#719）

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -669,7 +669,7 @@
 
 <div id="word-tip" style="display:none"></div>
 <script src="/static/shared.js?v=2"></script>
-<script src="/static/app.js?v=17"></script>
+<script src="/static/app.js?v=19"></script>
 
 <!-- Edit card modal -->
 <div id="edit-modal-overlay" onclick="closeEditCard()" style="display:none"></div>


### PR DESCRIPTION
## 改了什么

`static/index.html`：`app.js?v=17` → `v=19`。

## 为什么

#714 改了 `app.js` 但没递增这个手动缓存破坏参数，已经访问过站点的浏览器继续用缓存里的旧文件——服务器上代码是新的，界面上却没有那个面板。

跳过 18 直接到 19，是因为进行中的 `feat/712` 分支上已经占了 18，两边都写 18 合并后就等于没递增。

## 教训

凡是改 `static/app.js` / `static/shared.js` 的 PR，都必须同时递增 `index.html` 里对应的 `?v=`，否则改动对老用户等于没上线。

Closes #719