### PR TITLE
＋ 加词支持法语（平行的 Français 牌组树）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,7 @@ bash sync_offline.sh push    # 只推不拉，推完归档本地库
 
 同一个软件、同一个数据库里学习多种语言（2026-07-06 起，议题 #428–#431）。当前：中文（zh，默认）+ 法语（fr，CEFR B1，释义以德语为主）。
 
-- **`languages.py` 是语言注册表**：每种语言定义 TTS 语音、翻译源、分词方式（jieba/空格）、AI 提示词参数、功能开关（拼音/汉字/量词仅中文）。加新语言 = 加一个条目
+- **`languages.py` 是语言注册表**：每种语言定义 TTS 语音、翻译源、分词方式（jieba/空格）、AI 提示词参数、牌组树根名（`deck_root`，#726）、功能开关（拼音/汉字/量词仅中文）。加新语言 = 加一个条目
 - **`decks.lang` / `entries.lang`**（默认 `'zh'`）：目标语言；子牌组创建时继承父牌组的 lang
 - `word_zh` 对所有语言存"目标语言词形"（`_zh` 后缀是历史遗留）；法语词条的 pinyin/characters 留空
 - **等级共用 1–6 整数**（#596）：`entries.hsk_level` 对中文存 HSK 1–6，对法语存 CEFR（A1=1 … C2=6，YAML 里写 `level: "B1"`）；故事设置弹窗的背景词汇难度滑块两种语言通用（1–6），前端按 `languages.py` 的 `level_system` 显示 "HSK 3" 或 "B1"，法语故事提示词用滑块值生成 "CEFR A1-X" 上限（原来写死 A1-A2）
@@ -234,9 +234,9 @@ bash sync_offline.sh push    # 只推不拉，推完归档本地库
 
 导入机制本身仍然存在（`importer.py`、`POST /api/import`、`python main.py import`，读取 `imports/<Source>/*.yaml`）：需要批量导入新词汇时，重新创建该目录放入 YAML 即可。日常添加单个词条：界面顶栏 `＋` 按钮（见下），或 `de-zh-bot` 技能生成 YAML 后导入。
 
-### 界面内添加生词（#627、#636、#643、#715）
+### 界面内添加生词（#627、#636、#643、#715、#726）
 
-顶栏 `＋` → 输入中文词 → 回车或点"加" → 后台 DeepSeek 生成完整词条 → 进 **★ List**（`Saved` 牌组，挂起，不进任何复习队列）。
+顶栏 `＋` → 输入词 → 回车或点"加" → 后台 DeepSeek 生成完整词条 → 进 **★ List**（`Saved` 牌组，挂起，不进任何复习队列）。
 
 > **界面上只有 ★ List 这一个去处（#715，Daniel 2026-08-12 决定）**：顶栏 ＋、知识库详情页的生词表格、`/add` 页面三处的 Today/Tomorrow 按钮全部撤掉，一律 `day='list'`。新词先攒着，之后在 Browse 的 saved 视图主动提升（那个「→ Add to Daily」按钮**保留**——★ List 是暂存区，总得有出口）。**后端 `day` 参数照旧支持 `today|tomorrow|list`**：Daniel 已有的 iOS 快捷指令 `/add?word=X&day=today` 不该突然改行为，而且以后想恢复某个按钮只是加回一个按钮。`/add` 因此仍尊重 URL 里的 `day`，只是无参数时默认 `list`。
 
@@ -257,6 +257,14 @@ bash sync_offline.sh push    # 只推不拉，推完归档本地库
 - **不阻塞连续输入**（#636）：提交后立刻清空输入框，每个词进弹窗里的队列各自轮询自己的 job
 - **独立加词页 `/add`（#668）+ URL 参数（#686）**：可收藏的网址，打开就是输入框（存 iPhone 主屏当图标用）。`?word=生态`（或 `?w=`）+ 可选 `&day=today|tomorrow|list` → 打开即自动提交，供 iOS 快捷指令在任意 App 里一键加词；`day` 非法值回落 today（词才是重点，不该为此失败）。**提交后必须 `history.replaceState` 抹掉参数** —— 否则刷新或 iOS 恢复标签页会静默再花一次 AI 钱。`static/add.html` 是自包含页面，**故意不加载 `app.js`** —— 5.5 KB vs 完整应用的 77 KB + 491 KB JS，秒开就是这个功能的全部意义。为此把 `addWordViaAi()` 和 `api()` 从 `app.js` 抽到 `static/shared.js` 两页共用，**不复制第二份**（理由同下条；`tests/test_add_word.py` 有一条测试专门守着 `app.js` 里不能再出现这两个定义）
 - **`/api/add-word-ai` 是全应用唯一的加词入口**（#643）：顶栏 ＋、播客单集的 HSK 生词表格、复习界面长按词的菜单、以及 `/add` 页面，全部共用 `shared.js` 的 `addWordViaAi()`。原来播客/长按走的 `/api/quick-add-word` 已删除 —— 它只让 AI 填四个字段（无例句/汉字分解/量词/同义反义词），而且 `added_to_deck` 分支在词已学过时被 `INSERT OR IGNORE` + `UNIQUE(word_id, category)` 全部静默丢弃，却照样返回成功。**加词只能有一条管线**，否则修好的坑会在第二条路上重新出现
+- **加法语词（#726）**：`lang` 参数（`zh` 默认 / `fr`）同时决定提示词和牌组树
+  - **每种语言一棵平行的牌组树**，根名在 `languages.py` 的 `deck_root`（zh → `Daily`，fr → `Français`）：`Français::<日期> · Listening/…` + `Français::Saved`，牌组本身 `lang='fr'`。**必须如此**——全应用的语言过滤（`_lang_subquery_clause`、`get_descendant_leaf_deck_ids`）筛的是 `decks.lang` 而不是 `entries.lang`，法语卡放进中文牌组会在 fr 标签下消失、反而混进中文复习队列（生产库里 #726 之前导入的那 7 个法语词正是这个状态）
+  - `Français::Saved` 的**牌组名仍是 `Saved`**（路径末段），所以 Browse 的 saved 视图（认 `deck_name === 'Saved'`）一行都不用改
+  - **已存在的词按 `entries.lang` 落点，不听请求参数**：`word_zh` 是全局唯一的，lang 传错会把同一个词的三张卡撒进两棵语言树，两个标签下都看不见它。`promote_saved`（Browse 的 → Add to Daily）同理
+  - **按语言校验输入文字体系**（zh 必须含汉字；fr 不能含汉字且要有拉丁字母）：加词框没有反问的机会（`de-zh-bot`/`de-fr-bot` 技能是靠追问"你指哪个意思"的），把德语词喂给法语提示词会静默生成一个错词条。查文字体系分不出法语和德语，但至少挡住 `生态` 走法语提示词
+  - 法语输出**自带 `lang: fr` 头**，不靠目标牌组的语言推断——条目格式（`word:`/`level:`/`examples[].fr`）和 lang 必须一致，写在文档里能整类消灭"法语词条被当中文导入"
+  - 复习界面长按菜单的两个按钮（`+ Add to Daily`、`★ Save for later`）按**当前卡片的语言**走（`currentCardLang()`），跟主页在哪个标签无关——词是从这张卡里挑出来的
+  - `/add` 支持 `?lang=fr`（每种语言一个 iOS 快捷指令）；页面自己拉一次 `/api/langs` 决定是否显示语言切换钮，**不加载 `app.js`** 的原则不变
 
 - **YAML 格式完整文档：** `docs/yaml-format.md`（中文格式：词性/例句/词源/汉字分解；法语格式：`lang: fr` + `type: word|sentence`，经 `importer._normalize_fr_entry` 适配后复用全部下游逻辑）
 - 文件顶部可选 `lang:` 字段（默认 `zh`）决定导入到哪个语言的牌组
