### PR TITLE
知识库：Instagram Reel 转写 + 短素材跳过 AI 摘要（只翻译+标生词）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,7 @@
 ├── ai.py                  # AI 提供商调用（每种提示词类型一个函数）
 ├── news_fetcher.py        # 新闻抓取（Tagesschau API + RSS；按天缓存 data/news_cache/）
 ├── podcast.py             # 播客爬虫（#479）：播客 RSS 直链发现新单集（#497，退役 YouTube/yt-dlp）、每源 auto_process 开关+非自动源只入库元数据（#502，podcast_feeds 表）、转录链 NotebookLM 免费主力+听悟+Whisper 保底、单步异常不中止整链（#510 重排，链式降级，原 #498/#485/#486）、摘要 NotebookLM chat.ask 免费优先+DeepSeek/gpt API 链回退（api 路径内部 DeepSeek 优先省钱，#532；勾了 china-kritisch 的素材跳过 DeepSeek 直接用 OpenAI，#731）、邮件通知+Signal 通知（signal-cli 关联设备，发 Note to Self，#521，二者独立可选、互不影响；消息抬头播客名·星期·日期、链接在末尾，单集日期按 Europe/Berlin 显示，#532）、摘要 table.media 风格（`<p>` 段落+每段首句 `<b>` 加粗总结，#567）+详情页 Regenerate summary 按钮、邮件主题=`播客名 - 单集标题`（查不到播客名只用标题，不要退回死前缀）+ `summary_zh` 开头中文总结（#708 起是 `summary_de` 的**完整翻译**：同段落数、同顺序、同事实，同样 `<p>`+段首 `<b>`，HSK4-5 用词；提示词里德语先写、中文后译，JSON 里 `summary_de` 排在前面；渲染三处——邮件 `podcast._summary_zh_html`、详情页 `app.js._summaryZhHtml` 均"先全转义再放行 `<p>/<b>/<strong>/<em>/<i>/<br>`"，Signal 用 `_summary_to_plain_text` 剥标签；#708 之前的旧条目是纯文本，两处渲染都按空行补 `<p>`；**是增量不是必需**——成功判定只看 `summary_de`，模型漏掉中文总结不能让整集失败）+ 摘要里任何 HSK5+ 中文概念都标 `pinyin/汉字`（不限于提取的词表，宁多勿少，#631）；已泛化为知识库存储层，见 `knowledge/` 包
-├── knowledge/             # 知识库摄取（#650–#655，播客功能泛化，见「知识库」节）：youtube.py（字幕摄取）、article.py（正文抽取）、ingest.py（唯一入库管线）、mailbox.py（IMAP 邮件收件）、signal_inbox.py（Signal Note to Self 分享收件，#749）
+├── knowledge/             # 知识库摄取（#650–#655，播客功能泛化，见「知识库」节）：youtube.py（字幕摄取）、article.py（正文抽取）、instagram.py（Reel/Post 摄取，yt-dlp 元数据+音频下载，#750）、ingest.py（唯一入库管线）、mailbox.py（IMAP 邮件收件）、signal_inbox.py（Signal Note to Self 分享收件，#749）
 ├── zh_annotate.py         # 生词标注（#638，零 AI）：HSK 表+词库+jieba+pypinyin+谷歌翻译
 ├── translator.py          # 翻译（Google Translate，deep-translator，可选）
 ├── tts.py                 # edge-tts 封装（离线模式下只读缓存，#612）
@@ -357,6 +357,9 @@ python main.py status [--deck X]     # 显示每个牌组/类别的到期数量
 | `KNOWLEDGE_IMAP_HOST` / `KNOWLEDGE_IMAP_PORT` | 可选 | 知识库邮件收件（#655）的 IMAP 服务器；端口默认 `993`（SSL） |
 | `KNOWLEDGE_IMAP_USER` / `KNOWLEDGE_IMAP_PASSWORD` | 可选 | 知识库邮件收件（#655）专用邮箱的登录凭据；三者（含上面两个变量）任一未配置时 `scripts/knowledge_mail_check.py` 直接跳过，不连接 |
 | `KNOWLEDGE_MAIL_ALLOWED_SENDERS` | 可选 | 知识库邮件收件（#655）发件人白名单，逗号分隔的邮箱地址（不区分大小写，兼容 `Name <addr@x.de>` 格式）；**留空则整个邮箱检查被跳过，不处理任何邮件**——这是防止任何知道邮箱地址的人往服务器塞 URL 触发 AI 调用的唯一防线 |
+| `GROQ_API_KEY` | 可选 | Instagram Reel 转录（#750）的主力，Groq `whisper-large-v3-turbo`（约比 OpenAI 便宜 9 倍、快 10 倍）；未配置时自动回退已有的 OpenAI `whisper-1`（`OPENAI_API_KEY`），只是单价贵约 9 倍——不是本功能能否使用的前提。获取方式见 `scripts/README.md` |
+| `INSTAGRAM_COOKIES_FILE` | `data/instagram_cookies.txt` | Instagram Reel 摄取（#750）用的登录态 cookies（Netscape 格式，`yt-dlp --cookies`）；文件不存在时公开 Reel 仍会尝试下载，不一定成功。会过期，过期时的错误信息会明说，一次性导出步骤见 `scripts/README.md` |
+| `YT_DLP_PATH` | `yt-dlp` | Instagram Reel 摄取（#750）用的 yt-dlp 可执行文件路径；系统级命令行工具（同 `ffmpeg` 的处理方式），装在非默认位置时指过去 |
 
 注意：uvicorn 直接启动不建表——测试前先手动 `database.init_db()`（`run.sh`/`main.py` 会自动处理）。
 
@@ -564,6 +567,11 @@ FSRS 用毕业评分播种初始 stability/difficulty：默认权重下 **Good �
   - **代价**：NotebookLM 不能指定字幕语言，返回的是视频原声轨（那条视频拿回来的是英文 32633 字，不是本地能拿到的中文翻译轨 9833 字）。摘要提示词本来就容忍任意输入语言，所以功能通；要中文轨只能给字幕 API 配付费代理（`WebshareProxyConfig`），暂不做
 - 新依赖 `youtube-transcript-api`、`trafilatura`（已在 `requirements.txt`）
 - **一次性数据清理必须真的只跑一次（#688）**：`init_db()` 里 #497 那段"删除卡住的遗留 YouTube 行"按 `video_id` 是 11 位 + `status != 'summarized'` 判断，既没有一次性标记（每次启动都跑），又正好命中知识库摄取的视频 —— 生产 cron 每 2 分钟重启一次服务，于是每个新视频在 NotebookLM 转录完成前必被删除，界面上表现为"加完就消失"。现在两道保护：限定 `kind='podcast'` + `app_settings.purged_legacy_youtube_rows` 标记（标记写在"表已存在"迁移块之外，全新库首次启动也写）。**往 `init_db()` 里加任何 DELETE 之前，先想清楚它在第 100 次启动时会删掉什么**
+- **Instagram Reel 摄取（`knowledge/instagram.py`，#750）**：`kind='video'`，`video_id` 存 Instagram 的短码（shortcode）。没有字幕 API 可用，`ingest_url()` 只存元数据（`yt-dlp --dump-json` 拿标题/作者/时长，标题缺失时退回 `description` 首行再退回短码），下载音频+转录都推迟到 `.../process`（`podcast._transcribe_instagram`）。**转录是降级链**（本仓库转录链一贯的风格，同 `fetch_transcript()`）：① `GROQ_API_KEY` 已配置 → Groq `whisper-large-v3-turbo`（$0.04/小时，约比 OpenAI 便宜 9 倍、快 10 倍）；② 否则/失败 → 已有的 `podcast._transcribe_via_whisper()`（OpenAI `whisper-1`，$0.006/分钟，一条 60 秒 Reel ≈ $0.006）；③ 都不行 → `status='no_transcript'`。`GROQ_API_KEY` 因此是**可选**的，不是本功能能否用的前提
+  - **幻觉过滤两条转录路径都要过（`podcast._filter_whisper_hallucinations`）**：Reel 常是纯音乐无人声，Whisper 系模型会对着音乐编造整段文本。两条路径都请求 `response_format="verbose_json"` 拿到真正的分段元数据（`no_speech_prob`/`avg_logprob`）——OpenAI 这边为此把模型从播客路径默认的 `gpt-4o-mini-transcribe` 换成 `whisper-1`（前者不接受 `verbose_json`，只有 `whisper-1` 支持）。过滤三道：`no_speech_prob`/`avg_logprob` 超阈值的段落丢弃 → 同一段文本连续重复 ≥3 次判整条作废（比单看概率更强的信号）→ 剩余不足 20 词判 `no_transcript`。**绝不能把幻觉文本存进库假装成功**
+  - **Instagram cookies 会过期**：下载失败时错误信息明说"可能是 cookies 过期"（`knowledge/instagram.py._yt_dlp_error_message`），这是 Daniel 唯一能看到的诊断线索（走 #749 的 Signal 回执通道）。一次性安装/cookies 导出步骤见 `scripts/README.md`
+  - **短文本跳过 AI 摘要，YouTube/Instagram/文章共用（`podcast.SUMMARY_WORD_THRESHOLD=1000`）**：转录词数低于阈值（`podcast._word_count`，CJK 按字符数+西文按空格分词的混合估计）时 `_process_episode` 完全跳过 `summarize()`，改走零 AI 成本的 `podcast._zero_cost_summary()`——`summary_zh`/`summary_de` 靠 Google Translate（免费）互译，不靠 AI 三段式总结；生词表照常走 `zh_annotate.extract_new_words()`（这正是 Daniel 要的"只给我不认识的词"）。两段文本仍过 `_annotate_summary()` 同一套拼音/汉字标注，和 AI 摘要路径展示效果一致。**长素材（≥1000 词）行为完全不变**，仍走原 AI 摘要
+  - **翻译方向不能假设"转录永远是中文"**：`transcript_zh`/`build_transcript_de()` 历史上都假设 zh→de 单向；Reel 常是德语/英语音频，方向反了。`podcast._is_chinese_text()`（CJK 字符占比 ≥0.2）判断转录语言——非中文转录时 `build_transcript_de()` 直接返回 `[]`（不产出"德语翻德语"的垃圾），`_zero_cost_summary()` 按方向选择往哪边翻译。**不改列名、不建新表**——`transcript_zh` 存"任意语言源文本"是本仓库已有先例（同 `word_zh` 对法语存法语词形）
 
 ---
 

--- a/database/stats.py
+++ b/database/stats.py
@@ -89,7 +89,7 @@ def get_stats(deck_id: int | None = None, lang: str | None = None) -> dict:
 # this table is hand-maintained — update it (and the static price table in
 # static/index.html's story-setup modal) whenever a provider changes pricing
 # or a new model is adopted. See CLAUDE.md "规范与约束".
