### PR TITLE
新功能：应用内 AI 词典页 /dict（#746）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -1254,6 +1254,157 @@ def generate_word_entry_yaml(word_zh: str, model: str = DEFAULT_MODEL,
     return f"lang: {lang}\nentries:\n" + textwrap.indent(entry, "  ")
 
 
+DICTIONARY_PROMPT = """You are a Chinese dictionary for a German-speaking learner (Daniel, HSK 4-5).
+He types a word, phrase, or sentence in Chinese, German, or English and wants a
+structured lookup, not a chat reply. Never use Japanese.
+
+Behavior rules:
+- Chinese input -> give the FULL dictionary entry directly. List EVERY sense
+  (meaning) of the word/phrase, each as its own group. Do not ask him to
+  choose anything and do not present alternative translations to pick from
+  — there is nothing to choose, he already has the Chinese word.
+- German or English input (word, phrase, or a full sentence) -> always give an
+  ANALYSIS: an overall translation plus one or more groups of candidate
+  Chinese translations, each option labeled a/b/c... (NEVER use 1/2/3).
+  Exactly one option per group may be "recommended": true, and the
+  recommendation should lean toward spoken/colloquial Chinese (kǒuyǔ) — this
+  is Daniel's strongest, most repeated preference.
+- A full German sentence as input -> first give the whole-sentence Chinese
+  translation + pinyin (the "sentence" field), THEN break the sentence into
+  its components (each a candidate group of its own) so every component is
+  individually addable as a word.
+- Explanations, usage notes, and example sentence translations are always in
+  GERMAN. A French equivalent may optionally be added to a single-word option
+  (the "fr" field) — never for phrases or sentences.
+
+Quality rules (these decide whether the entry is useful at all):
+- At most 3-5 options per group, and only GENUINELY DIFFERENT translations —
+  different register, connotation, or part of speech. Do not pad a group with
+  near-synonyms; two options that a learner would use interchangeably are one
+  option.
+- EVERY option must carry example_zh + example_pinyin + example_de. An option
+  without an example is unusable: register claims are only believable when the
+  sentence shows them.
+- "usage" must say WHEN to use it (register, context, connotation), not repeat
+  the translation.
+- Pinyin always with tone marks (pài, not pai4 or pai).
+- "register" must be one of: spoken_colloquial, spoken_neutral, neutral,
+  formal_written, literary, slang.
+- For Chinese input, "headline" is the input word itself and each group's
+  "label" names one sense in German (e.g. "1. Ökologie (Biologie)").
+- "kind" is exactly one of: "chinese" (any Chinese input), "word",
+  "phrase", "sentence" (German/English input, by length). Only "sentence"
+  makes the "sentence" field appear.
+
+Output ONLY raw JSON — no markdown code fence, no prose before or after it.
+Match this shape exactly (omit "sentence" unless kind == "sentence"; "fr" is
+optional; every group needs at least one option; option "key" values are
+a/b/c... never digits):
+
+{{
+  "input_lang": "de",
+  "kind": "phrase",
+  "headline": "派任务",
+  "headline_pinyin": "pài rènwu",
+  "headline_de": "jemandem eine Aufgabe geben",
+  "notes": "kurze deutsche Anmerkung, optional",
+  "sentence": {{
+    "zh": "你下周什么时候有空？",
+    "pinyin": "Nǐ xià zhōu shénme shíhou yǒu kòng?",
+    "de": "Wann hast du nächste Woche Zeit?"
+  }},
+  "groups": [
+    {{
+      "label": "setzen / assign (Verb)",
+      "options": [
+        {{
+          "key": "a",
+          "zh": "派",
+          "pinyin": "pài",
+          "de": "beauftragen, jdm. eine Aufgabe geben",
+          "fr": "assigner",
+          "usage": "sehr umgangssprachlich, im Alltag am natürlichsten.",
+          "register": "spoken_colloquial",
+          "recommended": true,
+          "example_zh": "老师又给我派任务了。",
+          "example_pinyin": "Lǎoshī yòu gěi wǒ pài rènwu le.",
+          "example_de": "Der Lehrer hat mir schon wieder eine Aufgabe gegeben."
+        }}
+      ]
+    }}
+  ]
+}}
+
+Input to look up: {query}"""
+
+
+def _strip_code_fence(raw: str) -> str:
+    """Some models wrap JSON in ```json ... ``` despite being told not to."""
+    fenced = re.search(r"```(?:json)?\s*\n(.*?)```", raw, re.DOTALL)
+    return fenced.group(1) if fenced else raw
+
+
+def dictionary_lookup(query: str, lang: str = "zh", model: str | None = None) -> tuple[dict, str]:
+    """Look up a word/phrase/sentence for the /dict page (#746).
+
+    Returns (parsed result dict, model actually used). Raises ValueError if
+    the model's response doesn't parse into the expected shape — callers must
+    not store or return a placeholder, since a blank dictionary entry is worse
+    than an error (routes/dictionary.py turns this into a 500).
+
+    lang is the target vocabulary language. Only Chinese is implemented — a
+    French dictionary needs its own prompt (see the de-fr-bot skill), and
+    silently answering a French request with the Chinese prompt would produce
+    a plausible-looking but wrong entry, exactly the failure #726 guarded
+    against on the add-word side.
+    """
+    if lang != "zh":
+        raise ValueError(f"dictionary_lookup: language {lang!r} is not supported yet (only 'zh')")
+    use_model = model or DEFAULT_MODEL
+    prompt = DICTIONARY_PROMPT.format(query=query)
+
+    logger.info("[%s] dictionary_lookup: %s", use_model, query)
+    raw = _call_api(use_model, [{"role": "user", "content": prompt}], max_tokens=4000,
+                    purpose="dictionary", thinking=False)
+
+    stripped = _strip_code_fence(raw).strip()
+    try:
+        result = json.loads(stripped)
+    except json.JSONDecodeError as e:
+        raise ValueError(
+            f"dictionary_lookup: could not parse AI response as JSON: {e}. "
+            f"Raw response (first 500 chars): {raw[:500]!r}"
+        )
+
+    if not isinstance(result, dict):
+        raise ValueError(
+            f"dictionary_lookup: expected a JSON object, got {type(result).__name__}. "
+            f"Raw response (first 500 chars): {raw[:500]!r}"
+        )
+
+    groups = result.get("groups")
+    if not isinstance(groups, list):
+        raise ValueError(
+            f"dictionary_lookup: 'groups' missing or not a list. "
+            f"Raw response (first 500 chars): {raw[:500]!r}"
+        )
+    for group in groups:
+        options = group.get("options") if isinstance(group, dict) else None
+        if not isinstance(options, list) or not options:
+            raise ValueError(
+                f"dictionary_lookup: a group is missing non-empty 'options'. "
+                f"Raw response (first 500 chars): {raw[:500]!r}"
+            )
+        for option in options:
+            if not isinstance(option, dict) or not option.get("zh"):
+                raise ValueError(
+                    f"dictionary_lookup: an option is missing non-empty 'zh'. "
+                    f"Raw response (first 500 chars): {raw[:500]!r}"
+                )
+
+    return result, use_model
+
+
 def generate_character_info(char: str, pinyin: str, model: str = DEFAULT_MODEL) -> dict:
     """
     Generate etymology and translation for a single Chinese character.

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -8,3 +8,4 @@ from .stories import *
 from .stats import *
 from .podcast import *
 from .prompts import *
+from .dictionary import *

--- a/database/dictionary.py
+++ b/database/dictionary.py
@@ -1,0 +1,72 @@
+"""In-app AI dictionary storage (#746): every lookup's full structured result
+is saved so the /dict page can show a searchable history below the query
+box. All SQL for this feature lives here — routes/dictionary.py only calls
+into this module.
+"""
+from .core import get_db
+
+
+def save_dict_query(
+    query: str,
+    lang: str,
+    input_lang: str | None,
+    kind: str | None,
+    headline: str | None,
+    result_json: str,
+    model: str | None,
+) -> int:
+    """Insert a completed lookup and return its new row id."""
+    conn = get_db()
+    cur = conn.execute(
+        """INSERT INTO dict_queries (query, lang, input_lang, kind, headline, result_json, model)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        (query, lang, input_lang, kind, headline, result_json, model),
+    )
+    conn.commit()
+    new_id = cur.lastrowid
+    conn.close()
+    return new_id
+
+
+def get_dict_query(qid: int) -> dict | None:
+    """Full row for one lookup, including the raw result_json string — the
+    caller (routes/dictionary.py) is responsible for json.loads-ing it."""
+    conn = get_db()
+    row = conn.execute("SELECT * FROM dict_queries WHERE id = ?", (qid,)).fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def list_dict_queries(q: str | None = None, limit: int = 50) -> list[dict]:
+    """History list: only the columns the list view needs (not result_json —
+    parsing 50 JSON blobs just to show a headline would be wasteful, which is
+    why headline is denormalized onto the row at save time)."""
+    conn = get_db()
+    if q:
+        like = f"%{q}%"
+        rows = conn.execute(
+            """SELECT id, query, input_lang, kind, headline, created_at
+               FROM dict_queries
+               WHERE query LIKE ? OR headline LIKE ?
+               ORDER BY created_at DESC LIMIT ?""",
+            (like, like, limit),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            """SELECT id, query, input_lang, kind, headline, created_at
+               FROM dict_queries ORDER BY created_at DESC LIMIT ?""",
+            (limit,),
+        ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def delete_dict_query(qid: int) -> bool:
+    """Returns whether a row was actually deleted, so the route can report a
+    404 instead of pretending success on an id that never existed."""
+    conn = get_db()
+    cur = conn.execute("DELETE FROM dict_queries WHERE id = ?", (qid,))
+    conn.commit()
+    deleted = cur.rowcount > 0
+    conn.close()
+    return deleted

--- a/main.py
+++ b/main.py
@@ -199,7 +199,7 @@ try:
     import uvicorn
 
     from offline import LOCAL_MODE, OFFLINE_MODE
-    from routes import decks, review, story, browse, imports, podcast as podcast_routes, knowledge as knowledge_routes
+    from routes import decks, review, story, browse, imports, podcast as podcast_routes, knowledge as knowledge_routes, dictionary as dictionary_routes
 
     @asynccontextmanager
     async def lifespan(app):
@@ -446,6 +446,18 @@ try:
             "Expires": "0",
         })
 
