### PR TITLE
知识库故事：生成句子时可多选素材（#752）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -455,7 +455,7 @@ Return ONLY a numbered list of Chinese sentences, no explanation:
     照抄其中的名字和数字（用素材原文的语言写这部分），
     再用一句中文说明这句话在讲什么。面向 HSK 4-5 学习者，中文部分用词不要太难。
 21. 把事实写出来正是为了自查：任何两句的「事实：」都不许相同。
-
+{multi_source_block}
 五、输出前自检（内部进行，不要输出）
 - 句子数是否等于目标词数？
 - 每个目标词是否恰好出现一次？
@@ -486,7 +486,7 @@ PROMPT_TEMPLATE_VARIABLES: dict[str, list[str]] = {
     "story": ["words", "max_hsk", "grammar_block", "topic_block"],
     "qa": ["words", "max_hsk", "grammar_block", "topic"],
     "expository": ["words", "max_hsk", "grammar_block", "topic"],
-    "knowledge": ["words", "summary", "title", "max_hsk", "extra_hint"],
+    "knowledge": ["words", "summary", "title", "max_hsk", "extra_hint", "multi_source_block"],
 }
 
 
@@ -2681,14 +2681,11 @@ def _podcast_max_tokens(model: str, n_words: int) -> int:
 
 def generate_podcast_sentences(
     cards: list[dict],
-    material: str,            # transcript_zh (preferred) or summary_de fallback; caller ensures non-empty — see routes/story.py's _knowledge_material()
-    episode_title: str,
+    sources: list[dict],      # [{"index", "title", "kind", "url", "material"}, ...] — see routes/story.py's knowledge branch; caller ensures every entry has non-empty "material"
     model: str = DEFAULT_MODEL,     # #640: DeepSeek, same as kahneman
     max_hsk: int = 3,
     progress_key: str | None = None,
     attempt_label: str = "",
-    source_url: str | None = None,
-    source_title: str | None = None,
 ) -> tuple[list[dict], str]:
     """Podcast/knowledge mode rework (issue #561) — a lean single-purpose
     pipeline that replaces reuse of the briefing machinery (originally #482).
@@ -2714,14 +2711,19 @@ def generate_podcast_sentences(
     Deliberately has NO fact-check and NO whole-material validation retry —
     those are what make briefing slow and expensive, and podcast/knowledge
     content (unlike news) is not something to fact-check against an external
-    source in the same way. `material` is normally the item's full transcript
-    (transcript_zh, truncated to 15000 chars by the caller — issue #661;
-    Daniel explicitly asked for transcript-based cards, #561 had switched to
-    summary_de purely to cut cost/latency, which stopped mattering once cost
-    was confirmed to be ~$0.003/generation) with summary_de as a fallback for
-    rows that only have a summary (old synced-down data, etc.). The prompt
-    template's {summary} placeholder is reused for whichever text is passed
-    in, so custom prompt_presets Daniel already saved keep working unchanged.
+    source in the same way.
+
+    `sources` (issue #752, multi-source): one or more selected knowledge
+    items, each already carrying its own material text (the caller —
+    routes/story.py — has already resolved transcript_zh vs summary_de and
+    split the _KNOWLEDGE_MATERIAL_MAX_CHARS budget evenly across the
+    selection). With exactly one source, {title}/{summary} render as that
+    source's title/material verbatim and {multi_source_block} renders empty —
+    the single-source prompt must stay byte-for-byte identical to before this
+    was added, since Daniel is actively tuning it. With several sources,
+    {title} becomes a numbered list and {summary} a labeled concatenation of
+    every source's material, and {multi_source_block} adds the instruction to
+    spread sentences across sources and tag each with "source_index".
 
     attempt_label: chunk marker like " (2/3)" appended to every progress
     message — the route batches cards by MAX_NEWS_BATCH and calls this once
@@ -2732,7 +2734,7 @@ def generate_podcast_sentences(
     an extra_hint, so a prompt rebuilt afterwards would not be the one that
     produced these sentences, which is the whole point of keeping it (#697).
     """
-    if not cards or not material.strip():
+    if not cards or not sources:
         return [], ""
 
     # 模板可被用户自定义覆盖（issue #581）；默认渲染结果与旧内联 f-string 逐字一致。
