### PR TITLE
知识库：Signal 分享入口（Note to Self → 自动入库）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,7 @@
 ├── ai.py                  # AI 提供商调用（每种提示词类型一个函数）
 ├── news_fetcher.py        # 新闻抓取（Tagesschau API + RSS；按天缓存 data/news_cache/）
 ├── podcast.py             # 播客爬虫（#479）：播客 RSS 直链发现新单集（#497，退役 YouTube/yt-dlp）、每源 auto_process 开关+非自动源只入库元数据（#502，podcast_feeds 表）、转录链 NotebookLM 免费主力+听悟+Whisper 保底、单步异常不中止整链（#510 重排，链式降级，原 #498/#485/#486）、摘要 NotebookLM chat.ask 免费优先+DeepSeek/gpt API 链回退（api 路径内部 DeepSeek 优先省钱，#532；勾了 china-kritisch 的素材跳过 DeepSeek 直接用 OpenAI，#731）、邮件通知+Signal 通知（signal-cli 关联设备，发 Note to Self，#521，二者独立可选、互不影响；消息抬头播客名·星期·日期、链接在末尾，单集日期按 Europe/Berlin 显示，#532）、摘要 table.media 风格（`<p>` 段落+每段首句 `<b>` 加粗总结，#567）+详情页 Regenerate summary 按钮、邮件主题=`播客名 - 单集标题`（查不到播客名只用标题，不要退回死前缀）+ `summary_zh` 开头中文总结（#708 起是 `summary_de` 的**完整翻译**：同段落数、同顺序、同事实，同样 `<p>`+段首 `<b>`，HSK4-5 用词；提示词里德语先写、中文后译，JSON 里 `summary_de` 排在前面；渲染三处——邮件 `podcast._summary_zh_html`、详情页 `app.js._summaryZhHtml` 均"先全转义再放行 `<p>/<b>/<strong>/<em>/<i>/<br>`"，Signal 用 `_summary_to_plain_text` 剥标签；#708 之前的旧条目是纯文本，两处渲染都按空行补 `<p>`；**是增量不是必需**——成功判定只看 `summary_de`，模型漏掉中文总结不能让整集失败）+ 摘要里任何 HSK5+ 中文概念都标 `pinyin/汉字`（不限于提取的词表，宁多勿少，#631）；已泛化为知识库存储层，见 `knowledge/` 包
-├── knowledge/             # 知识库摄取（#650–#655，播客功能泛化，见「知识库」节）：youtube.py（字幕摄取）、article.py（正文抽取）、ingest.py（唯一入库管线）、mailbox.py（IMAP 邮件收件）
+├── knowledge/             # 知识库摄取（#650–#655，播客功能泛化，见「知识库」节）：youtube.py（字幕摄取）、article.py（正文抽取）、ingest.py（唯一入库管线）、mailbox.py（IMAP 邮件收件）、signal_inbox.py（Signal Note to Self 分享收件，#749）
 ├── zh_annotate.py         # 生词标注（#638，零 AI）：HSK 表+词库+jieba+pypinyin+谷歌翻译
 ├── translator.py          # 翻译（Google Translate，deep-translator，可选）
 ├── tts.py                 # edge-tts 封装（离线模式下只读缓存，#612）
@@ -235,7 +235,7 @@
 ├── requirements.txt       # Python 依赖清单
 ├── DEPLOY.md              # 服务器从零到上线的部署教程
 ├── deploy/                # systemd 单元、Caddyfile 示例、deploy.sh（自动部署）
-├── scripts/               # morning_pregen.py（早晨预生成故事+TTS）、podcast_check.py（播客爬虫定时脚本）、due_check.py（复习收尾提醒定时脚本，#701）、knowledge_mail_check.py（知识库邮件收件定时脚本，#655）、offline_sync_server.py + offline_tts_manifest.py（离线同步，#612）、fsrs_optimize.py（用 review_log 训练个人 FSRS 权重，#629）+ README
+├── scripts/               # morning_pregen.py（早晨预生成故事+TTS）、podcast_check.py（播客爬虫定时脚本）、due_check.py（复习收尾提醒定时脚本，#701）、knowledge_mail_check.py（知识库邮件收件定时脚本，#655）、signal_check.py（知识库 Signal 分享收件定时脚本，#749）、offline_sync_server.py + offline_tts_manifest.py（离线同步，#612）、fsrs_optimize.py（用 review_log 训练个人 FSRS 权重，#629）+ README
 ├── docs/yaml-format.md    # YAML 词条格式完整文档
 ├── docs/knowledge-base.md # 知识库功能总体设计（#650–#655 各 Issue 引用的唯一设计说明）
 └── data/
@@ -351,7 +351,7 @@ python main.py status [--deck X]     # 显示每个牌组/类别的到期数量
 | `SMTP_HOST` / `SMTP_PORT` / `SMTP_USERNAME` / `SMTP_PASSWORD` / `SMTP_FROM` | 可选 | 播客爬虫（#479）邮件通知用；`SMTP_PORT` 默认 587（STARTTLS）；未配置时跳过发信，记日志，不算失败 |
 | `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` | 可选 | 播客爬虫用 Spotify Web API 搜索单集链接；未配置时退化为 Spotify 搜索链接 |
 | `PUBLIC_BASE_URL` | `https://powerdaniel3000.duckdns.org` | 播客邮件/Signal 通知里转录页链接的域名前缀 |
-| `SIGNAL_ACCOUNT` / `SIGNAL_CLI_PATH` | 可选 | 播客爬虫（#521）Signal 通知用；`SIGNAL_ACCOUNT` 是 Daniel 关联设备所属号码（如 `+49…`），`SIGNAL_CLI_PATH` 默认 `signal-cli`；`SIGNAL_ACCOUNT` 未配置时跳过发送，记日志，不算失败。一次性 signal-cli 安装/扫码关联步骤见 `scripts/README.md` |
+| `SIGNAL_ACCOUNT` / `SIGNAL_CLI_PATH` | 可选 | 播客爬虫（#521）Signal 通知用，**以及**知识库 Signal 分享入口（#749）的收件用；`SIGNAL_ACCOUNT` 是 Daniel 关联设备所属号码（如 `+49…`），`SIGNAL_CLI_PATH` 默认 `signal-cli`；`SIGNAL_ACCOUNT` 未配置时发送/收件都跳过，记日志，不算失败。一次性 signal-cli 安装/扫码关联步骤见 `scripts/README.md`（两个用途共用同一次关联，不用配两遍） |
 | `ALIBABA_CLOUD_ACCESS_KEY_ID` / `ALIBABA_CLOUD_ACCESS_KEY_SECRET` | 可选 | 播客爬虫（#498）通义听悟（转录主力）用的阿里云 AccessKey；未配置时自动跳过，落到 Whisper/NotebookLM |
 | `TINGWU_APP_KEY` | 可选 | 播客爬虫（#498）通义听悟控制台创建的应用 AppKey；与上面两个 AccessKey 变量任一缺失都会跳过听悟。一次性开通步骤见 `scripts/README.md` |
 | `KNOWLEDGE_IMAP_HOST` / `KNOWLEDGE_IMAP_PORT` | 可选 | 知识库邮件收件（#655）的 IMAP 服务器；端口默认 `993`（SSL） |