-_PRICING_AS_OF = "2026-08-09"
+_PRICING_AS_OF = "2026-08-15"
 _MODEL_PRICING: dict[str, dict[str, float]] = {
     # OpenAI (news/briefing/podcast summaries)
     "gpt-5.6-sol":   {"input": 5.00, "cached": 0.50, "output": 30.00},
@@ -101,6 +101,14 @@ _MODEL_PRICING: dict[str, dict[str, float]] = {
     # OpenAI audio transcription (podcast Whisper path) — billed per minute;
     # input_tokens stores audio *seconds* for these rows (see podcast.py).
     "gpt-4o-mini-transcribe": {"per_minute": 0.003},
+    # whisper-1 (#750): the Instagram Reel transcription fallback
+    # (podcast._transcribe_instagram) — the only OpenAI transcription model
+    # that supports response_format="verbose_json" (needed for the
+    # hallucination filter's per-segment no_speech_prob/avg_logprob).
+    "whisper-1": {"per_minute": 0.006},
+    # Groq whisper-large-v3-turbo (#750): Instagram Reel transcription,
+    # primary path — $0.04/hour of audio = $0.04/60 per minute.
+    "whisper-large-v3-turbo": {"per_minute": 0.04 / 60},
     # DeepSeek (default story/enrichment models)
     "deepseek-v4-flash": {"input": 0.14,  "cached": 0.0028,   "output": 0.28},
     "deepseek-v4-pro":   {"input": 0.435, "cached": 0.003625, "output": 0.87},

--- a/knowledge/ingest.py
+++ b/knowledge/ingest.py
@@ -26,6 +26,7 @@ import re
 
 import database
 import knowledge.article
+import knowledge.instagram
 import knowledge.youtube
 
 logger = logging.getLogger(__name__)
@@ -54,6 +55,11 @@ def ingest_url(url: str, china_critical: bool = False) -> dict:
     video_id = knowledge.youtube.parse_video_id(url)
     if video_id:
         return _ingest_video(url, video_id, china_critical=china_critical)
+
+    shortcode = knowledge.instagram.parse_shortcode(url)
+    if shortcode:
+        return _ingest_instagram(url, shortcode, china_critical=china_critical)
+
     return _ingest_article(url, china_critical=china_critical)
 
 
@@ -83,6 +89,50 @@ def _ingest_video(url: str, video_id: str, china_critical: bool = False) -> dict
         youtube_url=url,
         audio_url=None,
         duration_seconds=None,
+        kind="video",
+        china_critical=china_critical,
+    )
+    if title_en:
+        database.update_episode(episode_id, title_en=title_en)
+
+    return {"episode_id": episode_id}
+
+
+def _ingest_instagram(url: str, shortcode: str, china_critical: bool = False) -> dict:
+    """Instagram Reel/Post ingestion (#750), metadata-only at add time —
+    mirrors _ingest_video: the audio download + transcription (Groq/OpenAI
+    Whisper, podcast._transcribe_instagram) happens later, in the
+    .../process call, not here. video_id is the Instagram shortcode
+    (Instagram's own unique-per-post id), the same dedup key _ingest_video
+    uses the YouTube video id for."""
+    existing = database.get_episode_by_video_id(shortcode)
+    if existing:
+        return {"status": "already_exists", "episode_id": existing["id"]}
+
+    try:
+        meta = knowledge.instagram.fetch_metadata(url)
+    except knowledge.instagram.InstagramError as e:
+        logger.warning("knowledge.ingest: Instagram metadata lookup failed for %s: %s", shortcode, e)
+        raise IngestError(str(e))
+    except Exception as e:
+        logger.warning("knowledge.ingest: Instagram metadata lookup failed for %s: %s", shortcode, e)
+        raise IngestError(f"Could not fetch Instagram metadata: {e}")
+
+    title = meta.get("title") or shortcode
+    # translate_title (#651) is one cheap AI call — best-effort, must not
+    # block/fail the ingest if it errors (translate_title itself already
+    # swallows exceptions and returns None in that case).
+    import ai
+    title_en = ai.translate_title(title)
+
+    episode_id = database.create_pending_episode(
+        video_id=shortcode,
+        channel_id=meta.get("uploader"),
+        title=title,
+        published_at=None,
+        youtube_url=meta.get("webpage_url") or url,
+        audio_url=None,
+        duration_seconds=meta.get("duration"),
         kind="video",
         china_critical=china_critical,
     )

--- a/knowledge/instagram.py
+++ b/knowledge/instagram.py
@@ -1,0 +1,184 @@
+"""Instagram Reel/Post ingestion (issue #750): resolve an Instagram URL to
+metadata (podcast._ingest_instagram / knowledge.ingest._ingest_instagram)
+and, later, downloadable audio for transcription
+(podcast._transcribe_instagram). Unlike knowledge/youtube.py there is no
+captions API to try first — Instagram exposes none — so every Reel/Post goes
+straight to "download the audio and transcribe it" (Groq whisper-large-v3-
+turbo, falling back to OpenAI whisper-1, see podcast.py).
+
+Uses yt-dlp — a system-level command-line tool, like ffmpeg, NOT a Python
+dependency (see requirements.txt / scripts/README.md) — rather than a
+hand-rolled scraper: Instagram's page markup changes often and yt-dlp
+already tracks it, and it needs a login cookie jar for reliable access
+anyway (see _cookies_file below).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+import urllib.parse
+
+logger = logging.getLogger(__name__)
+
+# instagram.com/reel/<code>/, /reels/<code>/, /p/<code>/, /tv/<code>/ — all
+# four path shapes Daniel might actually share (Reels, the older "post" and
+# "IGTV" video shapes), each followed by the shortcode.
+_SHORTCODE_RE = re.compile(r"^/(?:reel|reels|p|tv)/([A-Za-z0-9_-]+)")
+
+# yt-dlp timeouts: metadata is a single lightweight request; audio download
+# (+ Instagram's own throttling) needs more headroom. Both are well under
+# the outer HTTP request's own timeout budget for the add-a-URL flow.
+_METADATA_TIMEOUT = 60
+_DOWNLOAD_TIMEOUT = 300
+
+_DEFAULT_COOKIES_FILE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data", "instagram_cookies.txt",
+)
+
+
+class InstagramError(Exception):
+    """A Reel/Post URL could not be resolved to metadata, or its audio could
+    not be downloaded. Callers (knowledge.ingest, podcast._transcribe_instagram)
+    let this propagate so it lands on podcast_episodes.status='error' with a
+    readable message — see _yt_dlp_error_message for why that message
+    specifically calls out cookies when the failure looks cookie-shaped."""
+
+
+def _yt_dlp_path() -> str:
+    return os.environ.get("YT_DLP_PATH", "yt-dlp")
+
+
+def _cookies_file() -> str | None:
+    """INSTAGRAM_COOKIES_FILE (default data/instagram_cookies.txt), only if
+    it actually exists. Missing is NOT an error here — a public Reel
+    sometimes works without a login cookie at all — but yt-dlp reporting a
+    login/rate-limit-shaped failure without one gets the cookie hint in
+    _yt_dlp_error_message, since that's overwhelmingly the real cause."""
+    path = os.environ.get("INSTAGRAM_COOKIES_FILE", _DEFAULT_COOKIES_FILE)
+    return path if path and os.path.isfile(path) else None
+
+
+def parse_shortcode(url: str) -> str | None:
+    """Extract the Reel/Post shortcode from any Instagram URL shape Daniel
+    might share: /reel/<code>/, /reels/<code>/, /p/<code>/, /tv/<code>/,
+    with or without www., a trailing slash, or query params. Returns None
+    for anything that isn't a recognizable Instagram post/reel/video URL —
+    including Instagram's own non-post pages (profile, home, etc.)."""
+    if not url or not isinstance(url, str):
+        return None
+    url = url.strip()
+    if not url:
+        return None
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except ValueError:
+        return None
+
+    host = (parsed.hostname or "").lower()
+    if host.startswith("www."):
+        host = host[4:]
+    if host != "instagram.com":
+        return None
+
+    m = _SHORTCODE_RE.match(parsed.path)
+    return m.group(1) if m else None
+
+
+def _yt_dlp_error_message(stderr: str, action: str) -> str:
+    """Instagram cookies expire silently, and yt-dlp's failure for that looks
+    like an ordinary login-wall/rate-limit error, not a clean "your cookies
+    expired" status. Daniel only ever sees this via the Signal receipt
+    (#749's error channel) — the message must spell out the likely cause
+    rather than just relay yt-dlp's (often terse/cryptic) stderr verbatim."""
+    hint = (
+        " — possibly expired/missing Instagram cookies, see scripts/README.md"
+        if re.search(r"login|rate.?limit|private|cookie", stderr, re.IGNORECASE)
+        else ""
+    )
+    tail = stderr.strip()[-500:]
+    return f"yt-dlp {action} failed{hint}: {tail}"
+
+
+def _run_yt_dlp(cmd: list[str], timeout: int, action: str) -> subprocess.CompletedProcess:
+    """Shared subprocess wrapper for fetch_metadata/download_audio: turns a
+    missing binary or a timeout into the same InstagramError contract as an
+    ordinary yt-dlp failure, so callers only need one except clause."""
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired as e:
+        raise InstagramError(f"yt-dlp {action} timed out after {timeout}s") from e
+    except FileNotFoundError as e:
+        raise InstagramError(
+            f"yt-dlp not found (YT_DLP_PATH={_yt_dlp_path()!r}) — see scripts/README.md"
+        ) from e
+
+
+def fetch_metadata(url: str) -> dict:
+    """Reel/Post metadata via `yt-dlp --dump-json` (#750): {title, uploader,
+    duration, webpage_url}. Instagram titles are frequently empty or just
+    duplicate the full caption — title falls back to the first line of
+    `description`, then to the URL's shortcode, so there's always something
+    short and non-empty to store as podcast_episodes.title.
+
+    Raises InstagramError on any yt-dlp/parsing failure — same contract as
+    knowledge.youtube.fetch_metadata (nothing sensible to store without at
+    least a title).
+    """
+    cmd = [_yt_dlp_path(), "--dump-json", "--no-warnings"]
+    cookies = _cookies_file()
+    if cookies:
+        cmd += ["--cookies", cookies]
+    cmd.append(url)
+
+    result = _run_yt_dlp(cmd, _METADATA_TIMEOUT, "metadata lookup")
+    if result.returncode != 0:
+        raise InstagramError(_yt_dlp_error_message(result.stderr, "metadata lookup"))
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise InstagramError(f"yt-dlp returned unparsable metadata for {url}: {e}") from e
+
+    title = (data.get("title") or "").strip()
+    if not title:
+        description = (data.get("description") or "").strip()
+        title = description.splitlines()[0].strip() if description else ""
+    if not title:
+        title = parse_shortcode(url) or url
+
+    return {
+        "title": title,
+        "uploader": data.get("uploader"),
+        "duration": data.get("duration"),
+        "webpage_url": data.get("webpage_url") or url,
+    }
+
+
+def download_audio(url: str, dest_dir: str) -> str:
+    """Download `url`'s audio track as an mp3 into dest_dir via yt-dlp,
+    returning the mp3 path. Raises InstagramError on failure — see
+    _yt_dlp_error_message for the cookie-expiry hint
+    podcast._transcribe_instagram relies on to surface a useful error to
+    Daniel (via the Signal receipt, #749) rather than a bare "download
+    failed"."""
+    out_template = os.path.join(dest_dir, "audio.%(ext)s")
+    cmd = [
+        _yt_dlp_path(), "-f", "bestaudio", "-x", "--audio-format", "mp3",
+        "--no-warnings", "-o", out_template,
+    ]
+    cookies = _cookies_file()
+    if cookies:
+        cmd += ["--cookies", cookies]
+    cmd.append(url)
+
+    result = _run_yt_dlp(cmd, _DOWNLOAD_TIMEOUT, "audio download")
+    if result.returncode != 0:
+        raise InstagramError(_yt_dlp_error_message(result.stderr, "audio download"))
+
+    mp3_path = os.path.join(dest_dir, "audio.mp3")
+    if not os.path.isfile(mp3_path):
+        raise InstagramError(f"yt-dlp reported success but no mp3 was produced for {url}")
+    return mp3_path

--- a/podcast.py
+++ b/podcast.py
@@ -75,6 +75,33 @@ _ITUNES_NS = {"itunes": "http://www.itunes.com/dtds/podcast-1.0.dtd"}
 _AUDIO_MAX_SECONDS = 3 * 60 * 60  # 3h — guards against a mislabeled/huge episode
 _WHISPER_SEGMENT_SECONDS = 20 * 60  # 20min segments stay well under OpenAI's 25MB upload cap
 
+# Instagram Reel transcription (#750): Groq's OpenAI-compatible audio
+# endpoint running whisper-large-v3-turbo — ~9x cheaper and ~10x faster than
+# the OpenAI whisper-1 fallback below. GROQ_API_KEY is optional (same
+# contract as Tingwu/NotebookLM's credential checks): unset just means
+# "fall back to whisper-1", not a failure.
+_GROQ_MODEL = "whisper-large-v3-turbo"
+
+# Instagram Reel hallucination guardrails (#750): a Reel that's pure
+# background music with no speech makes Whisper-family models *invent*
+# plausible-sounding text rather than admit silence. Both transcription
+# providers in the Instagram chain (_transcribe_via_groq,
+# _transcribe_via_whisper with filter_hallucinations=True) are asked for
+# response_format="verbose_json" specifically so these checks — run by
+# _filter_whisper_hallucinations — have real per-segment metadata to work
+# with regardless of which provider actually ran.
+_HALLUCINATION_NO_SPEECH_PROB = 0.6    # Whisper's own "this might be silence" signal
+_HALLUCINATION_MIN_AVG_LOGPROB = -1.0  # the model's own token-confidence for the segment
+_HALLUCINATION_REPEAT_COUNT = 3        # same sentence N times in a row = looping on nothing
+_HALLUCINATION_MIN_WORDS = 20          # too short to be worth summarizing/carding either way
+
+# Short-transcript AI-summary skip (#750): a 60s Instagram Reel (or any other
+# short knowledge-base item) yields only a few hundred words — a paid 3-part
+# AI summary of that is both wasteful and less useful to Daniel than just the
+# full (translated) text plus a generated new-word table. See
+# _zero_cost_summary and its call site in _process_episode.
+SUMMARY_WORD_THRESHOLD = 1000
+
 # NotebookLM (#486) settings. The notebook is created once and its id cached
 # in podcast_config so every episode's audio lands in the same place; the
 # source is deleted right after we read its fulltext so the notebook never
@@ -369,13 +396,29 @@ def _split_audio_segments(mp3_path: str, tmp_dir: str, duration: float) -> list[
     return [os.path.join(tmp_dir, s) for s in segments]
 
 
-def _transcribe_via_whisper(mp3_path: str, duration: float, video_id: str, tmp_dir: str) -> str | None:
+def _transcribe_via_whisper(mp3_path: str, duration: float, video_id: str, tmp_dir: str,
+                            *, language: str | None = "zh",
+                            model: str = "gpt-4o-mini-transcribe",
+                            filter_hallucinations: bool = False) -> str | None:
     """Paid fallback (#485): segment the shared mp3 and transcribe each
     segment via OpenAI's audio.transcriptions endpoint.
 
+    `language`/`model`/`filter_hallucinations` (#750): defaults reproduce the
+    original Chinese-podcast-only behavior unchanged. The Instagram Reel
+    chain (_transcribe_instagram) instead calls this with
+    model="whisper-1" (the only OpenAI transcription model that accepts
+    response_format="verbose_json" — gpt-4o-mini-transcribe rejects that
+    value outright, so it can't give per-segment no_speech_prob/avg_logprob),
+    language=None (Reels are German/English, not Chinese — forcing "zh"
+    would corrupt the transcript), and filter_hallucinations=True so a
+    music-only Reel's invented text gets caught by
+    _filter_whisper_hallucinations exactly like the Groq path does.
+
     Returns None when OPENAI_API_KEY is simply missing (config choice, not a
-    failure). Raises on actual transcription failure; callers log and treat
-    that the same as no transcript.
+    failure), or — filter_hallucinations=True only — when everything
+    transcribed is filtered out as hallucination/silence. Raises on actual
+    transcription failure; callers log and treat that the same as no
+    transcript.
     """
     if not os.environ.get("OPENAI_API_KEY"):
         logger.warning("podcast: OPENAI_API_KEY not set, skipping Whisper for %s", video_id)
@@ -386,40 +429,290 @@ def _transcribe_via_whisper(mp3_path: str, duration: float, video_id: str, tmp_d
     import openai
     client = openai.OpenAI()
     texts: list[str] = []
+    raw_segments: list = []
     for seg_path in segments:
         seg_name = os.path.basename(seg_path)
-        text = None
+        result = None
         for attempt in range(2):  # one retry on transient failure
             try:
                 with open(seg_path, "rb") as f:
-                    resp = client.audio.transcriptions.create(
-                        model="gpt-4o-mini-transcribe", file=f, language="zh",
-                    )
-                text = resp.text
+                    kwargs = {"model": model, "file": f}
+                    if language:
+                        kwargs["language"] = language
+                    if filter_hallucinations:
+                        kwargs["response_format"] = "verbose_json"
+                    result = client.audio.transcriptions.create(**kwargs)
                 break
             except Exception as e:
                 logger.warning(
                     "podcast: Whisper transcription failed (attempt %d) for %s/%s: %s",
                     attempt + 1, video_id, seg_name, e,
                 )
-        if text is None:
+        if result is None:
             raise RuntimeError(f"podcast: Whisper transcription failed twice for {video_id}/{seg_name}")
-        texts.append(text.strip())
+
+        if filter_hallucinations:
+            seg_list = getattr(result, "segments", None) or []
+            if seg_list:
+                raw_segments.extend(seg_list)
+            else:
+                # This model/response_format combination didn't return
+                # per-segment metadata after all — degrade gracefully to a
+                # single pseudo-segment so the repeat/min-length checks in
+                # _filter_whisper_hallucinations still run, just without the
+                # no_speech_prob/avg_logprob checks (both skip cleanly on a
+                # segment missing those keys).
+                raw_segments.append({"text": (getattr(result, "text", "") or "").strip()})
+        else:
+            texts.append((result.text or "").strip())
+
+    # Whisper is billed per minute, not per token. Log the audio duration (in
+    # seconds) as input_tokens so database.stats._row_cost can price it via
+    # the "per_minute" pricing entry — only on success, since a failed call
+    # above already raised before reaching here.
+    database.log_api_call(
+        model=model, input_tokens=int(duration),
+        output_tokens=0, purpose="podcast-transcribe",
+    )
+
+    if filter_hallucinations:
+        transcript = _filter_whisper_hallucinations(raw_segments)
+        if not transcript:
+            logger.info("podcast: Whisper (%s) transcript for %s filtered out as hallucination/silence",
+                        model, video_id)
+            return None
+        logger.info("podcast: Whisper (%s) transcribed %s (%d segment(s), %.0fs audio)",
+                    model, video_id, len(segments), duration)
+        return transcript
 
     transcript = " ".join(t for t in texts if t)
     logger.info(
         "podcast: Whisper transcribed %s (%d segment(s), %.0fmin)",
         video_id, len(segments), duration / 60,
     )
-    # Whisper is billed per minute, not per token. Log the audio duration (in
-    # seconds) as input_tokens so database.stats._row_cost can price it via
-    # the "per_minute" pricing entry — only on success, since a failed call
-    # above already raised before reaching here.
+    return transcript or None
+
+
+def _seg_field(seg, name: str, default=None):
+    """Segment objects come back as SDK pydantic models (OpenAI/Groq clients,
+    production) but as plain dicts (tests, and the degraded pseudo-segment
+    fallback in _transcribe_via_whisper) — accept either (#750)."""
+    if isinstance(seg, dict):
+        return seg.get(name, default)
+    return getattr(seg, name, default)
+
+
+def _filter_whisper_hallucinations(segments: list) -> str:
+    """Drop hallucinated segments from a Whisper/Groq verbose_json response
+    and join what's left (#750). A Reel with no speech (background music
+    only) makes Whisper-family models invent text with real confidence in
+    the *words* they pick but strong internal signals that they're making it
+    up:
+
+    1. no_speech_prob > _HALLUCINATION_NO_SPEECH_PROB — the model's own guess
+       that this segment is silence/non-speech, worth ignoring the emitted
+       text for even though it went ahead and emitted some anyway.
+    2. avg_logprob < _HALLUCINATION_MIN_AVG_LOGPROB — the model's own
+       token-confidence for the segment.
+    3. the exact same segment text repeated >= _HALLUCINATION_REPEAT_COUNT
+       times in a row — a stronger signal than either probability alone, and
+       catches cases they miss. This voids the WHOLE transcript, not just
+       the repeats: a model confabulating anywhere in a clip this short
+       isn't trustworthy anywhere else in it either.
+    4. fewer than _HALLUCINATION_MIN_WORDS words survive checks 1-3 — too
+       short to be worth summarizing/carding regardless of confidence.
+
+    A segment missing no_speech_prob/avg_logprob (see
+    _transcribe_via_whisper's degraded-fallback comment) simply skips checks
+    1-2 for that segment; checks 3-4 still run on whatever text came back.
+    """
+    kept: list[str] = []
+    for seg in segments:
+        text = (_seg_field(seg, "text") or "").strip()
+        if not text:
+            continue
+        no_speech = _seg_field(seg, "no_speech_prob")
+        if no_speech is not None and no_speech > _HALLUCINATION_NO_SPEECH_PROB:
+            continue
+        avg_logprob = _seg_field(seg, "avg_logprob")
+        if avg_logprob is not None and avg_logprob < _HALLUCINATION_MIN_AVG_LOGPROB:
+            continue
+        kept.append(text)
+
+    if not kept:
+        return ""
+
+    run_text, run_len = None, 0
+    for text in kept:
+        if text == run_text:
+            run_len += 1
+        else:
+            run_text, run_len = text, 1
+        if run_len >= _HALLUCINATION_REPEAT_COUNT:
+            return ""
+
+    joined = " ".join(kept)
+    if _word_count(joined) < _HALLUCINATION_MIN_WORDS:
+        return ""
+    return joined
+
+
+_CJK_CHAR_RE = re.compile(r"[一-鿿]")
+_NON_CJK_TOKEN_RE = re.compile(r"[^\s一-鿿]+")
+
+
+def _word_count(text: str) -> int:
+    """Estimate a word count for mixed Chinese/Western text (#750), used to
+    decide whether a transcript is short enough to skip AI summarization
+    (SUMMARY_WORD_THRESHOLD) and whether a hallucination-filtered transcript
+    is still worth keeping (_HALLUCINATION_MIN_WORDS). Chinese has no spaces
+    between words, so this counts CJK *characters* (roughly one word/morpheme
+    each — close enough for a threshold check) and adds the count of
+    whitespace-delimited non-CJK tokens — a mixed transcript (e.g. a German
+    Reel with an occasional Chinese aside) gets a reasonable combined
+    estimate instead of one language's counting rule misapplied to the
+    other."""
+    if not text:
+        return 0
+    cjk_chars = len(_CJK_CHAR_RE.findall(text))
+    western_tokens = len(_NON_CJK_TOKEN_RE.findall(text))
+    return cjk_chars + western_tokens
+
+
+def _is_chinese_text(text: str, threshold: float = 0.2) -> bool:
+    """True when at least `threshold` fraction of `text`'s non-whitespace
+    characters are CJK (#750). Decides translation direction for both
+    build_transcript_de (zh->de) and _zero_cost_summary (any->zh + any->de)
+    so a German/English Instagram Reel transcript — stored in the same
+    transcript_zh column, see podcast_episodes' schema.sql docstring — isn't
+    treated as Chinese and run through a zh->de translator that would mangle
+    it. 0.2 is deliberately low: real Chinese text (even mixed with English
+    loanwords/numbers) sits well above it, while non-Chinese text with an
+    occasional Chinese aside (e.g. one word said in Mandarin) stays well
+    below."""
+    stripped = re.sub(r"\s+", "", text or "")
+    if not stripped:
+        return False
+    cjk = len(_CJK_CHAR_RE.findall(stripped))
+    return (cjk / len(stripped)) >= threshold
+
+
+def _probe_duration_seconds(path: str) -> float:
+    """ffprobe wrapper for an audio file's duration in seconds (#750) — used
+    for accurate per-minute Whisper/Groq cost logging when there's no RSS
+    itunes:duration to read (Instagram Reels have no RSS feed at all).
+    Best-effort: returns 0.0 (logged) on any failure, which only means the
+    cost log for that call undercounts — it must never block transcription."""
+    try:
+        result = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+             "-of", "default=noprint_wrappers=1:nokey=1", path],
+            capture_output=True, text=True, timeout=30,
+        )
+        return float(result.stdout.strip())
+    except Exception as e:
+        logger.warning("podcast: ffprobe duration probe failed for %s: %s", path, e)
+        return 0.0
+
+
+def _transcribe_via_groq(mp3_path: str, duration: float, video_id: str) -> str | None:
+    """Instagram Reel transcription, primary path (#750): Groq's
+    OpenAI-compatible audio endpoint running whisper-large-v3-turbo — ~9x
+    cheaper and ~10x faster than the OpenAI whisper-1 fallback
+    (_transcribe_via_whisper). Returns None (not a failure, same contract as
+    every other optional-credential transcriber in this module — Tingwu,
+    NotebookLM) when GROQ_API_KEY isn't configured, or when the whole
+    transcript is filtered out as hallucination/silence
+    (_filter_whisper_hallucinations). Raises on an actual API failure; the
+    caller (_transcribe_instagram) logs and falls through to whisper-1."""
+    api_key = os.environ.get("GROQ_API_KEY")
+    if not api_key:
+        logger.info("podcast: GROQ_API_KEY not set, skipping Groq for %s", video_id)
+        return None
+
+    import openai
+    client = openai.OpenAI(api_key=api_key, base_url="https://api.groq.com/openai/v1")
+    with open(mp3_path, "rb") as f:
+        resp = client.audio.transcriptions.create(
+            model=_GROQ_MODEL, file=f, response_format="verbose_json",
+        )
+
+    # Billed per minute of audio, same accounting convention as Whisper (see
+    # _transcribe_via_whisper) — only reached after a successful API call.
     database.log_api_call(
-        model="gpt-4o-mini-transcribe", input_tokens=int(duration),
+        model=_GROQ_MODEL, input_tokens=int(duration),
         output_tokens=0, purpose="podcast-transcribe",
     )
-    return transcript or None
+
+    seg_list = getattr(resp, "segments", None) or []
+    raw_segments = seg_list if seg_list else [{"text": (getattr(resp, "text", "") or "").strip()}]
+    transcript = _filter_whisper_hallucinations(raw_segments)
+    if not transcript:
+        logger.info("podcast: Groq transcript for %s filtered out as hallucination/silence", video_id)
+        return None
+    logger.info("podcast: Groq transcribed %s (%.0fs audio)", video_id, duration)
+    return transcript
+
+
+def _is_instagram_url(url: str) -> bool:
+    return "instagram.com" in (url or "").lower()
+
+
+def _transcribe_instagram(video: dict) -> tuple[str | None, dict]:
+    """Instagram Reel transcription chain (#750): download the audio once,
+    then try Groq's whisper-large-v3-turbo first (cheap/fast), falling back
+    to OpenAI's whisper-1 when GROQ_API_KEY isn't configured or Groq itself
+    errors. Both requests ask for response_format="verbose_json" so
+    _filter_whisper_hallucinations runs at full fidelity regardless of which
+    provider actually ran — Reels are very often pure background music with
+    no speech at all, and that filter is the entire reason this function
+    exists rather than just calling _transcribe_via_whisper the way the RSS
+    podcast path does.
+
+    The audio *download* failing (dead link, expired/missing Instagram
+    cookies, private post) is allowed to raise knowledge.instagram.
+    InstagramError straight through to _process_episode's outer except,
+    landing on status='error' with a message that names cookies as the
+    likely cause — that's the only diagnostic signal Daniel gets, via the
+    Signal receipt (#749). A clip that downloads fine but has nothing
+    (hallucination-filtered) or both transcribers unavailable instead
+    returns (None, meta), landing on status='no_transcript' — "downloaded
+    but nothing to transcribe" is not an error.
+    """
+    import knowledge.instagram as ig
+
+    video_id = video["video_id"]
+    url = video.get("youtube_url") or ""
+    meta = {"transcript_source": None}
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        mp3_path = ig.download_audio(url, tmp_dir)  # InstagramError propagates on purpose
+        duration = _probe_duration_seconds(mp3_path)
+
+        transcript = None
+        try:
+            transcript = _transcribe_via_groq(mp3_path, duration, video_id)
+        except Exception as e:
+            logger.warning("podcast: Groq step raised for %s: %s", video_id, e)
+        if transcript:
+            meta["transcript_source"] = "groq_whisper"
+            return transcript, meta
+
+        try:
+            transcript = _transcribe_via_whisper(
+                mp3_path, duration, video_id, tmp_dir,
+                language=None, model="whisper-1", filter_hallucinations=True,
+            )
+        except Exception as e:
+            logger.warning("podcast: Whisper step raised for %s: %s", video_id, e)
+            transcript = None
+        if transcript:
+            meta["transcript_source"] = "whisper"
+            return transcript, meta
+
+    logger.info("podcast: no usable transcript for Instagram Reel %s "
+                "(both transcribers unavailable/filtered)", video_id)
+    return None, meta
 
 
 async def _get_or_create_notebooklm_notebook(client) -> str:
@@ -938,6 +1231,14 @@ def fetch_transcript(video: dict) -> tuple[str | None, dict]:
     meta = {"title": title, "transcript_source": None}
 
     if video.get("kind") == "video":
+        if _is_instagram_url(video.get("youtube_url") or ""):
+            # Instagram Reel ingestion (#750): no captions API exists for
+            # Instagram at all, so this never touches knowledge.youtube —
+            # straight to download-audio + Groq/Whisper (_transcribe_instagram).
+            # Checked via the URL (kind='video' alone doesn't distinguish a
+            # Reel from a YouTube video) rather than transcript_source, which
+            # is only set *after* a transcription attempt succeeds.
+            return _transcribe_instagram(video)
         # YouTube ingestion (#651): captions only, no audio download/Whisper.
         # Dispatches out of the podcast RSS/Tingwu/NotebookLM/Whisper chain
         # entirely — that chain (below) is for kind='podcast' only.
@@ -1087,6 +1388,58 @@ def summarize(transcript: str, title: str, detail_level: str,
         transcript, title, detail_level, china_critical=china_critical))
 
 
