### PR TITLE
fix: 有故事时不再把到期卡排到新卡之后（#732）

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -353,6 +353,30 @@ def _still_learning(card: dict, learned_interval: int) -> bool:
     return card["state"] == "review" and (card.get("interval") or 0) < learned_interval
 
 
+def story_sort_key(card: dict, story_pos: dict) -> tuple[int, int]:
+    """Where a due card sits relative to today's story (issue #732).
+
+    Every caller that orders a review queue by story position used to write
+    `story_pos.get(word_id, <some max>)`, which drops cards missing from the
+    story behind *everything* — including new cards.  A story only covers the
+    words that were due when it was generated, so re-generating it after a
+    partial review session leaves the morning's leftovers (especially the ones
+    rated Again) outside it, and on a day with many new cards they were never
+    reached.  Deck badges still counted them, so they looked lost.
+
+    Three groups instead:
+      0 — due cards outside the story that are NOT new: real debt with no
+          sentence to read, and the learning-first order that applies when no
+          story exists must keep applying when one does.
+      1 — cards in the story, in narrative order.
+      2 — new cards outside the story (added or promoted after generation).
+    """
+    pos = story_pos.get(card.get("word_id"))
+    if pos is not None:
+        return (1, pos)
+    return (2, 0) if card.get("state") == "new" else (0, 0)
+
+
 def _interleave_cards(base: list, inserts: list) -> list:
     """Distribute inserts evenly across the full combined length.
 
@@ -541,8 +565,7 @@ def get_next_card(deck_id: int, category: str) -> dict | None:
         sentences = get_story_sentences(story["id"])
         # word_id → story position
         story_pos = {s["word_id"]: s["position"] for s in sentences}
-        NO_POS = len(sentences)  # cards not in story go last
-        cards.sort(key=lambda c: story_pos.get(c["word_id"], NO_POS))
+        cards.sort(key=lambda c: story_sort_key(c, story_pos))
 
     return cards[0]
 
@@ -973,12 +996,14 @@ def get_due_cards_any_cat(root_deck_id: int, lang: str | None = None) -> list[di
                 for wid in s["word_ids"]:
                     story_pos[wid] = s["position"]
 
-    NO_POS = 9999
     if story_pos:
         # Story exists: follow narrative order so the session reads top-to-bottom.
+        # Cards the story doesn't cover are grouped by story_sort_key (#732) —
+        # learning/review leftovers ahead of it, new cards behind it — instead of
+        # all landing behind every new card.
         # Use category_order as tiebreaker so same-word cards respect deck settings.
         all_cards.sort(key=lambda c: (
-            story_pos.get(c["word_id"], NO_POS),
+            story_sort_key(c, story_pos),
             cat_order.get(c["category"], 99),
         ))
     else:

--- a/routes/review.py
+++ b/routes/review.py
@@ -104,8 +104,11 @@ def _order_by_story(cards: list[dict], story_deck_id: int | None,
     """Reorder due cards to match today's News-flow-style story (briefing/news/
     paste — issue #454): word_id → story_sentences.position, via
     database.get_story_position_map(). `sorted` is stable, so cards whose word