@@ -547,6 +547,12 @@ FSRS 用毕业评分播种初始 stability/difficulty：默认权重下 **Good �
 - **不新建表，泛化 `podcast_episodes`**：加两列 `kind`（`podcast`|`video`|`article`）、`title_en`。**表名和历史列名故意不改**——改名要重建表+迁移生产库，风险远大于收益，本仓库已有同类先例（`youtube_url` 现在也存文章/播客链接，`word_zh` 对法语存法语词形）。`video_id` 对文章存 `normalize_url()` 去掉跟踪参数后的规范化 URL（`podcast_episodes` 的去重键），`transcript_source` 存 `youtube_captions`/`article`/`tingwu`/`whisper`/`notebooklm`
 - **`knowledge/` 包，`ingest.py` 是唯一入库管线**：`ingest_url()` 判断 YouTube 链接走 `youtube.py`（oEmbed 拿标题 + `youtube-transcript-api` 拿字幕，语言优先级 zh-Hans→zh-CN→zh→zh-TW→de→en，找不到任何字幕轨直接 `no_transcript`，**不跑 Whisper**；**YouTube 封锁云服务商 IP，所以服务器上字幕 API 恒返回 `RequestBlocked`，实际走的是 NotebookLM 兜底**，见下条），否则当文章走 `article.py`（`trafilatura` 抽正文，不足 200 字视为失败并抛 `ArticleExtractionError`——付费墙/登录墙/JS 页面绝不能存进库冒充正文，见其 docstring）。界面「粘贴 URL」框（`POST /api/knowledge/add`）和邮件收件（`mailbox.py`）**共用这一个函数**——理由同 #643 加词单一入口：两条平行管线迟早会让修好的坑在另一条上复活
 - **邮件收件（`knowledge/mailbox.py`，#655）**：IMAP 轮询 UNSEEN 邮件，标题+正文都扫 URL（手机分享到邮件，链接位置因 App 而异）。`KNOWLEDGE_MAIL_ALLOWED_SENDERS` 未配置时**整个邮箱检查被跳过，不读取也不标已读**——这是防止任何知道邮箱地址的人远程触发付费 AI 调用的唯一防线；处理失败的邮件同样不标已读，留给下一轮重试（`ingest_url()` 对已入库 URL 幂等返回 `already_exists`，重试安全）
+- **Signal 分享入口（`knowledge/signal_inbox.py`，#749）**：手机把链接分享到 Signal 自己的「Note to Self」，服务器用 #521 早就关联好的**同一个** signal-cli 设备（`SIGNAL_ACCOUNT`）把消息收下来，正文里的 URL 同样走 `ingest_url()`。与邮件收件方向相反、账号相同——`send_signal()` 是服务器→Daniel，这个是 Daniel→服务器
+  - **安全防线**：只收下**源账号和目的账号都等于 `SIGNAL_ACCOUNT` 自己**的消息（真正的 Note to Self）——关联设备会同步收到 Daniel 手机发出的所有消息，包括发给别人的，那些一律忽略。作用等同于 `KNOWLEDGE_MAIL_ALLOWED_SENDERS` 之于邮件入口
+  - **失败重试靠自己存队列，不是靠"留着不读"**：`signal-cli receive` 一次调用就把消息从 Signal 服务器上取走，不像 IMAP 能把邮件留成 UNSEEN 等下一轮。入库失败的 URL 存进 `app_settings['signal_retry_queue']`（JSON 列表），下一轮优先处理，满 3 次放弃并在回执里说明
+  - **新链接入库后立即同步处理**（转录+摘要），不像邮件/网页粘贴那样只入库、等前端另外调 `.../process`——Signal 分享的语义就是"现在就要"。处理复用 `podcast.retry_episode()`（`routes/podcast.py` 的 process 端点背后那个同步函数，脚本进程里直接调用，不起后台线程——脚本跑完就退出，线程会被杀掉）
+  - **`podcast.send_signal_text(text, context=...)`（#749 从 `send_signal()` 抽出）是发 Signal 消息的唯一函数**：`send_signal()`（摘要通知）和 `signal_inbox.send_receipt()`（收件回执）都调它，不重复写 subprocess 调用。处理成功时**不重复发一遍摘要**——`send_signal()` 已经在摘要成功后自动发了完整版，回执只发一行简短结果
+  - `scripts/signal_check.py`：cron 入口，结构照抄 `knowledge_mail_check.py`（同款 PID 锁 + `database.init_db()` 直连）
 - **前端：播客页 → 知识页**（#653，`static/app.js`）：🎙️/📺/📄 三个子标签，播客管理页原有的 RSS 源/详情/生词表格逻辑全部保留，只是按 `?kind=` 过滤。**旧的 `#podcast-<id>` hash 链接永久保留**——已发出去的邮件/Signal 消息里全是这种链接；播客条目仍生成旧格式 hash，只有视频/文章条目用新的 `#knowledge-<id>`
 - **独立收藏页 `/save`（#681）**：`/add` 的素材版 —— 可收藏的网址，🔗 Link / 📋 Text 两个标签，粘链接或粘正文，同样**不加载 `app.js`**（手机上从别的 App 分享文章时秒开）。入库逻辑抽到 `shared.js` 的 `ingestKnowledge()`，应用的知识页和本页共用一份；`knowledgeTitleFor()` 统一"标题留空则取首行"的规则。**两处都不许直接调 `/api/knowledge/add*`**，有测试守着
 - **china-kritisch 复选框（#731）**：摘要默认走便宜的 DeepSeek —— Daniel 的博客素材绝大多数不批评中国，没必要为它们付 OpenAI 的钱。少数确实批评中国的素材勾选后存 `podcast_episodes.china_critical=1`，摘要时把 DeepSeek 从候选模型里**彻底删掉**（不是排后面）：它对这类内容会悄悄弱化或拒答，而弱化后的摘要照样能解析出 `summary_de`，任何"解析失败就回退"的机制都永远不会触发

