### PR TITLE
知识库：粘贴链接加 china-kritisch 复选框；全应用停用 gpt-5.1（#731）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@
 │   # ── AI、内容与语音 ──
 ├── ai.py                  # AI 提供商调用（每种提示词类型一个函数）
 ├── news_fetcher.py        # 新闻抓取（Tagesschau API + RSS；按天缓存 data/news_cache/）
-├── podcast.py             # 播客爬虫（#479）：播客 RSS 直链发现新单集（#497，退役 YouTube/yt-dlp）、每源 auto_process 开关+非自动源只入库元数据（#502，podcast_feeds 表）、转录链 NotebookLM 免费主力+听悟+Whisper 保底、单步异常不中止整链（#510 重排，链式降级，原 #498/#485/#486）、摘要 NotebookLM chat.ask 免费优先+DeepSeek/gpt API 链回退（api 路径内部 DeepSeek 优先省钱，#532）、邮件通知+Signal 通知（signal-cli 关联设备，发 Note to Self，#521，二者独立可选、互不影响；消息抬头播客名·星期·日期、链接在末尾，单集日期按 Europe/Berlin 显示，#532）、摘要 table.media 风格（`<p>` 段落+每段首句 `<b>` 加粗总结，#567）+详情页 Regenerate summary 按钮、邮件主题=`播客名 - 单集标题`（查不到播客名只用标题，不要退回死前缀）+ `summary_zh` 开头中文总结（#708 起是 `summary_de` 的**完整翻译**：同段落数、同顺序、同事实，同样 `<p>`+段首 `<b>`，HSK4-5 用词；提示词里德语先写、中文后译，JSON 里 `summary_de` 排在前面；渲染三处——邮件 `podcast._summary_zh_html`、详情页 `app.js._summaryZhHtml` 均"先全转义再放行 `<p>/<b>/<strong>/<em>/<i>/<br>`"，Signal 用 `_summary_to_plain_text` 剥标签；#708 之前的旧条目是纯文本，两处渲染都按空行补 `<p>`；**是增量不是必需**——成功判定只看 `summary_de`，模型漏掉中文总结不能让整集失败）+ 摘要里任何 HSK5+ 中文概念都标 `pinyin/汉字`（不限于提取的词表，宁多勿少，#631）；已泛化为知识库存储层，见 `knowledge/` 包
+├── podcast.py             # 播客爬虫（#479）：播客 RSS 直链发现新单集（#497，退役 YouTube/yt-dlp）、每源 auto_process 开关+非自动源只入库元数据（#502，podcast_feeds 表）、转录链 NotebookLM 免费主力+听悟+Whisper 保底、单步异常不中止整链（#510 重排，链式降级，原 #498/#485/#486）、摘要 NotebookLM chat.ask 免费优先+DeepSeek/gpt API 链回退（api 路径内部 DeepSeek 优先省钱，#532；勾了 china-kritisch 的素材跳过 DeepSeek 直接用 OpenAI，#731）、邮件通知+Signal 通知（signal-cli 关联设备，发 Note to Self，#521，二者独立可选、互不影响；消息抬头播客名·星期·日期、链接在末尾，单集日期按 Europe/Berlin 显示，#532）、摘要 table.media 风格（`<p>` 段落+每段首句 `<b>` 加粗总结，#567）+详情页 Regenerate summary 按钮、邮件主题=`播客名 - 单集标题`（查不到播客名只用标题，不要退回死前缀）+ `summary_zh` 开头中文总结（#708 起是 `summary_de` 的**完整翻译**：同段落数、同顺序、同事实，同样 `<p>`+段首 `<b>`，HSK4-5 用词；提示词里德语先写、中文后译，JSON 里 `summary_de` 排在前面；渲染三处——邮件 `podcast._summary_zh_html`、详情页 `app.js._summaryZhHtml` 均"先全转义再放行 `<p>/<b>/<strong>/<em>/<i>/<br>`"，Signal 用 `_summary_to_plain_text` 剥标签；#708 之前的旧条目是纯文本，两处渲染都按空行补 `<p>`；**是增量不是必需**——成功判定只看 `summary_de`，模型漏掉中文总结不能让整集失败）+ 摘要里任何 HSK5+ 中文概念都标 `pinyin/汉字`（不限于提取的词表，宁多勿少，#631）；已泛化为知识库存储层，见 `knowledge/` 包
 ├── knowledge/             # 知识库摄取（#650–#655，播客功能泛化，见「知识库」节）：youtube.py（字幕摄取）、article.py（正文抽取）、ingest.py（唯一入库管线）、mailbox.py（IMAP 邮件收件）
 ├── zh_annotate.py         # 生词标注（#638，零 AI）：HSK 表+词库+jieba+pypinyin+谷歌翻译
 ├── translator.py          # 翻译（Google Translate，deep-translator，可选）
@@ -311,7 +311,7 @@ python main.py status [--deck X]     # 显示每个牌组/类别的到期数量
 |------|--------|------|
 | `ANTHROPIC_API_KEY` | 必填 | Claude API 密钥 |
 | `DEEPSEEK_API_KEY` / `ZHIPU_API_KEY` / `QWEN_API_KEY` | 可选 | 其他 AI 提供商密钥 |
-| `OPENAI_API_KEY` | 可选 | 新闻模式默认模型 `gpt-5-mini`（DeepSeek 会审查新闻，故用 OpenAI） |
+| `OPENAI_API_KEY` | 可选 | 新闻/briefing 模式（DeepSeek 会审查新闻内容，故用 OpenAI），以及 china-kritisch 素材的摘要（#731）。模型由 `BRIEFING_MODEL` 决定，默认 `gpt-5.6-luna`，回退链 luna → terra → `gpt-5-mini`。**`gpt-5.1` 自 #731 起全应用停用**（同样的活贵六倍），价格表里保留它只为解析历史成本记录 |
 | `DB_PATH` | `data/srs.db` | 数据库路径（开发用 `data/dev.db`） |
 | `DISABLE_AI` | `0` | 设为 `1` 跳过 AI 故事生成 |
 | `OFFLINE_MODE` | `0` | 设为 `1` 进入硬离线模式（#612）：隐含 `DISABLE_AI`，TTS 只读缓存，零网络请求，连探测都不做 |
@@ -521,6 +521,10 @@ FSRS 用毕业评分播种初始 stability/difficulty：默认权重下 **Good �
 - **邮件收件（`knowledge/mailbox.py`，#655）**：IMAP 轮询 UNSEEN 邮件，标题+正文都扫 URL（手机分享到邮件，链接位置因 App 而异）。`KNOWLEDGE_MAIL_ALLOWED_SENDERS` 未配置时**整个邮箱检查被跳过，不读取也不标已读**——这是防止任何知道邮箱地址的人远程触发付费 AI 调用的唯一防线；处理失败的邮件同样不标已读，留给下一轮重试（`ingest_url()` 对已入库 URL 幂等返回 `already_exists`，重试安全）
 - **前端：播客页 → 知识页**（#653，`static/app.js`）：🎙️/📺/📄 三个子标签，播客管理页原有的 RSS 源/详情/生词表格逻辑全部保留，只是按 `?kind=` 过滤。**旧的 `#podcast-<id>` hash 链接永久保留**——已发出去的邮件/Signal 消息里全是这种链接；播客条目仍生成旧格式 hash，只有视频/文章条目用新的 `#knowledge-<id>`
 - **独立收藏页 `/save`（#681）**：`/add` 的素材版 —— 可收藏的网址，🔗 Link / 📋 Text 两个标签，粘链接或粘正文，同样**不加载 `app.js`**（手机上从别的 App 分享文章时秒开）。入库逻辑抽到 `shared.js` 的 `ingestKnowledge()`，应用的知识页和本页共用一份；`knowledgeTitleFor()` 统一"标题留空则取首行"的规则。**两处都不许直接调 `/api/knowledge/add*`**，有测试守着