-    isn't in the story (or when there's no such story at all) keep their
-    existing interleaved order and sort after everything that is in the story.
+    isn't in the story keep their existing interleaved order within their group;
+    database.story_sort_key() decides the groups — learning/review leftovers the
+    story doesn't cover come first, new cards it doesn't cover come last (#732).
+    Without that split, a story regenerated mid-session (it only covers the words
+    due at generation time) pushed every leftover behind all new cards.
 
     Single-category sessions that don't find a per-category story also try the
     'unified' story — a unified story (from a mixed/"All" review session)
@@ -120,7 +123,7 @@ def _order_by_story(cards: list[dict], story_deck_id: int | None,
         pos = database.get_story_position_map(story_deck_id, "unified", today, lang)
     if not pos:
         return cards
-    ordered = sorted(cards, key=lambda c: pos.get(c.get("word_id"), float("inf")))
+    ordered = sorted(cards, key=lambda c: database.story_sort_key(c, pos))
     # Mark the result so QueueManager._build() knows story order is in effect:
     # already-due intraday learning cards must NOT jump ahead of it (issue #462).
     for c in ordered:

--- a/tests/test_story_queue_order.py
+++ b/tests/test_story_queue_order.py
@@ -1,0 +1,111 @@
+"""复习队列的故事排序（议题 #732）。
+
+场景：早上复习了一半 → 加新词 → 重新生成故事。新故事只覆盖生成那一刻到期的
+词，所以早上剩下的卡（尤其按了 Again 的）可能不在里面。原来它们被赋予一个最大
+排序值，落到**所有新卡之后**，新卡多的日子里永远轮不到——牌组角标却照常显示，
+看起来就像卡片丢了。
+
+这里守住的契约：有故事时，学习/复习态的欠账仍排在新卡之前。
+"""
+import datetime
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import database
+import database.core
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    """必须打 database.core.DB_PATH（见 conftest.py 与议题 #615）。"""
+    monkeypatch.setattr(database.core, "DB_PATH", str(tmp_path / "test_srs.db"))
+    database.init_db()
+
+
+# ---------------------------------------------------------------------------
+# story_sort_key —— 纯函数，不碰数据库
+# ---------------------------------------------------------------------------
+
+def test_key_groups_leftovers_before_story_before_new():
+    pos = {10: 0, 11: 1}
+    in_story = {"word_id": 10, "state": "new"}
+    leftover = {"word_id": 99, "state": "relearn"}
+    new_outside = {"word_id": 98, "state": "new"}
+
+    assert database.story_sort_key(leftover, pos) < database.story_sort_key(in_story, pos)
+    assert database.story_sort_key(in_story, pos) < database.story_sort_key(new_outside, pos)
+
+
+def test_key_keeps_narrative_order_inside_the_story():
+    pos = {10: 0, 11: 1}
+    first = database.story_sort_key({"word_id": 10, "state": "review"}, pos)
+    second = database.story_sort_key({"word_id": 11, "state": "review"}, pos)
+    assert first < second
+
+
+def test_key_without_story_treats_everything_as_outside():
+    """空故事映射时仍然是学习态优先——和 get_due_cards_any_cat 的无故事分支一致。"""
+    learning = database.story_sort_key({"word_id": 1, "state": "learning"}, {})
+    new = database.story_sort_key({"word_id": 2, "state": "new"}, {})
+    assert learning < new
+
+
+# ---------------------------------------------------------------------------
+# get_due_cards_any_cat —— 端到端复现议题 #732
+# ---------------------------------------------------------------------------
+
+def _add_entry(word: str) -> int:
+    conn = database.core.get_db()
+    cur = conn.execute(
+        "INSERT INTO entries (word_zh, pinyin, definition, note_type, lang) "
+        "VALUES (?, 'x', ?, 'vocabulary', 'zh')",
+        (word, word),
+    )
+    conn.commit()
+    wid = cur.lastrowid
+    conn.close()
+    return wid
+
+
+def test_leftover_due_cards_are_not_pushed_behind_new_cards(tmp_db):
+    root = database.get_or_create_deck("All")
+    daily = database.get_or_create_deck("Daily · test", parent_id=root)
+    leaves = database.get_or_create_category_decks(daily, "Daily · test")
+
+    today = database.anki_today().isoformat()
+    now = datetime.datetime.now().isoformat(timespec="seconds")
+
+    leftover_ids = []
+    for word in ("剩余一", "剩余二"):
+        wid = _add_entry(word)
+        leftover_ids.append(
+            database.insert_card(wid, "listening", leaves["listening"],
+                                 state="relearn", due=now))
+    new_ids = []
+    for word in ("新词一", "新词二", "新词三"):
+        wid = _add_entry(word)
+        new_ids.append(
+            database.insert_card(wid, "listening", leaves["listening"],
+                                 state="new", due=today))
+
+    # 重新生成的故事只覆盖新词——剩余的卡在生成那一刻已被复习过，不在到期集合里
+    story_sentences = [
+        {"position": i, "sentence_zh": f"句子{i}",
+         "word_ids": [database.get_card(cid)["word_id"]]}
+        for i, cid in enumerate(new_ids)
+    ]
+    database.create_story(today, "unified", root, story_sentences,
+                          gen_params={"mode": "knowledge"}, lang="zh")
+
+    order = [c["id"] for c in database.get_due_cards_any_cat(root)]
+
+    assert set(order) == set(leftover_ids + new_ids), "到期卡一张都不能丢"
+    last_leftover = max(order.index(cid) for cid in leftover_ids)
+    first_new = min(order.index(cid) for cid in new_ids)
+    assert last_leftover < first_new, (
+        "有故事时，不在故事里的到期卡被排到了新卡之后（议题 #732 回归）"
+    )


### PR DESCRIPTION
## 改了什么

有活跃故事时，复习队列按故事句子顺序排。三处代码都把**不在故事里**的到期卡赋成一个最大排序值：

- `get_due_cards_any_cat()` → `NO_POS = 9999`
- `get_next_card()` → `NO_POS = len(sentences)`
- `_order_by_story()` → `float("inf")`

结果是它们排在**所有新卡之后**。没有故事时走的是 learning-first（Anki 默认），有故事时这条保障就消失了。

故事只覆盖**生成那一刻到期**的词（生产日志：`regen deck=24 cat=unified due_cards=25`，上一版有 153 句），所以复习到一半加词再重新生成，早上剩下的卡必然被甩出故事 → 沉到队尾 → 新卡多的日子永远轮不到。牌组角标照常显示它们，看起来就像卡片丢了。

## 怎么修

抽出 `database.story_sort_key(card, story_pos)`，三处共用，分三组：

| 组 | 内容 | 理由 |
|---|---|---|
| 0 | 不在故事里的**非新卡** | 到期欠账，且没有句子可读；无故事时的 learning-first 有故事时也要成立 |
| 1 | 故事内的卡，按叙事顺序 | 保持"从上往下读"的体验 |
| 2 | 不在故事里的**新卡** | 生成之后才加进来/提升的词 |

## 怎么测

- `tests/test_story_queue_order.py`（新增 4 条）：排序键的三条分组契约 + 端到端复现——2 张 relearn 欠账 + 3 张新卡 + 只覆盖新词的故事，断言欠账排在新卡之前且一张不丢
- 已确认这 4 条在改动前**全部失败**
- 全套 `pytest tests/`：477 通过 / 4 跳过

Closes #732