--- a/knowledge/signal_inbox.py
+++ b/knowledge/signal_inbox.py
@@ -1,0 +1,322 @@
+"""Knowledge base Signal intake (issue #749): poll signal-cli's linked-device
+session for messages Daniel shared to his own "Note to Self" conversation,
+and ingest any URL found in them via the one shared pipeline,
+`knowledge.ingest.ingest_url()` — the exact same pipeline the paste-a-URL box
+in the UI uses (POST /api/knowledge/add) and knowledge/mailbox.py's IMAP
+intake use. No second/parallel "URL -> episode row" implementation here
+either — see knowledge/ingest.py's docstring for why that matters in this
+repo (#643 is the cautionary tale: two entry points, a bug fixed in one
+came back in the other).
+
+Unlike IMAP (mailbox.py can leave a message UNSEEN and retry it next poll),
+`signal-cli receive` permanently drains the queued messages off the Signal
+server the moment it's called — there is no "leave it, try again next run"
+option at the protocol level. So a URL whose ingest_url() call fails here is
+stashed in a small JSON retry queue (app_settings['signal_retry_queue'],
+via database.get_app_setting/set_app_setting) and re-attempted on the next
+poll, up to 3 attempts before it's dropped (and Daniel is told so in the
+receipt).
+
+Security: the server holds a *linked device* of Daniel's own Signal account
+(SIGNAL_ACCOUNT, same env var podcast.send_signal() sends notifications
+from). signal-cli syncs down EVERY message Daniel's primary device (his
+phone) sends, not just Note-to-Self ones — an ordinary message he sends to
+a friend shows up here too, as a `syncMessage.sentMessage` with a different
+destination. Only messages both FROM the account and addressed back TO the
+account itself (Note to Self) are ever treated as ingest input; anything
+else is ignored. This is the same role KNOWLEDGE_MAIL_ALLOWED_SENDERS plays
+for the mailbox intake — the one gate stopping this channel from turning
+into "anyone who can message Daniel triggers a paid AI call".
+"""
+import json
+import logging
+import os
+import subprocess
+
+import database
+import knowledge.ingest
+import podcast
+from knowledge.mailbox import extract_urls
+
+logger = logging.getLogger(__name__)
+
+_RETRY_QUEUE_KEY = "signal_retry_queue"
+_MAX_ATTEMPTS = 3
+
+# signal-cli's `receive` blocks briefly waiting for the server; 120s is
+# generous headroom over its usual few-second turnaround without letting a
+# hung connection stall the cron slot indefinitely.
+_RECEIVE_TIMEOUT = 120
+
+
+def _default_runner(args: list) -> str:
+    """Default `runner`: shell out to signal-cli for real. Tests always
+    inject a fake runner instead — see module tests, and knowledge/mailbox.py
+    which does the equivalent with `imap_factory` for the same reason
+    (CLAUDE.md: test suites must never reach real network services)."""
+    result = subprocess.run(args, capture_output=True, timeout=_RECEIVE_TIMEOUT)
+    stdout = result.stdout.decode("utf-8", "replace") if isinstance(result.stdout, bytes) else (result.stdout or "")
+    if result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", "replace") if isinstance(result.stderr, bytes) else (result.stderr or "")
+        raise RuntimeError(f"signal-cli exited {result.returncode}: {stderr.strip()}")
+    return stdout
+
+
+def _load_retry_queue() -> list:
+    raw = database.get_app_setting(_RETRY_QUEUE_KEY)
+    if not raw:
+        return []
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return []
+    return data if isinstance(data, list) else []
+
+
+def _save_retry_queue(queue: list) -> None:
+    database.set_app_setting(_RETRY_QUEUE_KEY, json.dumps(queue))
+
+
+def _extract_note_to_self_text(envelope: dict, account: str) -> str | None:
+    """Return the message body if `envelope` is a Note-to-Self message from
+    Daniel's own account (`account`), else None.
+
+    Two JSON shapes both count, matching signal-cli's `-o json receive`
+    output:
+      - envelope.syncMessage.sentMessage — the normal case for a linked
+        device: a sync copy of a message the phone sent. Only qualifies as
+        Note to Self if BOTH the envelope's source AND the sentMessage's
+        destination are the account itself (a message sent to a friend has
+        the same source but a different destination, and must be ignored —
+        see module docstring's Security section).
+      - envelope.dataMessage — a message addressed directly to this device
+        with source == account. Not how Note-to-Self normally arrives for a
+        linked device, but handled defensively rather than assumed away.
+
+    Every other shape (an ordinary incoming message from someone else, a
+    receipt, a typing indicator, ...) returns None.
+
+    This check is deliberately fail-closed: anything that isn't PROVEN to be
+    Note-to-Self is dropped, never guessed at as "probably fine". Two traps
+    that make this necessary:
+      - A message Daniel sends to a GROUP has no destinationNumber/Uuid at
+        all — only `groupInfo` — so a naive "dest is empty -> allow" check
+        (the bug this replaced) waves through every group message he sends
+        from his phone. He'd have no idea the server was fetching and
+        summarizing links from his group chats.
+      - Any other missing/ambiguous destination is treated the same way:
+        better to silently miss a legitimate Note-to-Self message (Daniel
+        just re-shares it, mildly annoying) than to silently spend money
+        transcribing/summarizing something he never meant to send here.
+    """
+    source = (envelope.get("sourceNumber") or envelope.get("sourceUuid") or
+              envelope.get("source") or "").strip()
+    if not source or source != account:
+        return None
+
+    sync = envelope.get("syncMessage") or {}
+    sent = sync.get("sentMessage")
+    if sent is not None:
+        if sent.get("groupInfo"):
+            # Sent to a group, not to himself — never Note to Self.
+            return None
+        dest = (sent.get("destinationNumber") or sent.get("destinationUuid") or
+                sent.get("destination") or "")
+        if not dest or dest != account:
+            # No provable recipient, or a recipient that isn't the account
+            # itself -> fail closed, do not guess.
+            return None
+        return sent.get("message")
+
+    data = envelope.get("dataMessage")
+    if data is not None:
+        if data.get("groupInfo"):
+            return None
+        return data.get("message")
+
+    return None
+
+
+def send_receipt(lines: list) -> bool:
+    """Send one Signal "Note to Self" receipt summarizing a
+    check_signal_inbox() run's results. No message is sent if `lines` is
+    empty — a run that found nothing to do must not show up on Daniel's
+    phone at all (module docstring / issue #749: "don't spam him")."""
+    if not lines:
+        return False
+    return podcast.send_signal_text("\n".join(lines), context="signal-inbox-receipt")
+
+
+def _process_new_episode(episode_id: int, result_lines: list) -> None:
+    """Synchronously run transcription+summary for a freshly-ingested
+    episode (the equivalent of POST /api/podcast/episodes/{id}/process, but
+    called in-process rather than over HTTP since this runs inside a
+    one-shot cron script — there is no long-lived server process here to
+    hand a background thread off to, it would just get killed when the
+    script exits). Appends one short status line to `result_lines`;
+    podcast.retry_episode -> podcast._process_episode already sends the
+    full summary via podcast.send_signal() on success, so this must NOT
+    repeat it (see issue #749's explicit "don't double-send the summary").
+
+    Never raises — podcast.retry_episode's underlying _process_episode is
+    documented as never raising (any failure is stored as status='error'),
+    but this is wrapped anyway so a genuinely unexpected exception here
+    still shows up in the receipt instead of vanishing.
+    """
+    try:
+        outcome = podcast.retry_episode(episode_id)
+    except Exception as e:
+        logger.error("knowledge.signal_inbox: 处理 episode %s 时异常: %s", episode_id, e)
+        result_lines.append(f"⚠️ 处理时出错（episode {episode_id}）— {e}")
+        return
+
+    status = outcome.get("status")
+    episode = database.get_episode(episode_id) or {}
+    title = episode.get("title") or f"episode {episode_id}"
+    if status == "summarized":
+        result_lines.append(f"🧠 已处理完成：{title}")
+    elif status == "no_transcript":
+        result_lines.append(f"⚠️ 未能获取内容：{title}")
+    else:
+        error = outcome.get("error") or "unknown error"
+        result_lines.append(f"⚠️ 处理失败：{title} — {error}")
+
+
+def check_signal_inbox(runner=None) -> dict:
+    """Poll signal-cli for new Note-to-Self messages (plus any previously
+    failed URLs sitting in the retry queue), ingest every URL found, and
+    kick off transcription+summary for newly-created episodes. Sends a
+    Signal receipt with the results (unless nothing happened this run).
+
+    `runner` is injectable for tests: a callable `(args: list[str]) -> str`
+    returning signal-cli's stdout. Defaults to a real subprocess call.
+    Never used for real signal-cli/network I/O in tests — see
+    knowledge/mailbox.py's `imap_factory` for the same pattern.
+    """
+    summary = {
+        "checked": 0, "processed": 0, "skipped": 0, "failed": 0,
+        "ingested": 0, "errors": [], "results": [],
+    }
+
+    account = os.environ.get("SIGNAL_ACCOUNT")
+    if not account:
+        logger.info("knowledge.signal_inbox: SIGNAL_ACCOUNT 未配置，跳过")
+        summary["reason"] = "no_account"
+        return summary
+
+    if runner is None:
+        runner = _default_runner
+    cli_path = os.environ.get("SIGNAL_CLI_PATH", "signal-cli")
+
+    # 先处理上一轮失败留下的重试队列（收到的顺序在前，即"更旧的失败优先"）。
+    retry_items = []
+    for item in _load_retry_queue():
+        url = (item or {}).get("url")
+        attempts = (item or {}).get("attempts", 0)
+        if url:
+            retry_items.append((url, attempts))
+
+    try:
+        stdout = runner([cli_path, "-a", account, "-o", "json", "receive"])
+    except Exception as e:
+        logger.warning("knowledge.signal_inbox: signal-cli receive 失败: %s", e)
+        summary["reason"] = "receive_failed"
+        summary["errors"].append(str(e))
+        return summary
+
+    new_urls = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except (ValueError, TypeError):
+            logger.debug("knowledge.signal_inbox: 忽略非 JSON 行: %s", line[:120])
+            continue
+
+        # `signal-cli -o json receive` wraps each event as {"envelope": {...},
+        # "account": "..."}. Fall back to the parsed object itself so a
+        # differently-shaped line (or a test fixture that hands over the
+        # envelope directly) still works rather than being silently dropped.
+        envelope = parsed.get("envelope") if isinstance(parsed, dict) else None
+        if envelope is None:
+            envelope = parsed if isinstance(parsed, dict) else {}
+
+        summary["checked"] += 1
+        text = _extract_note_to_self_text(envelope, account)
+        if text is None:
+            # 非本人发给自己的消息 —— 见模块顶部 Security 说明，一律忽略。
+            summary["skipped"] += 1
+            continue
+
+        found = extract_urls(text)
+        if not found:
+            summary["skipped"] += 1
+            continue
+        new_urls.extend(found)
+
+    # 合并重试队列 + 新链接，同一 URL 只处理一次（本轮内去重；跨轮去重靠
+    # ingest_url() 自身的 already_exists 幂等）。
+    seen = set()
+    work_items = []
+    for url, attempts in retry_items:
+        if url not in seen:
+            seen.add(url)
+            work_items.append((url, attempts))
+    for url in new_urls:
+        if url not in seen:
+            seen.add(url)
+            work_items.append((url, 0))
+
+    if work_items:
+        podcast.send_signal_text(
+            f"📥 已收到 {len(work_items)} 个链接，开始处理…",
+            context="signal-inbox-start",
+        )
+
+    next_retry_queue = []
+    receipt_lines = []
+
+    for url, attempts in work_items:
+        try:
+            result = knowledge.ingest.ingest_url(url)
+        except Exception as e:
+            attempts += 1
+            logger.warning("knowledge.signal_inbox: 入库失败（第 %d 次）%s: %s", attempts, url, e)
+            summary["errors"].append(f"{url}: {e}")
+            summary["results"].append({"url": url, "ok": False, "error": str(e)})
+            if attempts >= _MAX_ATTEMPTS:
+                summary["failed"] += 1
+                receipt_lines.append(f"❌ 已放弃：{url} — {e}")
+            else:
+                next_retry_queue.append({"url": url, "attempts": attempts})
+                # Every URL that triggers the "📥 已收到…开始处理" notice above
+                # must get SOME follow-up line, or Daniel sees "started" and
+                # then silence with no way to tell "still running" from
+                # "quietly retrying" from "the whole thing died" (this was a
+                # reported bug: attempts 1-2 wrote nothing here at all).
+                receipt_lines.append(f"⏳ 稍后重试（第 {attempts}/{_MAX_ATTEMPTS} 次）：{url} — {e}")
+            continue
+
+        summary["ingested"] += 1
+        summary["processed"] += 1
+        episode_id = result.get("episode_id")
+        already_exists = result.get("status") == "already_exists"
+        episode = database.get_episode(episode_id) if episode_id else None
+        title = episode.get("title") if episode else None
+
+        summary["results"].append({
+            "url": url, "ok": True, "episode_id": episode_id, "title": title,
+        })
+        if already_exists:
+            receipt_lines.append(f"↺ 已在库中：{title or url}")
+        else:
+            receipt_lines.append(f"✅ {title or url}")
+            if episode_id:
+                _process_new_episode(episode_id, receipt_lines)
+
+    _save_retry_queue(next_retry_queue)
+    send_receipt(receipt_lines)
+
+    return summary

