### PR TITLE
修复：GPT-5.6 Luna/Terra/Sol 被静默换成 DeepSeek

### DIFF
--- a/routes/story.py
+++ b/routes/story.py
@@ -209,6 +209,9 @@ ALLOWED_MODELS = {
     "gpt-5-mini",
     "gpt-5",
     "gpt-5.1",
+    "gpt-5.6-luna",
+    "gpt-5.6-terra",
+    "gpt-5.6-sol",
     "glm-5",
     "glm-4.7",
     "glm-4.7-flashx",
@@ -220,7 +223,12 @@ DEFAULT_MODEL = ai.DEFAULT_MODEL
 def _validated_model(model: str | None, default: str | None = None) -> str:
     if model and model in ALLOWED_MODELS:
         return model
-    return default or DEFAULT_MODEL
+    fallback = default or DEFAULT_MODEL
+    if model:
+        # 静默丢弃用户选的模型正是 #721 三个月没被发现的原因：下拉框加了
+        # gpt-5.6-*，白名单忘了同步，界面照常显示成功但用的是别的模型。
+        logger.warning("model %r not in ALLOWED_MODELS — falling back to %s", model, fallback)
+    return fallback
 
 
 def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,

--- a/static/app.js
+++ b/static/app.js
@@ -3877,6 +3877,9 @@ function _prettyModel(model) {
   return model
     .replace('claude-', '')
     .replace('-20251001', '')
+    .replace('gpt-5.6-luna', 'GPT-5.6 Luna')
+    .replace('gpt-5.6-terra', 'GPT-5.6 Terra')
+    .replace('gpt-5.6-sol', 'GPT-5.6 Sol')
     .replace('gpt-5.1', 'GPT-5.1')
     .replace('gpt-5-mini', 'GPT-5 Mini')
     .replace('gpt-4o-mini-transcribe', 'Whisper (audio)')

--- a/tests/test_model_whitelist.py
+++ b/tests/test_model_whitelist.py
@@ -1,0 +1,65 @@
+"""下拉框里的模型必须都在后端白名单里（议题 #721）。
+
+#721 的 bug：index.html 加了 gpt-5.6-luna/terra/sol 三个选项，但
+routes/story.py 的 ALLOWED_MODELS 忘了同步。_validated_model() 对白名单外
+的值静默回落到默认模型 —— 界面照常显示生成成功，用的却是 DeepSeek。
+选择被静默丢弃，所以三个月没人发现。
+
+这条测试直接从 HTML 里解析两个模型下拉框的 option value，与白名单对比，
+让下次加模型时忘掉任何一边都会立刻变红。
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+from routes.story import ALLOWED_MODELS
+
+INDEX_HTML = Path(__file__).resolve().parent.parent / "static" / "index.html"
+MODEL_SELECT_IDS = ["setup-model", "story-error-model"]
+
+
+def _select_options(html: str, select_id: str) -> list[str]:
+    """解析 <select id="..."> ... </select> 里所有 option 的 value。"""
+    m = re.search(rf'<select[^>]*id="{select_id}"[^>]*>(.*?)</select>', html, re.S)
+    assert m, f"index.html 里找不到 <select id={select_id}>"
+    return re.findall(r'<option[^>]*value="([^"]+)"', m.group(1))
+
+
+@pytest.mark.parametrize("select_id", MODEL_SELECT_IDS)
+def test_dropdown_models_are_whitelisted(select_id):
+    options = _select_options(INDEX_HTML.read_text(encoding="utf-8"), select_id)
+    assert options, f"{select_id} 一个 option 都没解析出来 —— 选择器多半失效了"
+
+    missing = [o for o in options if o not in ALLOWED_MODELS]
+    assert not missing, (
+        f"#{select_id} 里的这些模型不在 routes.story.ALLOWED_MODELS 里，"
+        f"选中后会被静默换成默认模型：{missing}"
+    )
+
+
+@pytest.mark.parametrize("select_id", MODEL_SELECT_IDS)
+def test_dropdown_models_have_pricing(select_id):
+    """选得到却算不出钱的模型，会在成本页显示为未知 —— 同样是静默的。"""
+    from database.stats import _lookup_pricing
+
+    options = _select_options(INDEX_HTML.read_text(encoding="utf-8"), select_id)
+    unpriced = [o for o in options if _lookup_pricing(o) is None]
+    assert not unpriced, f"{select_id} 里的这些模型没有价格表条目：{unpriced}"
+
+
+def test_gpt_56_models_whitelisted():
+    """#721 的三个具体模型 —— 回归锚点。"""
+    for model in ("gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"):
+        assert model in ALLOWED_MODELS
+
+
+def test_validated_model_falls_back_and_warns(caplog):
+    from routes.story import _validated_model
+
+    assert _validated_model("gpt-5.6-luna") == "gpt-5.6-luna"
+
+    with caplog.at_level("WARNING"):
+        result = _validated_model("no-such-model-9000")
+    assert result != "no-such-model-9000"
+    assert "no-such-model-9000" in caplog.text, "静默回落是 #721 的根因，必须留日志"


### PR DESCRIPTION
Closes #721

## 问题

Daniel 在故事设置里选 **GPT-5.6 Luna**，生成的故事却是 DeepSeek 写的，界面上没有任何提示。

`static/index.html` 的两个模型下拉框（`#setup-model`、`#story-error-model`）早就列出了 `gpt-5.6-luna` / `terra` / `sol`，但 `routes/story.py` 的 `ALLOWED_MODELS` 白名单没有同步。`_validated_model()` 对白名单外的值**静默回落**到 `DEFAULT_MODEL`——不报错、不记日志，所以这个 bug 一直没被发现。

价格表（`database/stats.py:95-97`）、provider 路由（`ai._openai_client` 的 `gpt-` 前缀）和 gpt-5 系列的参数处理（`max_completion_tokens` + `reasoning_effort="low"`）本来就都已就绪，**只差白名单这三行**。

## 改了什么

| 文件 | 改动 |
|------|------|
| `routes/story.py` | `ALLOWED_MODELS` 补上三个模型；`_validated_model()` 回落时记 `logger.warning` |
| `static/app.js` | `_prettyModel()` 补显示名映射，放在 `gpt-5.1`/`gpt-5-mini` **之前**（链式 replace，短 id 会抢先匹配） |
| `tests/test_model_whitelist.py` | 新增 |

## 为什么加日志

静默丢弃用户的选择正是这个 bug 存活至今的唯一原因。回落行为本身保留（旧故事的 `gen_params` 里可能存着已下线的模型 id，直接 400 会让历史数据打不开），但必须留下痕迹。

## 测试

新文件从 `index.html` **解析**两个下拉框的 option value，断言：
1. 每个都在 `ALLOWED_MODELS` 里
2. 每个都能在 `_lookup_pricing()` 查到价格（选得到却算不出钱同样是静默的）
3. `#721` 三个模型的回归锚点
4. `_validated_model` 对未知 id 会回落**且**留 warning

下次再加模型时，忘掉白名单或忘掉价格表都会立刻变红。

`pytest tests/` → **447 passed, 4 skipped**（新增 6 条）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)