@@ -482,9 +490,9 @@ GET  /api/costs/call/{id}                            → {prompt, response}（�
 
 # 其他
 POST /api/import                                     → 触发 YAML 导入
-GET  /add[?word=生态&day=today|tomorrow|list]         → 独立加词页（#668，可收藏/存主屏；不加载 app.js）；带 word 参数时打开即自动提交（#686，供 iOS 快捷指令用），提交后从地址栏抹掉该参数以免刷新重复扣费
+GET  /add[?word=生态&day=today|tomorrow|list&lang=zh|fr] → 独立加词页（#668，可收藏/存主屏；不加载 app.js）；带 word 参数时打开即自动提交（#686，供 iOS 快捷指令用），提交后从地址栏抹掉该参数以免刷新重复扣费；lang（#726）每种语言一个快捷指令
 GET  /save                                           → 独立素材收藏页（#681，Link/Text 两个标签；同样不加载 app.js）
-POST /api/add-word-ai                                → 界面内添加生词（#627）；body {word_zh, day?:today|tomorrow|list}（#636、#677；#715 起界面一律传 list，接口三值仍有效）；新词返回 {job_id}，已有词直接返回 {status}。**全应用唯一的加词入口**（#643）：顶栏 ＋、播客生词表格、复习界面长按菜单都走它
+POST /api/add-word-ai                                → 界面内添加生词（#627）；body {word_zh, day?:today|tomorrow|list, lang?:zh|fr}（#636、#677；#715 起界面一律传 list，接口三值仍有效；lang 见 #726，已存在的词按 entries.lang 落点、不听该参数）；新词返回 {job_id}，已有词直接返回 {status}。**全应用唯一的加词入口**（#643）：顶栏 ＋、播客生词表格、复习界面长按菜单都走它
 GET  /api/add-word-ai/progress/{job_id}              → 轮询后台生成+导入的结果
 GET  /api/browse                                     → {deck_id?, category?, state?, q?, lang?}
 GET  /api/stats ；/api/retention ；/api/card-evolution（均支持 ?lang=）

--- a/ai.py
+++ b/ai.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import re
+import textwrap
 import time
 
 import anthropic
@@ -1015,23 +1016,186 @@ EXAMPLE of the expected shape (for 生态):
 """
 
 
-def generate_word_entry_yaml(word_zh: str, model: str = DEFAULT_MODEL) -> str:
-    """Generate a complete de-zh-bot style YAML entry for a Chinese word.
+# ---------------------------------------------------------------------------
+# The French twin (issue #726) — same contract, different format: the entry is
+# the French half of docs/yaml-format.md ("法语格式"), ported from the de-fr-bot
+# skill. importer._normalize_fr_entry maps word/level/examples[].fr onto the
+# internal keys, so everything downstream stays shared with Chinese.
+# ---------------------------------------------------------------------------
 