+- **china-kritisch 复选框（#731）**：摘要默认走便宜的 DeepSeek —— Daniel 的博客素材绝大多数不批评中国，没必要为它们付 OpenAI 的钱。少数确实批评中国的素材勾选后存 `podcast_episodes.china_critical=1`，摘要时把 DeepSeek 从候选模型里**彻底删掉**（不是排后面）：它对这类内容会悄悄弱化或拒答，而弱化后的摘要照样能解析出 `summary_de`，任何"解析失败就回退"的机制都永远不会触发
+  - **免费的 NotebookLM 路径不受影响，照旧第一优先**：它是 Google 的，没理由审查这个话题，而且不花钱。勾选只改变它失败之后 API 兜底那一层选谁
+  - **标记必须在粘贴那一刻打上**：摘要发生在之后独立的 `POST .../process` 调用里（甚至是 cron 里），那时已经没人在旁边说明这是什么素材
+  - 三个入口（应用知识页的链接框/正文框、独立收藏页 `/save`）都有该复选框，**每次提交后自动复位**——粘性复选框会在之后所有素材上静默烧 GPT 的钱。请求字段可选且默认 false，所以不发这个字段的 iOS 快捷指令和邮件收件行为完全不变
 - **`GET /api/podcast/episodes` 加 `?kind=` 过滤**，`POST /api/knowledge/add` 只负责入库，**不在请求里做转录/摘要**——前端拿到 `episode_id` 后照常调用既有的 `POST /api/podcast/episodes/{id}/process`，造卡侧（`routes/story.py` 的 `knowledge` 模式，见「故事生成」）几乎零改动就能吃到播客以外的素材
 - **YouTube 字幕在服务器上必须走 NotebookLM（#681）**：YouTube 整片封锁云服务商 IP，Contabo 的服务器调字幕 API 永远得到 `RequestBlocked`。而 `RequestBlocked`/`IpBlocked`/`PoTokenRequired`/`AgeRestricted` **全是 `CouldNotRetrieveTranscript` 的子类** —— 原来只 `except` 基类，于是"被 YouTube 拒绝"被静默写成 `no_transcript`，一个有 9833 字中文字幕的视频在界面上显示"没有字幕"。现在拒绝类异常必须在基类**之前**捕获（`_blocked_error_types()`），先转 `podcast.transcribe_url_via_notebooklm()`（`sources.add_url()` 自动识别 YouTube 链接，由 Google 自己去取，绕开我们的出口 IP，免费、不下音频），兜底也空则抛 `CaptionsUnavailable` → `status='error'` + 可读原因。**真没字幕的视频不进兜底**，仍走廉价的 `no_transcript`，不浪费几分钟的 NotebookLM 轮次
   - **代价**：NotebookLM 不能指定字幕语言，返回的是视频原声轨（那条视频拿回来的是英文 32633 字，不是本地能拿到的中文翻译轨 9833 字）。摘要提示词本来就容忍任意输入语言，所以功能通；要中文轨只能给字幕 API 配付费代理（`WebshareProxyConfig`），暂不做
@@ -605,7 +609,7 @@ GET  /api/story-prompt/{story_id}                    → 生成该故事的完�
                                                        **不能**写成 /api/story/{id}/prompt——GET /api/story/{deck_id}/{category} 注册在前会把它当 category='prompt' 吃掉
 
 # 知识库（播客爬虫 #479 泛化，#650–#655；详见「知识库」节）
-POST /api/knowledge/add                               → body {url} → 新素材 {episode_id}；已存在 {status:"already_exists", episode_id}；不转录不摘要，前端拿 id 后另调 .../process
+POST /api/knowledge/add                               → body {url, china_critical?}（#731，默认 false）→ 新素材 {episode_id}；已存在 {status:"already_exists", episode_id}；不转录不摘要，前端拿 id 后另调 .../process
 GET/POST /api/known-words ；DELETE /api/known-words/{word} → 已认识词库（#710）：标记后 zh_annotate 不再当生词；不建卡不排程；DELETE 词不在表里返回 404（不假装成功）
 POST /api/podcast/check                              → 跑一轮抓取，返回汇总 {new, summarized, emailed, failed}
 GET  /api/podcast/episodes                            → 列表（不含转录全文；?feed_id= 按源过滤；?kind= 按 podcast/video/article 过滤，#650；手动处理中的单集 status 显示为 processing）

--- a/ai.py
+++ b/ai.py
@@ -26,9 +26,11 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL = "deepseek-v4-flash"
 
-# briefing mode (issue #444) — env var BRIEFING_MODEL, default gpt-5.1, verified
-# against the OpenAI models API with a fallback chain, cached for process lifetime.
-BRIEFING_MODEL_FALLBACKS = ("gpt-5.1", "gpt-5", "gpt-5-mini")
+# briefing mode (issue #444) — env var BRIEFING_MODEL, default gpt-5.6-luna,
+# verified against the OpenAI models API with a fallback chain, cached for
+# process lifetime. Retired gpt-5.1/gpt-5 here (#731, Daniel 2026-08-14): luna
+# is $0.20/$1.20 against their $1.25/$10.00 for the same job.
+BRIEFING_MODEL_FALLBACKS = ("gpt-5.6-luna", "gpt-5.6-terra", "gpt-5-mini")
 _briefing_model_cache: str | None = None
 
 # issue #514: if the OpenAI account runs out of quota mid-run (429
