### PR TITLE
修复：知识库故事生成时 AI 回复被截断导致整轮句子作废（#743）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -168,6 +168,12 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str,
         cached_tokens = getattr(msg.usage, "cache_read_input_tokens", 0) or 0
         logger.info("[%s] API call done in %.1fs — in=%d out=%d cached=%d purpose=%s",
                     model, elapsed, msg.usage.input_tokens, msg.usage.output_tokens, cached_tokens, purpose)
+        if getattr(msg, "stop_reason", None) == "max_tokens":
+            # #743: caller-side JSON salvage relies on knowing when a reply was
+            # cut off — this is the signal, not an exception.
+            logger.warning("[%s] response truncated (stop_reason=max_tokens, max_tokens=%d, "
+                           "output_tokens=%d, purpose=%s)", model, max_tokens,
+                           msg.usage.output_tokens, purpose)
         text = msg.content[0].text.strip()
         database.log_api_call(
             # Log the requested model id, not msg.model (the API returns a dated
@@ -256,8 +262,12 @@ def _call_api(model: str, messages: list, max_tokens: int, purpose: str,
                     model, max_tokens, reasoning_chars,
                 )
             else:
+                # #743: this is the signal callers (e.g. generate_podcast_sentences'
+                # JSON salvage) rely on to know a reply was cut off mid-content.
                 logger.warning("[%s] response truncated (finish_reason=length, max_tokens=%d, "
-                               "content_chars=%d)", model, max_tokens, len(content or ""))
+                               "completion_tokens=%d, content_chars=%d, purpose=%s)",
+                               model, max_tokens, resp.usage.completion_tokens,
+                               len(content or ""), purpose)
 
         if not content and not reasoning:
             logger.warning("[%s] empty response — no content and no reasoning (purpose=%s)",
@@ -2445,6 +2455,79 @@ def generate_briefing_sentences(
     return sentences
 
 
+def _parse_json_array_salvage(raw: str) -> tuple[list, bool]:
+    """从 AI 回复里解析 JSON 对象数组；数组被截断时救回其中完整的对象。
+
+    返回 (items, truncated)。truncated=True 表示整体解析失败、结果是逐个对象
+    扫描救回来的。#743：一次 154 个词的调用正好用满输出预算，回复在数组中间
+    断掉，原来整轮作废，几十句已经写好的句子和已经花掉的钱一起丢了。
+    """
+    json_start = raw.find("[")
+    if json_start == -1:
+        return [], True
+
+    json_end = raw.rfind("]") + 1
+    if json_end != 0:
+        try:
+            items = json.loads(raw[json_start:json_end])
+            if isinstance(items, list):
+                return items, False
+        except json.JSONDecodeError:
+            pass
+
+    # 括号深度扫描，逐个切出顶层 {...} 片段——必须正确处理字符串内的
+    # 花括号/引号（句子里可能出现 { } "），否则切割点会错位。
+    items = []
+    depth = 0
+    in_string = False
+    escape = False
+    obj_start = None
+    for i in range(json_start + 1, len(raw)):
+        ch = raw[i]
+        if obj_start is None:
+            if ch == "{":
+                obj_start = i
+                depth = 1
+                in_string = False
+                escape = False
+            continue
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    obj = json.loads(raw[obj_start:i + 1])
+                    if isinstance(obj, dict):
+                        items.append(obj)
+                except json.JSONDecodeError:
+                    pass
+                obj_start = None
+    return items, True
+
+
+def _podcast_max_tokens(model: str, n_words: int) -> int:
+    """#743：写死 8192 时 154 个词的一次性调用根本装不下（每句约需
+    150-200 tokens 用于 reasoning_zh + sentence_zh + target_word），回复在数组
+    中间被截断。按批次词数估算预算，按模型族封顶——gpt-5 系列的输出预算与内部
+    reasoning tokens 共享，给它更大的上限；deepseek/glm/qwen/claude 的单次
+    输出上限就在 8192 量级，写更大会被 provider 拒绝。
+    """
+    needed = 1500 + 200 * n_words
+    cap = 16384 if model.startswith("gpt-") else 8192
+    return max(4096, min(needed, cap))
+
+
 def generate_podcast_sentences(
     cards: list[dict],
     material: str,            # transcript_zh (preferred) or summary_de fallback; caller ensures non-empty — see routes/story.py's _knowledge_material()
@@ -2527,24 +2610,22 @@ def generate_podcast_sentences(
 
     def _run_round(batch: list[dict], extra_hint: str, label: str) -> None:
         """One AI call for `batch`; moves every word it covered out of `remaining`."""
-        # 8192: all-at-once batching (issue #563) can mean 30+ sentences in one
-        # response, and the gpt-5 series shares this budget with internal
-        # reasoning tokens (same rationale as the briefing call).
+        # #743: all-at-once batching (issue #563) can mean 30+ sentences in one
+        # response — a fixed 8192 cap left no room for that many, so the model's
+        # reply got cut off mid-array and the whole round used to be discarded.
+        # Budget scales with batch size (see _podcast_max_tokens); the gpt-5
+        # series shares this budget with internal reasoning tokens.
         prompt = _build_prompt(batch, extra_hint)
         prompts_sent.append(f"── {label} ──\n{prompt}" if prompts_sent else prompt)
         raw = _call_api(model, [{"role": "user", "content": prompt}],
-                         8192, purpose="podcast")
+                         _podcast_max_tokens(model, len(batch)), purpose="podcast")
 
-        json_start = raw.find("[")
-        json_end = raw.rfind("]") + 1
-        if json_start == -1 or json_end == 0:
-            log_progress(progress_key, f"{label}：AI 回复里找不到 JSON 数组，本轮作废")
+        items, truncated = _parse_json_array_salvage(raw)
+        if not items:
+            log_progress(progress_key, f"{label}：AI 回复无法解析，本轮作废")
             return
-        try:
-            items = json.loads(raw[json_start:json_end])
-        except json.JSONDecodeError as e:
-            log_progress(progress_key, f"{label}：JSON 解析失败（{e}），本轮作废")
-            return
+        if truncated:
+            log_progress(progress_key, f"{label}：AI 回复被截断，救回 {len(items)} 条")
 
         # Scan in order: not trusting the AI's target_word tag, only the actual
         # sentence content counts (same approach as briefing).

--- a/tests/test_podcast_sentences.py
+++ b/tests/test_podcast_sentences.py
@@ -133,3 +133,94 @@ def test_no_material_returns_empty_prompt(monkeypatch):
                         lambda *a, **kw: pytest.fail("素材为空时不该调 AI"))
     sentences, prompt = ai.generate_podcast_sentences(CARDS, "   ", "标题")
     assert sentences == [] and prompt == ""
+
+
+# ── #743: 截断 JSON 救回 ────────────────────────────────────────────────────
+
+def test_salvage_parses_complete_array():
+    raw = json.dumps([
+        {"sentence_zh": "第一句。"},
+        {"sentence_zh": "第二句。"},
+    ], ensure_ascii=False)
+    items, truncated = ai._parse_json_array_salvage(raw)
+    assert truncated is False
+    assert [i["sentence_zh"] for i in items] == ["第一句。", "第二句。"]
+
+
+def test_salvage_recovers_truncated_array():
+    """一个 3 元素数组的字符串，从中间某处砍掉——只留前两个完整对象。"""
+    full = json.dumps([
+        {"sentence_zh": "第一句。"},
+        {"sentence_zh": "第二句。"},
+        {"sentence_zh": "第三句，这句被砍掉了。"},
+    ], ensure_ascii=False)
+    # 砍在第三个对象的开头之后、闭合花括号之前——模拟 max_tokens 截断。
+    cut_at = full.rfind('"sentence_zh"')
+    truncated_raw = full[:cut_at] + '"sentence_zh": "第三句，这句'
+
+    items, truncated = ai._parse_json_array_salvage(truncated_raw)
+    assert truncated is True
+    assert len(items) == 2
+    assert [i["sentence_zh"] for i in items] == ["第一句。", "第二句。"]
+
+
+def test_salvage_handles_braces_and_quotes_in_content():
+    """句子内容里含 { } " 转义时不会解析错位。"""
+    raw = json.dumps([
+        {"sentence_zh": '他说："这个{词}很难"，然后笑了。'},
+        {"sentence_zh": "第二句正常。"},
+    ], ensure_ascii=False)
+    items, truncated = ai._parse_json_array_salvage(raw)
+    assert truncated is False
+    assert items[0]["sentence_zh"] == '他说："这个{词}很难"，然后笑了。'
+    assert items[1]["sentence_zh"] == "第二句正常。"
+
+
+def test_salvage_with_braces_and_quotes_when_truncated():
+    """截断场景下同样要正确跳过字符串内的花括号/引号，不能在里面误判对象结束。"""
+    full = json.dumps([
+        {"sentence_zh": '他说："这个{词}很难"，然后笑了。'},
+        {"sentence_zh": "第二句正常。"},
+        {"sentence_zh": "第三句被砍掉。"},
+    ], ensure_ascii=False)
+    cut_at = full.rfind('"sentence_zh"')
+    truncated_raw = full[:cut_at] + '"sentence_zh": "第三句被'
+
+    items, truncated = ai._parse_json_array_salvage(truncated_raw)
+    assert truncated is True
+    assert len(items) == 2
+    assert items[0]["sentence_zh"] == '他说："这个{词}很难"，然后笑了。'
+    assert items[1]["sentence_zh"] == "第二句正常。"
+
+
+def test_end_to_end_truncated_reply_still_yields_sentences(monkeypatch):
+    """原来：截断的一轮整轮作废，句子数为 0。现在：救回完整的那几条。"""
+    full = json.dumps([
+        {"sentence_zh": "张一鸣承认公司暂时落后。"},
+        {"sentence_zh": "他在抖音上刷视频，顺便就下了单。"},
+    ], ensure_ascii=False)
+    cut_at = full.rfind("]")
+    truncated_raw = full[:cut_at]  # 砍掉收尾的 ]
+
+    def fake_call(model, messages, *a, **kw):
+        return truncated_raw
+
+    monkeypatch.setattr(ai, "_call_api", fake_call)
+    sentences, prompt = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
+
+    assert len(sentences) > 0
+    assert not all("我学了" in s["sentence_zh"] for s in sentences)
+
+
+# ── #743: 输出预算按词数计算 ─────────────────────────────────────────────────
+
+def test_max_tokens_floor_for_small_batch():
+    assert ai._podcast_max_tokens("deepseek-v4-flash", 1) == 4096
+
+
+def test_max_tokens_caps_at_gpt_ceiling_for_large_batch():
+    assert ai._podcast_max_tokens("gpt-5.6-luna", 154) == 16384
+
+
+def test_max_tokens_caps_at_non_gpt_ceiling_for_large_batch():
+    assert ai._podcast_max_tokens("deepseek-v4-flash", 154) == 8192


### PR DESCRIPTION
Closes #743

## 问题

生产环境生成 knowledge 故事时进度日志显示：

```
开始生成播客句子：154 个词，模型 gpt-5.6-luna
第1轮：AI 回复里找不到 JSON 数组，本轮作废
```

## 根因（生产库查实）

- 故事 2158 的 `gen_params` 里 `batch_size: 200`，154 个词进了同一次 AI 调用。
- 对应的 `api_call_log`（id 4175/4176/4177/4181）`output_tokens` **正好都是 8192** —— 撞到 `_run_round` 里写死的输出上限，回复在 JSON 数组中间被截断，末尾没有 `]`。
- `_run_round` 只认完整数组，`rfind("]")` 找不到就 `return`。那次回复有 22057 个字符、几十句已经写好的句子，连同已经花掉的钱一起被丢弃。

## 改了什么

1. **`ai._parse_json_array_salvage(raw) -> (items, truncated)`**：先按老路整体 `json.loads`；失败时做括号深度扫描，逐个切出顶层 `{...}` 并单独解析，能救几句救几句。扫描维护 `in_string`/`escape` 状态，句子里出现 `{`、`}`、`"` 不会让切割点错位。
2. **`ai._podcast_max_tokens(model, n_words)`**：输出预算不再写死 —— `1500 + 200 × 词数`，下限 4096，`gpt-` 系列封顶 16384（预算与内部 reasoning tokens 共享），其余 provider 封顶 8192（再大会被拒）。
3. **`_run_round`** 改用上面两个函数：解析不出任何东西才记"本轮作废"；救回的情况记 `第N轮：AI 回复被截断，救回 M 条`，然后照常走原有的匹配逻辑，剩下的词交给既有的补漏轮。
4. **`_call_api`** 收到 `stop_reason=max_tokens`（Anthropic）/ `finish_reason=length`（OpenAI 系）时记 warning，含 model、purpose、max_tokens、输出 token 数 —— 截断不再无声无息。

## 怎么测的

`tests/test_podcast_sentences.py` 新增 7 条：完整数组解析、截断数组救回、内容含 `{}`/引号转义（截断与未截断两种）、端到端（打桩 `ai._call_api` 返回截断字符串，断言句子数 > 0 且不全是兜底句），以及 `_podcast_max_tokens` 的三个边界。

`pytest tests/` → **500 passed, 4 skipped**。

## 注意

`batch_size=200` 这个设置本身修完能用，但一次塞一百多个词会明显拉低模型对提示词规则（每句必须带素材里的专有名词、话题覆盖）的遵守度 —— `MAX_PODCAST_BATCH = 20` 就是这个理由。建议之后把设置弹窗里的「每次调用词数」调回空（默认）。