@@ -2742,22 +2744,76 @@ def generate_podcast_sentences(
     # 摘要）——改名会让 Daniel 已保存的自定义模板失效。
     tpl = _story_prompt_template("knowledge")
 
+    # #752: single source keeps {title}/{summary} rendering exactly as before
+    # multi-source support existed (Daniel is actively tuning this prompt, so
+    # the well-worn single-source path must not shift under him). Only with
+    # more than one source do these turn into a labeled listing, and only
+    # then does {multi_source_block} carry any text.
+    if len(sources) == 1:
+        title_block = sources[0].get("title") or ""
+        summary_block = sources[0].get("material") or ""
+        multi_source_block = ""
+    else:
+        title_block = "\n".join(
+            f"{s['index']}. 《{s.get('title') or '（无标题）'}》（{s.get('kind') or 'podcast'}）"
+            for s in sources
+        )
+        summary_block = "\n\n".join(
+            f"── 素材 {s['index']}：《{s.get('title') or '（无标题）'}》（{s.get('kind') or 'podcast'}）──\n"
+            f"{s.get('material') or ''}"
+            for s in sources
+        )
+        # 这段插在「四、reasoning_zh」与「五、输出前自检」之间，所以不另起大节号
+        # （避免出现「六」排在「五」前面），条目号顺着 21 往下接。
+        multi_source_block = (
+            "\n【本次有多份素材】\n"
+            "22. 上面的素材列表和内容各有编号，句子要分散覆盖到不同素材上，"
+            "尽量让每一份都至少被用到，不要全挤在第 1 份。\n"
+            "23. 同一句话只能依据一份素材，不许把不同素材的事实混进同一句。\n"
+            "24. 每个 JSON 元素都要多带一个整数字段 \"source_index\"，"
+            "写这句话依据的是上面第几份素材（对照素材编号）。\n"
+            "25. 输出前再自查一遍：每句都带了 source_index 吗？"
+            "是不是有素材一句都没用到？\n"
+        )
+
     def _build_prompt(batch: list[dict], extra_hint: str = "") -> str:
         word_list = "\n".join(
             f"{i + 1}. {c['word_zh']}（{c.get('pinyin', '')}）— {c.get('definition', '')}"
             for i, c in enumerate(batch)
         )
         return _render_prompt(tpl, {
-            "title": episode_title,
-            "summary": material,
+            "title": title_block,
+            "summary": summary_block,
             "words": word_list,
             "max_hsk": str(max_hsk),
             "extra_hint": extra_hint,
+            "multi_source_block": multi_source_block,
         })
 
     sentences: list[dict] = []
     remaining = list(cards)
     prompts_sent: list[str] = []
+
+    def _source_for(item: dict, label: str) -> dict:
+        """Resolve which source a sentence is attributed to (#752).
+
+        Single-source calls always use sources[0] — no index parsing needed
+        or expected. Multi-source calls read the model's "source_index"
+        (1-based, matching the numbering shown in the prompt); a missing,
+        non-integer, or out-of-range value falls back to sources[0] rather
+        than dropping the sentence — a wrong/missing attribution is a minor
+        cosmetic issue (wrong "open article" link), not worth discarding an
+        otherwise-good sentence over."""
+        if len(sources) == 1:
+            return sources[0]
+        raw_idx = item.get("source_index")
+        idx = raw_idx if isinstance(raw_idx, int) else None
+        if idx is None and isinstance(raw_idx, str) and raw_idx.strip().lstrip("-").isdigit():
+            idx = int(raw_idx)
+        if idx is not None and 1 <= idx <= len(sources):
+            return sources[idx - 1]
+        log_progress(progress_key, f"{label}：句子缺少有效 source_index，回退到素材 1")
+        return sources[0]
 
     def _run_round(batch: list[dict], extra_hint: str, label: str) -> None:
         """One AI call for `batch`; moves every word it covered out of `remaining`."""
@@ -2790,6 +2846,7 @@ def generate_podcast_sentences(
                 continue          # no target word → drop (this mode allows no context sentences)
             remaining.remove(matched)
             got += 1
+            src = _source_for(item, label)
             sentences.append({
                 "word_ids": [matched["word_id"]],
                 "sentence_zh": s_zh,
@@ -2800,8 +2857,8 @@ def generate_podcast_sentences(
                 # reasoning_zh before writing — keep it, it shows in the card's
                 # background popup like kahneman's does.
                 "reasoning_zh": (item.get("reasoning_zh") or "").strip(),
-                "source_url": source_url,
-                "source_title": source_title,
+                "source_url": src.get("url"),
+                "source_title": src.get("title"),
                 "tokens": [],
             })
         log_progress(progress_key, f"{label}：拿到 {got} 句，还差 {len(remaining)} 个词")
@@ -2858,8 +2915,8 @@ def generate_podcast_sentences(
             "concept_en": "",
             "concept_zh": "",
             "reasoning_zh": "",
-            "source_url": source_url,
-            "source_title": source_title,
+            "source_url": sources[0].get("url"),
+            "source_title": sources[0].get("title"),
             "tokens": [],
         })
 

--- a/routes/story.py
+++ b/routes/story.py
@@ -43,21 +43,51 @@ _AGAIN_ACTION_LABELS = {
 _KNOWLEDGE_MATERIAL_MAX_CHARS = 15000
 
 
-def _knowledge_material(episode: dict) -> str:
+def _knowledge_material(episode: dict, limit: int = _KNOWLEDGE_MATERIAL_MAX_CHARS) -> str:
     """Return the text to feed knowledge-mode story generation for `episode`.
 
     issue #661: prefer the full transcript (transcript_zh, truncated to
-    _KNOWLEDGE_MATERIAL_MAX_CHARS) — Daniel explicitly asked for this when
-    the feature shipped; #561 switched to summary_de purely to cut cost/
-    latency (skip fact-check + fewer tokens per call), which stopped
-    mattering once the per-generation cost was confirmed to be ~$0.003.
-    Rows synced down before this change (or otherwise missing a transcript)
-    may only have summary_de — fall back to it rather than erroring, so old
-    episodes keep working."""
+    `limit`) — Daniel explicitly asked for this when the feature shipped;
+    #561 switched to summary_de purely to cut cost/latency (skip fact-check +
+    fewer tokens per call), which stopped mattering once the per-generation
+    cost was confirmed to be ~$0.003. Rows synced down before this change (or
+    otherwise missing a transcript) may only have summary_de — fall back to
+    it rather than erroring, so old episodes keep working.
+
+    `limit` (issue #752): when generating from several sources at once, the
+    caller passes _KNOWLEDGE_MATERIAL_MAX_CHARS // len(sources) so the total
+    prompt stays within the same context-window budget as a single source —
+    each item just gets a smaller slice instead of the ceiling multiplying
+    with the number of selected items."""
     transcript = (episode.get("transcript_zh") or "").strip()
     if transcript:
-        return transcript[:_KNOWLEDGE_MATERIAL_MAX_CHARS]
-    return (episode.get("summary_de") or "").strip()
+        return transcript[:limit]
+    return (episode.get("summary_de") or "").strip()[:limit]
+
+
+def _parse_episode_ids(episode_ids: str | None, episode_id: int | None) -> list[int]:
+    """Parse the multi-select `episode_ids` query param (issue #752) into a
+    deduped, order-preserving list of ints.
+
+    `episode_ids` is a comma-separated string like "12,34,56" from the new
+    multi-select frontend. Falls back to the single legacy `episode_id` param
+    when `episode_ids` is absent — old bookmarked URLs / iOS shortcuts using
+    the singular param keep working unchanged. Malformed fragments (empty,
+    non-numeric) are dropped rather than raising: one bad id in a multi-select
+    submission shouldn't blow up the whole generation."""
+    if not episode_ids:
+        return [episode_id] if episode_id else []
+    seen: set[int] = set()
+    result: list[int] = []
+    for chunk in episode_ids.split(","):
+        chunk = chunk.strip()
+        if not chunk.lstrip("-").isdigit():
+            continue
+        eid = int(chunk)
+        if eid not in seen:
+            seen.add(eid)
+            result.append(eid)
+    return result
 
 # 《思考，快与慢》原书的 5 个部分（Part）—— 按章节号区间划分。
 # 数据文件不存部分信息，统一在此按章节号计算，保证一致性。
@@ -237,7 +267,7 @@ def _validated_model(model: str | None, default: str | None = None) -> str:
 def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
                         topic, max_hsk, model, grammar_focus, grammar_pct, mode,
                         chapter_ids, articles=None, progress_key, lang: str | None = None,
-                        origin: str | None = None, episode_id: int | None = None,
+                        origin: str | None = None, episode_ids: list[int] | None = None,
                         batch_size: int | None = None) -> dict | None:
     """Generate a story for `cards`, persist it, and return the stored story
     (with sentences) — or an error dict on failure, or None if there is nothing
@@ -266,7 +296,7 @@ def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
             topic=topic, max_hsk=max_hsk, model=model, grammar_focus=grammar_focus,
             grammar_pct=grammar_pct, mode=mode, chapter_ids=chapter_ids,
             articles=articles, progress_key=progress_key, lang=lang,
-            origin=origin, episode_id=episode_id, batch_size=batch_size,
+            origin=origin, episode_ids=episode_ids, batch_size=batch_size,
         )
 
 
@@ -290,7 +320,7 @@ def _action_label_for_story(mode: str, deck_id: int) -> str:
 def _generate_and_store_body(deck_id: int, category: str, today: str, cards: list, *,
                              topic, max_hsk, model, grammar_focus, grammar_pct, mode,
                              chapter_ids, articles, progress_key, lang: str,
-                             origin: str | None, episode_id: int | None,
+                             origin: str | None, episode_ids: list[int] | None,
                              batch_size: int | None = None) -> dict | None:
     kind = None  # knowledge mode's source kind (podcast/video/article, issue #654)
     try:
@@ -372,18 +402,48 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
             # generation. See _knowledge_material()'s docstring. Rows without
             # a transcript (synced-down snapshots, etc.) fall back to
             # summary_de automatically.
-            if not episode_id:
-                raise ValueError("Knowledge mode requires selecting a source item.")
-            episode = database.get_episode(episode_id)
-            if not episode:
-                raise ValueError(f"Knowledge item {episode_id} not found.")
-            material = _knowledge_material(episode)
-            if not material:
+            # #752: episode_ids can now hold several source items — the words
+            # are spread across all of them in one call instead of forcing a
+            # single source. sources[] built below only includes items that
+            # actually have material; an id that resolves to nothing usable
+            # is dropped with a warning rather than failing the whole batch,
+            # since Daniel picking 3 items where 1 has no transcript yet
+            # shouldn't block the other 2.
+            if not episode_ids:
+                raise ValueError("Knowledge mode requires selecting at least one source item.")
+            episodes = []
+            for eid in episode_ids:
+                episode = database.get_episode(eid)
+                if not episode:
+                    raise ValueError(f"Knowledge item {eid} not found.")
+                episodes.append(episode)
+            # Budget split evenly across sources (issue #752) so a 3-item
+            # selection stays within the same total context-window budget as
+            # a single item — see _knowledge_material()'s docstring.
+            per_source_limit = _KNOWLEDGE_MATERIAL_MAX_CHARS // len(episodes)
+            sources: list[dict] = []
+            for eid, episode in zip(episode_ids, episodes):
+                material = _knowledge_material(episode, limit=per_source_limit)
+                if not material:
+                    logger.warning("story  knowledge item %d has no transcript/summary — skipped", eid)
+                    continue
+                ep_kind = episode.get("kind") or "podcast"
+                sources.append({
+                    "index": len(sources) + 1,
+                    "title": episode.get("title") or "",
+                    "kind": ep_kind,
+                    "url": episode.get("youtube_url") or f"/#{ep_kind}-{eid}",
+                    "material": material,
+                })
+            if not sources:
                 raise ValueError("Selected item has no transcript or summary yet.")
-            kind = episode.get("kind") or "podcast"
+            # kind recorded in gen_params (issue #654): single source keeps its
+            # own kind, multiple sources collapse to "mixed" — there is no
+            # single kind to show in the frontend once items are combined.
+            kind = sources[0]["kind"] if len(sources) == 1 else "mixed"
             model = _validated_model(model, default=ai.DEFAULT_MODEL)
-            logger.info("story  knowledge model in use: %s kind=%s batch_size=%s",
-                        model, kind, batch_size)
+            logger.info("story  knowledge model in use: %s kind=%s sources=%d batch_size=%s",
+                        model, kind, len(sources), batch_size)
             # batch_size (issue #563): user-controlled words-per-call from the
             # setup modal; empty/0 = one single call, capped at MAX_PODCAST_BATCH
             # (#634). Spreading the words over the material's topics only works
@@ -397,11 +457,9 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
             for idx, chunk in enumerate(chunks):
                 label = f" ({idx + 1}/{len(chunks)})" if len(chunks) > 1 else ""
                 chunk_sentences, chunk_prompt = ai.generate_podcast_sentences(
-                    chunk, material, episode.get("title") or "",
+                    chunk, sources,
                     model=model, max_hsk=max_hsk, progress_key=progress_key,
-                    attempt_label=label,
-                    source_url=episode.get("youtube_url") or f"/#{kind}-{episode_id}",
-                    source_title=episode.get("title"))
+                    attempt_label=label)
                 sentences.extend(chunk_sentences)
                 if chunk_prompt:
                     chunk_prompts.append(
@@ -422,7 +480,7 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
             topic=topic, max_hsk=max_hsk, model=model,
             grammar_focus=grammar_focus, grammar_pct=grammar_pct,
             mode=mode, chapter_ids=chapter_ids, articles=articles, lang=lang,
-            origin=origin, episode_id=episode_id, batch_size=batch_size, kind=kind)
+            origin=origin, episode_ids=episode_ids, batch_size=batch_size, kind=kind)
         database.create_story(today, category, deck_id, sentences, prompt_text, topic, gen_params, lang=lang)
         story = database.get_active_story(today, category, deck_id, lang=lang)
     except Exception as e:
@@ -444,7 +502,7 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
 def _start_background_generation(deck_id: int, category: str, today: str, cards: list, *,
                                  topic, max_hsk, model, grammar_focus, grammar_pct,
                                  mode, chapter_ids, articles=None, progress_key,
-                                 lang: str | None = None, episode_id: int | None = None,
+                                 lang: str | None = None, episode_ids: list[int] | None = None,
                                  batch_size: int | None = None) -> None:
     """Spawn a daemon thread that generates+stores a story, recording a terminal
     progress state (done/error) the frontend can poll. De-duped by progress_key."""
@@ -456,7 +514,7 @@ def _start_background_generation(deck_id: int, category: str, today: str, cards:
                 topic=topic, max_hsk=max_hsk, model=model,
                 grammar_focus=grammar_focus, grammar_pct=grammar_pct,
                 mode=mode, chapter_ids=chapter_ids, articles=articles, progress_key=progress_key,
-                lang=lang, episode_id=episode_id, batch_size=batch_size)
+                lang=lang, episode_ids=episode_ids, batch_size=batch_size)
             if isinstance(result, dict) and result.get("error"):
                 ai._story_progress[progress_key] = {
                     "phase": "error", "percent": 0, "msg": result.get("reason", "Generation failed")}
@@ -478,7 +536,7 @@ def _start_background_generation(deck_id: int, category: str, today: str, cards:
 
 def _gen_params_dict(*, topic, max_hsk, model, grammar_focus, grammar_pct,
                      mode, chapter_ids, articles=None, lang="zh",
-                     origin=None, episode_id=None, batch_size=None,
+                     origin=None, episode_ids=None, batch_size=None,
                      kind=None) -> dict:
     """Bundle the story generation settings persisted on each story row, so the
     Again regeneration can reproduce the same style (see generate_sentence_for_word).
@@ -488,15 +546,18 @@ def _gen_params_dict(*, topic, max_hsk, model, grammar_focus, grammar_pct,
     origin: "pregen" when the story was created by the morning pregen —
     get_recent_story_keys skips those rows so pregen only ever reproduces
     user-initiated generations instead of feeding on its own output (issue #468).
-    episode_id: knowledge mode's selected source item (issue #482, renamed
+    episode_ids: knowledge mode's selected source item(s) (issue #482, renamed
     from "podcast" mode in #654; lean pipeline since #561, transcript-first
-    material since #661) — Again-regen re-fetches the item's transcript_zh
-    (falling back to summary_de) by this id rather than reusing `articles`
-    (knowledge stories don't store any).
-    kind: the selected item's source kind (podcast/video/article, issue #654)
-    at generation time — purely informational (regen re-derives it from the
-    episode row via episode_id), kept here so the frontend can show what kind
-    of source a knowledge story came from without an extra lookup.
+    material since #661; multi-source since #752) — Again-regen re-fetches
+    each item's transcript_zh (falling back to summary_de) by these ids rather
+    than reusing `articles` (knowledge stories don't store any). The legacy
+    singular `episode_id` key is also written (= episode_ids[0]) so old code
+    paths and old story rows reading that key keep working unchanged.
+    kind: the selected item's source kind (podcast/video/article, issue #654;
+    "mixed" when multiple sources were selected, #752) at generation time —
+    purely informational (regen re-derives it from the episode row(s) via
+    episode_ids), kept here so the frontend can show what kind of source a
+    knowledge story came from without an extra lookup.
     batch_size: user-chosen words-per-AI-call (issue #563 podcast-only, #574 all
     modes); None/0 = each mode's default chunking (knowledge: all at once; story
     family: CHUNK_SIZE; kahneman: per-chapter split capped at MAX_KAHNEMAN_BATCH;
@@ -514,7 +575,8 @@ def _gen_params_dict(*, topic, max_hsk, model, grammar_focus, grammar_pct,
         "articles": articles,
         "lang": lang,
         "origin": origin,
-        "episode_id": episode_id,
+        "episode_id": episode_ids[0] if episode_ids else None,
+        "episode_ids": episode_ids,
         "batch_size": batch_size,
         "kind": kind,
     }
@@ -572,25 +634,43 @@ def generate_sentence_for_word(card: dict, gen_params: dict | None) -> dict | No
                     sentences, _ = ai.generate_story([card], model=model, lang=lang)
             elif mode in ("knowledge", "podcast"):
                 # Knowledge Again-regen (issue #561, renamed from "podcast" in
-                # #654): same lean pipeline, one card + the item's material,
-                # honoring the story's stored user-picked model (old stories
-                # stored gpt-5.1, which is not whitelisted, so _validated_model
-                # falls back). mode="podcast" here means a *historical* story
-                # (new stories are generated with mode="knowledge" — #654
-                # rejects "podcast" at generation time, but old stories must
-                # keep regenerating). Material is transcript_zh with a
-                # summary_de fallback (issue #661, see _knowledge_material());
-                # no material at all → plain sentence.
-                ep = database.get_episode(gp["episode_id"]) if gp.get("episode_id") else None
-                material = _knowledge_material(ep) if ep else ""
-                if material:
-                    ep_kind = ep.get("kind") or "podcast"
+                # #654; multi-source since #752): same lean pipeline, one card
+                # + the selected item(s)' material, honoring the story's stored
+                # user-picked model (old stories stored gpt-5.1, which is not
+                # whitelisted, so _validated_model falls back). mode="podcast"
+                # here means a *historical* story (new stories are generated
+                # with mode="knowledge" — #654 rejects "podcast" at generation
+                # time, but old stories must keep regenerating). Material is
+                # transcript_zh with a summary_de fallback (issue #661, see
+                # _knowledge_material()); no material at all → plain sentence.
+                #
+                # There is no reliable way to know which single source (of the
+                # story's several) this particular card's earlier sentence
+                # came from, so every stored source is offered again and the
+                # model picks — same as the main multi-source generation path.
+                episode_ids = gp.get("episode_ids") or ([gp["episode_id"]] if gp.get("episode_id") else [])
+                episodes = [database.get_episode(eid) for eid in episode_ids]
+                episodes = [ep for ep in episodes if ep]
+                sources: list[dict] = []
+                if episodes:
+                    per_source_limit = _KNOWLEDGE_MATERIAL_MAX_CHARS // len(episodes)
+                    for ep in episodes:
+                        material = _knowledge_material(ep, limit=per_source_limit)
+                        if not material:
+                            continue
+                        ep_kind = ep.get("kind") or "podcast"
+                        sources.append({
+                            "index": len(sources) + 1,
+                            "title": ep.get("title") or "",
+                            "kind": ep_kind,
+                            "url": ep.get("youtube_url") or f"/#{ep_kind}-{ep['id']}",
+                            "material": material,
+                        })
+                if sources:
                     sentences, _ = ai.generate_podcast_sentences(
-                        [card], material, ep.get("title") or "",
+                        [card], sources,
                         model=_validated_model(gp.get("model"), default=ai.DEFAULT_MODEL),
-                        max_hsk=gp.get("max_hsk", 3),
-                        source_url=ep.get("youtube_url") or f"/#{ep_kind}-{ep['id']}",
-                        source_title=ep.get("title"))
+                        max_hsk=gp.get("max_hsk", 3))
                 else:
                     sentences, _ = ai.generate_story([card], model=model, lang=lang)
             elif mode in ("news", "paste", "briefing"):
@@ -628,6 +708,7 @@ def get_story(deck_id: int, category: str,
               mode: str = "story",
               chapter_ids: str | None = None,
               episode_id: int | None = None,
+              episode_ids: str | None = None,
               batch_size: int | None = None,
               no_generate: bool = False,
               background: bool = False,
@@ -648,6 +729,7 @@ def get_story(deck_id: int, category: str,
     """
     today = database.anki_today().isoformat()
     lang = lang or database.get_deck_lang(deck_id)
+    parsed_episode_ids = _parse_episode_ids(episode_ids, episode_id)
     # progress_key includes lang: without it, a zh generation and a fr generation
     # started back-to-back for the same aggregate deck+category would collide in
     # the _generating set / ai._story_progress dict (only one runs at a time via
@@ -708,7 +790,7 @@ def get_story(deck_id: int, category: str,
             topic=topic, max_hsk=max_hsk, model=chosen_model,
             grammar_focus=grammar_focus, grammar_pct=grammar_pct,
             mode=mode, chapter_ids=chapter_ids, progress_key=progress_key, lang=lang,
-            episode_id=episode_id, batch_size=batch_size)
+            episode_ids=parsed_episode_ids, batch_size=batch_size)
         return {"generating": True}
 
     # ── Synchronous mode (default): generate now and return the story ─────────
@@ -722,7 +804,7 @@ def get_story(deck_id: int, category: str,
         topic=topic, max_hsk=max_hsk, model=chosen_model,
         grammar_focus=grammar_focus, grammar_pct=grammar_pct,
         mode=mode, chapter_ids=chapter_ids, progress_key=progress_key, lang=lang,
-        episode_id=episode_id, batch_size=batch_size)
+        episode_ids=parsed_episode_ids, batch_size=batch_size)
     ai._story_progress.pop(progress_key, None)
     return result
 
@@ -735,6 +817,7 @@ def regenerate_story(deck_id: int, category: str,
                      mode: str = "story",
                      chapter_ids: str | None = None,
                      episode_id: int | None = None,
+                     episode_ids: str | None = None,
                      batch_size: int | None = None,
                      body: dict | None = None,
                      lang: str | None = None):
@@ -754,6 +837,7 @@ def regenerate_story(deck_id: int, category: str,
     chosen_model = _validated_model(model)
     today = database.anki_today().isoformat()
     lang = lang or database.get_deck_lang(deck_id)
+    parsed_episode_ids = _parse_episode_ids(episode_ids, episode_id)
     progress_key = f"{deck_id}/{category}/{lang}"
     articles = (body or {}).get("articles") or []
     cards = _get_cards_for_story(deck_id, category, lang=lang)
@@ -766,7 +850,7 @@ def regenerate_story(deck_id: int, category: str,
         topic=topic, max_hsk=max_hsk, model=chosen_model,
         grammar_focus=grammar_focus, grammar_pct=grammar_pct,
         mode=mode, chapter_ids=chapter_ids, articles=articles, progress_key=progress_key, lang=lang,
-        episode_id=episode_id, batch_size=batch_size)
+        episode_ids=parsed_episode_ids, batch_size=batch_size)
     ai._story_progress.pop(progress_key, None)
     if result:
         # A new story means word→position mapping changed — invalidate every

--- a/static/app.js
+++ b/static/app.js
@@ -4770,10 +4770,10 @@ function _resumeBackgroundReview(ctx) {
   deckName   = ctx.deckName;
   rootDeckId = ctx.rootDeckId;
   quickMode  = false;
-  _doStartReview(ctx.topic, ctx.maxHsk, ctx.model, ctx.grammarFocus, ctx.grammarPct, ctx.mode, ctx.chapterIds, null, ctx.episodeId);
+  _doStartReview(ctx.topic, ctx.maxHsk, ctx.model, ctx.grammarFocus, ctx.grammarPct, ctx.mode, ctx.chapterIds, null, ctx.episodeIds);
 }
 
-async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', chapterIds = null, articles = null, episodeId = null) {
+async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', chapterIds = null, articles = null, episodeIds = null) {
   if (quickMode) {
     setLoading('Loading audio…', true);
     try {
@@ -4803,19 +4803,19 @@ async function _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mo
     const resumeCtx = {
       key: `${storyDeckId}/${storyCategory}`,
       deckId, category, deckName, rootDeckId, storyDeckId, storyCategory,
-      topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeId,
+      topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeIds,
     };
     _bgLeaveRequested = false;
     _bgActiveResume = resumeCtx;
     _showLoadingBgButton();
 
-    const storyUrl = `/api/story/${storyDeckId}/${storyCategory}` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeId);
+    const storyUrl = `/api/story/${storyDeckId}/${storyCategory}` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeIds);
     const bgUrl = storyUrl + (storyUrl.includes('?') ? '&' : '?') + 'background=true';
     let todayData, storyData;
     try {
       todayData = await api('GET', `/api/today/${deckId}/${category}${_langQP('?')}`);
       storyData = await _fetchStoryOrNewsRegen(storyDeckId, storyCategory, topic, maxHsk, model,
-        grammarFocus, grammarPct, mode, chapterIds, articles, bgUrl, episodeId);
+        grammarFocus, grammarPct, mode, chapterIds, articles, bgUrl, episodeIds);
     } catch (e) {
       await _startQuickFallback(e.message);
       return;
@@ -4893,16 +4893,20 @@ async function _startQuickFallback(reason) {
 // a session); news mode auto-fetches today's news server-side (issue #387).
 async function _fetchStoryOrNewsRegen(storyDeckId, storyCategory, topic, maxHsk, model,
                                       grammarFocus, grammarPct, mode, chapterIds, articles, bgUrl,
-                                      episodeId) {
+                                      episodeIds) {
   if (mode === 'paste' && articles && articles.length) {
     const url = `/api/story/${storyDeckId}/${storyCategory}/regenerate`
-      + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeId);
+      + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeIds);
     return api('POST', url, { articles });
   }
   return _pollBackgroundStory(bgUrl);
 }
 
-function _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeId) {
+// episodeIds: array of item ids for knowledge mode (issue #752, multi-select —
+// previously a single episodeId / `episode_id` param). Backend accepts the new
+// comma-joined `episode_ids` and still accepts the old singular `episode_id`,
+// but the frontend only ever sends the former now.
+function _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeIds) {
   const p = new URLSearchParams();
   if (topic)                              p.set('topic', topic);
   if (maxHsk !== 3)                       p.set('max_hsk', maxHsk);
@@ -4911,7 +4915,7 @@ function _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chap
   if (grammarFocus && grammarPct !== 75)  p.set('grammar_pct', grammarPct);
   if (mode && mode !== 'story')           p.set('mode', mode);
   if (chapterIds && chapterIds.length)    p.set('chapter_ids', chapterIds.join(','));
-  if (episodeId)                          p.set('episode_id', episodeId);
+  if (episodeIds && episodeIds.length)    p.set('episode_ids', episodeIds.join(','));
   // Words per AI call (issue #563 podcast-only, #574 all modes) — persisted
   // per mode in localStorage (like setupModel) rather than yet another
   // positional parameter through every call chain. Unset = mode default.
@@ -4963,7 +4967,7 @@ async function startReviewMixed(id, name, noStory = false, quick = false) {
   }
 }
 
-async function _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', noStory = false, chapterIds = null, articles = null, episodeId = null) {
+async function _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', noStory = false, chapterIds = null, articles = null, episodeIds = null) {
   setLoading(noStory ? 'Loading…' : 'Generating stories…', !noStory);
   if (!noStory) {
     setLoadingStep(10, null, 'Sending request to AI…');
@@ -4984,8 +4988,8 @@ async function _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPc
       // Load a single unified story covering all categories (1 AI call instead of 3)
       try {
         story = (mode === 'paste' && articles && articles.length)
-          ? await api('POST', `/api/story/${rootDeckId}/unified/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeId), { articles })
-          : await api('GET', `/api/story/${rootDeckId}/unified` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeId));
+          ? await api('POST', `/api/story/${rootDeckId}/unified/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeIds), { articles })
+          : await api('GET', `/api/story/${rootDeckId}/unified` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeIds));
       } catch (e) {
         await _startQuickFallback(e.message);
         return;
@@ -5065,7 +5069,7 @@ async function startReviewUnfinished() {
   }
 }
 
-async function _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', chapterIds = null, articles = null, episodeId = null) {
+async function _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', chapterIds = null, articles = null, episodeIds = null) {
   unfinishedMode = true;
   setLoading('Loading cards…');
   // In "existing" story mode, never trigger generation — fetch cached stories only.
@@ -5086,9 +5090,9 @@ async function _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, gram
     try {
       if (!noGen && mode === 'paste' && articles && articles.length) {
         story = await api('POST', `/api/story/${firstDeckId}/unified/regenerate`
-          + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeId), { articles });
+          + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeIds), { articles });
       } else {
-        let url = `/api/story/${firstDeckId}/unified` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeId);
+        let url = `/api/story/${firstDeckId}/unified` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeIds);
         if (noGen) url += (url.includes('?') ? '&' : '?') + 'no_generate=true';
         story = await api('GET', url);
       }
@@ -7562,6 +7566,11 @@ function openStorySetup(sentenceCount, { isMixed = false, isUnfinished = false, 
   document.getElementById('setup-topic').value = '';
   document.getElementById('setup-grammar').value = '';
   document.getElementById('setup-grammar-pct').value = 50;
+  // Knowledge-item multi-select (issue #752): each fresh open of the modal starts
+  // with nothing picked, same as topic/grammar being cleared above — a leftover
+  // selection from a previous session would silently reuse the wrong sources.
+  _setupSelectedEpisodes.clear();
+  _renderSetupSelectedEpisodes();
   // In-session regenerate: prefill mode + HSK from the active story's gen_params
   // so a quick regenerate keeps News flow / kahneman / … instead of silently
   // downgrading to mode=story (issue #468 — a briefing was overwritten exactly
@@ -8133,6 +8142,11 @@ let _setupPodcastFeeds = null;              // null = not loaded yet
 // key `${kind}|${feedId}` ('' feedId = all podcasts, only meaningful for kind=podcast) → episodes array
 let _setupPodcastEpisodesByFeed = {};
 let _setupKnowledgeKind = localStorage.getItem('setupKnowledgeKind') || 'podcast';
+// Multi-select of knowledge-base items (issue #752): id -> {id, title, kind}. This
+// Map — not the checkbox DOM — is the single source of truth, because switching
+// Source type or podcast feed re-renders #setup-podcast-episodes from scratch and
+// would otherwise wipe out any selection made under a different kind/feed.
+let _setupSelectedEpisodes = new Map();
 // Words per AI call (issue #563 podcast-only, #574 all modes): persisted per
 // mode like setupModel. null = the mode's default chunking. Read by
 // _storyParams for every generation URL.
@@ -8195,8 +8209,9 @@ function _onKnowledgeKindChange() {
   localStorage.setItem('setupKnowledgeKind', _setupKnowledgeKind);
   const feedSel = document.getElementById('setup-podcast-feed');
   if (feedSel) feedSel.style.display = _setupKnowledgeKind === 'podcast' ? '' : 'none';
-  // Selecting a new item clears any previous radio pick — the episode ids
-  // aren't comparable across kinds.
+  // The list is re-rendered from scratch for the new kind, but the selection
+  // itself survives (issue #752) — _setupSelectedEpisodes, not the DOM, is
+  // the source of truth, and _renderPodcastEpisodes re-checks boxes from it.
   _loadPodcastEpisodesForCurrentFeed();
 }
 
@@ -8241,11 +8256,14 @@ function _renderPodcastEpisodes(cacheKey) {
     return;
   }
   const esc = s => String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  // Rows show just title + date (issue #561) — the summary preview was
-  // dropped, it made the list too tall to scan with many episodes.
+  // Checkboxes, not radios (issue #752 — multiple items can seed one story).
+  // `checked` is driven by _setupSelectedEpisodes, not by what was checked
+  // before the list was re-rendered (e.g. after switching Source type).
   container.innerHTML = episodes.map(ep => `
     <label class="kahneman-chapter-row">
-      <input type="radio" class="podcast-episode-radio" name="podcast-episode" value="${ep.id}">
+      <input type="checkbox" class="podcast-episode-cb" value="${ep.id}"
+        ${_setupSelectedEpisodes.has(ep.id) ? 'checked' : ''}
+        onchange="_onEpisodeCheckboxChange(this, ${ep.id}, '${_setupKnowledgeKind}')">
       <div class="kahneman-chapter-info">
         <span class="kahneman-chapter-title">${esc(ep.title || '(untitled)')}</span>
         <span class="kahneman-chapter-concept">${esc(_localDate(ep.published_at || ''))}</span>
@@ -8253,16 +8271,64 @@ function _renderPodcastEpisodes(cacheKey) {
     </label>`).join('');
 }
 
+// Checkbox change handler for the knowledge-item list (issue #752). Keeps
+// _setupSelectedEpisodes (the source of truth) in sync and re-renders the
+// "Selected: N" chip list above it. Title/kind are captured from the row at
+// check-time so the chip list still shows a name after the underlying list
+// is re-rendered for a different kind/feed.
+function _onEpisodeCheckboxChange(cb, id, kind) {
+  if (cb.checked) {
+    // Pull the title straight from the row rather than re-searching the
+    // cached lists — the row that fired this event always has it.
+    const title = cb.closest('.kahneman-chapter-row')
+      ?.querySelector('.kahneman-chapter-title')?.textContent || `#${id}`;
+    _setupSelectedEpisodes.set(id, { id, title, kind });
+  } else {
+    _setupSelectedEpisodes.delete(id);
+  }
+  _renderSetupSelectedEpisodes();
+}
+
+// Renders the "Selected: N" chip list above the item picker (issue #752).
+// Hidden entirely when nothing is selected — an empty chip bar is just noise.
+function _renderSetupSelectedEpisodes() {
+  const box = document.getElementById('setup-podcast-selected');
+  if (!box) return;
+  const esc = s => String(s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const items = Array.from(_setupSelectedEpisodes.values());
+  if (!items.length) { box.style.display = 'none'; box.innerHTML = ''; return; }
+  box.style.display = 'block';
+  const kindIcon = { podcast: '🎙️', video: '📺', article: '📄' };
+  box.innerHTML = `<div style="font-size:12px;color:var(--muted,#888);margin-bottom:4px">Selected: ${items.length}</div>` +
+    items.map(it => `
+      <span style="display:inline-flex;align-items:center;gap:4px;background:var(--hover-bg,#f0f0f0);
+        border-radius:12px;padding:2px 8px 2px 10px;margin:0 4px 4px 0;font-size:12px;max-width:100%">
+        <span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:220px">${kindIcon[it.kind] || ''} ${esc(it.title)}</span>
+        <span role="button" aria-label="Remove" onclick="_setupRemoveEpisode(${it.id})"
+          style="cursor:pointer;color:var(--muted,#888);font-weight:700;padding:0 2px">×</span>
+      </span>`).join('');
+}
+
+// Removing via the chip's × (issue #752): drop from the selection map, then
+// uncheck the corresponding checkbox if it's currently visible in the list
+// (it won't be if the user is looking at a different kind/feed right now).
+function _setupRemoveEpisode(id) {
+  _setupSelectedEpisodes.delete(id);
+  const cb = document.querySelector(`.podcast-episode-cb[value="${id}"]`);
+  if (cb) cb.checked = false;
+  _renderSetupSelectedEpisodes();
+}
+
 function _getSelectedChapterIds() {
   return Array.from(document.querySelectorAll('.kahneman-chapter-cb:checked'))
     .map(cb => parseInt(cb.value));
 }
 
-// Podcast episode picker (issue #482) — single-select, same idea as the
-// kahneman chapter checkboxes but radio-style (one episode per story).
-function _getSelectedEpisodeId() {
-  const checked = document.querySelector('.podcast-episode-radio:checked');
-  return checked ? parseInt(checked.value) : null;
+// Podcast/video/article item picker (issue #482, multi-select since #752).
+// Reads from _setupSelectedEpisodes (not the DOM) so a selection made under
+// a different Source type/feed — currently not rendered — still counts.
+function _getSelectedEpisodeIds() {
+  return Array.from(_setupSelectedEpisodes.keys());
 }
 
 function confirmStorySetup() {
@@ -8277,16 +8343,16 @@ function confirmStorySetup() {
   if (model && model !== 'briefing-server') localStorage.setItem('setupModel:' + mode, model);
   const chapterIds  = mode === 'kahneman' ? _getSelectedChapterIds() : null;
   const articles    = mode === 'paste' ? _collectPastedContents() : null;
-  const episodeId   = mode === 'knowledge' ? _getSelectedEpisodeId() : null;
+  const episodeIds  = mode === 'knowledge' ? _getSelectedEpisodeIds() : null;
   // News mode never sends articles: today's news is auto-fetched server-side
   // (issue #387). Paste mode requires at least one non-empty text (issue #396).
   if (mode === 'paste' && !articles.length) {
     showError('Paste mode needs at least one text — paste some content first.');
     return;
   }
-  // Knowledge mode requires picking exactly one source item (issue #482/#654).
-  if (mode === 'knowledge' && !episodeId) {
-    showError('Knowledge mode needs a source — select one first.');
+  // Knowledge mode requires picking at least one source item (issue #482/#654/#752).
+  if (mode === 'knowledge' && !episodeIds.length) {
+    showError('Knowledge mode needs a source — select at least one first.');
     return;
   }
   // Words per AI call (issue #563 podcast-only, #574 all modes): empty input
@@ -8318,20 +8384,20 @@ function confirmStorySetup() {
     return;
   }
   if (_setupIsDeckListRegen) {
-    _doRegenStoryForDeckList(_deckListRegenId, topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, articles, episodeId);
+    _doRegenStoryForDeckList(_deckListRegenId, topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, articles, episodeIds);
   } else if (_setupIsRegen) {
-    _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, articles, episodeId);
+    _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, articles, episodeIds);
   } else if (_setupIsUnfinished) {
-    _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, articles, episodeId);
+    _doStartReviewUnfinished(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, articles, episodeIds);
   } else if (_setupIsMixed) {
     // noStory=false: confirmStorySetup always wants a fresh generation, unlike
     // the `?scope=` quick paths above that call this with noStory=true directly.
     // (Pre-#482 this call under-supplied args, so chapterIds silently landed in
     // the noStory slot — harmless for story/paste/news since chapterIds was null
     // there, but it would have broken kahneman+podcast in mixed review.)
-    _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPct, mode, false, chapterIds, articles, episodeId);
+    _doStartReviewMixed(topic, maxHsk, model, grammarFocus, grammarPct, mode, false, chapterIds, articles, episodeIds);
   } else {
-    _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, articles, episodeId);
+    _doStartReview(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, articles, episodeIds);
   }
 }
 
@@ -8852,7 +8918,7 @@ async function regenerateStory() {
   }
 }
 
-async function _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', chapterIds = null, articles = null, episodeId = null) {
+async function _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', chapterIds = null, articles = null, episodeIds = null) {
   setLoading('Regenerating story…', true);
   setLoadingStep(10, null, 'Sending request to AI…');
   _startFakeProgress(10, 55, 45000);
@@ -8862,7 +8928,7 @@ async function _doRegenerateStory(topic, maxHsk, model, grammarFocus, grammarPct
     _startStoryProgressPoll(storyDeckId, storyCategory);
     let storyData;
     try {
-      storyData = await api('POST', `/api/story/${storyDeckId}/${storyCategory}/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeId), { articles });
+      storyData = await api('POST', `/api/story/${storyDeckId}/${storyCategory}/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeIds), { articles });
     } catch (e) {
       _stopFakeProgress(); _stopStoryProgressPoll();
       _showLoadingError('AI request failed', e.message);
@@ -8921,6 +8987,10 @@ async function regenerateStoryFromList(deckId) {
   document.getElementById('setup-grammar').value = '';
   document.getElementById('setup-grammar-pct').value = 50;
   document.getElementById('setup-hsk-slider').value = 3;
+  // Knowledge-item multi-select (issue #752) — reset on every fresh open, same
+  // reasoning as openStorySetup above.
+  _setupSelectedEpisodes.clear();
+  _renderSetupSelectedEpisodes();
   updateHskLabel();
   // Sync the per-mode control visibility to the current dropdown value (e.g. hide
   // story-only controls when Words-only is selected, #547).
@@ -8933,7 +9003,7 @@ async function regenerateStoryFromList(deckId) {
 // Regenerate a deck's story in the BACKGROUND: instead of a blocking full-screen
 // loader, show a small persistent banner and let the user keep reviewing. When
 // the new story is ready the banner turns into a clickable "open for review".
-async function _doRegenStoryForDeckList(deckId, topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', chapterIds = null, articles = null, episodeId = null) {
+async function _doRegenStoryForDeckList(deckId, topic, maxHsk, model, grammarFocus, grammarPct, mode = 'story', chapterIds = null, articles = null, episodeIds = null) {
   const deck = flatten(_cachedDecks || []).find(d => d.id === deckId);
   const deckName = deck ? deck.name : 'deck';
   const noStory = !!(deck && deck.no_story);
@@ -8947,7 +9017,7 @@ async function _doRegenStoryForDeckList(deckId, topic, maxHsk, model, grammarFoc
   }
 
   try {
-    await api('POST', `/api/story/${deckId}/unified/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeId), { articles });
+    await api('POST', `/api/story/${deckId}/unified/regenerate` + _storyParams(topic, maxHsk, model, grammarFocus, grammarPct, mode, chapterIds, episodeIds), { articles });
     // Warm the audio cache in the background so review starts fast; don't block
     // the "ready" banner on it.
     _preloadWithProgress(deckId, 'unified', () => {}).catch(() => {});

--- a/static/index.html
+++ b/static/index.html
@@ -766,11 +766,13 @@
         <option value="video">📺 Video</option>
         <option value="article">📄 Article</option>
       </select>
-      <label class="edit-label" style="margin:0">Item</label>
+      <label class="edit-label" style="margin:0">Items</label>
       <div style="font-size:12px;color:var(--muted,#888);margin:2px 0 6px">
-        Pick one summarized item — the sentences will be built from its content (no context sentences).
+        Pick one or more summarized items — the sentences will be spread across them (no context sentences).
       </div>
       <select class="edit-input" id="setup-podcast-feed" style="margin-bottom:6px"></select>
+      <!-- Selected-items chip list (issue #752 multi-select) — hidden when empty -->
+      <div id="setup-podcast-selected" style="display:none;margin-bottom:6px"></div>
       <div id="setup-podcast-episodes" style="max-height:220px;overflow-y:auto;border:1px solid var(--border,#ddd);border-radius:6px;padding:4px 0"></div>
       <div id="setup-podcast-loading" style="display:none;padding:12px;text-align:center;color:var(--muted,#888);font-size:13px">Loading items…</div>
     </div>

--- a/tests/test_knowledge_multi_source.py
+++ b/tests/test_knowledge_multi_source.py
@@ -1,0 +1,292 @@
+"""知识库故事模式的多素材生成（issue #752）：一次生成混合多个知识库素材
+（播客/视频/文章），到期词分散到几份材料上。
+
+覆盖：
+- routes.story._parse_episode_ids 的输入解析
+- 多素材时材料预算按素材数量均分，且 ai.generate_podcast_sentences 收到的
+  sources[] 结构正确（title/kind/url/material/index）
+- ai.generate_podcast_sentences 按模型返回的 source_index 回填每句的
+  source_url/source_title，越界/缺失时回退到第一个素材
+- 单素材路径下 {multi_source_block} 渲染为空，提示词与旧版逐字一致
+
+AI 一律打桩在 ai._call_api 上——打在某个提供商的客户端上会随默认模型变化而
+静默失效。隔离数据库只打 database.core.DB_PATH 这个补丁。
+"""
+import json
+
+import pytest
+from unittest.mock import patch
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+from fastapi.testclient import TestClient
+import ai
+import database
+import importer
+import main
+import routes.story as story_routes
+
+client = TestClient(main.app)
+
+ENTRY_你好 = {"type": "vocabulary", "simplified": "你好", "pinyin": "nǐ hǎo",
+               "english": "hello", "pos": "intj", "hsk": "1"}
+
+
+def write_yaml(tmp_path, name, entries):
+    import yaml
+    d = tmp_path / "Kouyu"
+    d.mkdir(exist_ok=True)
+    (d / name).write_text(yaml.dump({"entries": entries}, allow_unicode=True))
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setattr(database.core, "DB_PATH", str(db_file))
+    database.init_db()
+    return db_file
+
+
+@pytest.fixture
+def populated_db(tmp_db, tmp_path):
+    write_yaml(tmp_path, "words.yaml", [ENTRY_你好])
+    importer.import_all(str(tmp_path))
+    return next(d["id"] for d in database.get_all_decks() if d["name"] == "Kouyu")
+
+
+def _fake_podcast_sentences(cards, sources, **kwargs):
+    return [
+        {"word_id": c["word_id"], "sentence_zh": f"{c['word_zh']}出现在这一集里。",
+         "sentence_en": "", "target_word": c["word_zh"]}
+        for c in cards
+    ], "假提示词"
+
+
+# ── _parse_episode_ids ───────────────────────────────────────────────────────
+
+def test_parse_episode_ids_comma_separated():
+    assert story_routes._parse_episode_ids("12,34,56", None) == [12, 34, 56]
+
+
+def test_parse_episode_ids_falls_back_to_singular():
+    assert story_routes._parse_episode_ids(None, 7) == [7]
+    assert story_routes._parse_episode_ids("", 7) == [7]
+
+
+def test_parse_episode_ids_empty_input_returns_empty_list():
+    assert story_routes._parse_episode_ids(None, None) == []
+    assert story_routes._parse_episode_ids("", None) == []
+
+
+def test_parse_episode_ids_dedupes_and_preserves_order():
+    assert story_routes._parse_episode_ids("5,3,5,7,3", None) == [5, 3, 7]
+
+
+def test_parse_episode_ids_ignores_malformed_fragments():
+    assert story_routes._parse_episode_ids("12,,abc, 34 ,", None) == [12, 34]
+
+
+def test_parse_episode_ids_episode_ids_takes_priority_over_singular():
+    # both given: the multi-select param wins, the legacy singular is only a
+    # fallback for when episode_ids is absent.
+    assert story_routes._parse_episode_ids("1,2", 999) == [1, 2]
+
+
+# ── material budget split + sources[] structure ─────────────────────────────
+
+def test_multi_source_budget_split_evenly(populated_db):
+    """三个素材同时选中时，每份材料的预算是总预算的三分之一——不是三份各自
+    拿到全额（那会让总提示词随选择数量线性膨胀，撑爆上下文窗口）。"""
+    deck_id = populated_db
+    long_transcript_a = "甲" * 100
+    long_transcript_b = "乙" * 100
+    long_transcript_c = "丙" * 100
+    ids = []
+    for vid, transcript, title in [
+        ("m1", long_transcript_a, "素材甲"),
+        ("m2", long_transcript_b, "素材乙"),
+        ("m3", long_transcript_c, "素材丙"),
+    ]:
+        eid = database.create_pending_episode(
+            vid, "https://example.com/feed.xml", title, None,
+            f"https://example.com/{vid}", kind="podcast")
+        database.update_episode(eid, status="summarized", transcript_zh=transcript)
+        ids.append(eid)
+
+    captured = {}
+
+    def _capturing(cards, sources, **kwargs):
+        captured["sources"] = sources
+        return _fake_podcast_sentences(cards, sources, **kwargs)
+
+    with patch("ai.generate_podcast_sentences", side_effect=_capturing) as mock_gen:
+        r = client.get(f"/api/story/{deck_id}/listening",
+                       params={"mode": "knowledge",
+                               "episode_ids": ",".join(str(i) for i in ids)})
+
+    assert r.status_code == 200
+    assert not r.json().get("error")
+    mock_gen.assert_called_once()
+
+    sources = captured["sources"]
+    assert len(sources) == 3
+    expected_limit = story_routes._KNOWLEDGE_MATERIAL_MAX_CHARS // 3
+    for s in sources:
+        assert len(s["material"]) <= expected_limit
+    # every material distinct — budget applied per-source, not shared/truncated
+    # to a single common slice
+    assert sources[0]["material"][0] == "甲"
+    assert sources[1]["material"][0] == "乙"
+    assert sources[2]["material"][0] == "丙"
+    # index is 1-based and matches submission order
+    assert [s["index"] for s in sources] == [1, 2, 3]
+    assert [s["title"] for s in sources] == ["素材甲", "素材乙", "素材丙"]
+    assert all(s["kind"] == "podcast" for s in sources)
+
+    story = database.get_active_story(database.anki_today().isoformat(), "listening", deck_id)
+    gen_params = json.loads(story["gen_params"])
+    assert gen_params["episode_ids"] == ids
+    assert gen_params["episode_id"] == ids[0]   # legacy singular key = first id
+    assert gen_params["kind"] == "mixed"        # #752: multiple sources → "mixed"
+
+
+def test_multi_source_skips_items_without_material(populated_db):
+    """选了 3 个素材，其中 1 个还没有转录/摘要——生成不因此整体失败，
+    只是那一份被跳过（routes/story.py 的 knowledge 分支约定，见施工图）。"""
+    deck_id = populated_db
+    eid_ok1 = database.create_pending_episode(
+        "s1", "https://example.com/feed.xml", "有内容 1", None,
+        "https://example.com/s1", kind="podcast")
+    database.update_episode(eid_ok1, status="summarized", transcript_zh="正文一。")
+
+    eid_empty = database.create_pending_episode(
+        "s2", "https://example.com/feed.xml", "没内容", None,
+        "https://example.com/s2", kind="podcast")
+    database.update_episode(eid_empty, status="pending")  # 没有 transcript_zh/summary_de
+
+    eid_ok2 = database.create_pending_episode(
+        "s3", "https://example.com/feed.xml", "有内容 2", None,
+        "https://example.com/s3", kind="video")
+    database.update_episode(eid_ok2, status="summarized", transcript_zh="正文二。")
+
+    captured = {}
+
+    def _capturing(cards, sources, **kwargs):
+        captured["sources"] = sources
+        return _fake_podcast_sentences(cards, sources, **kwargs)
+
+    with patch("ai.generate_podcast_sentences", side_effect=_capturing) as mock_gen:
+        r = client.get(f"/api/story/{deck_id}/listening",
+                       params={"mode": "knowledge",
+                               "episode_ids": f"{eid_ok1},{eid_empty},{eid_ok2}"})
+
+    assert r.status_code == 200
+    assert not r.json().get("error")
+    mock_gen.assert_called_once()
+    sources = captured["sources"]
+    assert len(sources) == 2
+    assert [s["title"] for s in sources] == ["有内容 1", "有内容 2"]
+
+
+def test_knowledge_mode_requires_at_least_one_item(populated_db):
+    deck_id = populated_db
+    r = client.get(f"/api/story/{deck_id}/listening", params={"mode": "knowledge"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["error"] is True
+    assert "at least one" in body["reason"]
+
+
+def test_knowledge_mode_unknown_id_raises(populated_db):
+    deck_id = populated_db
+    r = client.get(f"/api/story/{deck_id}/listening",
+                   params={"mode": "knowledge", "episode_ids": "999999"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["error"] is True
+    assert "999999" in body["reason"]
+
+
+# ── ai.generate_podcast_sentences: source_index attribution ────────────────
+
+CARDS = [
+    {"word_id": 1, "word_zh": "承认", "pinyin": "chéngrèn", "definition": "admit"},
+    {"word_id": 2, "word_zh": "顺便", "pinyin": "shùnbiàn", "definition": "by the way"},
+]
+
+SOURCES_2 = [
+    {"index": 1, "title": "素材一", "kind": "podcast", "url": "https://a.example/1", "material": "第一份素材正文。"},
+    {"index": 2, "title": "素材二", "kind": "video", "url": "https://b.example/2", "material": "第二份素材正文。"},
+]
+
+
+def _reply(items):
+    return json.dumps(items, ensure_ascii=False)
+
+
+def test_source_index_attributes_sentence_to_right_source(monkeypatch):
+    monkeypatch.setattr(ai, "_call_api", lambda *a, **kw: _reply([
+        {"sentence_zh": "张一鸣承认公司暂时落后。", "source_index": 2},
+        {"sentence_zh": "他顺便去买了咖啡。", "source_index": 1},
+    ]))
+    sentences, _ = ai.generate_podcast_sentences(CARDS, SOURCES_2)
+
+    by_word = {s["word_ids"][0]: s for s in sentences}
+    assert by_word[1]["source_url"] == "https://b.example/2"
+    assert by_word[1]["source_title"] == "素材二"
+    assert by_word[2]["source_url"] == "https://a.example/1"
+    assert by_word[2]["source_title"] == "素材一"
+
+
+def test_source_index_out_of_range_falls_back_to_first_source(monkeypatch):
+    monkeypatch.setattr(ai, "_call_api", lambda *a, **kw: _reply([
+        {"sentence_zh": "张一鸣承认公司暂时落后。", "source_index": 99},
+        {"sentence_zh": "他顺便去买了咖啡。"},   # missing entirely
+    ]))
+    sentences, _ = ai.generate_podcast_sentences(CARDS, SOURCES_2)
+
+    for s in sentences:
+        assert s["source_url"] == "https://a.example/1"
+        assert s["source_title"] == "素材一"
+
+
+def test_multi_source_prompt_lists_sources_with_numbered_titles(monkeypatch):
+    sent = []
+
+    def fake_call(model, messages, *a, **kw):
+        sent.append(messages[0]["content"])
+        return _reply([{"sentence_zh": "张一鸣承认公司暂时落后。", "source_index": 1},
+                       {"sentence_zh": "他顺便去买了咖啡。", "source_index": 2}])
+
+    monkeypatch.setattr(ai, "_call_api", fake_call)
+    ai.generate_podcast_sentences(CARDS, SOURCES_2)
+
+    prompt = sent[0]
+    assert "1. 《素材一》（podcast）" in prompt
+    assert "2. 《素材二》（video）" in prompt
+    assert "第一份素材正文。" in prompt
+    assert "第二份素材正文。" in prompt
+    assert "source_index" in prompt   # multi_source_block instructs the model
+
+
+# ── single-source path: {multi_source_block} renders empty (逐字不变) ───────
+
+def test_single_source_prompt_has_no_multi_source_block(monkeypatch):
+    """单素材时提示词里不能出现 #752 新增的多素材说明，否则说明单素材路径
+    被这次改动动过了——Daniel 正在调这份提示词，单素材必须逐字不变。"""
+    sent = []
+
+    def fake_call(model, messages, *a, **kw):
+        sent.append(messages[0]["content"])
+        return _reply([{"sentence_zh": "张一鸣承认公司暂时落后。"},
+                       {"sentence_zh": "他顺便去买了咖啡。"}])
+
+    monkeypatch.setattr(ai, "_call_api", fake_call)
+    single_source = [{"index": 1, "title": "标题", "kind": "podcast",
+                       "url": None, "material": "Zusammenfassung"}]
+    ai.generate_podcast_sentences(CARDS, single_source)
+
+    prompt = sent[0]
+    assert "{multi_source_block}" not in prompt
+    assert "多份素材" not in prompt
+    assert "source_index" not in prompt

--- a/tests/test_knowledge_story_mode.py
+++ b/tests/test_knowledge_story_mode.py
@@ -46,8 +46,11 @@ def populated_db(tmp_db, tmp_path):
     return next(d["id"] for d in database.get_all_decks() if d["name"] == "Kouyu")
 
 
-def _fake_podcast_sentences(cards, summary, title, **kwargs):
+def _fake_podcast_sentences(cards, sources, **kwargs):
     # (sentences, prompt) since #697 — the route stores the prompt on the story.
+    # #752: signature is now (cards, sources, ...) — sources[0]["title"] stands
+    # in for the old bare `title` param since every test here uses one source.
+    title = sources[0]["title"] if sources else ""
     return [
         {"word_id": c["word_id"], "sentence_zh": f"{c['word_zh']}出现在这一集里。",
          "sentence_en": "", "target_word": c["word_zh"]}
@@ -189,9 +192,9 @@ def test_knowledge_mode_story_generation_uses_transcript(populated_db):
 
     seen_material = {}
 
-    def _capturing(cards, material, title, **kwargs):
-        seen_material["value"] = material
-        return _fake_podcast_sentences(cards, material, title, **kwargs)
+    def _capturing(cards, sources, **kwargs):
+        seen_material["value"] = sources[0]["material"] if sources else ""
+        return _fake_podcast_sentences(cards, sources, **kwargs)
 
     with patch("ai.generate_podcast_sentences", side_effect=_capturing) as mock_gen:
         r = client.get(f"/api/story/{deck_id}/listening",
@@ -215,9 +218,9 @@ def test_knowledge_mode_story_generation_falls_back_without_transcript(populated
 
     seen_material = {}
 
-    def _capturing(cards, material, title, **kwargs):
-        seen_material["value"] = material
-        return _fake_podcast_sentences(cards, material, title, **kwargs)
+    def _capturing(cards, sources, **kwargs):
+        seen_material["value"] = sources[0]["material"] if sources else ""
+        return _fake_podcast_sentences(cards, sources, **kwargs)
 
     with patch("ai.generate_podcast_sentences", side_effect=_capturing) as mock_gen:
         r = client.get(f"/api/story/{deck_id}/listening",

--- a/tests/test_podcast_sentences.py
+++ b/tests/test_podcast_sentences.py
@@ -15,6 +15,13 @@ CARDS = [
 ]
 
 
+def _sources(material, title="标题"):
+    """#752: generate_podcast_sentences now takes a list of source dicts
+    instead of a bare (material, title) pair — this builds a single-source
+    list, which is what most of these tests exercise."""
+    return [{"index": 1, "title": title, "kind": "podcast", "url": None, "material": material}]
+
+
 def _reply(items):
     return json.dumps(items, ensure_ascii=False)
 
@@ -28,7 +35,7 @@ def test_reasoning_is_kept(monkeypatch):
         {"reasoning_zh": "话题：抖音电商。", "sentence_zh": "他在抖音上刷视频，顺便就下了单。",
          "target_word": "顺便"},
     ]))
-    sentences, prompt = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
+    sentences, prompt = ai.generate_podcast_sentences(CARDS, _sources("Zusammenfassung"))
 
     assert [s["reasoning_zh"] for s in sentences] == [
         "话题：字节跳动的AI路线。", "话题：抖音电商。"]
@@ -41,7 +48,7 @@ def test_missing_reasoning_is_not_fatal(monkeypatch):
         {"sentence_zh": "张一鸣承认公司暂时落后。"},
         {"sentence_zh": "他在抖音上刷视频，顺便就下了单。"},
     ]))
-    sentences, prompt = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
+    sentences, prompt = ai.generate_podcast_sentences(CARDS, _sources("Zusammenfassung"))
 
     assert [s["reasoning_zh"] for s in sentences] == ["", ""]
     assert len(sentences) == 2
@@ -59,7 +66,7 @@ def test_skipped_word_is_re_requested(monkeypatch):
         return _reply([{"sentence_zh": "他在抖音上刷视频，顺便就下了单。"}])
 
     monkeypatch.setattr(ai, "_call_api", fake_call)
-    sentences, prompt = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
+    sentences, prompt = ai.generate_podcast_sentences(CARDS, _sources("Zusammenfassung"))
 
     assert len(prompts) == 2
     assert "顺便" in prompts[1] and "补漏轮" in prompts[1]
@@ -70,7 +77,7 @@ def test_skipped_word_is_re_requested(monkeypatch):
 def test_fallback_only_after_all_rounds(monkeypatch):
     """AI 始终不写句子时仍然收敛：每张卡都有句子，且轮数有上限。"""
     monkeypatch.setattr(ai, "_call_api", lambda *a, **kw: _reply([]))
-    sentences, prompt = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
+    sentences, prompt = ai.generate_podcast_sentences(CARDS, _sources("Zusammenfassung"))
 
     assert len(sentences) == 2
     assert all("我学了" in s["sentence_zh"] for s in sentences)
@@ -84,7 +91,7 @@ def test_progress_log_is_recorded(monkeypatch):
     ]))
     key = "test/reading/zh"
     ai.reset_story_log(key)
-    ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题", progress_key=key)
+    ai.generate_podcast_sentences(CARDS, _sources("Zusammenfassung"), progress_key=key)
 
     log = ai._story_log[key]
     assert any("开始生成播客句子" in line for line in log)
@@ -105,7 +112,7 @@ def test_returns_the_prompt_actually_sent(monkeypatch):
                        {"sentence_zh": "他在抖音上刷视频，顺便就下了单。"}])
 
     monkeypatch.setattr(ai, "_call_api", fake_call)
-    sentences, prompt = ai.generate_podcast_sentences(CARDS, "字节跳动的一集", "标题")
+    sentences, prompt = ai.generate_podcast_sentences(CARDS, _sources("字节跳动的一集"))
 
     assert prompt == sent[0]
     assert "字节跳动的一集" in prompt      # 素材
@@ -121,17 +128,19 @@ def test_prompt_includes_every_retry_round(monkeypatch):
         return _reply([{"sentence_zh": "他在抖音上刷视频，顺便就下了单。"}])
 
     monkeypatch.setattr(ai, "_call_api", fake_call)
-    _, prompt = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
+    _, prompt = ai.generate_podcast_sentences(CARDS, _sources("Zusammenfassung"))
 
     assert "补漏轮" in prompt
     assert prompt.count("【补漏轮】") == 1
 
 
 def test_no_material_returns_empty_prompt(monkeypatch):
-    """没有素材时不调 AI，也就没有提示词可存。"""
+    """没有素材（#752 起：没有任何可用素材源）时不调 AI，也就没有提示词可存。
+    caller（routes/story.py）在真正调用前就已经把无素材的条目过滤掉了，所以
+    这里模拟"过滤后什么都不剩"的情形：sources=[]。"""
     monkeypatch.setattr(ai, "_call_api",
                         lambda *a, **kw: pytest.fail("素材为空时不该调 AI"))
-    sentences, prompt = ai.generate_podcast_sentences(CARDS, "   ", "标题")
+    sentences, prompt = ai.generate_podcast_sentences(CARDS, [])
     assert sentences == [] and prompt == ""
 
 
@@ -206,7 +215,7 @@ def test_end_to_end_truncated_reply_still_yields_sentences(monkeypatch):
         return truncated_raw
 
     monkeypatch.setattr(ai, "_call_api", fake_call)
-    sentences, prompt = ai.generate_podcast_sentences(CARDS, "Zusammenfassung", "标题")
+    sentences, prompt = ai.generate_podcast_sentences(CARDS, _sources("Zusammenfassung"))
 
     assert len(sentences) > 0
     assert not all("我学了" in s["sentence_zh"] for s in sentences)

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -75,6 +75,7 @@ def test_knowledge_template_keeps_json_example_braces():
     rendered = ai._render_prompt(ai.DEFAULT_PROMPT_TEMPLATES["knowledge"], {
         "title": "T", "summary": "S", "words": "1. 蘑菇（mógū）— mushroom",
         "max_hsk": "3", "extra_hint": "",
+        "multi_source_block": "",  # #752: new placeholder, empty in the single-source case
     })
     # JSON 示例的花括号必须原样保留（替换只针对已知记号）。断言写在结构上而不是
     # 示例的逐字文本上——提示词本身会被反复调（#737/#741），逐字断言只会逼着


### PR DESCRIPTION
Closes #752

## 改了什么

`knowledge` 模式原来只能选一个素材，当天到期的词全部硬挤进一期播客的话题里。现在设置弹窗可以同时勾选多份素材（播客 / 视频 / 文章混合），句子分散到各份素材上。

**前端**
- 素材列表 radio → checkbox；已选项存在模块级 Map 里，切换 Source type 或播客源后不丢失
- 列表上方显示已选清单，每项可单独移除；校验改为「至少选一个」
- 请求参数改发 `episode_ids=12,34`（不再发 `episode_id`）

**后端**
- 新增 `episode_ids` 查询参数（逗号分隔），旧的单值 `episode_id` 继续接受（旧链接 / 旧 gen_params）
- 素材字数预算 `_KNOWLEDGE_MATERIAL_MAX_CHARS`（15000）**在素材间均分**，总输入量与单素材时相同
- 多素材时提示词列出编号素材，要求模型每句返回 `source_index`，后端据此回填该句的 `source_url`/`source_title`；缺失或越界回退到素材 1（错的链接是小事，为它丢掉好句子不值）
- **单素材时 `{multi_source_block}` 渲染为空，提示词逐字不变** —— Daniel 正在调这份提示词
- 选中的素材里有一份没转录/摘要时跳过它并记 warning，不因此让整次生成失败；全部为空才报错
- `gen_params` 同时存 `episode_ids` 列表和 `episode_id`（= 首个，兼容旧读取点）；`kind` 多素材时为 `mixed`
- Again 单句重生成无从知道该句原本出自哪份素材，所以把全部素材再喂一遍由模型自己挑

## 怎么测试

`pytest tests/` 全绿（602 passed）。新增 `tests/test_knowledge_multi_source.py` 14 条：`_parse_episode_ids` 各种输入、预算均分与 `sources[]` 结构、无材料素材被跳过、未知 id 报错、`source_index` 回填与越界回退、多素材提示词编号内容、**单素材提示词不含多素材块的任何痕迹**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)