+    # Standalone AI dictionary page (#746): the /add counterpart for lookups —
+    # type a word/phrase/sentence and get a structured, option-by-option
+    # translation with a one-tap add into ★ List. Same "no app.js" reasoning
+    # as /add and /save: bookmarkable/home-screen, opens fast.
+    @app.get("/dict")
+    def dictionary_page():
+        return FileResponse("static/dict.html", headers={
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            "Pragma": "no-cache",
+            "Expires": "0",
+        })
+
     # Bookmarkable knowledge-base tab links (#704): /knowledge/videos is the
     # browsing counterpart to /add and /save — a clean URL for the iPhone home
     # screen that lands on one sub-tab. Unlike those two this is *not* a
@@ -506,6 +518,7 @@ try:
     app.include_router(imports.router)
     app.include_router(podcast_routes.router)
     app.include_router(knowledge_routes.router)
+    app.include_router(dictionary_routes.router)
     # Sync only makes sense on a laptop copy — on the server these routes must
     # not exist at all, or a stray call would overwrite production (#625).
     if LOCAL_MODE or OFFLINE_MODE:

--- a/routes/dictionary.py
+++ b/routes/dictionary.py
@@ -1,0 +1,88 @@
+"""In-app AI dictionary API (#746): a single-turn structured lookup that
+replaces pasting words into a chat AI and copying the answer by hand. Every
+result is stored (database/dictionary.py) so the /dict page can show a
+searchable history. Adding a word from a result goes through the existing
+POST /api/add-word-ai — this router never touches cards/entries directly
+(#643's "one add pipeline" rule).
+"""
+import json
+import logging
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+import ai
+import database
+from routes.utils import ai_disabled
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+class DictLookupRequest(BaseModel):
+    query: str
+    lang: str = "zh"
+    model: str | None = None
+
+
+def _row_to_result(row: dict) -> dict:
+    """Shape shared by POST /lookup and GET /history/{id}: the stored row
+    plus the parsed JSON blob under "result"."""
+    return {
+        "id": row["id"],
+        "created_at": row["created_at"],
+        "query": row["query"],
+        "result": json.loads(row["result_json"]),
+    }
+
+
+@router.post("/api/dict/lookup")
+def lookup(body: DictLookupRequest):
+    query = (body.query or "").strip()
+    if not query:
+        raise HTTPException(400, "query required")
+    if ai_disabled():
+        raise HTTPException(400, "AI is disabled")
+    # A bad language is the caller's mistake, not a model failure — 400, not
+    # the 500 the ValueError below would otherwise produce.
+    if body.lang != "zh":
+        raise HTTPException(400, f"language {body.lang!r} is not supported yet (only 'zh')")
+
+    try:
+        result, model_used = ai.dictionary_lookup(query, lang=body.lang, model=body.model)
+    except ValueError as e:
+        logger.error("dict lookup failed for %r: %s", query, e)
+        raise HTTPException(500, str(e))
+
+    headline = result.get("headline") or None
+    new_id = database.save_dict_query(
+        query=query,
+        lang=body.lang,
+        input_lang=result.get("input_lang"),
+        kind=result.get("kind"),
+        headline=headline,
+        result_json=json.dumps(result, ensure_ascii=False),
+        model=model_used,
+    )
+    row = database.get_dict_query(new_id)
+    return _row_to_result(row)
+
+
+@router.get("/api/dict/history")
+def history(q: str | None = None, limit: int = 50):
+    return {"items": database.list_dict_queries(q=q, limit=limit)}
+
+
+@router.get("/api/dict/history/{qid}")
+def history_item(qid: int):
+    row = database.get_dict_query(qid)
+    if row is None:
+        raise HTTPException(404, "not found")
+    return _row_to_result(row)
+
+
+@router.delete("/api/dict/history/{qid}")
+def delete_history_item(qid: int):
+    if not database.delete_dict_query(qid):
+        raise HTTPException(404, "not found")
+    return {"status": "ok"}