-    Returns the raw YAML text (a one-item list), ready for
-    importer.import_yaml_content(). Raises ValueError if the model returns
+_ENTRY_YAML_EXAMPLE_FR = """- type: word
+  date: "07/21"
+  word: parler
+  pos: verbe
+  english: to speak, to talk
+  german: sprechen, reden
+  level: "A1"
+  register: neutral
+  note: |
+    Regelmäßiges Verb auf -er. Grundverb für „sprechen" — mit Sprache direkt
+    danach (parler français), mit „de" für „über etwas sprechen" (parler de qc),
+    mit „à" für den Gesprächspartner (parler à qn).
+
+    **Häufige Ausdrücke:**
+    - parler couramment — fließend sprechen
+    - entendre parler de — von etwas hören
+
+    **Étymologie:** Vom lateinischen *parabolare* („in Gleichnissen reden"),
+    abgeleitet von *parabola* — derselbe Ursprung wie dt. „Parabel".
+  examples:
+    - fr: Je parle un peu français.
+      english: I speak a little French.
+      german: Ich spreche ein wenig Französisch.
+    - fr: Nous avons parlé de toi hier.
+      english: We talked about you yesterday.
+      german: Wir haben gestern über dich gesprochen.
+  synonyms:
+    - word: discuter
+      meaning: diskutieren, sich unterhalten
+  antonyms:
+    - word: se taire
+      meaning: schweigen
+  conjugations:
+    présent:
+      je: parle
+      tu: parles
+      il/elle: parle
+      nous: parlons
+      vous: parlez
+      ils/elles: parlent
+    passé composé:
+      je: ai parlé
+      tu: as parlé
+      il/elle: a parlé
+      nous: avons parlé
+      vous: avez parlé
+      ils/elles: ont parlé
+    imparfait:
+      je: parlais
+      tu: parlais
+      il/elle: parlait
+      nous: parlions
+      vous: parliez
+      ils/elles: parlaient
+    futur simple:
+      je: parlerai
+      tu: parleras
+      il/elle: parlera
+      nous: parlerons
+      vous: parlerez
+      ils/elles: parleront
+    conditionnel présent:
+      je: parlerais
+      tu: parlerais
+      il/elle: parlerait
+      nous: parlerions
+      vous: parleriez
+      ils/elles: parleraient
+    subjonctif présent:
+      que je: parle
+      que tu: parles
+      qu'il/elle: parle
+      que nous: parlions
+      que vous: parliez
+      qu'ils/elles: parlent
+    impératif:
+      tu: parle
+      nous: parlons
+      vous: parlez
+    participe présent: parlant
+    participe passé: parlé (avoir)
+"""
+
+_ENTRY_YAML_PROMPT_FR = """You are a French dictionary expert producing an SRS flashcard entry for a
+German-speaking learner (CEFR B1, everyday spoken French). Generate a complete
+YAML entry for: {word}
+
+Return ONLY the YAML — a single list item starting with "- type:". No markdown
+fences, no commentary before or after.
+
+TYPE — pick exactly one:
+  word        a single word (verb, noun, adjective, adverb)
+  expression  a multi-word phrase acting as a unit (idiom, collocation)
+  sentence    a full sentence
+
+The headword key is named after the type: `word:`, `expression:` or `sentence:`.
+There is no `simplified` field and no Chinese in the output.
+
+REQUIRED FIELDS: type, the headword key, english, german, level, date: "{today}".
+  - pos: French part of speech — verbe, nom (m), nom (f), adjectif, adverbe,
+    locution … NOUNS ALWAYS CARRY THEIR GENDER. Omit pos for `sentence`.
+  - level: a quoted CEFR string "A1"…"C2"
+  - register: one of spoken_colloquial, spoken_neutral, neutral, formal_written,
+    literary, slang
+  - english / german: concise glosses; separate distinct meanings with " / "
+
+LANGUAGE RULES — these fields MUST be German:
+  note, explanations, synonyms[].meaning, antonyms[].meaning, examples[].german
+  examples[].english is English; the headword and examples[].fr are French.
+
+CONTENT:
+  - note (word/expression): German prose block scalar (|) covering usage,
+    common collocations, false-friend warnings, and a short
+    "**Étymologie:** …" line (1-2 sentences) — French has no separate
+    etymology column, so it belongs in the note.
+  - examples: 2-4 sentences, EACH with all three keys fr, english, german
+  - synonyms / antonyms: {{word, meaning}} items; include when they add real value
+  - conjugations: REQUIRED FOR EVERY VERB, omitted for everything else.
+    All of: présent, passé composé, imparfait, futur simple,
+    conditionnel présent, subjonctif présent, impératif, participe présent,
+    participe passé. Person keys are exactly je, tu, il/elle, nous, vous,
+    ils/elles (subjonctif: que je, que tu, qu'il/elle, que nous, que vous,
+    qu'ils/elles; impératif: only tu, nous, vous). The person key stays `je`
+    even where elision would give `j'…`, and the form is what follows the
+    pronoun (ai parlé, irai). passé composé includes the auxiliary; participe
+    passé names it in parentheses — parlé (avoir), allé (être). Pronominal
+    verbs keep the reflexive pronoun in the form (me lève). Never guess
+    irregular forms.
+  - sentence type: use `explanations` (German block scalar) instead of note,
+    add `source_de` with the German original, and optionally
+    similar_sentences: [{{fr, german}}].
+
+YAML SAFETY — the output is parsed by a strict loader:
+  - Never use double quotes for meaning/english/german fields. If a colon is
+    unavoidable inside an inline string, wrap it in single quotes; better yet,
+    rephrase to avoid the colon.
+  - A French apostrophe inside a single-quoted string must be doubled
+    ('l''école'). Prefer leaving such values unquoted.
+  - note / explanations use block scalars (|) — colons are safe there.
+  - Indent consistently with two spaces; no tab characters.
+
+EXAMPLE of the expected shape (for parler):
+
+{example}
+"""
+
+
+def generate_word_entry_yaml(word_zh: str, model: str = DEFAULT_MODEL,
+                             lang: str = "zh") -> str:
+    """Generate a complete dictionary YAML entry for one word.
+
+    `lang` picks the prompt and the output format: 'zh' produces a de-zh-bot
+    entry, 'fr' the de-fr-bot French format (issue #726). Returns YAML ready
+    for importer.import_yaml_content(). Raises ValueError if the model returns
     something that isn't a YAML list item — callers surface that to the user
     rather than importing garbage.
+
+    Non-Chinese output is wrapped in a `lang:` header rather than relying on
+    the target deck's language: the entry format and the lang have to agree, so
+    stating it in the document removes a whole class of "French entry imported
+    as Chinese" bugs.
     """
     from datetime import date as _date
 
-    prompt = _ENTRY_YAML_PROMPT.format(
+    template = _ENTRY_YAML_PROMPT if lang == "zh" else _ENTRY_YAML_PROMPT_FR
+    example = _ENTRY_YAML_EXAMPLE if lang == "zh" else _ENTRY_YAML_EXAMPLE_FR
+    prompt = template.format(
         word=word_zh,
         today=_date.today().strftime("%m/%d"),
-        example=_ENTRY_YAML_EXAMPLE,
+        example=example,
     )
 
-    logger.info("[%s] generate_word_entry_yaml: %s", model, word_zh)
+    logger.info("[%s] generate_word_entry_yaml (%s): %s", model, lang, word_zh)
     raw = _call_api(model, [{"role": "user", "content": prompt}], max_tokens=4000,
                     purpose=f"add_word:{word_zh}")
 
@@ -1047,7 +1211,10 @@ def generate_word_entry_yaml(word_zh: str, model: str = DEFAULT_MODEL) -> str:
                      word_zh, raw[:300])
         raise ValueError("AI did not return a YAML entry")
 
-    return raw[start:].rstrip() + "\n"
+    entry = raw[start:].rstrip() + "\n"
+    if lang == "zh":
+        return entry
+    return f"lang: {lang}\nentries:\n" + textwrap.indent(entry, "  ")
 
 
 def generate_character_info(char: str, pinyin: str, model: str = DEFAULT_MODEL) -> dict:

--- a/database/decks.py
+++ b/database/decks.py
@@ -3,6 +3,8 @@ import sqlite3
 import time
 from datetime import date
 
+from languages import DEFAULT_LANG, deck_root
+
 from .core import anki_today, get_db, _ensure_default_preset
 
 
@@ -292,10 +294,30 @@ def get_or_create_category_decks(parent_deck_id: int, parent_name: str) -> dict:
     }
 
 
