### PR TITLE
GPT 调用默认关闭推理：省 6 倍钱、快一倍，质量无差别

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -95,6 +95,40 @@ def _openai_client(model: str) -> openai.OpenAI:
     raise ValueError(f"Unknown provider for model: {model}")
 
 
+# gpt-5 系列关闭推理时用的最低档 —— 两代的名字互不兼容（2026-08-12 实测，#724）：
+#   gpt-5 / gpt-5-mini   支持 minimal, low, medium, high   —— 发 'none' 报 400
+#   gpt-5.1 / gpt-5.6-*  支持 none, low, medium, high, xhigh —— 5.6 发 'minimal' 报 400
+# 实测生成故事句子时 low 要烧 403 个推理 token（比 none 贵 6.2 倍、慢一倍），
+# 而输出质量看不出差别 —— 这类任务不需要思维链。
+_GPT_MIN_EFFORT = {
+    "gpt-5": "minimal",
+    "gpt-5-mini": "minimal",
+    "gpt-5.1": "none",
+    "gpt-5.6-luna": "none",
+    "gpt-5.6-terra": "none",
+    "gpt-5.6-sol": "none",
+}
+# 表里没有的 gpt 模型走这个值：任何一代都接受，绝不会 400。新模型上线时
+# 宁可多花钱，也不能因为猜错档位名而让整条流程静默挂掉。
+_GPT_SAFE_EFFORT = "low"
+
+# OpenAI 的 id 可能带日期快照后缀（gpt-5.1-2026-04-14）—— 查表前先剥掉，
+# 否则每出一个快照都要往表里加一行。同 database.stats._SNAPSHOT_SUFFIX_RE。
+_SNAPSHOT_SUFFIX_RE = re.compile(r"(-\d{4}-\d{2}-\d{2}|-\d{8})$")
+
+
+def _gpt_reasoning_effort(model: str, thinking: bool) -> str:
+    """gpt-5 系列该发哪个 reasoning_effort。
+
+    thinking=True 时用 "low"（够用且各代通用）；默认的 thinking=False 查
+    _GPT_MIN_EFFORT，未知模型回落到 _GPT_SAFE_EFFORT。
+    """
+    if thinking:
+        return _GPT_SAFE_EFFORT
+    base = _SNAPSHOT_SUFFIX_RE.sub("", model)
+    return _GPT_MIN_EFFORT.get(model) or _GPT_MIN_EFFORT.get(base) or _GPT_SAFE_EFFORT
+
+
 def _extract_prompt(messages: list) -> str:
     """Join the content of ALL messages (for cost-modal display).
 
@@ -116,9 +150,11 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str,
               thinking: bool = False) -> str:
     """Call the appropriate provider, log usage, and return the raw text response.
 
-    thinking: enable DeepSeek thinking/reasoning mode (default False — disabled).
+    thinking: enable the provider's thinking/reasoning mode (default False — disabled).
               deepseek-v4-flash defaults to thinking=on server-side, so we must
               explicitly disable it for tasks that don't need chain-of-thought.