--- a/schema.sql
+++ b/schema.sql
@@ -687,3 +687,25 @@ CREATE TABLE IF NOT EXISTS podcast_feeds (
     auto_process INTEGER NOT NULL DEFAULT 0,  -- 1 = new episodes are transcribed+summarized automatically
     created_at   TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+-- ---------------------------------------------------------------------------
+-- In-app AI dictionary (#746): Daniel used to paste words into a chat AI and
+-- copy the answer into the add-word box by hand. This table stores each
+-- lookup's full structured result (see ai.dictionary_lookup()) so the /dict
+-- page can show a searchable history below the query box. Adding a word from
+-- a result still goes through /api/add-word-ai (#643's single add pipeline)
+-- — this table only remembers what the dictionary said, not any card state.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS dict_queries (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    query       TEXT NOT NULL,              -- user's raw input, verbatim
+    lang        TEXT NOT NULL DEFAULT 'zh', -- target vocabulary language (only 'zh' for now)
+    input_lang  TEXT,                       -- AI-detected input language: zh|de|en|fr
+    kind        TEXT,                       -- chinese|word|phrase|sentence
+    headline    TEXT,                       -- short display title, denormalized so the
+                                             -- history list doesn't need to parse result_json for every row
+    result_json TEXT NOT NULL,              -- full JSON returned by ai.dictionary_lookup()
+    model       TEXT,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now','localtime'))
+);
+CREATE INDEX IF NOT EXISTS idx_dict_queries_created ON dict_queries(created_at DESC);

--- a/static/dict.html
+++ b/static/dict.html
@@ -1,0 +1,439 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Dictionary</title>
+<!-- Saved to the iPhone home screen this opens without Safari's chrome, same as
+     add.html (#668) and save.html (#681). Deliberately does NOT load app.js —
+     77 KB of HTML + 491 KB of JS would defeat the entire point of a page whose
+     job is "open instantly, type a word, get an answer" (#746). -->
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-title" content="Dictionary">
+<meta name="theme-color" content="#c7871f">
+<style>
+  :root { color-scheme: light dark; --bg:#f4f5f7; --card:#fff; --fg:#1c1e21; --muted:#6b7075;
+          --line:#d7d9dd; --accent:#c7871f; --ok:#1f7a44; --err:#a3232b;
+          --ok-bg:#e6f4ec; --err-bg:#fdecee; --star-bg:#fff7e6; --star-line:#f0d38a; }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg:#16181c; --card:#232629; --fg:#e6e6e6; --muted:#9aa0a6;
+            --line:#3a3d42; --ok:#6ed49b; --err:#ff9ba1;
+            --ok-bg:#1d3328; --err-bg:#3a2326; --star-bg:#332c18; --star-line:#5c4c22; }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh; padding: 1.5rem 1rem calc(1.5rem + env(safe-area-inset-bottom));
+    font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: var(--bg); color: var(--fg);
+  }
+  main { max-width: 560px; margin: 0 auto; }
+  header { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 1.25rem; }
+  h1 { margin: 0; font-size: 1.15rem; }
+  header a { color: var(--muted); font-size: .85rem; text-decoration: none; }
+  h2 { margin: 1.4rem 0 .5rem; font-size: .8rem; font-weight: 600; color: var(--muted);
+       text-transform: uppercase; letter-spacing: .03em; }
+  .card { padding: 1rem; border-radius: 14px; background: var(--card); }
+
+  textarea#query {
+    display: block; width: 100%; min-height: 4.5rem; padding: .75rem;
+    font: inherit; font-size: 1.1rem; color: inherit; resize: vertical;
+    border: 1px solid var(--line); border-radius: 10px; background: var(--bg);
+  }
+  textarea#query:focus { outline: 2px solid var(--accent); outline-offset: -1px; border-color: var(--accent); }
+  button.go {
+    width: 100%; padding: .8rem; margin-top: .6rem;
+    font-size: 1.05rem; font-weight: 600;
+    color: #fff; background: var(--accent); border: 0; border-radius: 10px; cursor: pointer;
+  }
+  button.go:disabled { opacity: .5; }
+  .hint { margin: .8rem 0 0; font-size: .8rem; color: var(--muted); }
+
+  /* Result area */
+  #result { margin-top: 1.1rem; }
+  #result:empty { display: none; }
+  .headline-row { display: flex; align-items: baseline; gap: .6rem; flex-wrap: wrap; }
+  .headline { font-size: 1.6rem; font-weight: 700; }
+  .headline-pinyin { color: var(--muted); font-size: 1rem; }
+  .headline-de { color: var(--fg); opacity: .8; margin-top: .15rem; }
+  .notes { margin-top: .5rem; font-size: .9rem; color: var(--muted); }
+
+  .sentence-card {
+    margin-top: 1rem; padding: .8rem; border-radius: 10px;
+    background: var(--star-bg); border: 1px solid var(--star-line);
+    display: flex; align-items: flex-start; justify-content: space-between; gap: .6rem;
+  }
+  .sentence-card .text { flex: 1; min-width: 0; }
+  .sentence-card .zh { font-size: 1.25rem; font-weight: 600; }
+  .sentence-card .pinyin { color: var(--muted); font-size: .9rem; margin-top: .1rem; }
+  .sentence-card .de { font-size: .9rem; margin-top: .2rem; opacity: .85; }
+
+  .group { margin-top: 1.1rem; }
+  .group-label { font-size: .85rem; font-weight: 600; color: var(--muted); margin-bottom: .4rem; }
+  .option {
+    display: flex; align-items: flex-start; gap: .6rem;
+    padding: .6rem .7rem; margin-bottom: .5rem; border-radius: 10px;
+    background: var(--bg); border: 1px solid var(--line);
+  }
+  .option.recommended { background: var(--star-bg); border-color: var(--star-line); }
+  .option .key { color: var(--muted); font-size: .85rem; min-width: 1rem; }
+  .option .body { flex: 1; min-width: 0; }
+  .option .zh-row { display: flex; align-items: baseline; gap: .5rem; flex-wrap: wrap; }
+  .option .zh { font-size: 1.15rem; font-weight: 700; }
+  .option .pinyin { color: var(--muted); font-size: .9rem; }
+  .option .star-mark { font-size: .95rem; }
+  .option .register {
+    font-size: .7rem; color: var(--muted); background: var(--card);
+    border: 1px solid var(--line); border-radius: 6px; padding: .05rem .4rem;
+  }
+  .option .trans { font-size: .88rem; margin-top: .2rem; }
+  .option .trans .lbl { color: var(--muted); }
+  .option .usage { font-size: .85rem; margin-top: .3rem; color: var(--fg); opacity: .85; }
+  .option .example { font-size: .85rem; margin-top: .35rem; padding-top: .35rem; border-top: 1px dashed var(--line); }
+  .option .example .ex-zh { font-weight: 600; }
+  .option .example .ex-pinyin { color: var(--muted); }
+  .option .example .ex-de { opacity: .8; }
+
+  button.star {
+    flex-shrink: 0; width: 2.1rem; height: 2.1rem; padding: 0;
+    font-size: 1.1rem; line-height: 1; border-radius: 8px; cursor: pointer;
+    background: var(--card); border: 1px solid var(--line); color: var(--fg);
+  }
+  button.star:hover { background: var(--line); }
+  button.star:disabled { cursor: default; }
+  button.star.running { opacity: .6; }
+  button.star.done { background: var(--ok-bg); border-color: var(--ok); color: var(--ok); }
+  button.star.error { background: var(--err-bg); border-color: var(--err); color: var(--err); }
+  .star-err-msg { font-size: .78rem; color: var(--err); margin-top: .3rem; overflow-wrap: anywhere; }
+
+  #status { margin-top: .8rem; font-size: .9rem; color: var(--muted); }
+  #status.error { color: var(--err); }
+
+  /* History */
+  input[type=text]#hist-search {
+    width: 100%; padding: .6rem .75rem; font: inherit; font-size: .95rem; color: inherit;
+    border: 1px solid var(--line); border-radius: 10px; background: var(--bg);
+  }
+  ul#hist-list { list-style: none; margin: .7rem 0 0; padding: 0; }
+  ul#hist-list li {
+    display: flex; align-items: center; gap: .6rem;
+    padding: .55rem .7rem; margin-bottom: .35rem; border-radius: 10px;
+    background: var(--card); font-size: .88rem; cursor: pointer;
+  }
+  ul#hist-list li:hover { background: var(--line); }
+  ul#hist-list .hist-main { flex: 1; min-width: 0; }
+  ul#hist-list .hist-q { font-weight: 600; }
+  ul#hist-list .hist-headline { color: var(--muted); overflow-wrap: anywhere; }
+  ul#hist-list .hist-time { color: var(--muted); font-size: .78rem; white-space: nowrap; }
+  ul#hist-list button.hist-del {
+    flex-shrink: 0; background: none; border: none; color: var(--muted);
+    font-size: 1.1rem; cursor: pointer; padding: .1rem .3rem; line-height: 1;
+  }
+  ul#hist-list button.hist-del:hover { color: var(--err); }
+  #hist-empty { color: var(--muted); font-size: .88rem; margin-top: .5rem; }
+</style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>Dictionary</h1>
+    <a href="/">← app</a>
+  </header>
+
+  <div class="card">
+    <textarea id="query" placeholder="German / English / Chinese word, phrase or sentence…"
+              autocapitalize="none" autocorrect="off" spellcheck="false" autofocus></textarea>
+    <button class="go" id="go">Look up</button>
+    <p class="hint">Enter to look up, Shift+Enter for a new line. Single question — no follow-up.</p>
+    <div id="status"></div>
+  </div>
+
+  <div id="result"></div>
+
+  <h2>History</h2>
+  <div class="card">
+    <input type="text" id="hist-search" placeholder="Search history…" autocomplete="off"
+           autocapitalize="none" autocorrect="off" spellcheck="false">
+    <ul id="hist-list"></ul>
+    <p id="hist-empty" style="display:none">No queries yet.</p>
+  </div>
+</main>
+
+<script src="/static/shared.js?v=3"></script>
+<script>
+  // Standalone dictionary page (#746). Daniel already uses DeepSeek as an
+  // ad-hoc dictionary — this gives that a home with history and one-tap
+  // add-to-★-List, without pulling in the full app bundle. Single-shot
+  // lookups only: no follow-up/refinement round, so the UI never needs to
+  // remember conversational state between queries.
+  const queryEl = document.getElementById('query');
+  const goBtn = document.getElementById('go');
+  const statusEl = document.getElementById('status');
+  const resultEl = document.getElementById('result');
+  const histSearch = document.getElementById('hist-search');
+  const histList = document.getElementById('hist-list');
+  const histEmpty = document.getElementById('hist-empty');
+
+  function setStatus(text, isError) {
+    statusEl.textContent = text || '';
+    statusEl.classList.toggle('error', !!isError);
+  }
+
+  function fmtTime(iso) {
+    // created_at is 'datetime(now,localtime)' — a plain "YYYY-MM-DD HH:MM:SS"
+    // string, not a Date the browser will parse reliably across engines.
+    if (!iso) return '';
+    const d = new Date(iso.replace(' ', 'T'));
+    if (isNaN(d)) return iso;
+    const now = new Date();
+    const sameDay = d.toDateString() === now.toDateString();
+    return sameDay
+      ? d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+      : d.toLocaleDateString([], { month: 'short', day: 'numeric' });
+  }
+
+  // ---- Star button: adds option.zh to the ★ List via the one shared
+  // add-word pipeline (#643). Each button tracks its own state so several
+  // can be "running" (~30s each) at once without blocking one another —
+  // addWordViaAi already polls its own job, we just need to not share state.
+  function makeStarButton(zh) {
+    const btn = document.createElement('button');
+    btn.className = 'star';
+    btn.type = 'button';
+    btn.textContent = '★';
+    btn.title = `Add "${zh}" to your ★ List`;
+    const errMsg = document.createElement('div');
+    errMsg.className = 'star-err-msg';
+    errMsg.style.display = 'none';
+
+    btn.onclick = () => {
+      btn.disabled = true;
+      btn.classList.add('running');
+      btn.textContent = '…';
+      errMsg.style.display = 'none';
+      addWordViaAi(zh, 'list', (state, text) => {
+        if (state === 'running') {
+          btn.classList.add('running');
+          btn.textContent = '…';
+        } else if (state === 'done') {
+          btn.classList.remove('running');
+          btn.classList.add('done');
+          btn.textContent = '✓';
+          btn.title = text || 'Added';
+        } else if (state === 'error') {
+          btn.classList.remove('running');
+          btn.classList.add('error');
+          btn.textContent = '⚠';
+          btn.disabled = false;
+          errMsg.textContent = text || 'Failed to add';
+          errMsg.style.display = '';
+        }
+      }, 'zh');
+    };
+
+    const wrap = document.createElement('div');
+    wrap.style.flexShrink = '0';
+    wrap.append(btn, errMsg);
+    return wrap;
+  }
+
+  function textEl(tag, cls, text) {
+    const el = document.createElement(tag);
+    if (cls) el.className = cls;
+    if (text != null) el.textContent = text;
+    return el;
+  }
+
+  // Renders one {id, created_at, query, result} record into #result.
+  // Everything from the AI is untrusted text — textContent only, never
+  // innerHTML, all the way through this function.
+  function renderResult(record) {
+    const r = record.result || {};
+    resultEl.replaceChildren();
+
+    const head = document.createElement('div');
+    const hrow = textEl('div', 'headline-row');
+    hrow.append(textEl('span', 'headline', r.headline || record.query));
+    if (r.headline_pinyin) hrow.append(textEl('span', 'headline-pinyin', r.headline_pinyin));
+    head.append(hrow);
+    if (r.headline_de) head.append(textEl('div', 'headline-de', r.headline_de));
+    if (r.notes) head.append(textEl('div', 'notes', r.notes));
+    resultEl.append(head);
+
+    if (r.kind === 'sentence' && r.sentence) {
+      const card = document.createElement('div');
+      card.className = 'sentence-card';
+      const text = document.createElement('div');
+      text.className = 'text';
+      text.append(textEl('div', 'zh', r.sentence.zh || ''));
+      if (r.sentence.pinyin) text.append(textEl('div', 'pinyin', r.sentence.pinyin));
+      if (r.sentence.de) text.append(textEl('div', 'de', r.sentence.de));
+      card.append(text);
+      if (r.sentence.zh) card.append(makeStarButton(r.sentence.zh));
+      resultEl.append(card);
+    }
+
+    for (const group of (r.groups || [])) {
+      const g = document.createElement('div');
+      g.className = 'group';
+      if (group.label) g.append(textEl('div', 'group-label', group.label));
+      for (const opt of (group.options || [])) {
+        g.append(renderOption(opt));
+      }
+      resultEl.append(g);
+    }
+  }
+
+  function renderOption(opt) {
+    const row = document.createElement('div');
+    row.className = 'option' + (opt.recommended ? ' recommended' : '');
+
+    row.append(textEl('div', 'key', opt.key || ''));
+
+    const body = document.createElement('div');
+    body.className = 'body';
+
+    const zhRow = textEl('div', 'zh-row');
+    zhRow.append(textEl('span', 'zh', opt.zh || ''));
+    if (opt.pinyin) zhRow.append(textEl('span', 'pinyin', opt.pinyin));
+    if (opt.recommended) zhRow.append(textEl('span', 'star-mark', '⭐'));
+    if (opt.register) zhRow.append(textEl('span', 'register', opt.register));
+    body.append(zhRow);
+
+    if (opt.de) {
+      const t = textEl('div', 'trans');
+      t.append(textEl('span', 'lbl', 'de: '), document.createTextNode(opt.de));
+      body.append(t);
+    }
+    if (opt.fr) {
+      const t = textEl('div', 'trans');
+      t.append(textEl('span', 'lbl', 'fr: '), document.createTextNode(opt.fr));
+      body.append(t);
+    }
+    if (opt.usage) body.append(textEl('div', 'usage', opt.usage));
+
+    if (opt.example_zh) {
+      const ex = document.createElement('div');
+      ex.className = 'example';
+      ex.append(textEl('div', 'ex-zh', opt.example_zh));
+      if (opt.example_pinyin) ex.append(textEl('div', 'ex-pinyin', opt.example_pinyin));
+      if (opt.example_de) ex.append(textEl('div', 'ex-de', opt.example_de));
+      body.append(ex);
+    }
+
+    row.append(body);
+    if (opt.zh) row.append(makeStarButton(opt.zh));
+    return row;
+  }
+
+  // ---- Lookup ----
+  async function lookup(q) {
+    if (!q) return;
+    goBtn.disabled = true;
+    queryEl.disabled = true;
+    setStatus('Looking up… (5–15s)');
+    try {
+      const record = await api('POST', '/api/dict/lookup', { query: q, lang: 'zh' });
+      setStatus('');
+      // Cleared only on success: a failed lookup (AI hiccup, bad JSON) is worth
+      // retrying verbatim, and retyping a pasted German sentence is painful.
+      if (queryEl.value.trim() === q) queryEl.value = '';
+      renderResult(record);
+      loadHistory(histSearch.value.trim());
+    } catch (e) {
+      setStatus(e.message || 'Lookup failed', true);
+    } finally {
+      goBtn.disabled = false;
+      queryEl.disabled = false;
+      queryEl.focus();
+    }
+  }
+
+  function submit() {
+    const q = queryEl.value.trim();
+    if (!q) return;
+    lookup(q);
+  }
+
+  goBtn.onclick = submit;
+  queryEl.addEventListener('keydown', e => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      submit();
+    }
+  });
+
+  // ---- History ----
+  let histSeq = 0;
+  async function loadHistory(q) {
+    const seq = ++histSeq;
+    let data;
+    try {
+      data = await api('GET', `/api/dict/history?q=${encodeURIComponent(q || '')}&limit=50`);
+    } catch {
+      return;
+    }
+    if (seq !== histSeq) return; // a newer search superseded this one
+    const items = (data && data.items) || [];
+    histEmpty.style.display = items.length ? 'none' : '';
+    histList.replaceChildren(...items.map(it => {
+      const li = document.createElement('li');
+      const main = document.createElement('div');
+      main.className = 'hist-main';
+      main.append(textEl('div', 'hist-q', it.query));
+      if (it.headline) main.append(textEl('div', 'hist-headline', it.headline));
+      li.append(main, textEl('span', 'hist-time', fmtTime(it.created_at)));
+
+      const del = document.createElement('button');
+      del.className = 'hist-del';
+      del.type = 'button';
+      del.textContent = '×';
+      del.title = 'Delete';
+      del.onclick = async (ev) => {
+        ev.stopPropagation();
+        if (!confirm(`Delete "${it.query}" from history?`)) return;
+        try {
+          await api('DELETE', `/api/dict/history/${it.id}`);
+          loadHistory(histSearch.value.trim());
+        } catch (e) {
+          alert(e.message || 'Failed to delete');
+        }
+      };
+      li.append(del);
+
+      li.onclick = async () => {
+        setStatus('Loading…');
+        try {
+          const record = await api('GET', `/api/dict/history/${it.id}`);
+          setStatus('');
+          renderResult(record);
+          queryEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        } catch (e) {
+          setStatus(e.message || 'Failed to load', true);
+        }
+      };
+      return li;
+    }));
+  }
+
+  let histDebounce;
+  histSearch.addEventListener('input', () => {
+    clearTimeout(histDebounce);
+    histDebounce = setTimeout(() => loadHistory(histSearch.value.trim()), 250);
+  });
+
+  loadHistory('');
+
+  // URL parameters — /dict?q=anordnen — so an iOS Shortcut or a link can open
+  // straight into a lookup. Accepts ?query= as an alias. Must strip the param
+  // afterwards (history.replaceState): a reload or an iOS "restore tabs" would
+  // otherwise silently spend another AI call, the same trap #686 hit on /add.
+  const params = new URLSearchParams(location.search);
+  const preset = (params.get('q') || params.get('query') || '').trim();
+  if (preset) {
+    history.replaceState(null, '', location.pathname);
+    queryEl.value = preset;
+    lookup(preset);
+  }
+</script>
+</body>
+</html>

