### PR TITLE
修复：递增 app.js 缓存版本号（#721 后续）

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -669,7 +669,7 @@
 
 <div id="word-tip" style="display:none"></div>
 <script src="/static/shared.js?v=2"></script>
-<script src="/static/app.js?v=19"></script>
+<script src="/static/app.js?v=20"></script>
 
 <!-- Edit card modal -->
 <div id="edit-modal-overlay" onclick="closeEditCard()" style="display:none"></div>


### PR DESCRIPTION
#721 改动了 `static/app.js` 的 `_prettyModel()`，但 `index.html` 仍指向 `app.js?v=19`——浏览器继续用缓存里的旧版本，成本页照样显示原始 id `gpt-5.6-luna` 而不是 `GPT-5.6 Luna`。与 #719 完全同一个坑。

后端白名单的修复不受影响（服务端的，已经生效），只有前端显示名需要这一步。

`v=19` → `v=20`。

Refs #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)