+              GLM-4.5+ 同理。gpt-5 系列自 #724 起也尊重这个参数：False 时发该
+              模型支持的最低 reasoning_effort（见 _gpt_reasoning_effort）。
     """
     t0 = time.time()
     prompt_text = _extract_prompt(messages)
@@ -158,11 +194,13 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str,
             if model.startswith("gpt-"):
                 # gpt-5 series (Chat Completions): max_completion_tokens replaces max_tokens
                 # and is shared with internal reasoning tokens; custom temperature is not
-                # supported. reasoning_effort="low" — sentence generation needs no deep
-                # reasoning, and higher efforts can eat the whole token budget.
+                # supported. reasoning_effort 由 _gpt_reasoning_effort 按模型决定 ——
+                # 与 DeepSeek/GLM 分支一样尊重 thinking 参数（#724）。
+                effort = _gpt_reasoning_effort(model, thinking)
+                logger.debug("[%s] reasoning_effort=%s (thinking=%s)", model, effort, thinking)
                 resp = client.chat.completions.create(
                     model=model, max_completion_tokens=max_tokens, messages=messages,
-                    reasoning_effort="low",
+                    reasoning_effort=effort,
                 )
             else:
                 resp = client.chat.completions.create(

--- a/tests/test_gpt_reasoning.py
+++ b/tests/test_gpt_reasoning.py
@@ -1,0 +1,138 @@
+"""gpt-5 系列的 reasoning_effort 选择（议题 #724）。
+
+_call_api 的 thinking 参数原来只有 DeepSeek 和 GLM 分支尊重，gpt 分支硬编码
+reasoning_effort="low"。实测生成故事句子时 low 要烧 403 个推理 token，比关掉
+贵 6.2 倍、慢一倍，输出质量却看不出差别。
+
+难点在于两代模型的最低档名字互不兼容（2026-08-12 实测）：
+  gpt-5 / gpt-5-mini   支持 minimal, low, medium, high    —— 发 'none' 报 400
+  gpt-5.1 / gpt-5.6-*  支持 none, low, medium, high, xhigh —— 5.6 发 'minimal' 报 400
+
+gpt-5-mini 是 briefing（新闻简报）的实际默认模型，发错值整条新闻流程会 400。
+"""
+import pytest
+
+import ai
+
+
+@pytest.mark.parametrize("model,expected", [
+    # gpt-5 那一代：最低是 minimal，不认 none
+    ("gpt-5", "minimal"),
+    ("gpt-5-mini", "minimal"),
+    # gpt-5.1 起支持 none
+    ("gpt-5.1", "none"),
+    ("gpt-5.6-luna", "none"),
+    ("gpt-5.6-terra", "none"),
+    ("gpt-5.6-sol", "none"),
+])
+def test_min_effort_per_model(model, expected):
+    assert ai._gpt_reasoning_effort(model, thinking=False) == expected
+
+
+@pytest.mark.parametrize("model", [
+    "gpt-5", "gpt-5-mini", "gpt-5.1", "gpt-5.6-luna", "gpt-6-not-released-yet",
+])
+def test_thinking_true_uses_low(model):
+    """thinking=True 一律 low —— 各代都接受这个值。"""
+    assert ai._gpt_reasoning_effort(model, thinking=True) == "low"
+
+
+def test_unknown_model_falls_back_to_safe_value():
+    """表里没有的新模型必须走 low：任何一代都接受，绝不会 400。
+
+    猜错档位名的代价是整条流程挂掉，多花点钱的代价只是钱。
+    """
+    assert ai._gpt_reasoning_effort("gpt-7-brandnew", thinking=False) == "low"
+    assert ai._gpt_reasoning_effort("gpt-5.9-whatever", thinking=False) == "low"
+
+
+def test_dated_snapshot_suffix_is_stripped():
+    """OpenAI 会返回带日期的 id，不能因此掉进未知回落。"""
+    assert ai._gpt_reasoning_effort("gpt-5.1-2026-04-14", thinking=False) == "none"
+    assert ai._gpt_reasoning_effort("gpt-5-mini-20260414", thinking=False) == "minimal"
+
+
+def test_call_api_sends_the_resolved_effort(monkeypatch):
+    """端到端：_call_api 真的把查出来的值发给了 OpenAI。"""
+    sent = {}
+
+    class _FakeUsage:
+        prompt_tokens = 10
+        completion_tokens = 5
+        prompt_tokens_details = None
+
+    class _FakeMessage:
+        content = "好"
+        reasoning_content = None
+
+    class _FakeChoice:
+        message = _FakeMessage()
+        finish_reason = "stop"
+
+    class _FakeResp:
+        choices = [_FakeChoice()]
+        usage = _FakeUsage()
+
+    class _FakeCompletions:
+        def create(self, **kwargs):
+            sent.update(kwargs)
+            return _FakeResp()
+
+    class _FakeClient:
+        chat = type("C", (), {"completions": _FakeCompletions()})()
+
+    monkeypatch.setattr(ai, "_openai_client", lambda model: _FakeClient())
+    monkeypatch.setattr(ai.database, "log_api_call", lambda **kw: None)
+
+    msgs = [{"role": "user", "content": "hi"}]
+
+    ai._call_api("gpt-5.6-luna", msgs, 100, purpose="test")
+    assert sent["reasoning_effort"] == "none"
+    # gpt-5 系列必须用 max_completion_tokens，不是 max_tokens
+    assert sent["max_completion_tokens"] == 100
+    assert "max_tokens" not in sent
+
+    ai._call_api("gpt-5-mini", msgs, 100, purpose="test")
+    assert sent["reasoning_effort"] == "minimal", "gpt-5-mini 收到 none 会 400"
+
+    ai._call_api("gpt-5.6-luna", msgs, 100, purpose="test", thinking=True)
+    assert sent["reasoning_effort"] == "low"
+
+
+def test_non_gpt_models_unaffected(monkeypatch):
+    """DeepSeek 分支不该出现 reasoning_effort。"""
+    sent = {}
+
+    class _FakeUsage:
+        prompt_tokens = 10
+        completion_tokens = 5
+        prompt_cache_hit_tokens = 0
+        prompt_tokens_details = None
+
+    class _FakeMessage:
+        content = "好"
+        reasoning_content = None
+
+    class _FakeChoice:
+        message = _FakeMessage()
+        finish_reason = "stop"
+
+    class _FakeResp:
+        choices = [_FakeChoice()]
+        usage = _FakeUsage()
+
+    class _FakeCompletions:
+        def create(self, **kwargs):
+            sent.clear()
+            sent.update(kwargs)
+            return _FakeResp()
+
+    class _FakeClient:
+        chat = type("C", (), {"completions": _FakeCompletions()})()
+
+    monkeypatch.setattr(ai, "_openai_client", lambda model: _FakeClient())
+    monkeypatch.setattr(ai.database, "log_api_call", lambda **kw: None)
+
+    ai._call_api("deepseek-v4-flash", [{"role": "user", "content": "hi"}], 100, purpose="test")
+    assert "reasoning_effort" not in sent
+    assert sent["extra_body"] == {"thinking": {"type": "disabled"}}


### PR DESCRIPTION
Closes #724

## 问题

`ai._call_api` 的 `thinking` 参数（默认 `False`）被 DeepSeek 和 GLM 分支尊重——都会显式关闭思维链。**唯独 gpt 分支忽略它**，硬编码 `reasoning_effort="low"`。

## 实测（2026-08-12，gpt-5.6-luna，真实故事生成提示词）

| effort | 耗时 | 推理 token | 成本 | 输出质量 |
|---|---|---|---|---|
| `none` | 2.3s | 0 | $0.000093 | 8 句全合格 |
| `low`（现状） | 5.0s | 403 | $0.000577（**6.2 倍**） | 无差别 |
| `medium` | 10.2s | 1024 | $0.001337（14 倍） | 无差别 |

生成 HSK 1-2 词汇的短句不需要思维链。

## 陷阱：两代模型的最低档名字互不兼容

| 模型 | 支持的值 |
|---|---|
| `gpt-5`、`gpt-5-mini` | `minimal, low, medium, high` — 发 `none` **400** |
| `gpt-5.1`、`gpt-5.6-*` | `none, low, medium, high, xhigh` — 5.6 发 `minimal` **400** |

`gpt-5-mini` 是 briefing（新闻简报）的实际默认模型（`BRIEFING_MODEL_FALLBACKS`），一刀切发 `none` 会让整条新闻流程挂掉。所以按模型查 `_GPT_MIN_EFFORT` 表，查表前先剥掉日期快照后缀（`gpt-5.1-2026-04-14`）。

## 未知模型的取舍

表里没有的新模型回落到 `"low"`——现状行为，任何一代都接受，绝不会 400。**猜错档位名的代价是整条流程静默挂掉，多花点钱的代价只是钱。**

`thinking=True` 仍给 `low`，行为不变。

## 验证

真实 API 调用（走 `_call_api`，不是探针）：

```
gpt-5.6-luna: OK   out=55    （改之前同样任务 out=462）
gpt-5-mini:   OK   out=70    ← 收到 minimal，没有 400
```

新增 `tests/test_gpt_reasoning.py`（15 条）：每个模型的查表值、`thinking=True`、未知模型回落、快照后缀剥离，以及端到端断言 `_call_api` 真的发出了查到的值、DeepSeek 分支不受影响。

`pytest tests/` → **462 passed, 4 skipped**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)