--- a/static/index.html
+++ b/static/index.html
@@ -53,6 +53,7 @@
     <!-- Local instance only — injected visible by _renderOfflineBanner() (#625) -->
     <button id="sync-btn" onclick="openSyncPopup()" title="Sync with the server" style="display:none">⟳</button>
     <button id="add-word-btn" onclick="openAddWordModal()" title="Add a new word to today's deck">＋</button>
+    <a id="dict-link-btn" href="/dict" title="Dictionary lookup">📖</a>
     <button id="random-words-btn" onclick="openRandomWords()" title="10 random words for today">🎲</button>
     <button id="header-regen-btn" onclick="regenerateStory()" title="Regenerate story" style="display:none">↺</button>
   </div>

--- a/static/style.css
+++ b/static/style.css
@@ -87,6 +87,22 @@ header h1 { font-size: 18px; font-weight: 700; }
   margin-left: 4px;
 }
 #random-words-btn:hover { background: var(--border); }
+/* Dictionary page link (#746) — plain nav icon like #random-words-btn, not a
+   create action, so it doesn't get the primary-colour treatment #add-word-btn has. */
+#dict-link-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 6px;
+  line-height: 1;
+  margin-left: 4px;
+  color: var(--muted);
+  text-decoration: none;
+}
+#dict-link-btn:hover { background: var(--border); }
 /* The one action button in the header that creates something — give it the
    primary colour and a real touch target instead of the browser default (#636) */
 #add-word-btn {

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -1,0 +1,195 @@
+"""Tests for the in-app AI dictionary (issue #746).
+
+The AI is stubbed at ai._call_api — the single choke point every provider
+goes through (see tests/test_add_word.py for why not a provider client).
+"""
+import json
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+import ai
+import database
+import main
+import routes.dictionary
+
+client = TestClient(main.app)
+
+
+GOOD_RESULT = {
+    "input_lang": "de",
+    "kind": "phrase",
+    "headline": "派任务",
+    "headline_pinyin": "pài rènwu",
+    "headline_de": "jemandem eine Aufgabe geben",
+    "notes": "口语里最自然的说法是 派任务",
+    "groups": [
+        {
+            "label": "assign (Verb)",
+            "options": [
+                {
+                    "key": "a",
+                    "zh": "派",
+                    "pinyin": "pài",
+                    "de": "beauftragen",
+                    "usage": "sehr umgangssprachlich",
+                    "register": "spoken_colloquial",
+                    "recommended": True,
+                    "example_zh": "老师又给我派任务了。",
+                    "example_pinyin": "Lǎoshī yòu gěi wǒ pài rènwu le.",
+                    "example_de": "Der Lehrer hat mir schon wieder eine Aufgabe gegeben.",
+                }
+            ],
+        }
+    ],
+}
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    """Fresh temp database. Patch database.core.DB_PATH — the package-level
+    name is only a copy (issue #615)."""
+    monkeypatch.setattr(database.core, "DB_PATH", str(tmp_path / "test.db"))
+    database.init_db()
+    monkeypatch.setattr(routes.dictionary, "ai_disabled", lambda: False)
+    return tmp_path
+
+
+def _stub_response(result=GOOD_RESULT):
+    return json.dumps(result, ensure_ascii=False)
+
+
+def test_lookup_saves_and_returns_full_result(tmp_db):
+    with patch.object(ai, "_call_api", return_value=_stub_response()):
+        r = client.post("/api/dict/lookup", json={"query": "jemandem eine Aufgabe geben"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["query"] == "jemandem eine Aufgabe geben"
+    assert body["result"]["headline"] == "派任务"
+    assert body["result"]["groups"][0]["options"][0]["zh"] == "派"
+    assert "id" in body and "created_at" in body
+
+
+def test_history_roundtrip_and_search(tmp_db):
+    with patch.object(ai, "_call_api", return_value=_stub_response()):
+        client.post("/api/dict/lookup", json={"query": "jemandem eine Aufgabe geben"})
+
+    other = dict(GOOD_RESULT, headline="生态")
+    with patch.object(ai, "_call_api", return_value=_stub_response(other)):
+        client.post("/api/dict/lookup", json={"query": "ecology"})
+
+    items = client.get("/api/dict/history").json()["items"]
+    assert len(items) == 2
+    assert {i["headline"] for i in items} == {"派任务", "生态"}
+
+    # Search matches on query OR headline.
+    by_query = client.get("/api/dict/history", params={"q": "Aufgabe"}).json()["items"]
+    assert len(by_query) == 1 and by_query[0]["headline"] == "派任务"
+
+    by_headline = client.get("/api/dict/history", params={"q": "生态"}).json()["items"]
+    assert len(by_headline) == 1 and by_headline[0]["query"] == "ecology"
+
+    no_match = client.get("/api/dict/history", params={"q": "nonexistent"}).json()["items"]
+    assert no_match == []
+
+
+def test_history_item_full_shape(tmp_db):
+    with patch.object(ai, "_call_api", return_value=_stub_response()):
+        created = client.post("/api/dict/lookup", json={"query": "test"}).json()
+
+    r = client.get(f"/api/dict/history/{created['id']}")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["result"] == GOOD_RESULT
+    assert body["query"] == "test"
+
+
+def test_history_item_missing_is_404(tmp_db):
+    assert client.get("/api/dict/history/999").status_code == 404
+
+
+def test_delete_history_item(tmp_db):
+    with patch.object(ai, "_call_api", return_value=_stub_response()):
+        created = client.post("/api/dict/lookup", json={"query": "test"}).json()
+
+    r = client.delete(f"/api/dict/history/{created['id']}")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+    assert client.get(f"/api/dict/history/{created['id']}").status_code == 404
+
+
+def test_delete_missing_history_item_is_404(tmp_db):
+    """Deleting a nonexistent row must not pretend success (project rule:
+    never fake a successful result)."""
+    assert client.delete("/api/dict/history/999").status_code == 404
+
+
+def test_empty_query_is_rejected(tmp_db):
+    assert client.post("/api/dict/lookup", json={"query": "   "}).status_code == 400
+
+
+def test_ai_disabled_is_rejected(tmp_db, monkeypatch):
+    monkeypatch.setattr(routes.dictionary, "ai_disabled", lambda: True)
+    r = client.post("/api/dict/lookup", json={"query": "test"})
+    assert r.status_code == 400
+
+
+def test_garbage_ai_response_fails_loudly_and_writes_nothing(tmp_db):
+    """A model that answers in prose (or otherwise unparseable JSON) must
+    surface as a server error, and — critically — never reach the database:
+    a blank/garbage dictionary entry is worse than an error."""
+    with patch.object(ai, "_call_api", return_value="Sorry, I cannot help with that."):
+        r = client.post("/api/dict/lookup", json={"query": "test"})
+    assert r.status_code == 500
+    assert client.get("/api/dict/history").json()["items"] == []
+
+
+def test_ai_response_missing_groups_is_rejected(tmp_db):
+    bad = {"input_lang": "de", "kind": "phrase", "headline": "x"}
+    with patch.object(ai, "_call_api", return_value=json.dumps(bad)):
+        r = client.post("/api/dict/lookup", json={"query": "test"})
+    assert r.status_code == 500
+    assert client.get("/api/dict/history").json()["items"] == []
+
+
+def test_ai_response_with_empty_zh_option_is_rejected(tmp_db):
+    bad = {
+        "input_lang": "de", "kind": "phrase", "headline": "x",
+        "groups": [{"label": "g", "options": [{"key": "a", "zh": ""}]}],
+    }
+    with patch.object(ai, "_call_api", return_value=json.dumps(bad)):
+        r = client.post("/api/dict/lookup", json={"query": "test"})
+    assert r.status_code == 500
+    assert client.get("/api/dict/history").json()["items"] == []
+
+
+# ---------------------------------------------------------------------------
+# ai.dictionary_lookup() itself
+# ---------------------------------------------------------------------------
+
+def test_dictionary_lookup_strips_code_fence():
+    fenced = "```json\n" + json.dumps(GOOD_RESULT) + "\n```"
+    with patch.object(ai, "_call_api", return_value=fenced):
+        result, model = ai.dictionary_lookup("test")
+    assert result["headline"] == "派任务"
+    assert model == ai.DEFAULT_MODEL
+
+
+def test_dictionary_lookup_raises_on_unparseable_response():
+    with patch.object(ai, "_call_api", return_value="not json at all"):
+        with pytest.raises(ValueError):
+            ai.dictionary_lookup("test")
+
+
+# ---------------------------------------------------------------------------
+# /dict standalone page
+# ---------------------------------------------------------------------------
+
+def test_dict_page_is_served():
+    r = client.get("/dict")
+    assert r.status_code == 200


### PR DESCRIPTION
## 改了什么

新页面 `/dict`：输入德语/英语/中文的词、词组或句子 → AI 返回**结构化**查词结果 → 每个候选译法旁边一个 `★` 按钮，一键加进 ★ List。页面下方是可搜索的历史记录。

单轮问答，不做追问 —— Daniel 明确说他从不追问，查完直接输下一个。

## 为什么

Daniel 长期把 DeepSeek 聊天当中文词典用，然后手工把结果复制、粘贴进本应用的加词框。词典和词库分在两个地方，加词路径很别扭。

## 关键设计

- **结构化 JSON 而非自由 Markdown**：只有结构化才能让选项变成可点的按钮。
- **加词走 `/api/add-word-ai`**（`shared.js` 的 `addWordViaAi()`）。#643 定死了「加词只能有一条管线」，词典不得成为第二条 —— 所以 `★` 之后照常花 30 秒生成完整词条（例句/汉字分解/量词/同义反义词齐全）。
- **提示词移植 `de-zh-bot` 技能的规则**：中文输入直接给全部义项、不给选择；德/英输入一律先分析 + `a/b/c` 选项（不用数字）+ **明确推荐、倾向口语**；整句先翻译再逐词拆解，每个成分都可单独加词；解释语言德语，单词可附法语。
- **解析失败不写库**：AI 返回的 JSON 解析不出来 → `ValueError` → 500 带原始回复前 500 字。空壳词典条目比报错更糟。
- **`headline` 反范式存一列**：历史列表不该为了显示一行标题去解析 50 份 `result_json`。
- **`/dict` 不加载 `app.js`**（同 `/add` #668、`/save` #681）；`?q=` 自动查询后 `history.replaceState` 抹掉参数 —— 否则刷新或 iOS 恢复标签页会静默再花一次 AI 钱（#686 踩过）。
- **AI 文本一律 `textContent` 渲染**，全页无 `innerHTML` 拼接。
- `lang` 目前只支持 `zh`，传别的值返回 400 而不是拿中文提示词静默生成一个错词条（同 #726 的教训）。

## 怎么测试

- `pytest tests/test_dictionary.py -q` → 14 passed；全套 `pytest tests/ -q` → 514 passed, 4 skipped（无新增失败）
- 实机跑了三条真实 DeepSeek 查询验证提示词：`anordnen`（德语词 → 两个义项组，各自推荐）、`生态`（中文 → 三个义项直接给出，无选择步骤）、`Wann hast du nächste Woche Zeit?`（整句 → 整句翻译 + 拆成 4 个可加词成分）

Closes #746