### PR TITLE
修复：复习中保存牌组设置后被跳回主页（#738）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -4611,7 +4611,11 @@ async function saveOptions() {
       }
     }));
     closeModal();
-    loadDecks();
+    // Options can be opened mid-review (the `o` shortcut), and loadDecks()
+    // would otherwise showView('decks') and throw the session away. Refresh
+    // the deck tree in the background instead — the backend already
+    // invalidated the queue, so the rebuilt one picks up the new settings.
+    loadDecks({ keepView: _currentView !== 'decks' });
   } catch (e) {
     showError('Save failed: ' + e.message);
   }


### PR DESCRIPTION
## 改了什么

`static/app.js` 的 `saveOptions()`：结尾的 `loadDecks()` 改为 `loadDecks({ keepView: _currentView !== 'decks' })`。

## 为什么

复习时按 `o` 打开牌组设置，改完点 Save 后界面直接跳回主页，复习被中断。原因是 `loadDecks()` 默认执行 `showView('decks')`。该函数早有 `keepView` 选项（加词后台刷新用的），这条路径没用上。

后端 `PUT /api/decks/{id}/preset` 已经 `queue_mgr.invalidate()`，队列会按新设置重建，所以留在复习界面继续作答是安全的。

## 怎么测试

- 复习中按 `o` → 改设置 → Save → 停留在复习界面，可继续作答
- 主页点 ⚙ → Save → 牌组树照常刷新（行为不变）

Closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)