@@ -267,9 +269,9 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str,
 def resolve_briefing_model() -> str:
     """Resolve the OpenAI model id used for briefing mode (issue #444).
 
-    Reads BRIEFING_MODEL (default "gpt-5.1"), verifies on first use that the id
-    actually exists via the OpenAI models API, and falls back through
-    gpt-5.1 → gpt-5 → gpt-5-mini if not (or if the id is some other unlisted
+    Reads BRIEFING_MODEL (default "gpt-5.6-luna"), verifies on first use that
+    the id actually exists via the OpenAI models API, and falls back through
+    luna → terra → gpt-5-mini if not (or if the id is some other unlisted
     string). The resolved id is cached for the process lifetime — the models
     API is only ever hit once per process. OpenAI only (briefing is OpenAI-only,
     same reasoning as news/paste: DeepSeek censors news content).
@@ -2793,7 +2795,8 @@ def parse_podcast_summary_json(raw: str) -> dict:
 
 
 def summarize_podcast_transcript(transcript: str, title: str,
-                                 detail_level: str = "detailed") -> dict:
+                                 detail_level: str = "detailed",
+                                 china_critical: bool = False) -> dict:
     """Podcast crawler (issue #479): one AI call that turns a raw Chinese
     transcript into a German summary + a list of HSK5+ vocabulary worth
     reviewing before listening.
@@ -2804,6 +2807,13 @@ def summarize_podcast_transcript(transcript: str, title: str,
     DeepSeek pass is preferred to save money (#532). Falls back to
     resolve_briefing_model() (OpenAI/gpt) if DeepSeek is unavailable or its
     reply fails to parse — gpt is the paid-but-reliable backstop.
+
+    `china_critical` (#731) is the exception Daniel flags at paste time: for
+    material critical of China, DeepSeek is the censorship-sensitive case
+    after all, and it doesn't announce it — it quietly waters the summary
+    down or refuses, and a watered-down summary still parses, so no fallback
+    would ever trigger. The flag therefore drops DeepSeek from the candidate
+    list entirely rather than merely reordering it.
 
     This is the "api" summarizer path — podcast.summarize() (#510) tries the
     free NotebookLM chat.ask path first when podcast_config.summarizer=auto,
@@ -2817,7 +2827,7 @@ def summarize_podcast_transcript(transcript: str, title: str,
     prompt = build_podcast_summary_prompt(transcript, title, detail_level)
 
     candidates = []
-    if os.environ.get("DEEPSEEK_API_KEY"):
+    if os.environ.get("DEEPSEEK_API_KEY") and not china_critical:
         candidates.append(DEFAULT_MODEL)
     fallback = resolve_briefing_model()
     if fallback not in candidates:

--- a/database/core.py
+++ b/database/core.py
@@ -657,6 +657,9 @@ def init_db() -> None:
             conn.execute("ALTER TABLE podcast_episodes ADD COLUMN kind TEXT NOT NULL DEFAULT 'podcast'")
         if "title_en" not in pe_cols:
             conn.execute("ALTER TABLE podcast_episodes ADD COLUMN title_en TEXT")
+        if "china_critical" not in pe_cols:
+            conn.execute("ALTER TABLE podcast_episodes ADD COLUMN "
+                         "china_critical INTEGER NOT NULL DEFAULT 0")
         conn.commit()
 
 

--- a/database/podcast.py
+++ b/database/podcast.py
@@ -164,7 +164,8 @@ def create_pending_episode(video_id: str, channel_id: str | None, title: str,
                            published_at: str | None, youtube_url: str,
                            audio_url: str | None = None,
                            duration_seconds: int | None = None,
-                           kind: str = 'podcast') -> int:
+                           kind: str = 'podcast',
+                           china_critical: bool = False) -> int:
     """Insert a new episode row with status=pending. Returns the new id.
 
     `channel_id` stores the source RSS feed URL (#497, was a YouTube channel
@@ -173,13 +174,16 @@ def create_pending_episode(video_id: str, channel_id: str | None, title: str,
     `audio_url`/`duration_seconds` (#497) come from the RSS enclosure and
     itunes:duration. `kind` (#650) is 'podcast' | 'video' | 'article' — see
     docs/knowledge-base.md for what the generic columns mean per kind.
+    `china_critical` (#731) makes the API summary fallback skip DeepSeek and
+    use OpenAI directly — see podcast.summarize().
     """
     conn = get_db()
     cur = conn.execute(
         """INSERT INTO podcast_episodes
-           (video_id, channel_id, title, published_at, youtube_url, audio_url, duration_seconds, status, kind)
-           VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?)""",
-        (video_id, channel_id, title, published_at, youtube_url, audio_url, duration_seconds, kind),
+           (video_id, channel_id, title, published_at, youtube_url, audio_url, duration_seconds, status, kind, china_critical)
+           VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)""",
+        (video_id, channel_id, title, published_at, youtube_url, audio_url, duration_seconds,
+         kind, 1 if china_critical else 0),
     )
     conn.commit()
     episode_id = cur.lastrowid
@@ -265,7 +269,7 @@ def list_episodes(limit: int = 100, feed_url: str | None = None, kind: str | Non
     query = """SELECT id, video_id, channel_id, title, title_en, kind, published_at, youtube_url, spotify_url,
                       audio_url, duration_seconds,
                       summary_de, hsk_words, detail_level, status, error, email_sent_at, created_at,
-                      transcript_source,
+                      transcript_source, china_critical,
                       (transcript_zh IS NOT NULL AND transcript_zh != '') AS has_transcript
                FROM podcast_episodes"""
     clauses: list = []

--- a/knowledge/ingest.py
+++ b/knowledge/ingest.py
@@ -37,21 +37,27 @@ class IngestError(Exception):
     failed, pasted text too short, ...)."""
 
 
-def ingest_url(url: str) -> dict:
+def ingest_url(url: str, china_critical: bool = False) -> dict:
     """Resolve `url` to a podcast_episodes row and return either
     {"episode_id": int} (newly created) or {"status": "already_exists",
-    "episode_id": int} (deduped). Raises IngestError on failure."""
+    "episode_id": int} (deduped). Raises IngestError on failure.
+
+    `china_critical` (#731) is stored on the row and only read much later,
+    at summarize time (podcast.summarize) — the summary happens in the
+    separate .../process call when nobody is watching, so the flag has to be
+    captured here, at paste time, which is the only moment Daniel knows what
+    he is adding. A deduped row keeps whatever flag it already had."""
     url = (url or "").strip()
     if not url:
         raise IngestError("url is required")
 
     video_id = knowledge.youtube.parse_video_id(url)
     if video_id:
-        return _ingest_video(url, video_id)
-    return _ingest_article(url)
+        return _ingest_video(url, video_id, china_critical=china_critical)
+    return _ingest_article(url, china_critical=china_critical)
 
 
-def _ingest_video(url: str, video_id: str) -> dict:
+def _ingest_video(url: str, video_id: str, china_critical: bool = False) -> dict:
     existing = database.get_episode_by_video_id(video_id)
     if existing:
         return {"status": "already_exists", "episode_id": existing["id"]}
@@ -78,6 +84,7 @@ def _ingest_video(url: str, video_id: str) -> dict:
         audio_url=None,
         duration_seconds=None,
         kind="video",
+        china_critical=china_critical,
     )
     if title_en:
         database.update_episode(episode_id, title_en=title_en)
@@ -96,7 +103,8 @@ def _existing_episode(video_id: str) -> dict | None:
 
 
 def _store_article(*, video_id: str, title: str, site: str | None, published_at,
-                    source_url: str | None, text: str, transcript_source: str) -> dict:
+                    source_url: str | None, text: str, transcript_source: str,
+                    china_critical: bool = False) -> dict:
     """Create the kind='article' podcast_episodes row and store `text` as
     transcript_zh immediately — this is the ONE row-building code path for
     both _ingest_article (URL) and ingest_text (pasted body, #668); they
@@ -125,6 +133,7 @@ def _store_article(*, video_id: str, title: str, site: str | None, published_at,
         audio_url=None,
         duration_seconds=None,
         kind="article",
+        china_critical=china_critical,
     )
     updates = {"transcript_zh": text, "transcript_source": transcript_source}
     if title_en:
@@ -134,7 +143,7 @@ def _store_article(*, video_id: str, title: str, site: str | None, published_at,
     return {"episode_id": episode_id}
 
 
-def _ingest_article(url: str) -> dict:
+def _ingest_article(url: str, china_critical: bool = False) -> dict:
     """Article ingestion (#652): anything that isn't a recognized YouTube
     URL is treated as an article. normalize_url() (strips utm_*/fbclid/...)
     is the dedup key, so the same article shared via different links lands
@@ -163,6 +172,7 @@ def _ingest_article(url: str) -> dict:
         source_url=url,
         text=article["text"],
         transcript_source="article",
+        china_critical=china_critical,
     )
 
 
@@ -173,7 +183,8 @@ _MIN_TEXT_CHARS = knowledge.article._MIN_ARTICLE_CHARS
 _MAX_TEXT_CHARS = knowledge.article._MAX_ARTICLE_CHARS
 
 
-def ingest_text(title: str, text: str, source_url: str | None = None) -> dict:
+def ingest_text(title: str, text: str, source_url: str | None = None,
+                china_critical: bool = False) -> dict:
     """Ingest a pasted article body (#668) — for paywalled articles
     (Spiegel+, FAZ, ...) the server can't fetch, but the user can read in
     their browser and paste the text in directly. Same kind='article' row
@@ -216,4 +227,5 @@ def ingest_text(title: str, text: str, source_url: str | None = None) -> dict:
         source_url=source_url,
         text=text,
         transcript_source="pasted",
+        china_critical=china_critical,
     )

--- a/podcast.py
+++ b/podcast.py
@@ -1065,20 +1065,26 @@ def fetch_transcript(video: dict) -> tuple[str | None, dict]:
 # AI summary
 # ---------------------------------------------------------------------------
 
-def summarize(transcript: str, title: str, detail_level: str) -> dict:
+def summarize(transcript: str, title: str, detail_level: str,
+              china_critical: bool = False) -> dict:
     """Summarize a transcript into {"summary_de", "words"} (#479, NotebookLM
     path added in #510). When podcast_config.summarizer is 'auto' (default)
     and NotebookLM credentials are present, tries the free
     _summarize_via_notebooklm path first; any failure (or summarizer='api')
     falls back to the paid/quota-limited API chain in
-    ai.summarize_podcast_transcript so the pipeline never breaks over it."""
+    ai.summarize_podcast_transcript so the pipeline never breaks over it.
+
+    `china_critical` (#731) only affects that API fallback — it picks OpenAI
+    over DeepSeek there. NotebookLM stays first regardless: it is Google's,
+    so it has no reason to censor the topic, and it is free."""
     cfg = database.get_podcast_config()
     summarizer = cfg.get("summarizer") or "auto"
     if summarizer == "auto" and _notebooklm_credentials_available():
         result = _summarize_via_notebooklm(transcript, title, detail_level)
         if result:
             return _annotate_summary(result)
-    return _annotate_summary(ai.summarize_podcast_transcript(transcript, title, detail_level))
+    return _annotate_summary(ai.summarize_podcast_transcript(
+        transcript, title, detail_level, china_critical=china_critical))
 
 
 def _annotate_summary(result: dict) -> dict:
@@ -1574,7 +1580,12 @@ def _process_episode(episode_id: int, video: dict, detail_level: str, summary: d
                     logger.warning("podcast: transcript_de build failed for %s: %s",
                                    video["video_id"], e)
 
-            result = summarize(transcript, video["title"], detail_level)
+            # china_critical (#731) is read from the row, not from `video`:
+            # `video` is an RSS item for the crawler path and has no such
+            # field — only the stored row knows what was ticked at paste time.
+            china_critical = bool((database.get_episode(episode_id) or {}).get("china_critical"))
+            result = summarize(transcript, video["title"], detail_level,
+                               china_critical=china_critical)
             if not result.get("summary_de"):
                 database.update_episode(episode_id, status="error",
                                         error="AI summary failed or empty")
@@ -1648,7 +1659,8 @@ def regenerate_summary(episode_id: int) -> dict:
 
     with database.action_context(f"Regenerate summary: {episode['title'][:30]}"):
         try:
-            result = summarize(_normalize_transcript(transcript), episode["title"], detail_level)
+            result = summarize(_normalize_transcript(transcript), episode["title"], detail_level,
+                               china_critical=bool(episode.get("china_critical")))
         except Exception as e:
             logger.error("podcast: summary regeneration raised for episode %s: %s", episode_id, e)
             return {"regenerated": False, "error": str(e)}

--- a/routes/knowledge.py
+++ b/routes/knowledge.py
@@ -24,18 +24,24 @@ router = APIRouter()
 
 class AddKnowledgeRequest(BaseModel):
     url: str
+    # #731: ticked at paste time for material critical of China, which is the
+    # one case DeepSeek can't summarize honestly. Defaults to False so the
+    # iOS-shortcut / mailbox callers that don't send it keep the cheap
+    # DeepSeek-first behavior.
+    china_critical: bool = False
 
 
 class AddKnowledgeTextRequest(BaseModel):
     title: str
     text: str
     source_url: str | None = None
+    china_critical: bool = False
 
 
 @router.post("/api/knowledge/add")
 def add_knowledge(body: AddKnowledgeRequest):
     try:
-        return knowledge.ingest.ingest_url(body.url)
+        return knowledge.ingest.ingest_url(body.url, china_critical=body.china_critical)
     except knowledge.ingest.IngestError as e:
         raise HTTPException(400, str(e))
 
@@ -47,7 +53,8 @@ def add_knowledge_text(body: AddKnowledgeTextRequest):
     episode_id}) — the frontend's add flow branches on URL vs. text but
     otherwise treats the result identically (poll .../process next)."""
     try:
-        return knowledge.ingest.ingest_text(body.title, body.text, source_url=body.source_url)
+        return knowledge.ingest.ingest_text(body.title, body.text, source_url=body.source_url,
+                                            china_critical=body.china_critical)
     except knowledge.ingest.IngestError as e:
         raise HTTPException(400, str(e))
 

--- a/routes/story.py
+++ b/routes/story.py
@@ -208,7 +208,10 @@ ALLOWED_MODELS = {
     "claude-opus-4-6",
     "gpt-5-mini",
     "gpt-5",
-    "gpt-5.1",
+    # gpt-5.1 retired here and in the model dropdown (#731) — gpt-5.6-luna
+    # does the same job at a sixth of the price. Old stories that stored it
+    # fall back via _validated_model; its pricing row stays in
+    # database/stats.py so historical cost records still resolve.
     "gpt-5.6-luna",
     "gpt-5.6-terra",
     "gpt-5.6-sol",
@@ -317,7 +320,7 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
         elif mode in ("paste", "briefing"):
             # Briefing (issue #444) and paste (issue #481) share the briefing
             # pipeline and ignore the frontend's model selection — they always
-            # use BRIEFING_MODEL (env, default gpt-5.1, verified/cached via
+            # use BRIEFING_MODEL (env, default gpt-5.6-luna, verified/cached via
             # ai.resolve_briefing_model()), OpenAI only. Resolved before the
             # article-selection call so summarize_news_items uses the same
             # model as the sentence generation (issue #448).

--- a/schema.sql
+++ b/schema.sql
@@ -662,6 +662,12 @@ CREATE TABLE IF NOT EXISTS podcast_episodes (
     error            TEXT,
     email_sent_at    TEXT,
     processing_started_at TEXT,  -- set while _process_episode runs, cleared on exit; a leftover value = killed mid-transcription, recovered at startup (#598)
+    -- china_critical (#731): set at paste time, read at summarize time. The
+    -- API summary fallback normally prefers DeepSeek to save money; for
+    -- material critical of China DeepSeek censors/waters down the answer, so
+    -- 1 means "skip DeepSeek, go straight to OpenAI". The free NotebookLM
+    -- path stays first either way — Google doesn't censor the topic.
+    china_critical   INTEGER NOT NULL DEFAULT 0,
     created_at       TEXT NOT NULL DEFAULT (datetime('now'))
 );
 

--- a/static/app.js
+++ b/static/app.js
@@ -3376,6 +3376,10 @@ function _renderKnowledgeMaterialList() {
           </div>
           <button class="btn-secondary" onclick="submitKnowledgeText()" style="flex-shrink:0">Add</button>
         </div>
+        <label class="keymap-row" style="gap:6px;font-size:12px;color:var(--muted);cursor:pointer">
+          <input type="checkbox" id="knowledge-add-china" style="margin:0">
+          china-kritisch — summarize with GPT instead of DeepSeek
+        </label>
         <span id="knowledge-add-msg" style="font-size:12px;color:var(--muted)"></span>
       </div>`
     : `<div class="keymap-panel">
@@ -3385,6 +3389,10 @@ function _renderKnowledgeMaterialList() {
                  onkeydown="if(event.key==='Enter') submitKnowledgeUrl()">
           <button class="btn-secondary" onclick="submitKnowledgeUrl()">Add</button>
         </div>
+        <label class="keymap-row" style="gap:6px;font-size:12px;color:var(--muted);cursor:pointer">
+          <input type="checkbox" id="knowledge-add-china" style="margin:0">
+          china-kritisch — summarize with GPT instead of DeepSeek
+        </label>
         <span id="knowledge-add-msg" style="font-size:12px;color:var(--muted)"></span>
       </div>`;
   el.innerHTML = `
@@ -3439,8 +3447,11 @@ async function submitKnowledgeUrl() {
   const msg = document.getElementById('knowledge-add-msg');
   const url = (input?.value || '').trim();
   if (!url) return;
+  // Read the checkbox BEFORE clearing/re-rendering — _submitKnowledgeAdd
+  // rebuilds this panel's DOM when it refreshes the list.
+  const china_critical = _knowledgeChinaCriticalChecked();
   if (input) { input.value = ''; input.focus(); }
-  await _submitKnowledgeAdd({ url }, msg);
+  await _submitKnowledgeAdd({ url, china_critical }, msg);
 }
 
 // Paste-text box (article tab only, #668) — for paywalled pieces the server
@@ -3457,9 +3468,19 @@ async function submitKnowledgeText() {
     if (msg) msg.textContent = 'Need a title (or a non-blank first line).';
     return;
   }
+  const china_critical = _knowledgeChinaCriticalChecked();
   if (titleInput) titleInput.value = '';
   if (textInput) { textInput.value = ''; textInput.focus(); }
-  await _submitKnowledgeAdd({ title, text }, msg);
+  await _submitKnowledgeAdd({ title, text, china_critical }, msg);
+}
+
+// china-kritisch (#731): DeepSeek summarizes these dishonestly, so the box
+// sends a flag that makes the server's API fallback use GPT. Deliberately
+// resets to unchecked on every re-render — the overwhelming majority of
+// material is fine on the cheap model, and a sticky checkbox would silently
+// spend GPT money on all of it.
+function _knowledgeChinaCriticalChecked() {
+  return !!document.getElementById('knowledge-add-china')?.checked;
 }
 
 // Shared tail end of both paste boxes: ingest (shared.js kicks off processing),
@@ -7716,7 +7737,7 @@ function _autoSwitchModelForMode(mode) {
 
   // Briefing and paste (issues #481/#444) share the briefing pipeline and
   // ignore this dropdown server-side — the server always resolves
-  // BRIEFING_MODEL (env, default gpt-5.1). Lock the control and show that
+  // BRIEFING_MODEL (env, default gpt-5.6-luna). Lock the control and show that
   // honestly instead of a stale gpt-5-mini selection (issue #448).
   const serverOpt = document.getElementById('setup-model-server-opt');
   if (mode === 'briefing' || mode === 'paste') {
@@ -7728,7 +7749,7 @@ function _autoSwitchModelForMode(mode) {
       const opt = document.createElement('option');
       opt.id = 'setup-model-server-opt';
       opt.value = 'briefing-server';   // ignored by the server for briefing/paste
-      opt.textContent = 'Server: BRIEFING_MODEL (gpt-5.1)';
+      opt.textContent = 'Server: BRIEFING_MODEL (gpt-5.6-luna)';
       modelSel.appendChild(opt);
     }
     if (modelSel.value !== 'briefing-server') {
@@ -7736,7 +7757,7 @@ function _autoSwitchModelForMode(mode) {
       modelSel.value = 'briefing-server';
     }
     modelSel.disabled = true;
-    modelSel.title = 'News flow always uses BRIEFING_MODEL on the server (default gpt-5.1)';
+    modelSel.title = 'News flow always uses BRIEFING_MODEL on the server (default gpt-5.6-luna)';
     _modelSelMode = null;   // dropdown shows the server placeholder, not a real mode's model
     return;
   }

--- a/static/index.html
+++ b/static/index.html
@@ -825,7 +825,6 @@
         <option value="claude-sonnet-4-6">Sonnet — Anthropic, $3.00/$15.00</option>
         <option value="gpt-5-mini">GPT-5 Mini — OpenAI, $0.25/$2.00</option>
         <option value="gpt-5">GPT-5 — OpenAI, $1.25/$10.00</option>
-        <option value="gpt-5.1">GPT-5.1 — OpenAI, $1.25/$10.00</option>
         <option value="gpt-5.6-luna">GPT-5.6 Luna — OpenAI, $0.20/$1.20</option>
         <option value="gpt-5.6-terra">GPT-5.6 Terra — OpenAI, $2.00/$12.00</option>
         <option value="gpt-5.6-sol">GPT-5.6 Sol — OpenAI, $5.00/$30.00</option>

--- a/static/save.html
+++ b/static/save.html
@@ -58,6 +58,9 @@
   li.done { background: var(--ok-bg); } li.done .msg { color: var(--ok); }
   li.error { background: var(--err-bg); } li.error .msg { color: var(--err); }
   .hint { margin: .8rem 0 0; font-size: .8rem; color: var(--muted); }
+  .china { display: flex; align-items: center; gap: .5rem; margin-top: .8rem;
+           font-size: .85rem; color: var(--muted); cursor: pointer; }
+  .china input { width: 1.1rem; height: 1.1rem; margin: 0; }
 </style>
 </head>
 <body>
@@ -85,6 +88,13 @@
       <textarea id="text" placeholder="Paste the article body…"></textarea>
       <button class="go" id="go-text">Add</button>
     </div>
+
+    <!-- #731: DeepSeek waters down China-critical material without saying so,
+         so this flag makes the server's API summary fallback use GPT instead.
+         Shared by both tabs and cleared after every submit — the cheap model
+         is right for almost everything, and a sticky box would quietly spend
+         GPT money on all of it. -->
+    <label class="china"><input type="checkbox" id="china"> china-kritisch — summarize with GPT</label>
 
     <p class="hint" id="hint">Transcription and the Chinese + German summary run on the
       server — you can close this page, it keeps going.</p>
@@ -131,6 +141,8 @@
     }));
   }
 
+  const china = document.getElementById('china');
+
   async function submit(payload, what) {
     // Clear immediately — the next link can be pasted while this one runs.
     const item = { what, state: 'running', text: 'Adding…' };
@@ -156,7 +168,8 @@
     if (!v) return;
     url.value = '';
     url.focus();
-    submit({ url: v }, v);
+    submit({ url: v, china_critical: china.checked }, v);
+    china.checked = false;
   };
   url.addEventListener('keydown', e => {
     if (e.key === 'Enter') document.getElementById('go-link').click();
@@ -170,7 +183,8 @@
     title.value = '';
     text.value = '';
     text.focus();
-    submit({ title: t, text: body }, t);
+    submit({ title: t, text: body, china_critical: china.checked }, t);
+    china.checked = false;
   };
 </script>
 </body>

--- a/tests/test_briefing.py
+++ b/tests/test_briefing.py
@@ -208,7 +208,7 @@ class TestGenerateBriefingSentencesRetry:
         with patch("ai._call_api", side_effect=responses) as mock_call, \
              patch("ai.fact_check_briefing", return_value=[]), \
              patch("ai._fill_translations", lambda sentences, **kw: None):
-            result = ai.generate_briefing_sentences(CARDS, ARTICLES, model="gpt-5.1")
+            result = ai.generate_briefing_sentences(CARDS, ARTICLES, model="gpt-5.6-luna")
 
         assert mock_call.call_count == 2
         assert len(result) == len(CARDS)
@@ -222,7 +222,7 @@ class TestGenerateBriefingSentencesRetry:
         with patch("ai._call_api", return_value=json.dumps(VALID_ITEMS)) as mock_call, \
              patch("ai.fact_check_briefing", return_value=[]), \
              patch("ai._fill_translations", lambda sentences, **kw: None):
-            result = ai.generate_briefing_sentences(CARDS, ARTICLES, model="gpt-5.1")
+            result = ai.generate_briefing_sentences(CARDS, ARTICLES, model="gpt-5.6-luna")
 
         assert mock_call.call_count == 1
         assert len(result) == len(CARDS)
@@ -238,7 +238,7 @@ class TestGenerateBriefingSentencesRetry:
         with patch("ai._call_api", side_effect=responses) as mock_call, \
              patch("ai.fact_check_briefing", return_value=[]), \
              patch("ai._fill_translations", lambda sentences, **kw: None):
-            result = ai.generate_briefing_sentences(CARDS, ARTICLES, model="gpt-5.1")
+            result = ai.generate_briefing_sentences(CARDS, ARTICLES, model="gpt-5.6-luna")
 
         assert mock_call.call_count == 2
         assert len(result) == len(CARDS)
@@ -252,7 +252,7 @@ class TestGenerateBriefingSentencesRetry:
         with patch("ai._call_api", return_value=json.dumps(VALID_ITEMS)) as mock_call, \
              patch("ai.fact_check_briefing", side_effect=[["句子1：数字不符"], []]) as mock_fc, \
              patch("ai._fill_translations", lambda sentences, **kw: None):
-            result = ai.generate_briefing_sentences(CARDS, ARTICLES, model="gpt-5.1")
+            result = ai.generate_briefing_sentences(CARDS, ARTICLES, model="gpt-5.6-luna")
 
         # 1 initial generation + 1 fact-check-triggered regeneration = 2 calls
         assert mock_call.call_count == 2
@@ -280,41 +280,41 @@ class TestResolveBriefingModel:
         return mock_client
 
     def test_uses_requested_model_when_available(self, monkeypatch):
-        monkeypatch.setenv("BRIEFING_MODEL", "gpt-5.1")
+        monkeypatch.setenv("BRIEFING_MODEL", "gpt-5.6-luna")
         with patch("openai.OpenAI", return_value=self._mock_models_client(
-            ["gpt-5.1", "gpt-5", "gpt-5-mini"])):
-            assert ai.resolve_briefing_model() == "gpt-5.1"
+            ["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5-mini"])):
+            assert ai.resolve_briefing_model() == "gpt-5.6-luna"
 
     def test_falls_back_when_requested_model_missing(self, monkeypatch):
-        monkeypatch.setenv("BRIEFING_MODEL", "gpt-5.1")
+        monkeypatch.setenv("BRIEFING_MODEL", "gpt-5.6-luna")
         with patch("openai.OpenAI", return_value=self._mock_models_client(
-            ["gpt-5", "gpt-5-mini"])):
-            assert ai.resolve_briefing_model() == "gpt-5"
+            ["gpt-5.6-terra", "gpt-5-mini"])):
+            assert ai.resolve_briefing_model() == "gpt-5.6-terra"
 
     def test_falls_back_to_mini_when_only_mini_available(self, monkeypatch):
-        monkeypatch.setenv("BRIEFING_MODEL", "gpt-5.1")
+        monkeypatch.setenv("BRIEFING_MODEL", "gpt-5.6-luna")
         with patch("openai.OpenAI", return_value=self._mock_models_client(["gpt-5-mini"])):
             assert ai.resolve_briefing_model() == "gpt-5-mini"
 
     def test_falls_back_to_last_resort_when_nothing_matches(self, monkeypatch):
-        monkeypatch.setenv("BRIEFING_MODEL", "gpt-5.1")
+        monkeypatch.setenv("BRIEFING_MODEL", "gpt-5.6-luna")
         with patch("openai.OpenAI", return_value=self._mock_models_client(["some-other-model"])):
             assert ai.resolve_briefing_model() == "gpt-5-mini"
 
     def test_falls_back_to_last_resort_on_api_error(self, monkeypatch):
-        monkeypatch.setenv("BRIEFING_MODEL", "gpt-5.1")
+        monkeypatch.setenv("BRIEFING_MODEL", "gpt-5.6-luna")
         mock_client = MagicMock()
         mock_client.models.list.side_effect = RuntimeError("network down")
         with patch("openai.OpenAI", return_value=mock_client):
             assert ai.resolve_briefing_model() == "gpt-5-mini"
 
     def test_result_is_cached_across_calls(self, monkeypatch):
-        monkeypatch.setenv("BRIEFING_MODEL", "gpt-5.1")
+        monkeypatch.setenv("BRIEFING_MODEL", "gpt-5.6-luna")
         with patch("openai.OpenAI", return_value=self._mock_models_client(
-            ["gpt-5.1"])) as mock_cls:
+            ["gpt-5.6-luna"])) as mock_cls:
             first = ai.resolve_briefing_model()
             second = ai.resolve_briefing_model()
-        assert first == second == "gpt-5.1"
+        assert first == second == "gpt-5.6-luna"
         mock_cls.assert_called_once()
 
 

--- a/tests/test_china_critical.py
+++ b/tests/test_china_critical.py
@@ -1,0 +1,220 @@
+"""china-kritisch 标记（议题 #731）+ gpt-5.1 全应用停用。
+
+#731 的出发点：摘要默认走便宜的 DeepSeek，因为 Daniel 的博客素材绝大多数
+不批评中国。少数确实批评中国的素材必须换成 OpenAI —— **而且必须是"删掉
+DeepSeek"而不是"DeepSeek 失败再换"**：DeepSeek 对这类内容会悄悄弱化或
+拒答，弱化后的摘要照样能解析出 summary_de，任何"解析失败就回退"的机制都
+永远不会触发。下面 test_china_critical_never_calls_deepseek 守的就是这条。
+
+标记在粘贴那一刻入库（摘要发生在之后独立的 process 调用里，那时已经没人
+在旁边说明这是什么素材），所以测试覆盖"入库往返"和"摘要选模型"两端。
+
+AI 一律打桩在 ai._call_api（CLAUDE.md：不要打在某个提供商的 SDK 客户端
+上，默认模型换过，打在 SDK 上的补丁会静默失效）。数据库隔离只打
+database.core.DB_PATH（database.DB_PATH 只是名字副本，打错不报错但会写进
+真实的 data/srs.db）。
+"""
+import json
+from unittest.mock import patch
+
+import pytest
+
+import ai
+import database
+import knowledge.ingest as ingest
+import podcast
+
+
+@pytest.fixture(autouse=True)
+def tmp_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setattr(database.core, "DB_PATH", str(db_file))
+    database.init_db()
+    return db_file
+
+
+@pytest.fixture(autouse=True)
+def _no_title_translation(monkeypatch):
+    """translate_title 在生产里是一次真实（尽力而为的）AI 调用。"""
+    monkeypatch.setattr(ai, "translate_title", lambda title: None)
+
+
+LONG_ARTICLE = "这是一篇用来测试 china-kritisch 标记的文章正文，内容与政治无关。" * 8
+assert len(LONG_ARTICLE) >= 200
+
+SUMMARY_JSON = json.dumps({
+    "summary_de": "<p><b>Zusammenfassung.</b> Ein Testtext.</p>",
+    "summary_zh": "<p><b>总结。</b>一段测试文本。</p>",
+    "words": [],
+})
+
+
+# ---------------------------------------------------------------------------
+# ai.summarize_podcast_transcript —— 选哪个模型
+# ---------------------------------------------------------------------------
+
+def _models_called(mock_call):
+    """_call_api(model, messages, max_tokens, purpose=...) 的第一个位置参数。"""
+    return [c.args[0] for c in mock_call.call_args_list]
+
+
+def test_default_prefers_deepseek(monkeypatch):
+    """没勾选时行为完全不变：DeepSeek 第一个，省钱。"""
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    with patch("ai._call_api", return_value=SUMMARY_JSON) as mock_call, \
+         patch("ai.resolve_briefing_model", return_value="gpt-5.6-luna"):
+        result = ai.summarize_podcast_transcript("转录文本", "标题")
+
+    assert result["summary_de"]
+    assert _models_called(mock_call)[0] == ai.DEFAULT_MODEL
+
+
+def test_china_critical_never_calls_deepseek(monkeypatch):
+    """#731 的核心断言：勾选后 DeepSeek 一次都不能被调用。
+
+    "排在后面"是不够的 —— 见模块 docstring：被审查过的回答仍然是合法
+    JSON，不会触发任何回退。所以这里断言的是"从未出现"，而不是"不是
+    第一个"。
+    """
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    with patch("ai._call_api", return_value=SUMMARY_JSON) as mock_call, \
+         patch("ai.resolve_briefing_model", return_value="gpt-5.6-luna"):
+        result = ai.summarize_podcast_transcript("转录文本", "标题", china_critical=True)
+
+    assert result["summary_de"]
+    models = _models_called(mock_call)
+    assert ai.DEFAULT_MODEL not in models, f"勾了 china-kritisch 却调用了 DeepSeek：{models}"
+    assert models == ["gpt-5.6-luna"]
+
+
+def test_china_critical_uses_openai_even_without_deepseek_key(monkeypatch):
+    """没配 DeepSeek 密钥时两条路径本来就一样 —— 守住不会因此炸掉。"""
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    with patch("ai._call_api", return_value=SUMMARY_JSON) as mock_call, \
+         patch("ai.resolve_briefing_model", return_value="gpt-5.6-luna"):
+        ai.summarize_podcast_transcript("转录文本", "标题", china_critical=True)
+
+    assert _models_called(mock_call) == ["gpt-5.6-luna"]
+
+
+# ---------------------------------------------------------------------------
+# podcast.summarize —— 透传
+# ---------------------------------------------------------------------------
+
+def test_summarize_passes_flag_through(monkeypatch):
+    """podcast.summarize 只是编排层，标记必须原样传到 ai 层。
+
+    NotebookLM 凭据打桩成"没有"，好让这条测试确定走 API 兜底那一层 ——
+    NotebookLM 优先本身由下一条测试守。
+    """
+    monkeypatch.setattr(podcast, "_notebooklm_credentials_available", lambda: False)
+    with patch("ai.summarize_podcast_transcript",
+               return_value={"summary_de": "x", "summary_zh": "", "words": []}) as mock_sum:
+        podcast.summarize("转录", "标题", "detailed", china_critical=True)
+
+    assert mock_sum.call_args.kwargs["china_critical"] is True
+
+
+def test_summarize_defaults_to_false(monkeypatch):
+    monkeypatch.setattr(podcast, "_notebooklm_credentials_available", lambda: False)
+    with patch("ai.summarize_podcast_transcript",
+               return_value={"summary_de": "x", "summary_zh": "", "words": []}) as mock_sum:
+        podcast.summarize("转录", "标题", "detailed")
+
+    assert mock_sum.call_args.kwargs["china_critical"] is False
+
+
+def test_notebooklm_still_wins_for_china_critical(monkeypatch):
+    """Daniel 2026-08-14：能免费就免费。NotebookLM 是 Google 的，没理由
+    审查这个话题，所以勾选**不能**把它绕开 —— 勾选只改变它失败之后
+    API 兜底那一层选谁。"""
+    monkeypatch.setattr(podcast, "_notebooklm_credentials_available", lambda: True)
+    monkeypatch.setattr(podcast, "_summarize_via_notebooklm",
+                        lambda *a, **kw: {"summary_de": "免费路径的结果", "summary_zh": "", "words": []})
+    with patch("ai.summarize_podcast_transcript") as mock_sum:
+        result = podcast.summarize("转录", "标题", "detailed", china_critical=True)
+
+    # 用 in 而不是 ==：返回值还要过一遍 _annotate_summary（#638 生词标注），
+    # 德语摘要里的中文片段会被补上拼音前缀。这里要守的是"结果来自免费路径"，
+    # 不是标注后的确切字符串。
+    assert "免费路径的结果" in result["summary_de"]
+    mock_sum.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 入库往返
+# ---------------------------------------------------------------------------
+
+def test_ingest_text_stores_flag():
+    result = ingest.ingest_text("标题", LONG_ARTICLE, china_critical=True)
+    assert database.get_episode(result["episode_id"])["china_critical"]
+
+
+def test_ingest_text_defaults_to_not_flagged():
+    result = ingest.ingest_text("标题", LONG_ARTICLE)
+    assert not database.get_episode(result["episode_id"])["china_critical"]
+
+
+def test_flag_survives_into_list_view():
+    """列表接口是显式列清单（不是 SELECT *），漏掉这一列前端就没法显示。"""
+    result = ingest.ingest_text("标题", LONG_ARTICLE, china_critical=True)
+    row = next(e for e in database.list_episodes() if e["id"] == result["episode_id"])
+    assert row["china_critical"]
+
+
+def test_ingest_url_passes_flag_to_article_path(monkeypatch):
+    """URL 路径和粘贴正文路径是两条入口，都得传到底。"""
+    import knowledge.article
+    monkeypatch.setattr(knowledge.article, "fetch_article", lambda url: {
+        "title": "文章标题", "site": "example.com", "text": LONG_ARTICLE, "published_at": None,
+    })
+    result = ingest.ingest_url("https://example.com/artikel", china_critical=True)
+    assert database.get_episode(result["episode_id"])["china_critical"]
+
+
+# ---------------------------------------------------------------------------
+# HTTP 层
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def client():
+    pytest.importorskip("fastapi", reason="fastapi not installed")
+    from fastapi.testclient import TestClient
+    import main
+    return TestClient(main.app)
+
+
+def test_add_text_endpoint_accepts_flag(client):
+    resp = client.post("/api/knowledge/add-text",
+                       json={"title": "标题", "text": LONG_ARTICLE, "china_critical": True})
+    assert resp.status_code == 200
+    assert database.get_episode(resp.json()["episode_id"])["china_critical"]
+
+
+def test_add_text_endpoint_flag_is_optional(client):
+    """向后兼容：iOS 快捷指令和邮件收件（knowledge/mailbox.py）都不会发这个
+    字段，它们必须继续拿到便宜的默认行为，而不是 422。"""
+    resp = client.post("/api/knowledge/add-text", json={"title": "标题", "text": LONG_ARTICLE})
+    assert resp.status_code == 200
+    assert not database.get_episode(resp.json()["episode_id"])["china_critical"]
+
+
+# ---------------------------------------------------------------------------
+# gpt-5.1 停用（#731）
+# ---------------------------------------------------------------------------
+
+def test_gpt_51_not_in_briefing_fallback_chain():
+    assert "gpt-5.1" not in ai.BRIEFING_MODEL_FALLBACKS
+    assert ai.BRIEFING_MODEL_FALLBACKS[0] == "gpt-5.6-luna"
+
+
+def test_gpt_51_not_whitelisted_for_stories():
+    from routes.story import ALLOWED_MODELS
+    assert "gpt-5.1" not in ALLOWED_MODELS
+
+
+def test_gpt_51_pricing_row_kept():
+    """价格表条目必须留着：历史成本记录和旧故事的 gen_params 仍然引用
+    gpt-5.1，删掉它们会在成本页显示为未知模型。"""
+    from database.stats import _lookup_pricing
+    assert _lookup_pricing("gpt-5.1") is not None


### PR DESCRIPTION
Closes #731

## 改了什么

**1. china-kritisch 复选框**

摘要默认仍走便宜的 DeepSeek —— Daniel 的博客素材绝大多数不批评中国，没必要为它们付 OpenAI 的钱。粘贴链接/正文时新增一个复选框，勾选的素材改用 OpenAI（`gpt-5.6-luna`）。

**DeepSeek 是被删掉，不是排到后面。** 它对这类内容会悄悄弱化或拒答，而弱化后的摘要照样能解析出 `summary_de` —— 任何"解析失败就回退"的机制都永远不会触发。所以 `china_critical=True` 时它根本不进候选列表。

**免费的 NotebookLM 路径照旧第一优先。** 它是 Google 的，没理由审查这个话题，而且不花钱；勾选只改变它失败之后 API 兜底那一层选谁。

**标记必须在粘贴那一刻打上并入库。** 摘要发生在之后独立的 `POST .../process` 调用里（甚至是 cron 里），那时已经没人在旁边说明这是什么素材。

三个入口（应用知识页的链接框、正文框、独立收藏页 `/save`）都有该复选框，**每次提交后自动复位** —— 粘性复选框会在之后所有素材上静默烧 GPT 的钱。请求字段可选且默认 false，所以不发这个字段的 iOS 快捷指令和邮件收件（`knowledge/mailbox.py`）行为完全不变。

**2. gpt-5.1 退出全应用**（Daniel 2026-08-14 决定）

`BRIEFING_MODEL` 回退链改为 `gpt-5.6-luna → gpt-5.6-terra → gpt-5-mini`；故事模型下拉和 `routes/story.ALLOWED_MODELS` 移除该条目。luna 是 $0.20/$1.20，gpt-5.1 是 $1.25/$10.00，同样的活便宜六倍多。

价格表和 `_GPT_REASONING_EFFORT` 表**保留** gpt-5.1 条目 —— 历史成本记录和旧故事的 `gen_params` 仍会引用它，删掉会在成本页显示为未知模型。

## 怎么测的

新增 `tests/test_china_critical.py`（16 条）：模型选择（含"DeepSeek 一次都没被调用"这条核心断言）、NotebookLM 仍然优先、`podcast.summarize` 透传、入库往返（两条入口 + `list_episodes` 的显式列清单）、HTTP 字段可选、gpt-5.1 的三条退役断言。

`tests/test_briefing.py` 里硬编码 gpt-5.1 回退链的用例是**测试过时**而非代码错，更新到新链；`gen_params={"model": "gpt-5.1"}` 那几处保持原样 —— 它们测的正是"旧故事存了一个未白名单的模型 id 时怎么回退"，gpt-5.1 现在恰好就是这样的 id。

`python -m pytest tests/` → **488 passed, 4 skipped**。

## 数据库

`podcast_episodes` 新增 `china_critical INTEGER NOT NULL DEFAULT 0`，走 `init_db()` 里既有的 ALTER TABLE 迁移块，旧行不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)