### PR TITLE
修复：★ List 的「→ Add to Daily」提升到今天而不是明天（#728）

### DIFF
--- a/routes/imports.py
+++ b/routes/imports.py
@@ -13,7 +13,7 @@ import importer
 from fastapi import APIRouter, Form, HTTPException, UploadFile
 from languages import DEFAULT_LANG, is_valid_lang
 
-from .utils import ai_disabled
+from .utils import ai_disabled, queue_mgr
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -382,6 +382,9 @@ def add_word_ai(body: dict):
             # Saved cards carry no progress, so that move is a promotion, not a
             # reset — the frontend words them differently.
             status = "promoted" if was_only_saved else "reset"
+        # Same in-memory-queue staleness as promote_saved (#728): a card moved
+        # into today has to reach a queue that may already have been built.
+        queue_mgr.invalidate()
         return {
             "status": status,
             "word_zh": word_zh, "entry_id": existing["id"],
@@ -417,6 +420,9 @@ def add_word_ai(body: dict):
                 if entry:
                     database.stage_word_in_saved(
                         entry["id"], database.get_or_create_saved_deck(lang))
+            if result.get("imported") and not to_list:
+                # New cards due today must reach queues built earlier (#728).
+                queue_mgr.invalidate()
             with _import_jobs_lock:
                 started_at = _import_jobs[job_id]["started_at"]
                 _import_jobs[job_id] = {
@@ -515,8 +521,15 @@ def save_word(body: dict):
 
 
 @router.post("/api/saved/{word_id}/promote")
-def promote_saved(word_id: int):
-    """Move a saved word's suspended cards into tomorrow's daily deck as active new cards.
+def promote_saved(word_id: int, day: str = "today"):
+    """Move a saved word's suspended cards into a daily deck as active new cards.
+
+    Defaults to *today* (#728): ★ List is the "keep it for later" staging area
+    (#715), so clicking promote means "I want to study this now" — landing the
+    cards in tomorrow's deck instead hid them behind the future-daily-deck lock
+    (parse_daily_deck_date) for the rest of the day. `day='tomorrow'` keeps the
+    old behaviour; as everywhere else, the deck and the due date have to move
+    together or a card sits due-today inside a locked deck (#636).
 
     Both decks are the ones belonging to the word's own language (#726) — the
     word knows its language, the caller doesn't have to.
@@ -524,12 +537,16 @@ def promote_saved(word_id: int):
     entry = database.get_word(word_id)
     lang = (entry or {}).get("lang") or DEFAULT_LANG
     saved_deck_id = database.get_or_create_saved_deck(lang)
-    tomorrow = (date.today() + timedelta(days=1)).isoformat()
-    daily_deck_id, deck_path = database.get_or_create_daily_deck(tomorrow, lang)
-    leaf_decks = database.get_or_create_category_decks(daily_deck_id, tomorrow)
+    target_day = (date.today() + timedelta(days=1 if day == "tomorrow" else 0)).isoformat()
+    daily_deck_id, deck_path = database.get_or_create_daily_deck(target_day, lang)
+    leaf_decks = database.get_or_create_category_decks(daily_deck_id, target_day)
 
-    count = database.promote_saved_word(word_id, leaf_decks, saved_deck_id, tomorrow)
+    count = database.promote_saved_word(word_id, leaf_decks, saved_deck_id, target_day)
     if not count:
         raise HTTPException(status_code=404, detail="No saved cards found for this word")
+    # Session queues are built once per Anki day and kept in memory, so a card
+    # that becomes due today after the build would not be served until tomorrow
+    # (#728). Landing in a future deck used to make this moot.
+    queue_mgr.invalidate()
 
     return {"status": "promoted", "count": count, "deck_path": deck_path, "deck_id": daily_deck_id}

--- a/static/app.js
+++ b/static/app.js
@@ -2042,7 +2042,7 @@ function _wordRow(w) {
     rightHtml =
       (w.definition ? '' :
         `<button class="bw-saved-btn" onclick="event.stopPropagation();savedGenerate(${w.id},this)" title="Generate content with AI">✨ Generate</button>`) +
-      `<button class="bw-saved-btn bw-saved-promote" onclick="event.stopPropagation();savedPromote(${w.id},this)" title="Add to tomorrow's Daily deck">→ Add to Daily</button>`;
+      `<button class="bw-saved-btn bw-saved-promote" onclick="event.stopPropagation();savedPromote(${w.id},this)" title="Add to today's Daily deck">→ Add to Daily</button>`;
   } else if (_browseCardStatus === 'leech' && w.cards.some(c => c.is_leech)) {
     rightHtml =
       `<button class="bw-unleech-btn" onclick="event.stopPropagation();browseUnleechWord(${w.id},this)"` +
@@ -2106,7 +2106,7 @@ async function savedGenerate(wordId, btn) {
   }
 }
 
-// Promote a saved word into tomorrow's Daily deck (leaves the Saved list).
+// Promote a saved word into today's Daily deck (leaves the Saved list, #728).
 async function savedPromote(wordId, btn) {
   btn.disabled = true;
   const orig = btn.textContent;

--- a/tests/test_add_word.py
+++ b/tests/test_add_word.py
@@ -450,8 +450,10 @@ def test_listed_word_can_be_promoted_into_a_daily_deck(tmp_db):
 
     r = client.post(f"/api/saved/{entry_id}/promote")
     assert r.status_code == 200, r.text
-    tomorrow = (date.today() + timedelta(days=1)).isoformat()
-    assert r.json()["deck_path"] == f"Daily::{tomorrow}"
+    # Today, not tomorrow (#728): a future daily deck is locked, so the word
+    # would be invisible for the rest of the day Daniel asked for it.
+    today = date.today().isoformat()
+    assert r.json()["deck_path"] == f"Daily::{today}"
 
     conn = database.get_db()
     rows = conn.execute(
@@ -459,8 +461,28 @@ def test_listed_word_can_be_promoted_into_a_daily_deck(tmp_db):
         (entry_id,),
     ).fetchall()
     conn.close()
+    assert {r["deck_id"] for r in rows} == set(_daily_leaf_decks(today).values())
+    assert all(r["state"] == "new" and r["due"] == today for r in rows)
+
+
+def test_listed_word_can_still_be_promoted_to_tomorrow(tmp_db):
+    """day=tomorrow keeps the pre-#728 behaviour; deck and due move together."""
+    _run_add_word("生态", day="list")
+    entry_id = database.get_word_by_zh("生态")["id"]
+
+    r = client.post(f"/api/saved/{entry_id}/promote?day=tomorrow")
+    assert r.status_code == 200, r.text
+    tomorrow = (date.today() + timedelta(days=1)).isoformat()
+    assert r.json()["deck_path"] == f"Daily::{tomorrow}"
+
+    conn = database.get_db()
+    rows = conn.execute(
+        "SELECT deck_id, due FROM cards WHERE word_id=? AND deleted_at IS NULL",
+        (entry_id,),
+    ).fetchall()
+    conn.close()
     assert {r["deck_id"] for r in rows} == set(_daily_leaf_decks(tomorrow).values())
-    assert all(r["state"] == "new" and r["due"] == tomorrow for r in rows)
+    assert all(r["due"] == tomorrow for r in rows)
 
 
 def test_invalid_day_still_rejected_and_list_accepted(tmp_db):
@@ -635,14 +657,14 @@ def test_listed_french_word_is_promoted_inside_its_own_tree(tmp_db):
 
     r = client.post(f"/api/saved/{entry_id}/promote")
     assert r.status_code == 200, r.text
-    tomorrow = (date.today() + timedelta(days=1)).isoformat()
-    assert r.json()["deck_path"] == f"Français::{tomorrow}"
+    today = date.today().isoformat()
+    assert r.json()["deck_path"] == f"Français::{today}"
 
     conn = database.get_db()
     decks = {row["deck_id"] for row in conn.execute(
         "SELECT deck_id FROM cards WHERE word_id=? AND deleted_at IS NULL", (entry_id,))}
     conn.close()
-    assert decks == set(_fr_leaf_decks(tomorrow).values())
+    assert decks == set(_fr_leaf_decks(today).values())
 
 
 def test_existing_word_ignores_a_wrong_lang_and_follows_its_own(tmp_db):


### PR DESCRIPTION
## 问题

Browse 的 ★ List 里点「→ Add to Daily」后，词在今天的主页上完全看不到，新卡计数不变。

原因：`/api/saved/{word_id}/promote` 把卡片放进**明天**的 Daily 牌组，而未来日期的 Daily 牌组被 `parse_daily_deck_date` / `get_locked_deck_ids()` 锁住不可复习。★ List 是「先攒着、想学了再主动提升」的暂存区（#715），点提升就等于「我现在要学它」，落到明天与这个语义矛盾。

## 改动

1. `promote_saved` 默认 `day=today`；保留 `day=tomorrow`（牌组与 due 一起走，见 #636 的约束）
2. **失效会话队列缓存**：队列每个 Anki 日只构建一次并常驻内存，落到今天的新卡如果队列已建好就依然轮不到。落明天时这个问题不存在，所以以前没写。同一个坑也补在 `/api/add-word-ai` 的 today 分支（已有词的 reset、新词后台导入）——iOS 快捷指令 `?day=today` 会真踩到
3. 前端按钮 title 与注释改为 today

## 测试

- 更新两条既有测试（中文/法语）断言落今天
- 新增 `test_listed_word_can_still_be_promoted_to_tomorrow` 守住 `day=tomorrow`
- 本地全套 `pytest tests/`：473 passed, 4 skipped

Closes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)