--- a/podcast.py
+++ b/podcast.py
@@ -1402,6 +1402,40 @@ def _summary_to_plain_text(summary: str | None) -> str:
     return text
 
 
+def send_signal_text(text: str, *, context: str = "signal") -> bool:
+    """Send one plain-text Signal "Note to Self" message via a linked-device
+    signal-cli install (#521, extracted #749 so knowledge/signal_inbox.py's
+    receipts can share this instead of re-implementing the subprocess call).
+    Returns True if sent, False if skipped (SIGNAL_ACCOUNT not configured) —
+    skipping is not an error, mirrors send_mail(). Never raises.
+
+    `context` is only used in log lines to identify the caller (an episode's
+    video_id for send_signal(), "signal-inbox-receipt" for the inbox script).
+    """
+    account = os.environ.get("SIGNAL_ACCOUNT")
+    if not account:
+        logger.info("podcast: SIGNAL_ACCOUNT not configured, skipping Signal message (%s)", context)
+        return False
+
+    cli_path = os.environ.get("SIGNAL_CLI_PATH", "signal-cli")
+    try:
+        result = subprocess.run(
+            [cli_path, "-a", account, "send", "--note-to-self", "-m", text],
+            capture_output=True, timeout=60,
+        )
+    except Exception as e:
+        logger.warning("podcast: signal-cli invocation failed for %s: %s", context, e)
+        return False
+
+    if result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", "replace") if isinstance(result.stderr, bytes) else result.stderr
+        logger.warning("podcast: signal-cli exited %s for %s: %s", result.returncode, context, stderr)
+        return False
+
+    logger.info("podcast: Signal message sent (%s)", context)
+    return True
+
+
 def send_signal(episode: dict) -> bool:
     """Send a plain-text Signal "Note to Self" notification for a freshly-
     summarized episode via a linked-device signal-cli install (#521).
@@ -1413,7 +1447,6 @@ def send_signal(episode: dict) -> bool:
                      episode["video_id"])
         return False
 
-    cli_path = os.environ.get("SIGNAL_CLI_PATH", "signal-cli")
     public_base = os.environ.get("PUBLIC_BASE_URL", "https://powerdaniel3000.duckdns.org")
     transcript_link = f"{public_base}/#podcast-{episode['id']}"
 
@@ -1471,23 +1504,7 @@ def send_signal(episode: dict) -> bool:
         lines.append(episode["spotify_url"])
     text = "\n".join(lines)
 
-    try:
-        result = subprocess.run(
-            [cli_path, "-a", account, "send", "--note-to-self", "-m", text],
-            capture_output=True, timeout=60,
-        )
-    except Exception as e:
-        logger.warning("podcast: signal-cli invocation failed for %s: %s", episode["video_id"], e)
-        return False
-
-    if result.returncode != 0:
-        stderr = result.stderr.decode("utf-8", "replace") if isinstance(result.stderr, bytes) else result.stderr
-        logger.warning("podcast: signal-cli exited %s for %s: %s",
-                        result.returncode, episode["video_id"], stderr)
-        return False
-
-    logger.info("podcast: Signal notification sent for %s", episode["video_id"])
-    return True
+    return send_signal_text(text, context=episode["video_id"])
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -301,6 +301,12 @@ SIGNAL_CLI_PATH=/usr/local/bin/signal-cli   # 可省略，默认就是 "signal-c
 `send_signal` 只记 info 日志并返回 `False`（视为"未启用"）——**不会**让
 爬虫报错，与邮件通知完全独立、互不影响。
 
+🔴 **`/home/anki/.local/share/signal-cli` 必须纳入服务器备份**——丢了这
+个目录（换机、误删）唯一的恢复办法是重新扫码关联，没有其他找回途径。
+issue #749 的 Signal 知识库入口（见下面 `signal_check.py`）复用的是同一
+个关联账号/同一份会话数据，所以这个目录现在同时承载"发通知"和"收链接"
+两种用途，重要性比 #521 时更高。
+
 用法与环境变量同 `morning_pregen.py`（`BASE_URL`/`AUTH_USERNAME`/`AUTH_PASSWORD`）。
 另外邮件发送需要 SMTP 环境变量（`SMTP_HOST`/`SMTP_PORT`/`SMTP_USERNAME`/
 `SMTP_PASSWORD`/`SMTP_FROM`/`PUBLIC_BASE_URL`，见 CLAUDE.md 环境变量表），
@@ -376,3 +382,54 @@ python scripts/knowledge_mail_check.py
 
 退出码：跳过（未配置白名单/凭据）或全部成功为 `0`；有失败邮件时为 `1`
 （方便 cron 邮件通知/监控接入）。
+
+---
+
+## signal_check.py（issue #749）
+
+知识库 Signal 分享入口：手机把链接分享到 Signal 自己的「Note to Self」
+（给自己的备忘），服务器用**已经关联好的同一个 signal-cli 设备**（见上
+面"Signal 通知一次性安装/关联设置"，#521 建立的那份关联——不需要再关联
+一次）把消息收下来，从正文里提取 URL，逐个走
+`knowledge.ingest.ingest_url()`——和知识页粘贴框、`knowledge_mail_check.py`
+用的是**同一条入库管线**。新入库的链接接着同步跑一遍转录+摘要
+（`podcast.retry_episode()`），完成后把结果发回 Note to Self。
+
+**这是"发通知"的反方向**：`send_signal()`（#521）是服务器 → Daniel，这
+个脚本是 Daniel → 服务器，走的是同一个关联设备、同一个 `SIGNAL_ACCOUNT`。
+
+**和 IMAP 邮箱收件的关键差异**：`imaplib` 可以把处理失败的邮件留成
+UNSEEN，下一轮重新看到；但 `signal-cli receive` 一次调用就会把消息从
+Signal 服务器上永久取走，没有"留着不读"这个选项。所以入库失败的 URL
+由 `knowledge/signal_inbox.py` 自己存进一个 JSON 重试队列
+（`app_settings['signal_retry_queue']`），下一轮优先处理，最多重试 3 次
+后放弃，并在回执里告诉 Daniel。
+
+**安全**：只有源账号和目的账号都是 `SIGNAL_ACCOUNT` 自己的消息（Note to
+Self）才会被当作入库输入——signal-cli 作为关联设备会同步收到 Daniel 手
+机发出的**所有**消息，包括发给别人的；发给别人的消息、以及任何来自其他
+号码的消息一律忽略。这条防线和 `KNOWLEDGE_MAIL_ALLOWED_SENDERS` 对邮件
+入口的作用相同：挡住"服务器替任何人抓取 URL 并触发付费 AI 调用"。
+
+### 环境变量
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `SIGNAL_ACCOUNT` | 无（**必须配置**） | 关联设备所属的 Signal 号码；未配置时整个检查被跳过 |
+| `SIGNAL_CLI_PATH` | `signal-cli` | 可执行文件路径 |
+| `DB_PATH` | `data/srs.db` | 数据库路径 |
+
+### 用法
+
+```bash
+python scripts/signal_check.py
+```
+
+### 服务器 cron：每 5 分钟检查一次
+
+```cron
+*/5 * * * * cd /opt/ankiadvanced && /usr/bin/python3 scripts/signal_check.py >> data/signal-check.log 2>&1
+```
+
+退出码：跳过（未配置账号）或全部成功为 `0`；`signal-cli receive` 失败或
+有 URL 最终放弃时为 `1`。

--- a/scripts/signal_check.py
+++ b/scripts/signal_check.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""知识库 Signal 收件定时脚本（issue #749）。
+
+轮询服务器上关联的 signal-cli 设备（`signal -a $SIGNAL_ACCOUNT -o json
+receive`），把 Daniel 发给自己「Note to Self」的消息里的 URL 逐个送进
+`knowledge.ingest.ingest_url()`——和界面「粘贴 URL」用的是同一条管线
+（见 `knowledge/ingest.py`、`knowledge/signal_inbox.py` 的模块说明）。新
+入库的链接接着同步跑一遍转录+摘要（`podcast.retry_episode()`），完成后
+通过 Signal 把结果发回 Daniel 自己（收到确认 + 每条一行简短结果；已有
+完整摘要通知走 `podcast.send_signal()`，这里不重复发）。
+
+和 `scripts/knowledge_mail_check.py` 是同一套设计（不复制第二份实现，
+入库都走 `knowledge.ingest.ingest_url()`），只是收件通道不同：IMAP 邮箱
+可以把处理失败的邮件留成 UNSEEN 下轮重试，但 `signal-cli receive` 一次
+就会把消息从 Signal 服务器上取走，没有"留着不读、下次再看"这个选项。
+所以失败的 URL 由 `knowledge/signal_inbox.py` 自己存进一个小的 JSON 重
+试队列（`app_settings['signal_retry_queue']`），最多重试 3 次后放弃并
+在回执里告知。
+
+风格照抄 `scripts/knowledge_mail_check.py`：直接 `import database` +
+`database.init_db()` 后在本进程里完成，不经过任何 HTTP 接口；用同一种
+PID 锁文件方式防止 cron 叠跑（处理链接可能触发文章抓取/YouTube 转录/AI
+摘要，慢的话能到几分钟到十几分钟）。
+
+用法：
+    python scripts/signal_check.py
+
+环境变量（见 CLAUDE.md 环境变量表）：
+    SIGNAL_ACCOUNT      关联设备所属的 Signal 号码（如 +49…）；未配置则
+                        整个检查被跳过
+    SIGNAL_CLI_PATH     signal-cli 可执行文件路径，默认 `signal-cli`
+    DB_PATH             数据库路径，默认 data/srs.db
+
+signal-cli 的会话状态（关联设备凭据）存在 `~/.local/share/signal-cli`，
+丢了要重新扫码关联——务必把这个目录纳入服务器备份。一次性关联步骤见
+`scripts/README.md`。
+"""
+import fcntl
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+LOCK_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data", ".signal_check.lock")
+
+
+def _log(msg: str) -> None:
+    ts = time.strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[{ts}] {msg}", flush=True)
+
+
+def main() -> int:
+    os.makedirs(os.path.dirname(LOCK_PATH), exist_ok=True)
+    lock_file = open(LOCK_PATH, "w")
+    try:
+        fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        _log("上一轮 Signal 收件检查仍在进行，本轮跳过。")
+        return 0
+
+    try:
+        lock_file.write(str(os.getpid()))
+        lock_file.flush()
+
+        import database
+        database.init_db()
+        import knowledge.signal_inbox
+
+        _log("Signal 收件检查开始")
+        summary = knowledge.signal_inbox.check_signal_inbox()
+
+        reason = summary.get("reason")
+        if reason == "no_account":
+            _log("SIGNAL_ACCOUNT 未配置，跳过。")
+            return 0
+        if reason == "receive_failed":
+            _log("signal-cli receive 失败。")
+            for err in summary.get("errors", []):
+                _log(f"错误: {err}")
+            return 1
+
+        _log(
+            f"收到消息: {summary['checked']}  已处理: {summary['processed']}  "
+            f"跳过: {summary['skipped']}  失败: {summary['failed']}  "
+            f"入库 URL 数: {summary['ingested']}"
+        )
+        for err in summary.get("errors", []):
+            _log(f"错误: {err}")
+
+        return 0 if not summary["failed"] else 1
+    except Exception as e:
+        _log(f"Signal 收件检查异常: {e}")
+        return 1
+    finally:
+        try:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        lock_file.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_signal_inbox.py
+++ b/tests/test_signal_inbox.py
@@ -1,0 +1,368 @@
+"""Tests for knowledge/signal_inbox.py (issue #749).
+
+signal-cli is entirely faked: `runner` (injected into check_signal_inbox)
+is a plain callable that returns canned JSON-Lines stdout instead of
+actually shelling out — CLAUDE.md is explicit that test suites must never
+reach real network services / external processes, mirroring how
+knowledge/mailbox.py fakes IMAP via `imap_factory`.
+
+knowledge.ingest.ingest_url and podcast.retry_episode/send_signal_text are
+monkeypatched too: exercising the real ingest/transcribe/summarize pipeline
+is covered elsewhere (tests/test_knowledge_youtube.py,
+tests/test_knowledge_article.py, tests/test_podcast*.py).
+"""
+import json
+
+import pytest
+
+import database
+import knowledge.ingest
+import knowledge.signal_inbox as signal_inbox
+import podcast
+
+
+ACCOUNT = "+491234567890"
+OTHER = "+499999999999"
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    """Fresh temp database — retry-queue state lives in app_settings.
+    Patch database.core.DB_PATH, not database.DB_PATH (issue #615: the
+    latter is only a name copy, get_db() reads the former)."""
+    monkeypatch.setattr(database.core, "DB_PATH", str(tmp_path / "test.db"))
+    database.init_db()
+
+
+@pytest.fixture(autouse=True)
+def _no_real_signal(monkeypatch):
+    """Belt-and-suspenders: even if a test forgets to patch send_signal_text
+    itself, nothing here should ever shell out to a real signal-cli."""
+    monkeypatch.setattr(podcast, "send_signal_text", lambda text, context="signal": True)
+
+
+def _envelope_note_to_self(message: str, source=ACCOUNT, destination=ACCOUNT) -> dict:
+    """A linked-device sync copy of a message the phone sent to Note to
+    Self: source == account, sentMessage.destination == account."""
+    return {
+        "sourceNumber": source,
+        "syncMessage": {"sentMessage": {"destinationNumber": destination, "message": message}},
+    }
+
+
+def _envelope_sent_to_other(message: str) -> dict:
+    """A sync copy of a message Daniel's phone sent to someone ELSE — same
+    source as Note to Self, different destination. Must be ignored."""
+    return {
+        "sourceNumber": ACCOUNT,
+        "syncMessage": {"sentMessage": {"destinationNumber": "+493333333333", "message": message}},
+    }
+
+
+def _envelope_sent_to_group(message: str) -> dict:
+    """A sync copy of a message Daniel's phone sent to a GROUP — same
+    source as Note to Self, no destinationNumber at all, only groupInfo.
+    This is the fail-closed case: a naive "no destination -> allow" check
+    would wave this through. Must be ignored."""
+    return {
+        "sourceNumber": ACCOUNT,
+        "syncMessage": {"sentMessage": {"groupInfo": {"groupId": "abc123"}, "message": message}},
+    }
+
+
+def _envelope_sent_message_no_destination(message: str) -> dict:
+    """A sentMessage with no destination and no groupInfo either — an
+    ambiguous/unrecognized shape. Must fail closed (ignored), not guessed
+    at as Note to Self."""
+    return {
+        "sourceNumber": ACCOUNT,
+        "syncMessage": {"sentMessage": {"message": message}},
+    }
+
+
+def _envelope_from_other(message: str) -> dict:
+    """An ordinary incoming message from someone who is not Daniel's own
+    account. Must be ignored — the security gate under test."""
+    return {
+        "sourceNumber": OTHER,
+        "dataMessage": {"message": message},
+    }
+
+
+def _lines(*envelopes) -> str:
+    return "\n".join(json.dumps(e) for e in envelopes)
+
+
+def _make_runner(stdout: str, calls=None):
+    def runner(args):
+        if calls is not None:
+            calls.append(args)
+        return stdout
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# SIGNAL_ACCOUNT not configured
+# ---------------------------------------------------------------------------
+
+def test_no_account_configured_skips_everything(tmp_db, monkeypatch):
+    monkeypatch.delenv("SIGNAL_ACCOUNT", raising=False)
+    calls = []
+    summary = signal_inbox.check_signal_inbox(runner=_make_runner("", calls))
+
+    assert summary["reason"] == "no_account"
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Security: only Note-to-Self from the account itself is ingested
+# ---------------------------------------------------------------------------
+
+def test_message_from_someone_else_is_skipped(tmp_db, monkeypatch):
+    monkeypatch.setenv("SIGNAL_ACCOUNT", ACCOUNT)
+    stdout = _lines(_envelope_from_other("https://example.com/from-stranger"))
+
+    ingest_calls = []
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", lambda url: ingest_calls.append(url) or {"episode_id": 1})
+
+    summary = signal_inbox.check_signal_inbox(runner=_make_runner(stdout))
+
+    assert summary["skipped"] == 1
+    assert summary["checked"] == 1
+    assert ingest_calls == []
+
+
+def test_message_sent_to_someone_else_is_skipped(tmp_db, monkeypatch):
+    """Same source (Daniel's own account) as Note to Self, but addressed to
+    a different destination — must not be treated as inbox input."""
+    monkeypatch.setenv("SIGNAL_ACCOUNT", ACCOUNT)
+    stdout = _lines(_envelope_sent_to_other("https://example.com/to-a-friend"))
+
+    ingest_calls = []
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", lambda url: ingest_calls.append(url) or {"episode_id": 1})
+
+    summary = signal_inbox.check_signal_inbox(runner=_make_runner(stdout))
+
+    assert summary["skipped"] == 1
+    assert ingest_calls == []
+
+
+def test_message_sent_to_a_group_is_skipped(tmp_db, monkeypatch):
+    """Same source as Note to Self, but sent to a GROUP (no destination
+    field, only groupInfo) — the fail-closed bug this test guards against:
+    a naive "no destination -> allow" check would ingest every link Daniel
+    ever shares with a group chat, without him knowing."""
+    monkeypatch.setenv("SIGNAL_ACCOUNT", ACCOUNT)
+    stdout = _lines(_envelope_sent_to_group("https://example.com/group-link"))
+
+    ingest_calls = []
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", lambda url: ingest_calls.append(url) or {"episode_id": 1})
+
+    summary = signal_inbox.check_signal_inbox(runner=_make_runner(stdout))
+
+    assert summary["skipped"] == 1
+    assert ingest_calls == []
+
+
+def test_sent_message_with_no_destination_is_skipped(tmp_db, monkeypatch):
+    """No destination and no groupInfo either — an unrecognized/ambiguous
+    shape must fail closed, not be guessed at as Note to Self."""
+    monkeypatch.setenv("SIGNAL_ACCOUNT", ACCOUNT)
+    stdout = _lines(_envelope_sent_message_no_destination("https://example.com/ambiguous"))
+
+    ingest_calls = []
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", lambda url: ingest_calls.append(url) or {"episode_id": 1})
+
+    summary = signal_inbox.check_signal_inbox(runner=_make_runner(stdout))
+
+    assert summary["skipped"] == 1
+    assert ingest_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Note-to-Self URLs are extracted and ingested
+# ---------------------------------------------------------------------------
+
+def test_note_to_self_url_is_ingested(tmp_db, monkeypatch):
+    monkeypatch.setenv("SIGNAL_ACCOUNT", ACCOUNT)
+    stdout = _lines(_envelope_note_to_self("Schau dir das an: https://example.com/article-1"))
+
+    ingest_calls = []
+
+    def fake_ingest(url):
+        ingest_calls.append(url)
+        return {"episode_id": 1}
+
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", fake_ingest)
+    # New episode -> processing is triggered too; keep it a no-op here.
+    monkeypatch.setattr(podcast, "retry_episode", lambda episode_id: {"status": "summarized", "error": None})
+    monkeypatch.setattr(database, "get_episode", lambda episode_id: {"id": episode_id, "title": "Article One"})
+
+    summary = signal_inbox.check_signal_inbox(runner=_make_runner(stdout))
+
+    assert ingest_calls == ["https://example.com/article-1"]
+    assert summary["ingested"] == 1
+    assert summary["processed"] == 1
+    assert summary["results"][0]["ok"] is True
+    assert summary["results"][0]["episode_id"] == 1
+
+
+def test_dedup_same_url_twice_ingests_once(tmp_db, monkeypatch):
+    monkeypatch.setenv("SIGNAL_ACCOUNT", ACCOUNT)
+    stdout = _lines(
+        _envelope_note_to_self("https://example.com/dup"),
+        _envelope_note_to_self("nochmal: https://example.com/dup"),
+    )
+
+    ingest_calls = []
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", lambda url: ingest_calls.append(url) or {"episode_id": 1})
+    monkeypatch.setattr(podcast, "retry_episode", lambda episode_id: {"status": "summarized", "error": None})
+    monkeypatch.setattr(database, "get_episode", lambda episode_id: {"id": episode_id, "title": "Dup"})
+
+    summary = signal_inbox.check_signal_inbox(runner=_make_runner(stdout))
+
+    assert ingest_calls == ["https://example.com/dup"]
+    assert summary["ingested"] == 1
+
+
+def test_already_existing_episode_is_not_reprocessed(tmp_db, monkeypatch):
+    monkeypatch.setenv("SIGNAL_ACCOUNT", ACCOUNT)
+    stdout = _lines(_envelope_note_to_self("https://example.com/already-there"))
+
+    monkeypatch.setattr(knowledge.ingest, "ingest_url",
+                         lambda url: {"status": "already_exists", "episode_id": 7})
+    process_calls = []
+    monkeypatch.setattr(podcast, "retry_episode", lambda episode_id: process_calls.append(episode_id) or {"status": "summarized"})
+    monkeypatch.setattr(database, "get_episode", lambda episode_id: {"id": episode_id, "title": "Already There"})
+
+    summary = signal_inbox.check_signal_inbox(runner=_make_runner(stdout))
+
+    assert process_calls == []
+    assert summary["results"][0]["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Retry queue for failed ingests
+# ---------------------------------------------------------------------------
+
+def test_ingest_failure_goes_to_retry_queue(tmp_db, monkeypatch):
+    monkeypatch.setenv("SIGNAL_ACCOUNT", ACCOUNT)
+    stdout = _lines(_envelope_note_to_self("https://example.com/flaky"))
+
+    def failing_ingest(url):
+        raise knowledge.ingest.IngestError("temporary failure")
+
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", failing_ingest)
+
+    summary = signal_inbox.check_signal_inbox(runner=_make_runner(stdout))
+
+    assert summary["failed"] == 0  # not yet given up
+    assert len(summary["errors"]) == 1
+    queue = signal_inbox._load_retry_queue()
+    assert queue == [{"url": "https://example.com/flaky", "attempts": 1}]
+
+
+def test_first_failure_still_sends_a_receipt_line(tmp_db, monkeypatch):
+    """Bug fix: the "📥 已收到…开始处理" notice was being sent even when the
+    only outcome was "queued for retry", leaving Daniel with no follow-up
+    message at all — no way to tell "still running" from "silently
+    retrying" from "died". Every URL that triggers the start notice must
+    produce a corresponding line in the final receipt, even on attempt 1."""
+    monkeypatch.setenv("SIGNAL_ACCOUNT", ACCOUNT)
+    stdout = _lines(_envelope_note_to_self("https://example.com/flaky"))
+
+    def failing_ingest(url):
+        raise knowledge.ingest.IngestError("temporary failure")
+
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", failing_ingest)
+
+    sent = []
+    monkeypatch.setattr(podcast, "send_signal_text", lambda text, context="signal": sent.append(text) or True)
+
+    summary = signal_inbox.check_signal_inbox(runner=_make_runner(stdout))
+
+    assert summary["failed"] == 0
+    # sent[0] is the "received, starting" notice; sent[1] is the receipt —
+    # the receipt must mention the URL even though it isn't a final failure.
+    assert len(sent) == 2
+    assert "https://example.com/flaky" in sent[1]
+
+
+def test_retry_queue_is_retried_and_dropped_after_three_attempts(tmp_db, monkeypatch):
+    monkeypatch.setenv("SIGNAL_ACCOUNT", ACCOUNT)
+
+    def failing_ingest(url):
+        raise knowledge.ingest.IngestError("still broken")
+
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", failing_ingest)
+
+    # No new messages this run — only the retry queue is processed.
+    signal_inbox._save_retry_queue([{"url": "https://example.com/flaky", "attempts": 2}])
+
+    summary = signal_inbox.check_signal_inbox(runner=_make_runner(""))
+
+    assert summary["failed"] == 1
+    assert signal_inbox._load_retry_queue() == []
+    assert any("已放弃" in line or "flaky" in line for line in summary["errors"])
+
+
+def test_retry_queue_processed_before_new_messages(tmp_db, monkeypatch):
+    monkeypatch.setenv("SIGNAL_ACCOUNT", ACCOUNT)
+    signal_inbox._save_retry_queue([{"url": "https://example.com/old", "attempts": 1}])
+    stdout = _lines(_envelope_note_to_self("https://example.com/new"))
+
+    order = []
+
+    def fake_ingest(url):
+        order.append(url)
+        return {"episode_id": 1}
+
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", fake_ingest)
+    monkeypatch.setattr(podcast, "retry_episode", lambda episode_id: {"status": "summarized"})
+    monkeypatch.setattr(database, "get_episode", lambda episode_id: {"id": episode_id, "title": "T"})
+
+    signal_inbox.check_signal_inbox(runner=_make_runner(stdout))
+
+    assert order == ["https://example.com/old", "https://example.com/new"]
+
+
+# ---------------------------------------------------------------------------
+# Receipts
+# ---------------------------------------------------------------------------
+
+def test_no_receipt_sent_when_nothing_to_do(tmp_db, monkeypatch):
+    monkeypatch.setenv("SIGNAL_ACCOUNT", ACCOUNT)
+    stdout = _lines(_envelope_note_to_self("kein Link hier, nur Text"))
+
+    sent = []
+    monkeypatch.setattr(podcast, "send_signal_text", lambda text, context="signal": sent.append(text) or True)
+
+    summary = signal_inbox.check_signal_inbox(runner=_make_runner(stdout))
+
+    assert summary["skipped"] == 1
+    assert sent == []
+
+
+def test_receipt_sent_when_url_processed(tmp_db, monkeypatch):
+    monkeypatch.setenv("SIGNAL_ACCOUNT", ACCOUNT)
+    stdout = _lines(_envelope_note_to_self("https://example.com/one"))
+
+    sent = []
+    monkeypatch.setattr(podcast, "send_signal_text", lambda text, context="signal": sent.append(text) or True)
+    monkeypatch.setattr(knowledge.ingest, "ingest_url", lambda url: {"episode_id": 1})
+    monkeypatch.setattr(podcast, "retry_episode", lambda episode_id: {"status": "summarized"})
+    monkeypatch.setattr(database, "get_episode", lambda episode_id: {"id": episode_id, "title": "One"})
+
+    signal_inbox.check_signal_inbox(runner=_make_runner(stdout))
+
+    # Two sends: the "received, starting" notice and the final receipt.
+    assert len(sent) == 2
+    assert "已收到" in sent[0]
+    assert "One" in sent[1]
+
+
+def test_send_receipt_noop_on_empty_lines(monkeypatch):
+    called = []
+    monkeypatch.setattr(podcast, "send_signal_text", lambda text, context="signal": called.append(text) or True)
+    assert signal_inbox.send_receipt([]) is False
+    assert called == []


### PR DESCRIPTION
Closes #749

手机分享链接到 Signal 的「Note to Self」→ 服务器作为关联设备收下 → 自动入知识库并转录摘要 → Signal 回执。

## 改了什么
- `knowledge/signal_inbox.py`（新）：轮询 `signal-cli -o json receive`，抽 URL，走唯一入库管线 `knowledge.ingest.ingest_url()`
- `scripts/signal_check.py`（新）：cron 入口，结构照 `knowledge_mail_check.py`（fcntl 锁、中文分步日志、返回码约定）
- `podcast.py`：把 signal-cli 调用从 `send_signal()` 抽成通用的 `send_signal_text()`，收发两个方向共用一份（同 `send_mail()` 的先例）
- `tests/test_signal_inbox.py`（新）：15 条
- `CLAUDE.md` / `scripts/README.md`：功能说明 + signal-cli 关联步骤

## 两个关键设计
**安全门 fail-closed**：服务器是 Daniel 自己号码的关联设备，signal-cli 会同步下他手机发出的**每一条**消息，不只是 Note to Self。只有明确「source == account 且 destination == account 且无 groupInfo」才放行。群消息没有 destination 只有 `groupInfo` —— 审查时发现的第一版会因为「dest 为空就放行」把他发给群的每个链接都抓来烧 AI 的钱。

**重试队列**：`signal-cli receive` 一调用就把消息从服务器取走了，不像 IMAP 能留着不标已读。失败的 URL 存进 `app_settings.signal_retry_queue`，下轮先处理，3 次后放弃并告知。`ingest_url()` 幂等，重试安全。

## 怎么测的
`pytest tests/` → 529 passed, 4 skipped。测试覆盖：未配置账号跳过、他人消息被忽略、群消息被忽略、destination 缺失被忽略、URL 抽取与去重、重试队列累加/重试/3 次后丢弃、无事发生时不发回执。

未做（下一个 PR，#750）：Instagram Reel 下载转写 + 短文本跳过摘要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)