+def _zero_cost_summary(transcript: str) -> dict:
+    """Skip AI summarization entirely for a short transcript (#750): produce
+    {"summary_zh", "summary_de"} via Google Translate (free) instead of a
+    paid 3-part AI summary. Called from _process_episode when
+    _word_count(transcript) < SUMMARY_WORD_THRESHOLD — a 60s Instagram Reel
+    yields only a few hundred words, and a short AI summary of that is both
+    wasteful and less useful than the full (translated) transcript plus the
+    generated new-word table. The result is passed through _annotate_summary()
+    exactly like summarize()'s result, so pinyin annotation and
+    zh_annotate.extract_new_words() run identically either way — that word
+    table, not a summary, is the actual point of this path.
+
+    Direction depends on _is_chinese_text(transcript): an already-Chinese
+    transcript needs no zh translation and instead gets translated INTO
+    German (keeping summary_de's "always German" contract intact for every
+    downstream renderer); anything else (Reels are commonly German/English)
+    is assumed to already be summary_de-shaped and gets translated INTO
+    Chinese instead.
+
+    Best-effort like build_transcript_de: a translation failure degrades to
+    the untranslated original in that slot rather than losing the episode —
+    Daniel would rather see the raw transcript in the "wrong" language than
+    no episode at all.
+    """
+    if _is_chinese_text(transcript):
+        summary_zh = transcript
+        summary_de = transcript
+        segs = _split_transcript_segments(transcript)
+        if segs:
+            try:
+                de_segs = _translate_segments(segs, target="de", source="zh-CN")
+                joined = " ".join(d for d in de_segs if d)
+                if joined:
+                    summary_de = joined
+            except Exception as e:
+                logger.warning("podcast: zero-cost zh->de translation failed: %s", e)
+    else:
+        summary_de = transcript
+        summary_zh = transcript
+        segs = _split_segments_any(transcript)
+        if segs:
+            try:
+                zh_segs = _translate_segments(segs, target="zh-CN", source="auto")
+                joined = "".join(z for z in zh_segs if z)
+                if joined:
+                    summary_zh = joined
+            except Exception as e:
+                logger.warning("podcast: zero-cost ->zh translation failed: %s", e)
+
+    return {"summary_zh": summary_zh, "summary_de": summary_de}
+
+
 def _annotate_summary(result: dict) -> dict:
     """Add the AI-free vocabulary annotations (#638) to a fresh summary. Done
     here, at the single choke point both summarizer paths and both callers
@@ -1143,30 +1496,60 @@ def _split_transcript_segments(text: str) -> list[str]:
     return [p.strip() for p in parts if p.strip()]
 
 
-def _translate_segments_de(zh_segments: list[str]) -> list[str]:
-    """Translate each Chinese segment to German via Google Translate, batching
-    under the free endpoint's ~5000-char request limit (translate_batch joins
+_SENTENCE_SPLIT_ANY_RE = re.compile(r"(?<=[。！？…])\s*|(?<=[.!?])\s+")
+
+
+def _split_segments_any(text: str) -> list[str]:
+    """Sentence-ish split usable for Chinese OR Western text (#750). Unlike
+    _split_transcript_segments (CJK sentence-final punctuation only), this
+    also breaks after '.', '!', '?' followed by whitespace — needed for
+    _zero_cost_summary's zh->de/any->zh translation batching, where the
+    source language isn't known ahead of time (Instagram Reels are commonly
+    German or English, not Chinese)."""
+    if not text:
+        return []
+    parts = _SENTENCE_SPLIT_ANY_RE.split(text)
+    return [p.strip() for p in parts if p.strip()]
+
+
+def _translate_segments(segs: list[str], target: str, source: str) -> list[str]:
+    """Translate `segs` to `target` from `source`, batching under Google
+    Translate's ~5000-char free-endpoint request limit (translate_batch joins
     a batch with newlines into one request). Returns a list aligned 1:1 with
-    zh_segments (translate_batch already falls back to the source text for any
-    segment it can't translate)."""
+    segs (translate_batch already falls back to the source text for any
+    segment it can't translate). Generalized (#750) from the zh->de-only
+    original (_translate_segments_de, kept below as a thin wrapper) so
+    _zero_cost_summary can reuse the exact same batching logic for any
+    direction instead of a second copy."""
     out: list[str] = []
     batch: list[str] = []
     size = 0
-    for seg in zh_segments:
+    for seg in segs:
         if batch and size + len(seg) > 4500:
-            out.extend(translator.translate_batch(batch, target="de", source="zh-CN"))
+            out.extend(translator.translate_batch(batch, target=target, source=source))
             batch, size = [], 0
         batch.append(seg)
         size += len(seg) + 1
     if batch:
-        out.extend(translator.translate_batch(batch, target="de", source="zh-CN"))
+        out.extend(translator.translate_batch(batch, target=target, source=source))
     return out
+
+
+def _translate_segments_de(zh_segments: list[str]) -> list[str]:
+    """zh->de translation — build_transcript_de's original narrow entry
+    point, now a thin wrapper over _translate_segments (#750)."""
+    return _translate_segments(zh_segments, target="de", source="zh-CN")
 
 
 def build_transcript_de(transcript_zh: str) -> list[dict]:
     """Build the bilingual segment-pair list [{"zh","de"}] for a transcript
-    (#553). Best-effort: returns [] if the transcript is empty or translation
-    is unavailable/fails."""
+    (#553). Best-effort: returns [] if the transcript is empty, isn't
+    (mostly) Chinese (#750 — e.g. a German/English Instagram Reel stored in
+    this same transcript_zh column, see podcast_episodes' schema.sql
+    docstring — translating that zh->de would mangle it), or translation is
+    unavailable/fails."""
+    if not _is_chinese_text(transcript_zh):
+        return []
     segs = _split_transcript_segments(transcript_zh)
     if not segs:
         return []
@@ -1601,8 +1984,16 @@ def _process_episode(episode_id: int, video: dict, detail_level: str, summary: d
             # `video` is an RSS item for the crawler path and has no such
             # field — only the stored row knows what was ticked at paste time.
             china_critical = bool((database.get_episode(episode_id) or {}).get("china_critical"))
-            result = summarize(transcript, video["title"], detail_level,
-                               china_critical=china_critical)
+            word_count = _word_count(transcript)
+            if word_count < SUMMARY_WORD_THRESHOLD:
+                # Short transcript (#750): skip the paid AI summarizer
+                # entirely — see _zero_cost_summary's docstring for why.
+                logger.info("podcast: transcript for %s is %d words (< %d), skipping AI summary",
+                            video["video_id"], word_count, SUMMARY_WORD_THRESHOLD)
+                result = _annotate_summary(_zero_cost_summary(transcript))
+            else:
+                result = summarize(transcript, video["title"], detail_level,
+                                   china_critical=china_critical)
             if not result.get("summary_de"):
                 database.update_episode(episode_id, status="error",
                                         error="AI summary failed or empty")

--- a/schema.sql
+++ b/schema.sql
@@ -658,7 +658,7 @@ CREATE TABLE IF NOT EXISTS podcast_episodes (
     detail_level     TEXT,   -- detail_level used for the summary (short|medium|detailed)
     status           TEXT NOT NULL DEFAULT 'pending'
                      CHECK(status IN ('pending', 'no_transcript', 'summarized', 'error')),
-    transcript_source TEXT,  -- 'tingwu' | 'whisper' | 'notebooklm' | 'youtube_captions' (#651) | 'article' (#652) | NULL; legacy rows may say 'captions'
+    transcript_source TEXT,  -- 'tingwu' | 'whisper' | 'notebooklm' | 'youtube_captions' (#651) | 'article' (#652) | 'groq_whisper' (#750, Instagram Reels — 'whisper' also occurs here when the Groq step was skipped/failed and the OpenAI whisper-1 fallback ran instead) | NULL; legacy rows may say 'captions'
     error            TEXT,
     email_sent_at    TEXT,
     processing_started_at TEXT,  -- set while _process_episode runs, cleared on exit; a leftover value = killed mid-transcription, recovered at startup (#598)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -433,3 +433,69 @@ python scripts/signal_check.py
 
 退出码：跳过（未配置账号）或全部成功为 `0`；`signal-cli receive` 失败或
 有 URL 最终放弃时为 `1`。
+
+---
+
+## Instagram Reel 摄取（issue #750）：yt-dlp + cookies + Groq
+
+知识库现在能吃 Instagram Reel/Post 链接（`knowledge/instagram.py`），走和
+YouTube/文章一样的入口——粘贴框、`signal_check.py`、
+`knowledge_mail_check.py` 都自动支持，不需要额外配置这三个入口本身。要让
+转录真正跑起来，服务器上需要一次性配置以下三样。
+
+### 1. 安装 yt-dlp（需要 nightly 版）
+
+Instagram 的页面结构变化快，稳定版 yt-dlp 经常滞后几周才修复对应的解析
+逻辑；nightly 构建修复更快。系统级命令行工具，**不进 `requirements.txt`**
+（和 `ffmpeg` 一个处理方式）：
+
+```bash
+# 装最新 nightly（pip 方式，跨发行版通用）
+python3 -m pip install --upgrade --pre "yt-dlp[default]"
+
+# 验证
+yt-dlp --version
+```
+
+非默认路径（例如装进虚拟环境）时设置 `YT_DLP_PATH` 指向可执行文件。
+
+### 2. 导出 Instagram cookies.txt
+
+公开 Reel 有时不需要登录也能下载，但大多数情况下（尤其是被限流/需要登录
+才能看的账号）需要一份登录态的 cookies：
+
+1. 电脑浏览器登录 Instagram（用一个愿意专门给这个用的账号，不要用 Daniel
+   的主账号——cookies 会存在服务器上）
+2. 装一个"导出 cookies.txt"的浏览器扩展（Chrome/Firefox 商店搜
+   "Get cookies.txt LOCALLY"之类，选支持 Netscape 格式导出的）
+3. 在 instagram.com 页面上用扩展导出，文件存到服务器
+   `data/instagram_cookies.txt`（或任意路径，配 `INSTAGRAM_COOKIES_FILE`
+   指过去）
+
+Cookies **会过期**（登录态失效/被 Instagram 判定异常）。过期后
+`knowledge/instagram.py` 的失败信息会明确提示"可能是 cookies 过期"，
+Daniel 会在 Signal 回执里读到——看到这条提示就重新导出一份替换旧文件即可，
+不需要重启服务。
+
+### 3. Groq API key（转录主力，可选）
+
+Instagram Reel 转录优先用 Groq 的 `whisper-large-v3-turbo`（比 OpenAI
+Whisper 便宜约 9 倍、快约 10 倍）：
+
+1. https://console.groq.com 注册账号，创建 API key
+2. 服务器 `.env` 加一行：`GROQ_API_KEY=gsk_xxxxxxxx`
+
+`GROQ_API_KEY` **是可选的**——未配置时自动回退到已有的 OpenAI
+`whisper-1`（服务器上已配好 `OPENAI_API_KEY`），只是单价贵约 9 倍（一条
+60 秒 Reel 约 $0.006，仍然便宜到可以忽略）。两条转录路径都过同一道
+幻觉过滤（`podcast._filter_whisper_hallucinations`）——Reel 常常是纯音乐
+无人声，过滤器负责把 Whisper 对着音乐编出来的假文本挡掉，不管实际是哪家
+转录的。
+
+### 环境变量小结
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `GROQ_API_KEY` | 无（可选） | 未配置时自动回退 OpenAI `whisper-1`，只是贵约 9 倍 |
+| `INSTAGRAM_COOKIES_FILE` | `data/instagram_cookies.txt` | Instagram cookies.txt 路径；文件不存在时公开 Reel 仍会尝试（不一定成功） |
+| `YT_DLP_PATH` | `yt-dlp` | yt-dlp 可执行文件路径，装在非默认位置时指过去 |

--- a/static/index.html
+++ b/static/index.html
@@ -811,6 +811,15 @@
           </tbody>
         </table>
         <p class="price-table-note">Prices per 1M tokens (USD)</p>
+        <table class="price-table">
+          <thead><tr><th>Transcription</th><th>Provider</th><th colspan="2">Per minute of audio</th></tr></thead>
+          <tbody>
+            <tr><td>Whisper-large-v3-turbo</td><td>Groq</td><td colspan="2">$0.0007</td></tr>
+            <tr><td>Whisper-1</td><td>OpenAI</td><td colspan="2">$0.006</td></tr>
+            <tr><td>GPT-4o-mini-transcribe</td><td>OpenAI</td><td colspan="2">$0.003</td></tr>
+          </tbody>
+        </table>
+        <p class="price-table-note">Instagram Reels: Groq first, OpenAI Whisper-1 fallback (#750)</p>
       </div>
       <!-- Prices: $input/$output per 1M tokens (issue #584); keep in sync with
            database/stats.py _MODEL_PRICING and the ℹ price table above -->

--- a/tests/test_instagram_ingest.py
+++ b/tests/test_instagram_ingest.py
@@ -1,0 +1,718 @@
+"""Tests for Instagram Reel ingestion (issue #750):
+
+- knowledge/instagram.py: parse_shortcode (pure), fetch_metadata/download_audio
+  (subprocess stubbed — never actually shell out to yt-dlp)
+- podcast.py: hallucination filtering (_filter_whisper_hallucinations),
+  word counting (_word_count), the Groq/whisper-1 fallback chain
+  (_transcribe_instagram), the short-transcript AI-summary skip
+  (SUMMARY_WORD_THRESHOLD / _zero_cost_summary), and the non-Chinese
+  transcript guard on build_transcript_de.
+- knowledge/ingest.py: ingest_url() dispatching Instagram URLs to
+  _ingest_instagram (real throwaway sqlite db via database.init_db(), same
+  pattern as test_knowledge_ingest_text.py).
+
+CLAUDE.md's hard rules for this suite: never actually reach yt-dlp/Groq/
+OpenAI/a network service; AI is stubbed at ai._call_api or the public
+function, never at a provider client; isolated db only via
+database.core.DB_PATH.
+"""
+import subprocess
+
+import pytest
+
+import ai
+import database
+import knowledge.instagram as ig
+import podcast
+import zh_annotate
+
+
+# ---------------------------------------------------------------------------
+# knowledge.instagram.parse_shortcode — pure, no I/O
+# ---------------------------------------------------------------------------
+
+def test_parse_reel_url():
+    assert ig.parse_shortcode("https://www.instagram.com/reel/AbC123xyz/") == "AbC123xyz"
+
+
+def test_parse_reels_plural_url():
+    assert ig.parse_shortcode("https://www.instagram.com/reels/AbC123xyz/") == "AbC123xyz"
+
+
+def test_parse_post_url():
+    assert ig.parse_shortcode("https://instagram.com/p/AbC123xyz/") == "AbC123xyz"
+
+
+def test_parse_tv_url():
+    assert ig.parse_shortcode("https://www.instagram.com/tv/AbC123xyz/") == "AbC123xyz"
+
+
+def test_parse_no_www_prefix():
+    assert ig.parse_shortcode("https://instagram.com/reel/AbC123xyz/") == "AbC123xyz"
+
+
+def test_parse_without_trailing_slash():
+    assert ig.parse_shortcode("https://www.instagram.com/reel/AbC123xyz") == "AbC123xyz"
+
+
+def test_parse_with_query_params():
+    assert ig.parse_shortcode("https://www.instagram.com/reel/AbC123xyz/?igsh=abc123") == "AbC123xyz"
+
+
+def test_parse_rejects_non_instagram_url():
+    assert ig.parse_shortcode("https://example.com/reel/AbC123xyz/") is None
+
+
+def test_parse_rejects_instagram_homepage():
+    assert ig.parse_shortcode("https://www.instagram.com/") is None
+
+
+def test_parse_rejects_profile_url():
+    assert ig.parse_shortcode("https://www.instagram.com/someusername/") is None
+
+
+def test_parse_rejects_empty_and_none():
+    assert ig.parse_shortcode("") is None
+    assert ig.parse_shortcode(None) is None
+
+
+def test_parse_rejects_garbage_string():
+    assert ig.parse_shortcode("not a url at all") is None
+
+
+# ---------------------------------------------------------------------------
+# knowledge.instagram.fetch_metadata / download_audio — subprocess stubbed
+# ---------------------------------------------------------------------------
+
+class _FakeCompleted:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_fetch_metadata_parses_title_uploader_duration(monkeypatch):
+    def fake_run(cmd, capture_output, text, timeout):
+        assert cmd[0] == "yt-dlp"
+        assert "--dump-json" in cmd
+        return _FakeCompleted(
+            0, stdout='{"title": "Ein toller Reel", "uploader": "someuser", '
+                      '"duration": 42, "webpage_url": "https://www.instagram.com/reel/AbC/"}',
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(ig, "_cookies_file", lambda: None)
+
+    meta = ig.fetch_metadata("https://www.instagram.com/reel/AbC/")
+    assert meta["title"] == "Ein toller Reel"
+    assert meta["uploader"] == "someuser"
+    assert meta["duration"] == 42
+
+
+def test_fetch_metadata_falls_back_to_description_first_line(monkeypatch):
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompleted(0, stdout='{"title": "", "description": "Erste Zeile\\nZweite Zeile"}'),
+    )
+    monkeypatch.setattr(ig, "_cookies_file", lambda: None)
+
+    meta = ig.fetch_metadata("https://www.instagram.com/reel/AbC/")
+    assert meta["title"] == "Erste Zeile"
+
+
+def test_fetch_metadata_falls_back_to_shortcode(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _FakeCompleted(0, stdout='{}'))
+    monkeypatch.setattr(ig, "_cookies_file", lambda: None)
+
+    meta = ig.fetch_metadata("https://www.instagram.com/reel/AbC123/")
+    assert meta["title"] == "AbC123"
+
+
+def test_fetch_metadata_raises_on_nonzero_exit(monkeypatch):
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompleted(1, stderr="ERROR: Requested content is not available, rate-limit reached"),
+    )
+    monkeypatch.setattr(ig, "_cookies_file", lambda: None)
+
+    with pytest.raises(ig.InstagramError) as excinfo:
+        ig.fetch_metadata("https://www.instagram.com/reel/AbC/")
+    assert "cookies" in str(excinfo.value).lower()
+
+
+def test_fetch_metadata_raises_on_unparsable_json(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _FakeCompleted(0, stdout="not json"))
+    monkeypatch.setattr(ig, "_cookies_file", lambda: None)
+
+    with pytest.raises(ig.InstagramError):
+        ig.fetch_metadata("https://www.instagram.com/reel/AbC/")
+
+
+def test_fetch_metadata_missing_binary_raises_instagram_error(monkeypatch):
+    def fake_run(*a, **k):
+        raise FileNotFoundError("no such file")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(ig, "_cookies_file", lambda: None)
+
+    with pytest.raises(ig.InstagramError) as excinfo:
+        ig.fetch_metadata("https://www.instagram.com/reel/AbC/")
+    assert "yt-dlp not found" in str(excinfo.value)
+
+
+def test_download_audio_returns_mp3_path(monkeypatch, tmp_path):
+    def fake_run(cmd, capture_output, text, timeout):
+        # Simulate yt-dlp actually producing the file.
+        (tmp_path / "audio.mp3").write_bytes(b"fake mp3 bytes")
+        return _FakeCompleted(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(ig, "_cookies_file", lambda: None)
+
+    path = ig.download_audio("https://www.instagram.com/reel/AbC/", str(tmp_path))
+    assert path == str(tmp_path / "audio.mp3")
+
+
+def test_download_audio_error_message_flags_cookies(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _FakeCompleted(1, stderr="ERROR: [Instagram] login required to access this content"),
+    )
+    monkeypatch.setattr(ig, "_cookies_file", lambda: None)
+
+    with pytest.raises(ig.InstagramError) as excinfo:
+        ig.download_audio("https://www.instagram.com/reel/AbC/", str(tmp_path))
+    assert "cookies" in str(excinfo.value).lower()
+
+
+def test_download_audio_missing_output_raises(monkeypatch, tmp_path):
+    """yt-dlp exits 0 but somehow produced no file — must not silently
+    return a path to nothing."""
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _FakeCompleted(0))
+    monkeypatch.setattr(ig, "_cookies_file", lambda: None)
+
+    with pytest.raises(ig.InstagramError):
+        ig.download_audio("https://www.instagram.com/reel/AbC/", str(tmp_path))
+
+
+def test_cookies_file_used_when_present(monkeypatch, tmp_path):
+    cookies = tmp_path / "cookies.txt"
+    cookies.write_text("# Netscape HTTP Cookie File\n")
+    captured = {}
+
+    def fake_run(cmd, capture_output, text, timeout):
+        captured["cmd"] = cmd
+        return _FakeCompleted(0, stdout="{}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setenv("INSTAGRAM_COOKIES_FILE", str(cookies))
+
+    ig.fetch_metadata("https://www.instagram.com/reel/AbC/")
+    assert "--cookies" in captured["cmd"]
+    assert str(cookies) in captured["cmd"]
+
+
+def test_cookies_file_omitted_when_missing(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_run(cmd, capture_output, text, timeout):
+        captured["cmd"] = cmd
+        return _FakeCompleted(0, stdout="{}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setenv("INSTAGRAM_COOKIES_FILE", str(tmp_path / "does-not-exist.txt"))
+
+    ig.fetch_metadata("https://www.instagram.com/reel/AbC/")
+    assert "--cookies" not in captured["cmd"]
+
+
+# ---------------------------------------------------------------------------
+# podcast._filter_whisper_hallucinations
+# ---------------------------------------------------------------------------
+
+def _segs(*texts_and_probs):
+    """Build segment dicts from (text, no_speech_prob, avg_logprob) tuples;
+    trailing fields default to None (missing metadata)."""
+    out = []
+    for t in texts_and_probs:
+        text = t[0]
+        no_speech = t[1] if len(t) > 1 else None
+        avg_logprob = t[2] if len(t) > 2 else None
+        out.append({"text": text, "no_speech_prob": no_speech, "avg_logprob": avg_logprob})
+    return out
+
+
+def _real_speech_segments(n=25):
+    """n distinct, plausible segments — long enough to clear
+    _HALLUCINATION_MIN_WORDS after joining."""
+    return _segs(*[(f"this is spoken sentence number {i} with real content", 0.1, -0.2) for i in range(n)])
+
+
+def test_normal_speech_passes_through():
+    text = podcast._filter_whisper_hallucinations(_real_speech_segments())
+    assert text
+    assert "sentence number 0" in text
+    assert "sentence number 24" in text
+
+
+def test_high_no_speech_prob_segment_dropped():
+    segs = _real_speech_segments() + _segs(("music noise", 0.95, -0.2))
+    text = podcast._filter_whisper_hallucinations(segs)
+    assert "music noise" not in text
+
+
+def test_low_avg_logprob_segment_dropped():
+    segs = _real_speech_segments() + _segs(("garbled guess", 0.1, -2.5))
+    text = podcast._filter_whisper_hallucinations(segs)
+    assert "garbled guess" not in text
+
+
+def test_consecutive_repetition_voids_whole_transcript():
+    """The classic music-hallucination shape: the same phrase repeated many
+    times in a row. Must void the ENTIRE transcript, not just the repeats."""
+    segs = _real_speech_segments(10) + _segs(
+        ("subscribe now", 0.1, -0.2),
+        ("subscribe now", 0.1, -0.2),
+        ("subscribe now", 0.1, -0.2),
+        ("subscribe now", 0.1, -0.2),
+    )
+    assert podcast._filter_whisper_hallucinations(segs) == ""
+
+
+def test_two_repeats_not_enough_to_void():
+    """Below the repeat threshold (3) — two repeats can be a real refrain,
+    not a hallucination loop."""
+    segs = _real_speech_segments(10) + _segs(("chorus line", 0.1, -0.2), ("chorus line", 0.1, -0.2))
+    text = podcast._filter_whisper_hallucinations(segs)
+    assert "chorus line" in text
+
+
+def test_too_short_after_filtering_returns_empty():
+    segs = _segs(("just a few words here", 0.1, -0.2))
+    assert podcast._filter_whisper_hallucinations(segs) == ""
+
+
+def test_pure_music_no_speech_returns_empty():
+    """The headline scenario: a Reel with only background music. Every
+    segment is high no_speech_prob -> nothing survives -> empty string, not
+    fabricated text."""
+    segs = _segs(
+        ("thanks for watching", 0.9, -0.1),
+        ("like and subscribe", 0.85, -0.1),
+        ("don't forget to follow", 0.92, -0.1),
+    )
+    assert podcast._filter_whisper_hallucinations(segs) == ""
+
+
+def test_missing_metadata_still_runs_repeat_and_length_checks():
+    """A segment with no no_speech_prob/avg_logprob (degraded provider path)
+    skips checks 1-2 but must still be subject to the repeat/min-length
+    checks."""
+    segs = [{"text": "same phrase over and over"} for _ in range(4)]
+    assert podcast._filter_whisper_hallucinations(segs) == ""
+
+
+def test_pydantic_like_segment_objects_supported():
+    """Segment objects from the real SDK are attribute-access, not dicts —
+    _seg_field must handle both."""
+    class FakeSeg:
+        def __init__(self, text, no_speech_prob, avg_logprob):
+            self.text = text
+            self.no_speech_prob = no_speech_prob
+            self.avg_logprob = avg_logprob
+
+    segs = [FakeSeg(f"real spoken content number {i} right here", 0.1, -0.2) for i in range(25)]
+    text = podcast._filter_whisper_hallucinations(segs)
+    assert "real spoken content number 0" in text
+
+
+# ---------------------------------------------------------------------------
+# podcast._word_count
+# ---------------------------------------------------------------------------
+
+def test_word_count_chinese_counts_characters():
+    # 10 CJK characters, no whitespace.
+    assert podcast._word_count("这是一个测试句子啊啊") == 10
+
+
+def test_word_count_western_counts_whitespace_tokens():
+    assert podcast._word_count("this is a test sentence") == 5
+
+
+def test_word_count_mixed_sums_both():
+    text = "hello 你好 world 世界"  # 2 western tokens + 2 western + 4 cjk chars
+    # tokens: "hello", "world" = 2; cjk chars: 你好世界 = 4
+    assert podcast._word_count(text) == 6
+
+
+def test_word_count_empty_string():
+    assert podcast._word_count("") == 0
+    assert podcast._word_count(None) == 0
+
+
+# ---------------------------------------------------------------------------
+# podcast._is_chinese_text
+# ---------------------------------------------------------------------------
+
+def test_is_chinese_text_true_for_chinese():
+    assert podcast._is_chinese_text("这是一段完全用中文写的话，内容随便什么都行。")
+
+
+def test_is_chinese_text_false_for_german():
+    assert not podcast._is_chinese_text(
+        "Das ist ein ganz normaler deutscher Satz ohne jegliche chinesische Zeichen."
+    )
+
+
+def test_is_chinese_text_false_for_english():
+    assert not podcast._is_chinese_text("This is a completely ordinary English sentence with no Chinese at all.")
+
+
+def test_is_chinese_text_false_for_empty():
+    assert not podcast._is_chinese_text("")
+    assert not podcast._is_chinese_text(None)
+
+
+def test_is_chinese_text_mostly_chinese_with_a_few_latin_words():
+    assert podcast._is_chinese_text("这是一段中文，但是里面有一个 App 和一个 iPhone 这样的词。")
+
+
+# ---------------------------------------------------------------------------
+# podcast.build_transcript_de guards against non-Chinese input (#750)
+# ---------------------------------------------------------------------------
+
+def test_build_transcript_de_returns_empty_for_non_chinese(monkeypatch):
+    def fail_if_called(*a, **k):
+        raise AssertionError("translate_segments_de must not be called for non-Chinese input")
+
+    monkeypatch.setattr(podcast, "_translate_segments_de", fail_if_called)
+    assert podcast.build_transcript_de("This is an English transcript, not Chinese at all.") == []
+
+
+def test_build_transcript_de_still_works_for_chinese(monkeypatch):
+    monkeypatch.setattr(podcast, "_translate_segments_de", lambda segs: [f"DE:{s}" for s in segs])
+    pairs = podcast.build_transcript_de("你好世界。今天天气不错。")
+    assert pairs
+    assert all(p["de"].startswith("DE:") for p in pairs)
+
+
+# ---------------------------------------------------------------------------
+# podcast._zero_cost_summary
+# ---------------------------------------------------------------------------
+
+def test_zero_cost_summary_chinese_transcript_keeps_zh_translates_de(monkeypatch):
+    monkeypatch.setattr(podcast, "_translate_segments", lambda segs, target, source: [f"[{target}]{s}" for s in segs])
+    result = podcast._zero_cost_summary("你好世界。今天天气不错。")
+    assert result["summary_zh"] == "你好世界。今天天气不错。"
+    assert "[de]" in result["summary_de"]
+
+
+def test_zero_cost_summary_non_chinese_translates_to_zh(monkeypatch):
+    monkeypatch.setattr(podcast, "_translate_segments", lambda segs, target, source: [f"[{target}]{s}" for s in segs])
+    result = podcast._zero_cost_summary("This is an English transcript with real content in it.")
+    assert result["summary_de"] == "This is an English transcript with real content in it."
+    assert "[zh-CN]" in result["summary_zh"]
+
+
+def test_zero_cost_summary_translation_failure_degrades_to_original(monkeypatch):
+    def boom(segs, target, source):
+        raise RuntimeError("translate service down")
+
+    monkeypatch.setattr(podcast, "_translate_segments", boom)
+    result = podcast._zero_cost_summary("这是一段中文文本内容测试。")
+    assert result["summary_zh"] == "这是一段中文文本内容测试。"
+    assert result["summary_de"] == "这是一段中文文本内容测试。"
+
+
+# ---------------------------------------------------------------------------
+# _process_episode: SUMMARY_WORD_THRESHOLD branch (both sides)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def tmp_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setattr(database.core, "DB_PATH", str(db_file))
+    database.init_db()
+    return db_file
+
+
+@pytest.fixture(autouse=True)
+def _no_ai_disabled(monkeypatch):
+    """_process_episode short-circuits under ai_disabled() (DISABLE_AI) —
+    these tests exercise the summarize-vs-zero-cost branch, so AI must be
+    "enabled" even though the actual AI call itself is stubbed below."""
+    import routes.utils
+    monkeypatch.setattr(routes.utils, "ai_disabled", lambda: False)
+
+
+@pytest.fixture(autouse=True)
+def _no_notifications(monkeypatch):
+    """Email/Signal notifications are irrelevant to the summary-skip
+    decision and must not try to actually send anything."""
+    monkeypatch.setattr(podcast, "send_email", lambda episode: False)
+    monkeypatch.setattr(podcast, "send_signal", lambda episode: None)
+    monkeypatch.setattr(podcast, "find_spotify_url", lambda title: "https://open.spotify.com/search/x")
+
+
+@pytest.fixture(autouse=True)
+def _no_real_translation(monkeypatch):
+    """_annotate_summary (both the AI-summary and zero-cost paths) calls
+    zh_annotate for pinyin/gloss annotation, which calls Google Translate for
+    each new word's German gloss — stub that one choke point (same pattern
+    as tests/test_zh_annotate.py) so this suite never reaches a real network
+    service."""
+    monkeypatch.setattr(zh_annotate, "_gloss_de", lambda w: f"DE:{w}")
+
+
+def _make_video_episode(transcript: str) -> tuple[int, dict]:
+    episode_id = database.create_pending_episode(
+        video_id="ig:test123", channel_id="someuser", title="Test Reel",
+        published_at=None, youtube_url="https://www.instagram.com/reel/test123/",
+        audio_url=None, duration_seconds=30, kind="video",
+    )
+    database.update_episode(episode_id, transcript_zh=transcript, transcript_source="groq_whisper")
+    video = {"video_id": "ig:test123", "title": "Test Reel", "audio_url": None, "duration_seconds": 30, "kind": "video"}
+    return episode_id, video
+
+
+def test_short_transcript_skips_ai_summary(monkeypatch):
+    """< SUMMARY_WORD_THRESHOLD words -> _zero_cost_summary runs,
+    ai.summarize_podcast_transcript must NOT be called."""
+    called = {"ai": False}
+
+    def fake_ai_summarize(*a, **k):
+        called["ai"] = True
+        return {"summary_de": "should not happen", "words": []}
+
+    monkeypatch.setattr(ai, "summarize_podcast_transcript", fake_ai_summarize)
+    monkeypatch.setattr(podcast, "build_transcript_de", lambda transcript: [])
+    monkeypatch.setattr(podcast, "_translate_segments", lambda segs, target, source: [f"[{target}]{s}" for s in segs])
+
+    short_transcript = "这是一段很短的转录文本，内容不多，用来测试短文本跳过摘要的功能。" * 2
+    assert podcast._word_count(short_transcript) < podcast.SUMMARY_WORD_THRESHOLD
+
+    episode_id, video = _make_video_episode(short_transcript)
+    summary = {"summarized": 0, "failed": 0, "emailed": 0}
+    podcast._process_episode(episode_id, video, "medium", summary)
+
+    assert called["ai"] is False
+    episode = database.get_episode(episode_id)
+    assert episode["status"] == "summarized"
+    assert episode["summary_zh"]
+    assert episode["summary_de"]
+    # New-word table still gets populated from the zero-cost summary text.
+    assert isinstance(episode["hsk_words"], list)
+
+
+def test_long_transcript_still_uses_ai_summary(monkeypatch):
+    """>= SUMMARY_WORD_THRESHOLD words -> the existing AI summarizer path
+    runs unchanged."""
+    called = {"ai": False}
+
+    def fake_ai_summarize(transcript, title, detail_level, china_critical=False):
+        called["ai"] = True
+        return {"summary_zh": "中文摘要", "summary_de": "Deutsche Zusammenfassung", "words": []}
+
+    monkeypatch.setattr(ai, "summarize_podcast_transcript", fake_ai_summarize)
+    monkeypatch.setattr(database, "get_podcast_config", lambda: {"summarizer": "api"})
+    monkeypatch.setattr(podcast, "build_transcript_de", lambda transcript: [])
+
+    long_transcript = "这是一句用来测试长文本的句子，句子会被重复很多次以便超过一千字的阈值。" * 30
+    assert podcast._word_count(long_transcript) >= podcast.SUMMARY_WORD_THRESHOLD
+
+    episode_id, video = _make_video_episode(long_transcript)
+    summary = {"summarized": 0, "failed": 0, "emailed": 0}
+    podcast._process_episode(episode_id, video, "medium", summary)
+
+    assert called["ai"] is True
+    episode = database.get_episode(episode_id)
+    assert episode["status"] == "summarized"
+
+
+# ---------------------------------------------------------------------------
+# podcast._transcribe_instagram: Groq-first, whisper-1 fallback chain
+# ---------------------------------------------------------------------------
+
+def test_transcribe_instagram_uses_groq_when_configured(monkeypatch, tmp_path):
+    monkeypatch.setattr(ig, "download_audio", lambda url, dest_dir: str(tmp_path / "audio.mp3"))
+    monkeypatch.setattr(podcast, "_probe_duration_seconds", lambda path: 30.0)
+    monkeypatch.setattr(podcast, "_transcribe_via_groq", lambda mp3, dur, vid: "groq transcript text")
+
+    def fail_if_called(*a, **k):
+        raise AssertionError("whisper-1 fallback must not run when Groq succeeds")
+
+    monkeypatch.setattr(podcast, "_transcribe_via_whisper", fail_if_called)
+
+    video = {"video_id": "ig:test1", "youtube_url": "https://www.instagram.com/reel/test1/", "kind": "video"}
+    text, meta = podcast._transcribe_instagram(video)
+    assert text == "groq transcript text"
+    assert meta["transcript_source"] == "groq_whisper"
+
+
+def test_transcribe_instagram_falls_back_to_whisper_when_groq_unavailable(monkeypatch, tmp_path):
+    """No GROQ_API_KEY (or Groq otherwise returns None) -> falls back to the
+    existing OpenAI whisper-1 path."""
+    monkeypatch.setattr(ig, "download_audio", lambda url, dest_dir: str(tmp_path / "audio.mp3"))
+    monkeypatch.setattr(podcast, "_probe_duration_seconds", lambda path: 30.0)
+    monkeypatch.setattr(podcast, "_transcribe_via_groq", lambda mp3, dur, vid: None)
+
+    calls = {}
+
+    def fake_whisper(mp3_path, duration, video_id, tmp_dir, *, language=None, model=None, filter_hallucinations=False):
+        calls["model"] = model
+        calls["language"] = language
+        calls["filter_hallucinations"] = filter_hallucinations
+        return "whisper fallback transcript"
+
+    monkeypatch.setattr(podcast, "_transcribe_via_whisper", fake_whisper)
+
+    video = {"video_id": "ig:test2", "youtube_url": "https://www.instagram.com/reel/test2/", "kind": "video"}
+    text, meta = podcast._transcribe_instagram(video)
+    assert text == "whisper fallback transcript"
+    assert meta["transcript_source"] == "whisper"
+    assert calls["model"] == "whisper-1"
+    assert calls["language"] is None
+    assert calls["filter_hallucinations"] is True
+
+
+def test_transcribe_instagram_both_unavailable_returns_no_transcript(monkeypatch, tmp_path):
+    monkeypatch.setattr(ig, "download_audio", lambda url, dest_dir: str(tmp_path / "audio.mp3"))
+    monkeypatch.setattr(podcast, "_probe_duration_seconds", lambda path: 30.0)
+    monkeypatch.setattr(podcast, "_transcribe_via_groq", lambda mp3, dur, vid: None)
+    monkeypatch.setattr(podcast, "_transcribe_via_whisper", lambda *a, **k: None)
+
+    video = {"video_id": "ig:test3", "youtube_url": "https://www.instagram.com/reel/test3/", "kind": "video"}
+    text, meta = podcast._transcribe_instagram(video)
+    assert text is None
+
+
+def test_transcribe_instagram_download_failure_propagates(monkeypatch):
+    """Cookie expiry / dead link etc: InstagramError must propagate (lands
+    on status='error' with a readable message), never silently become
+    no_transcript."""
+    def fail_download(url, dest_dir):
+        raise ig.InstagramError("yt-dlp audio download failed — possibly expired/missing Instagram cookies")
+
+    monkeypatch.setattr(ig, "download_audio", fail_download)
+
+    video = {"video_id": "ig:test4", "youtube_url": "https://www.instagram.com/reel/test4/", "kind": "video"}
+    with pytest.raises(ig.InstagramError) as excinfo:
+        podcast._transcribe_instagram(video)
+    assert "cookies" in str(excinfo.value).lower()
+
+
+def test_transcribe_via_groq_returns_none_without_api_key(monkeypatch):
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    assert podcast._transcribe_via_groq("/fake/path.mp3", 30.0, "vid1") is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_transcript dispatches Instagram URLs away from YouTube captions
+# ---------------------------------------------------------------------------
+
+def test_fetch_transcript_routes_instagram_kind_video_to_instagram_chain(monkeypatch):
+    called = {"instagram": False, "youtube": False}
+    monkeypatch.setattr(podcast, "_transcribe_instagram", lambda video: (called.__setitem__("instagram", True), ("x", {}))[1])
+
+    import knowledge.youtube
+    def fail_youtube(video_id):
+        called["youtube"] = True
+        return None, {}
+    monkeypatch.setattr(knowledge.youtube, "fetch_captions", fail_youtube)
+
+    video = {"video_id": "shortcode1", "title": "t", "audio_url": None, "duration_seconds": 0,
+             "kind": "video", "youtube_url": "https://www.instagram.com/reel/shortcode1/"}
+    podcast.fetch_transcript(video)
+    assert called["instagram"] is True
+    assert called["youtube"] is False
+
+
+def test_fetch_transcript_still_routes_youtube_kind_video_to_youtube(monkeypatch):
+    called = {"instagram": False, "youtube": False}
+    monkeypatch.setattr(podcast, "_transcribe_instagram", lambda video: called.__setitem__("instagram", True))
+
+    import knowledge.youtube
+    def fake_youtube(video_id):
+        called["youtube"] = True
+        return "captions text", {"transcript_source": "youtube_captions"}
+    monkeypatch.setattr(knowledge.youtube, "fetch_captions", fake_youtube)
+
+    video = {"video_id": "abc123", "title": "t", "audio_url": None, "duration_seconds": 0,
+             "kind": "video", "youtube_url": "https://www.youtube.com/watch?v=abc123"}
+    text, meta = podcast.fetch_transcript(video)
+    assert called["youtube"] is True
+    assert called["instagram"] is False
+    assert text == "captions text"
+
+
+# ---------------------------------------------------------------------------
+# knowledge.ingest.ingest_url() dispatches Instagram URLs
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _no_title_translation(monkeypatch):
+    monkeypatch.setattr(ai, "translate_title", lambda title: None)
+
+
+def test_ingest_url_creates_instagram_episode(monkeypatch):
+    monkeypatch.setattr(
+        ig, "fetch_metadata",
+        lambda url: {"title": "Ein Reel", "uploader": "someuser", "duration": 45,
+                     "webpage_url": "https://www.instagram.com/reel/abc123/"},
+    )
+
+    import knowledge.ingest as ingest
+    result = ingest.ingest_url("https://www.instagram.com/reel/abc123/")
+    assert "episode_id" in result
+
+    episode = database.get_episode(result["episode_id"])
+    assert episode["kind"] == "video"
+    assert episode["video_id"] == "abc123"
+    assert episode["title"] == "Ein Reel"
+    assert episode["channel_id"] == "someuser"
+    assert episode["duration_seconds"] == 45
+
+
+def test_ingest_url_instagram_dedup(monkeypatch):
+    monkeypatch.setattr(
+        ig, "fetch_metadata",
+        lambda url: {"title": "Ein Reel", "uploader": "someuser", "duration": 45,
+                     "webpage_url": url},
+    )
+
+    import knowledge.ingest as ingest
+    first = ingest.ingest_url("https://www.instagram.com/reel/dup123/")
+    second = ingest.ingest_url("https://www.instagram.com/reel/dup123/")
+    assert second == {"status": "already_exists", "episode_id": first["episode_id"]}
+
+
+def test_ingest_url_instagram_metadata_failure_raises_ingest_error(monkeypatch):
+    def fail_metadata(url):
+        raise ig.InstagramError("yt-dlp metadata lookup failed — possibly expired/missing Instagram cookies")
+
+    monkeypatch.setattr(ig, "fetch_metadata", fail_metadata)
+
+    import knowledge.ingest as ingest
+    with pytest.raises(ingest.IngestError) as excinfo:
+        ingest.ingest_url("https://www.instagram.com/reel/fail123/")
+    assert "cookies" in str(excinfo.value).lower()
+
+
+def test_ingest_url_does_not_treat_instagram_as_article(monkeypatch):
+    """Regression guard: an Instagram URL must never fall through to
+    _ingest_article (which would try trafilatura on an Instagram page and
+    almost certainly fail or produce garbage)."""
+    def fail_if_called(url):
+        raise AssertionError("article extraction must not run for an Instagram URL")
+
+    import knowledge.article
+    monkeypatch.setattr(knowledge.article, "fetch_article", fail_if_called)
+    monkeypatch.setattr(
+        ig, "fetch_metadata",
+        lambda url: {"title": "Ein Reel", "uploader": None, "duration": None, "webpage_url": url},
+    )
+
+    import knowledge.ingest as ingest
+    result = ingest.ingest_url("https://www.instagram.com/reel/notanarticle/")
+    episode = database.get_episode(result["episode_id"])
+    assert episode["kind"] == "video"


### PR DESCRIPTION
Closes #750。接 #749（Signal 分享入口）。

分享一条 Reel 到 Signal 的 Note to Self → yt-dlp 下音频 → Whisper 转写 → **不摘要**，直接给中文全文 + 不在词库里的生词表。

## 三块改动

### 1. `knowledge/instagram.py`（新）
yt-dlp 取元数据 + 下音频，接进 `ingest_url()` 的分派（YouTube → Instagram → 文章）。Instagram cookies 会过期，而 yt-dlp 那时的报错跟普通登录墙一模一样，所以错误信息必须明说「可能是 cookies 过期」——这是 Daniel 在 Signal 回执里唯一能看到的诊断线索。

### 2. 转录降级链：Groq → OpenAI whisper-1
`GROQ_API_KEY` **可选**，未配置时回退已配好的 OpenAI（贵 9 倍，但一条 60 秒 Reel 才 $0.006，不是能否使用本功能的前提）。

**幻觉过滤两条路径都过**——这是本功能成立的前提：Reel 常常是纯音乐无人声，Whisper 系模型会对着音乐编造整段文本。三道：`no_speech_prob`/`avg_logprob` 超阈值的段落丢弃 → 同一句连续重复 ≥3 次判整条作废（比单看概率更强的信号）→ 剩余不足 20 词判 `no_transcript`。**绝不把幻觉文本存进库假装成功**。OpenAI 路径为拿到分段元数据从 `gpt-4o-mini-transcribe` 换成 `whisper-1`（前者不支持 `verbose_json`）。

### 3. 短文本跳过 AI 摘要（YouTube / Instagram / 文章共用）
`SUMMARY_WORD_THRESHOLD = 1000` 词以下完全跳过 `summarize()`：`summary_zh`/`summary_de` 靠 Google Translate 互译（免费），生词表照常走 `zh_annotate.extract_new_words()`，判定入口仍只有 `_known_words()` 一处。两段文本仍过 `_annotate_summary()` 同一套拼音标注，展示效果与 AI 路径一致。**长素材（≥1000 词）行为完全不变**，有测试守着。

## 翻译方向的坑
现有管线假设「转录永远是中文」（列名 `transcript_zh`，`build_transcript_de()` 是 zh→de 单向）。Reel 是德语/英语音频，方向反了。`_is_chinese_text()` 判断语言，非中文转录时 `build_transcript_de()` 直接返回空，不产出「德语翻德语」的垃圾。**不改列名、不建新表**——`transcript_zh` 存任意语言源文本是本仓库已有先例（同 `word_zh` 对法语存法语词形），改名要重建表+迁移生产库，风险远大于收益。

## 怎么测的
`pytest tests/` → 588 passed, 4 skipped。新增 `tests/test_instagram_ingest.py`：URL 解析、幻觉过滤三道全覆盖、词数统计、**阈值两侧**（<1000 词断言 AI 摘要未被调用；≥1000 词断言被调用）、Groq→OpenAI 回退链、非中文转录不产垃圾 `transcript_de`。

## 上线前还需要的一次性配置
服务器装 yt-dlp、导出 Instagram cookies.txt（步骤已写进 `scripts/README.md`）。Groq key 可选。

🤖 Generated with [Claude Code](https://claude.com/claude-code)