-def get_or_create_saved_deck() -> int:
+def get_or_create_saved_deck(lang: str | None = None) -> int:
     """The fixed 'Saved' staging deck: holds suspended compound words the user
-    set aside for later (see /api/save-word). Promoting moves them to a Daily deck."""
-    return get_or_create_deck_path("Saved")
+    set aside for later (see /api/save-word). Promoting moves them to a Daily deck.
+
+    Non-Chinese languages get their own staging deck inside their own tree
+    (issue #726) — 'Français::Saved' — because every language filter in the app
+    keys off decks.lang. Its deck *name* is still 'Saved' (paths name the leaf),
+    so Browse's saved view, which matches on deck_name == 'Saved', needs no change.
+    """
+    if not lang or lang == DEFAULT_LANG:
+        return get_or_create_deck_path("Saved")
+    return get_or_create_deck_path(f"{deck_root(lang)}::Saved", lang=lang)
+
+
+def get_or_create_daily_deck(day: str, lang: str | None = None) -> tuple[int, str]:
+    """Ensure the per-language daily deck for `day` (ISO date) exists.
+
+    Returns (deck_id, deck_path). zh keeps the historical 'Daily::<date>' path;
+    other languages live in a parallel tree ('Français::<date>') whose decks
+    carry their own lang — see get_or_create_saved_deck for why.
+    """
+    path = f"{deck_root(lang)}::{day}"
+    lang_arg = None if not lang or lang == DEFAULT_LANG else lang
+    return get_or_create_deck_path(path, lang=lang_arg), path
 
 
 # ---------------------------------------------------------------------------

--- a/languages.py
+++ b/languages.py
@@ -28,6 +28,12 @@ LANGUAGES = {
         "translator_source": "zh-CN",
         # ── Story tokenization for click-to-lookup: 'jieba' | 'whitespace' ──
         "tokenizer": "jieba",
+        # ── Deck tree root for words added through the UI (issue #726) ──
+        # Each language owns a parallel tree under 'All' whose decks carry that
+        # lang, because every language filter in the app keys off decks.lang —
+        # a French card in a zh deck is invisible under the fr tab and shows up
+        # in the Chinese review queue instead.
+        "deck_root": "Daily",
         # ── AI prompt fragments ──
         "level_system": "HSK",
         "learner_level": "HSK 4-5",            # the learner's level
@@ -51,6 +57,7 @@ LANGUAGES = {
         "say_voice": "Thomas",
         "translator_source": "fr",
         "tokenizer": "whitespace",
+        "deck_root": "Français",
         "level_system": "CEFR",
         "learner_level": "CEFR B1",            # Daniel's French level (2026-07-06)
         "background_vocab": "CEFR A1-A2",
@@ -76,3 +83,12 @@ def get_lang_config(lang: str | None) -> dict:
 
 def is_valid_lang(lang: str | None) -> bool:
     return lang in LANGUAGES
+
+
+def deck_root(lang: str | None) -> str:
+    """Name of the language's top-level deck under 'All' (issue #726).
+
+    zh keeps the historical 'Daily' root, so nothing about existing decks or
+    their names changes; every other language gets its own parallel tree.
+    """
+    return get_lang_config(lang).get("deck_root", "Daily")

--- a/routes/imports.py
+++ b/routes/imports.py
@@ -465,7 +465,7 @@ def save_word(body: dict):
     the cards — content is generated later on demand, and the word only enters
     the study algorithm when promoted to a Daily deck (see /api/saved/{id}/promote).
 
-    Body: { word_zh, pinyin?, meaning? }
+    Body: { word_zh, pinyin?, meaning?, lang? }
     Returns: { status: "saved"|"already_saved"|"exists_elsewhere", entry_id, saved_deck_id }
     """
     word_zh = (body.get("word_zh") or "").strip()
@@ -474,8 +474,14 @@ def save_word(body: dict):
 
     pinyin = (body.get("pinyin") or "").strip()
     meaning = (body.get("meaning") or "").strip()
+    # The word was picked out of a card, so it carries that card's language
+    # (#726) — staging a French word in the Chinese Saved deck would hide it
+    # under the fr tab and promote it into the Chinese daily deck later.
+    lang = (body.get("lang") or DEFAULT_LANG).strip()
+    if not is_valid_lang(lang):
+        raise HTTPException(status_code=400, detail=f"Unknown language: {lang!r}")
 
-    saved_deck_id = database.get_or_create_saved_deck()
+    saved_deck_id = database.get_or_create_saved_deck(lang)
 
     existing = database.get_word_by_zh(word_zh)
     if existing:
@@ -499,6 +505,7 @@ def save_word(body: dict):
             "pinyin": pinyin,
             "definition": meaning,
             "note_type": "vocabulary",
+            "lang": lang,
         })
 
     for category in ("listening", "reading", "creating"):

--- a/routes/imports.py
+++ b/routes/imports.py
@@ -11,6 +11,7 @@ import ai
 import database
 import importer
 from fastapi import APIRouter, Form, HTTPException, UploadFile
+from languages import DEFAULT_LANG, is_valid_lang
 
 from .utils import ai_disabled
 
@@ -268,15 +269,45 @@ def _total_repetitions(entry_id: int) -> int:
     return row["n"]
 
 
+_HAN_RE = re.compile(r"[一-鿿]")
+_LATIN_RE = re.compile(r"[A-Za-zÀ-ÿ]")
+
+
+def _validate_word_for_lang(word: str, lang: str) -> None:
+    """Reject input that plainly isn't the language the caller asked for.
+
+    The add-word box takes no follow-up questions (unlike the de-zh-bot /
+    de-fr-bot skills, which ask which meaning is wanted), so a German word
+    typed under the French tab would silently become a wrong entry. Checking
+    the script is the one cheap guard available: it can't tell French from
+    German, but it does stop 生态 from being sent to the French prompt and
+    séjour from being sent to the Chinese one.
+    """
+    if lang == "zh":
+        if not _HAN_RE.search(word):
+            raise HTTPException(status_code=400,
+                                detail="Please enter the word in Chinese characters")
+        return
+    if _HAN_RE.search(word):
+        raise HTTPException(status_code=400,
+                            detail="That looks like Chinese — switch the language first")
+    if not _LATIN_RE.search(word):
+        raise HTTPException(status_code=400, detail="Please enter the word in French")
+
+
 @router.post("/api/add-word-ai")
 def add_word_ai(body: dict):
-    """Add one Chinese word with an AI-generated entry.
+    """Add one word with an AI-generated entry.
 
-    Body: { word_zh, day?: "today"|"tomorrow"|"list" }
-      today/tomorrow → cards go into that day's Daily deck, due then.
+    Body: { word_zh, day?: "today"|"tomorrow"|"list", lang?: "zh"|"fr" }
+      today/tomorrow → cards go into that day's daily deck, due then.
       list (#677)    → the entry is generated in full but its cards are parked
                        suspended in the Saved deck, so the word enters no review
                        queue until it is promoted from Browse.
+      lang (#726)    → which language's prompt and deck tree to use; every
+                       language owns a parallel tree ('Daily::…' for zh,
+                       'Français::…' for fr) because the app's language filters
+                       key off decks.lang.
     Returns either {job_id, deck_path} — generation runs in the background,
     poll /api/add-word-ai/progress/{job_id} — or, when the word is already in
     the database, a finished {status, ...} with no AI call at all.
@@ -284,9 +315,10 @@ def add_word_ai(body: dict):
     word_zh = (body.get("word_zh") or "").strip()
     if not word_zh:
         raise HTTPException(status_code=400, detail="word_zh is required")
-    if not re.search(r"[一-鿿]", word_zh):
-        raise HTTPException(status_code=400,
-                            detail="Please enter the word in Chinese characters")
+
+    lang = (body.get("lang") or DEFAULT_LANG).strip()
+    if not is_valid_lang(lang):
+        raise HTTPException(status_code=400, detail=f"Unknown language: {lang!r}")
 
     day = (body.get("day") or "today").strip()
     if day not in ("today", "tomorrow", "list"):
@@ -304,8 +336,6 @@ def add_word_ai(body: dict):
     # tomorrow" semantics — the cards just have to be due then too (#636).
     due_offset_days = 1 if day == "tomorrow" else 0
     target_day = (date.today() + timedelta(days=due_offset_days)).isoformat()
-    deck_path = "Saved" if to_list else f"Daily::{target_day}"
-    deck_id = database.get_or_create_deck_path(f"Daily::{target_day}")
 
     # Known word → don't pay for a second generation; the importer would skip
     # it as a duplicate anyway. `cards` has UNIQUE(word_id, category), so a word
@@ -319,8 +349,21 @@ def add_word_ai(body: dict):
     # than reporting a bland success.
     existing = database.get_word_by_zh(word_zh)
     if existing:
+        # An existing word moves inside its OWN language's tree, whatever the
+        # request said (#726): word_zh is globally unique, so a mistyped lang
+        # would otherwise scatter one word's cards across two language trees
+        # and make it invisible under both tabs.
+        lang = existing["lang"] or DEFAULT_LANG
+    else:
+        _validate_word_for_lang(word_zh, lang)
+
+    daily_deck_id, daily_path = database.get_or_create_daily_deck(target_day, lang)
+    deck_id = daily_deck_id
+    deck_path = "Saved" if to_list else daily_path
+
+    if existing:
         card_decks = _card_deck_ids(existing["id"])
-        saved_deck_id = database.get_or_create_saved_deck()
+        saved_deck_id = database.get_or_create_saved_deck(lang)
         was_only_saved = bool(card_decks) and card_decks <= {saved_deck_id}
         # Count the progress about to be dropped *before* the reset clears it.
         reps = _total_repetitions(existing["id"])
@@ -362,7 +405,7 @@ def add_word_ai(body: dict):
 
     def _run():
         try:
-            yaml_text = ai.generate_word_entry_yaml(word_zh)
+            yaml_text = ai.generate_word_entry_yaml(word_zh, lang=lang)
             result = importer.import_yaml_content(yaml_text, deck_id,
                                                   due_offset_days=due_offset_days)
             if result.get("yaml_error"):
@@ -373,7 +416,7 @@ def add_word_ai(body: dict):
                 entry = database.get_word_by_zh(word_zh)
                 if entry:
                     database.stage_word_in_saved(
-                        entry["id"], database.get_or_create_saved_deck())
+                        entry["id"], database.get_or_create_saved_deck(lang))
             with _import_jobs_lock:
                 started_at = _import_jobs[job_id]["started_at"]
                 _import_jobs[job_id] = {
@@ -466,11 +509,16 @@ def save_word(body: dict):
 
 @router.post("/api/saved/{word_id}/promote")
 def promote_saved(word_id: int):
-    """Move a saved word's suspended cards into tomorrow's Daily deck as active new cards."""
-    saved_deck_id = database.get_or_create_saved_deck()
+    """Move a saved word's suspended cards into tomorrow's daily deck as active new cards.
+
+    Both decks are the ones belonging to the word's own language (#726) — the
+    word knows its language, the caller doesn't have to.
+    """
+    entry = database.get_word(word_id)
+    lang = (entry or {}).get("lang") or DEFAULT_LANG
+    saved_deck_id = database.get_or_create_saved_deck(lang)
     tomorrow = (date.today() + timedelta(days=1)).isoformat()
-    deck_path = f"Daily::{tomorrow}"
-    daily_deck_id = database.get_or_create_deck_path(deck_path)
+    daily_deck_id, deck_path = database.get_or_create_daily_deck(tomorrow, lang)
     leaf_decks = database.get_or_create_category_decks(daily_deck_id, tomorrow)
 
     count = database.promote_saved_word(word_id, leaf_decks, saved_deck_id, tomorrow)

--- a/static/add.html
+++ b/static/add.html
@@ -51,6 +51,15 @@
   li.done { background: var(--ok-bg); } li.done .msg { color: var(--ok); }
   li.error { background: var(--err-bg); } li.error .msg { color: var(--err); }
   .hint { margin: .8rem 0 0; font-size: .8rem; color: var(--muted); }
+  /* Language picker (#726) — hidden until /api/langs says more than one
+     language is in use, so a Chinese-only install looks exactly as before. */
+  .langs { display: none; gap: .4rem; margin-bottom: .7rem; }
+  .langs button {
+    padding: .35rem .9rem; font: inherit; font-size: .85rem; font-weight: 600;
+    color: var(--muted); background: var(--bg);
+    border: 1px solid var(--line); border-radius: 8px; cursor: pointer;
+  }
+  .langs button.active { background: var(--accent); border-color: var(--accent); color: #fff; }
 </style>
 </head>
 <body>
@@ -61,6 +70,7 @@
   </header>
 
   <div class="card">
+    <div class="langs" id="langs"></div>
     <div class="row">
       <input type="text" id="word" placeholder="中文生词" autocomplete="off"
              autocapitalize="none" autocorrect="off" spellcheck="false" enterkeyhint="done" autofocus>
@@ -72,7 +82,7 @@
   <ul id="queue"></ul>
 </main>
 
-<script src="/static/shared.js?v=2"></script>
+<script src="/static/shared.js?v=3"></script>
 <script>
   // Standalone quick-add page (#668). Deliberately does NOT load app.js: the
   // point is a link that opens instantly on the phone. All the real work goes
@@ -90,6 +100,49 @@
   const queue = document.getElementById('queue');
 
   const DAYS = ['today', 'tomorrow', 'list'];
+
+  // Language of the next word (#726). Chinese unless ?lang= or the picker says
+  // otherwise; the backend rejects the wrong script, so the placeholder has to
+  // say which language the box currently expects.
+  let lang = 'zh';
+  const LANG_LABELS = { zh: '中文', fr: 'Français' };
+  const PLACEHOLDERS = { zh: '中文生词', fr: 'nouveau mot' };
+
+  function setLang(l) {
+    lang = l;
+    input.placeholder = PLACEHOLDERS[l] || l;
+    for (const b of document.getElementById('langs').children) {
+      b.classList.toggle('active', b.dataset.lang === l);
+    }
+    input.focus();
+  }
+
+  // The picker needs to know which languages exist, which only the server
+  // knows. One tiny request, fired after first paint — this page's whole point
+  // is opening instantly, so nothing waits on it. A ?lang= URL still works
+  // even if the request fails.
+  async function loadLangs() {
+    let langs;
+    try {
+      langs = await api('GET', '/api/langs');
+    } catch { return; }
+    if (!langs || !langs.length) return;
+    // A ?lang= naming a language this install doesn't use falls back to zh
+    // rather than sending the server something it will reject.
+    if (!langs.includes(lang)) setLang('zh');
+    if (langs.length <= 1) return;
+    const el = document.getElementById('langs');
+    el.replaceChildren(...langs.map(l => {
+      const b = document.createElement('button');
+      b.type = 'button';
+      b.dataset.lang = l;
+      b.textContent = LANG_LABELS[l] || l;
+      b.onclick = () => setLang(l);
+      return b;
+    }));
+    el.style.display = 'flex';
+    setLang(langs.includes(lang) ? lang : 'zh');
+  }
 
   function render() {
     queue.replaceChildren(...items.map(it => {
@@ -122,7 +175,7 @@
       item.state = state;
       item.text = text;
       render();
-    });
+    }, lang);
   }
 
   document.getElementById('go').onclick = submit;
@@ -137,10 +190,17 @@
   // That is the whole point of the parameter, but it also means the word is
   // stripped from the address bar afterwards (history.replaceState): a reload
   // or a "restore tabs" on the phone would otherwise silently add it again.
+  //
+  // ?lang=fr (#726) picks the language, so Daniel can keep one Shortcut per
+  // language. An unknown value is ignored the same way an unknown day is —
+  // the server would reject it, and the word is what matters.
   const params = new URLSearchParams(location.search);
   const preset = (params.get('word') || params.get('w') || '').trim();
   const dayParam = (params.get('day') || '').trim();
+  const langParam = (params.get('lang') || '').trim();
   if (DAYS.includes(dayParam)) day = dayParam;
+  if (langParam) setLang(langParam);
+  loadLangs();
   if (preset) {
     input.value = preset;
     history.replaceState(null, '', location.pathname);

--- a/static/app.js
+++ b/static/app.js
@@ -6415,7 +6415,10 @@ async function doSaveWord(wordZh, pinyin, meaning, btn) {
   btn.disabled = true;
   btn.textContent = '…';
   try {
-    const result = await api('POST', '/api/save-word', { word_zh: wordZh, pinyin, meaning });
+    // Same reasoning as doQuickAdd: the word came out of a card, so it is
+    // staged in that card's language's Saved deck (#726).
+    const result = await api('POST', '/api/save-word',
+                             { word_zh: wordZh, pinyin, meaning, lang: currentCardLang() });
     closeQuickAddMenu();
     const msgs = {
       saved:            `★ "${wordZh}" saved for later`,
@@ -6438,12 +6441,14 @@ function doQuickAdd(wordZh, btn) {
   // reports through the banner, so reviewing is never blocked (#643).
   closeQuickAddMenu();
   showQuickAddBanner(`⏳ Generating entry for "${wordZh}"…`, true);
+  // The word was long-pressed inside a card, so it belongs to that card's
+  // language — never to whatever tab the home page happens to be on (#726).
   addWordViaAi(wordZh, 'tomorrow', (state, text, deckPath) => {
     if (state === 'running') return;
     showQuickAddBanner(
       state === 'done' ? `✓ "${wordZh}" added to ${deckPath}` : `❌ "${wordZh}": ${text}`,
       state !== 'done');
-  });
+  }, currentCardLang());
 }
 
 function showQuickAddBanner(msg, isInfo) {
@@ -6471,6 +6476,39 @@ function showQuickAddBanner(msg, isInfo) {
 // own job while the user types the next one (#636).
 let _addWordQueue = [];             // [{key, wordZh, state, text}]
 let _addWordSeq = 0;
+// Which language the next word is added in (#726). Set from the home page's
+// active tab each time the modal opens, then switchable per word: adding one
+// French word should not mean leaving the Chinese tab and coming back.
+let _addWordLang = 'zh';
+
+// Placeholder + hint lead per language — the backend rejects the wrong script
+// outright, so the box has to say which one it wants.
+const _ADD_WORD_PROMPTS = {
+  zh: { placeholder: '新词…',     lead: 'Enter a Chinese word' },
+  fr: { placeholder: 'nouveau mot…', lead: 'Enter a French word' },
+};
+
+function setAddWordLang(lang) {
+  _addWordLang = lang;
+  const p = _ADD_WORD_PROMPTS[lang] || _ADD_WORD_PROMPTS.zh;
+  const input = document.getElementById('add-word-input');
+  input.placeholder = p.placeholder;
+  document.getElementById('add-word-hint-lead').textContent = p.lead;
+  _renderAddWordLangs();
+  input.focus();
+}
+
+function _renderAddWordLangs() {
+  const el = document.getElementById('add-word-langs');
+  if (!el) return;
+  // One language in use → no picker at all, exactly as before #726.
+  if (_availableLangs.length <= 1) { el.innerHTML = ''; return; }
+  el.innerHTML = _availableLangs.map(l => {
+    const label = _LANG_TAB_LABELS[l] || l;
+    const active = l === _addWordLang ? ' lang-tab-active' : '';
+    return `<button class="lang-tab${active}" onclick="setAddWordLang('${l}')">${label}</button>`;
+  }).join('');
+}
 
 function openAddWordModal() {
   document.getElementById('add-word-overlay').style.display = 'block';
@@ -6479,6 +6517,9 @@ function openAddWordModal() {
   input.value = '';
   input.disabled = false;
   document.getElementById('add-word-status').textContent = '';
+  // Follow the home page's language tab, but only for languages that exist —
+  // a stale localStorage value must not send words into an unknown tree.
+  setAddWordLang(_availableLangs.includes(activeLang()) ? activeLang() : 'zh');
   // Jobs that finished while the modal was closed already reported via banner.
   _addWordQueue = _addWordQueue.filter(item => item.state === 'running');
   _renderAddWordQueue();
@@ -6541,7 +6582,7 @@ function submitAddWord() {
         document.getElementById('add-word-modal').style.display === 'none') {
       showQuickAddBanner(`✓ "${wordZh}" added to ${deckPath}`, false);
     }
-  });
+  }, _addWordLang);
 }
 
 // ── Listening hint slider (HSK-aware) ───────────────────────────────────────

--- a/static/index.html
+++ b/static/index.html
@@ -668,8 +668,8 @@
 </div>
 
 <div id="word-tip" style="display:none"></div>
-<script src="/static/shared.js?v=2"></script>
-<script src="/static/app.js?v=20"></script>
+<script src="/static/shared.js?v=3"></script>
+<script src="/static/app.js?v=21"></script>
 
 <!-- Edit card modal -->
 <div id="edit-modal-overlay" onclick="closeEditCard()" style="display:none"></div>
@@ -936,14 +936,19 @@
     <button class="edit-modal-close" onclick="closeAddWordModal()">✕</button>
   </div>
   <div id="add-word-body">
+    <!-- Language picker (#726): only rendered when more than one language is
+         in use. Defaults to the home page's active tab, but can be switched
+         per word so a French word can be added without leaving the zh tab. -->
+    <div id="add-word-langs" class="lang-tabs"></div>
     <div id="add-word-row">
       <input id="add-word-input" type="text" placeholder="新词…" autocomplete="off"
              onkeydown="if (event.key === 'Enter') submitAddWord()">
       <button id="add-word-submit" type="button" onclick="submitAddWord()">加</button>
     </div>
     <div id="add-word-hint">
-      Enter a Chinese word — DeepSeek writes the full entry (definitions,
-      examples, character breakdown) into your <b id="add-word-deck">★ List</b>
+      <span id="add-word-hint-lead">Enter a Chinese word</span> — DeepSeek writes
+      the full entry (definitions, examples, character breakdown) into your
+      <b id="add-word-deck">★ List</b>
       (Saved, not reviewed until promoted from Browse).
       Generation runs in the background, so you can keep typing the next word.
     </div>

--- a/static/save.html
+++ b/static/save.html
@@ -93,7 +93,7 @@
   <ul id="queue"></ul>
 </main>
 
-<script src="/static/shared.js?v=2"></script>
+<script src="/static/shared.js?v=3"></script>
 <script>
   // Standalone knowledge-base page (#681), the /add counterpart for material.
   // Deliberately does NOT load app.js — the point is a link that opens

--- a/static/shared.js
+++ b/static/shared.js
@@ -31,10 +31,14 @@ async function api(method, path, body) {
 // logic would drift, and every fix would have to be made twice.
 //
 // onUpdate(state, text) is called with 'running' | 'done' | 'error'.
-async function addWordViaAi(wordZh, day, onUpdate) {
+// lang (#726) picks the language's prompt and deck tree; omitted means Chinese,
+// so every pre-#726 call site keeps behaving exactly as before. A word already
+// in the database ignores it and moves inside its own language's tree.
+async function addWordViaAi(wordZh, day, onUpdate, lang) {
   let result;
   try {
-    result = await api('POST', '/api/add-word-ai', { word_zh: wordZh, day });
+    result = await api('POST', '/api/add-word-ai',
+                       lang ? { word_zh: wordZh, day, lang } : { word_zh: wordZh, day });
   } catch (e) {
     onUpdate('error', e.message || 'Failed to add word');
     return;

--- a/tests/test_add_word.py
+++ b/tests/test_add_word.py
@@ -63,11 +63,13 @@ def tmp_db(tmp_path, monkeypatch):
     return tmp_path
 
 
-def _run_add_word(word_zh, yaml_text=ENTRY_YAML, day=None):
+def _run_add_word(word_zh, yaml_text=ENTRY_YAML, day=None, lang=None):
     """POST the word and, if a background job started, wait for it to finish."""
     payload = {"word_zh": word_zh}
     if day:
         payload["day"] = day
+    if lang:
+        payload["lang"] = lang
     with patch.object(ai, "_call_api", return_value=yaml_text):
         r = client.post("/api/add-word-ai", json=payload)
         assert r.status_code == 200, r.text
@@ -511,3 +513,195 @@ def test_add_page_defaults_to_the_list():
     assert "let day = 'list'" in src
     # …but an explicit ?day= from an existing Shortcut is still honoured.
     assert "params.get('day')" in src
+
+
+# ---------------------------------------------------------------------------
+# French (issue #726) — the same pipeline with the French prompt and a parallel
+# deck tree. The tree matters: every language filter in the app keys off
+# decks.lang, so a French card in a zh deck is invisible under the fr tab and
+# turns up in the Chinese review queue instead.
+# ---------------------------------------------------------------------------
+
+ENTRY_YAML_FR = """- type: word
+  date: "08/13"
+  word: séjour
+  pos: nom (m)
+  english: stay, sojourn
+  german: Aufenthalt
+  level: "B1"
+  register: neutral
+  note: |
+    Bezeichnet den Aufenthalt an einem Ort.
+
+    **Étymologie:** Vom altfranzösischen *sejorner*.
+  examples:
+    - fr: Bon séjour à Paris !
+      english: Enjoy your stay in Paris!
+      german: Schönen Aufenthalt in Paris!
+  synonyms:
+    - word: visite
+      meaning: Besuch
+"""
+
+ENTRY_YAML_FR_VERB = """- type: word
+  date: "08/13"
+  word: parler
+  pos: verbe
+  english: to speak
+  german: sprechen
+  level: "A1"
+  register: neutral
+  note: |
+    Regelmäßiges Verb auf -er.
+  examples:
+    - fr: Je parle français.
+      english: I speak French.
+      german: Ich spreche Französisch.
+  conjugations:
+    présent:
+      je: parle
+      tu: parles
+      il/elle: parle
+    participe passé: parlé (avoir)
+"""
+
+
+def _fr_leaf_decks(day=None):
+    day = day or date.today().isoformat()
+    deck_id, _ = database.get_or_create_daily_deck(day, "fr")
+    return database.get_or_create_category_decks(deck_id, day)
+
+
+def test_french_word_lands_in_the_french_deck_tree(tmp_db):
+    result = _run_add_word("séjour", yaml_text=ENTRY_YAML_FR, lang="fr")
+    assert result["job"]["status"] == "done", result["job"]
+    assert result["job"]["summary"]["imported"] == 1
+    assert result["deck_path"] == f"Français::{date.today().isoformat()}"
+
+    entry = database.get_word_by_zh("séjour")
+    assert entry["lang"] == "fr"
+    assert entry["definition_de"] == "Aufenthalt"
+    # level: "B1" → the shared 1-6 scale (#596)
+    assert entry["hsk_level"] == 3
+
+    conn = database.get_db()
+    rows = conn.execute(
+        """SELECT c.deck_id, d.lang FROM cards c JOIN decks d ON d.id = c.deck_id
+           WHERE c.word_id=? AND c.deleted_at IS NULL""",
+        (entry["id"],),
+    ).fetchall()
+    conn.close()
+    assert {r["deck_id"] for r in rows} == set(_fr_leaf_decks().values())
+    # The whole point: the decks themselves are French, not just the entry.
+    assert all(r["lang"] == "fr" for r in rows)
+
+
+def test_french_entry_keeps_its_conjugations(tmp_db):
+    """The French format's one structural extra (#596) has to survive the trip
+    — otherwise the in-app entry is poorer than a hand-imported one."""
+    _run_add_word("parler", yaml_text=ENTRY_YAML_FR_VERB, lang="fr")
+    entry = database.get_word_by_zh("parler")
+    detail = database.get_word_full(entry["id"])
+    forms = {(c["tense"], c["person"]): c["form"] for c in detail["conjugations"]}
+    assert forms[("présent", "je")] == "parle"
+    # Impersonal forms are stored with an empty person.
+    assert forms[("participe passé", "")] == "parlé (avoir)"
+
+
+def test_french_word_is_listed_in_the_french_saved_deck(tmp_db):
+    """★ List must stage the word inside the French tree; the Chinese 'Saved'
+    deck would hide it under the fr tab."""
+    _run_add_word("séjour", yaml_text=ENTRY_YAML_FR, lang="fr", day="list")
+    entry = database.get_word_by_zh("séjour")
+
+    fr_saved = database.get_or_create_saved_deck("fr")
+    assert fr_saved != _saved_deck_id(), "French words must not share the zh Saved deck"
+    conn = database.get_db()
+    rows = conn.execute(
+        "SELECT deck_id, state FROM cards WHERE word_id=? AND deleted_at IS NULL",
+        (entry["id"],),
+    ).fetchall()
+    conn.close()
+    assert {r["deck_id"] for r in rows} == {fr_saved}
+    assert all(r["state"] == "suspended" for r in rows)
+    # Browse's saved view matches on the deck *name*, which the path's last
+    # segment still is — that is why no Browse change was needed.
+    assert database.get_deck(fr_saved)["name"] == "Saved"
+
+
+def test_listed_french_word_is_promoted_inside_its_own_tree(tmp_db):
+    _run_add_word("séjour", yaml_text=ENTRY_YAML_FR, lang="fr", day="list")
+    entry_id = database.get_word_by_zh("séjour")["id"]
+
+    r = client.post(f"/api/saved/{entry_id}/promote")
+    assert r.status_code == 200, r.text
+    tomorrow = (date.today() + timedelta(days=1)).isoformat()
+    assert r.json()["deck_path"] == f"Français::{tomorrow}"
+
+    conn = database.get_db()
+    decks = {row["deck_id"] for row in conn.execute(
+        "SELECT deck_id FROM cards WHERE word_id=? AND deleted_at IS NULL", (entry_id,))}
+    conn.close()
+    assert decks == set(_fr_leaf_decks(tomorrow).values())
+
+
+def test_existing_word_ignores_a_wrong_lang_and_follows_its_own(tmp_db):
+    """word_zh is globally unique, so trusting the request's lang would scatter
+    one word's cards over two language trees and hide it under both tabs."""
+    _run_add_word("séjour", yaml_text=ENTRY_YAML_FR, lang="fr", day="list")
+    entry_id = database.get_word_by_zh("séjour")["id"]
+
+    with patch.object(ai, "_call_api", side_effect=AssertionError("AI was called")):
+        body = client.post("/api/add-word-ai",
+                           json={"word_zh": "séjour", "lang": "zh"}).json()
+
+    assert body["deck_path"].startswith("Français::")
+    conn = database.get_db()
+    decks = {row["deck_id"] for row in conn.execute(
+        "SELECT deck_id FROM cards WHERE word_id=? AND deleted_at IS NULL", (entry_id,))}
+    conn.close()
+    assert decks == set(_fr_leaf_decks().values())
+
+
+def test_wrong_script_is_rejected_per_language(tmp_db):
+    """The box takes no follow-up questions, so a word in the wrong script must
+    fail loudly instead of being fed to the wrong prompt."""
+    assert client.post("/api/add-word-ai",
+                       json={"word_zh": "生态", "lang": "fr"}).status_code == 400
+    assert client.post("/api/add-word-ai",
+                       json={"word_zh": "séjour", "lang": "zh"}).status_code == 400
+
+
+def test_unknown_lang_is_rejected(tmp_db):
+    assert client.post("/api/add-word-ai",
+                       json={"word_zh": "séjour", "lang": "es"}).status_code == 400
+
+
+def test_french_prompt_is_used_for_french(tmp_db):
+    """Sending the Chinese prompt would produce a Chinese-format entry that the
+    French half of the importer can't read."""
+    with patch.object(ai, "_call_api", return_value=ENTRY_YAML_FR) as call:
+        ai.generate_word_entry_yaml("séjour", lang="fr")
+    prompt = call.call_args[0][1][0]["content"]
+    assert "French dictionary expert" in prompt
+    assert "CEFR" in prompt and "conjugations" in prompt
+
+
+def test_french_yaml_carries_its_lang_header(tmp_db):
+    """The document states its language rather than relying on the target
+    deck's — the entry format and the lang have to agree."""
+    with patch.object(ai, "_call_api", return_value=ENTRY_YAML_FR):
+        out = ai.generate_word_entry_yaml("séjour", lang="fr")
+    import yaml as _yaml
+    doc = _yaml.safe_load(out)
+    assert doc["lang"] == "fr"
+    assert doc["entries"][0]["word"] == "séjour"
+
+
+def test_add_page_and_modal_pass_the_language():
+    """One client-side pipeline (#643): both entry points hand lang to the same
+    shared helper, neither talks to the endpoint directly."""
+    assert "lang) {" in _static("shared.js") or "onUpdate, lang)" in _static("shared.js")
+    assert "_addWordLang" in _static("app.js")
+    assert "params.get('lang')" in _static("add.html")
+    assert "/api/add-word-ai" not in _static("add.html")


### PR DESCRIPTION
Closes #726

## 改了什么

顶栏 `＋`、`/add` 页面、复习界面长按菜单现在都能加**法语词**，生成的词条与手工 `lang: fr` YAML 导入完全一致（例句、变位表、同反义词），落在语言隔离正确的牌组里。

### 为什么要新建一棵牌组树

全应用的语言过滤（`database.cards._lang_subquery_clause`、`get_descendant_leaf_deck_ids`）筛的是 **`decks.lang`**，不是 `entries.lang`。生产库里 #726 之前导入的 7 个法语词的卡片落在 `lang='zh'` 的 `07-24 · Listening/…` 里 —— 结果是它们在 fr 标签下看不见，反而混进中文复习队列。所以每种语言在 `All` 下拥有平行的树，根名写进 `languages.py` 的 `deck_root`（加新语言仍然只是加一个条目）：

```
All
├─ Daily::2026-08-13 · Listening/Reading/Creating     (zh)
├─ Saved                                              (zh)
├─ Français::2026-08-13 · Listening/Reading/Creating  (fr)
└─ Français::Saved                                    (fr)
```

`Français::Saved` 的牌组**名**仍是 `Saved`（路径末段），所以 Browse 的 saved 视图（认 `deck_name === 'Saved'`）一行都没改。

### 几个刻意的决定

- **已存在的词按 `entries.lang` 落点，不听请求参数**：`word_zh` 是全局唯一的，lang 传错会把同一个词的三张卡撒进两棵语言树，两个标签下都看不见它。`promote_saved` 同理
- **按语言校验输入文字体系**（zh 必须含汉字；fr 不能含汉字且要有拉丁字母）：加词框没有反问的机会（`de-zh-bot`/`de-fr-bot` 技能靠追问"你指哪个意思"），把德语词喂给法语提示词会静默生成一个错词条。查文字体系分不出法语和德语，但至少挡住 `生态` 走法语提示词
- **法语输出自带 `lang: fr` 头**，不靠目标牌组的语言推断 —— 条目格式和 lang 必须一致，写在文档里能整类消灭"法语词条被当中文导入"
- **长按菜单的两个按钮**（`+ Add to Daily`、`★ Save for later`）按**当前卡片**的语言走，跟主页在哪个标签无关 —— 词是从这张卡里挑出来的。`/api/save-word` 因此也接 `lang`
- 法语提示词移植自 `de-fr-bot` 技能：德语 note + Étymologie、CEFR `level`、名词带性别、动词必带完整 `conjugations`（7 时态 + 两个分词，人称键固定）

## 怎么测的

- `pytest tests/` **472 通过**（新增 10 条法语测试）
- **真实 DeepSeek 调用**验证提示词：`se débrouiller`（代词式动词 → `me débrouille`、`débrouillé (être)`、9 个时态齐全）、`chômage`（`nom (m)`）
- **真实端到端**（临时库）：`faire la queue` → 识别为 `expression` → 落在 `Français::Saved`（牌组 `lang='fr'`，父牌组 `Français`），三张卡挂起，例句完整

## 不在本 PR 范围

- 不迁移已有那 7 个落在中文牌组里的法语词（数据迁移单独议题）
- 不做输入语言自动识别（将来加第二种拉丁语言就会失效）

🤖 Generated with [Claude Code](https://claude.com/claude-code)