### PR TITLE
修复：Signal 收件首轮超时（receive 缺 -t）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -555,6 +555,8 @@ FSRS 用毕业评分播种初始 stability/difficulty：默认权重下 **Good �
   - **失败重试靠自己存队列，不是靠"留着不读"**：`signal-cli receive` 一次调用就把消息从 Signal 服务器上取走，不像 IMAP 能把邮件留成 UNSEEN 等下一轮。入库失败的 URL 存进 `app_settings['signal_retry_queue']`（JSON 列表），下一轮优先处理，满 3 次放弃并在回执里说明
   - **新链接入库后立即同步处理**（转录+摘要），不像邮件/网页粘贴那样只入库、等前端另外调 `.../process`——Signal 分享的语义就是"现在就要"。处理复用 `podcast.retry_episode()`（`routes/podcast.py` 的 process 端点背后那个同步函数，脚本进程里直接调用，不起后台线程——脚本跑完就退出，线程会被杀掉）
   - **`podcast.send_signal_text(text, context=...)`（#749 从 `send_signal()` 抽出）是发 Signal 消息的唯一函数**：`send_signal()`（摘要通知）和 `signal_inbox.send_receipt()`（收件回执）都调它，不重复写 subprocess 调用。处理成功时**不重复发一遍摘要**——`send_signal()` 已经在摘要成功后自动发了完整版，回执只发一行简短结果
+  - **`receive` 必须带 `-t`，且超时要给足（#755）**：不带 `-t` 的 `signal-cli receive` **不会**"取空就退"，它会一直监听等新消息直到被杀——cron 一次性调用因此永远等到 subprocess 超时，一条都收不到。另外**首轮特别慢**：这个账号自 #521 起只发不收，Signal 服务端攒了大量待投递消息，实测消化超过 2 分钟（原来 120 秒的上限就是这么被撑爆的），所以 `_RECEIVE_TIMEOUT=300`。之后每 5 分钟一轮只有零星消息，秒级返回
+  - **`receive` 会把 Daniel 与所有人的对话都同步下来**（#755 实测）：别人的消息正文、附件元数据、已读回执、正在输入指示，全都在返回的 envelope 流里。上面那道安全门挡住了它们入库，但它们**经过了本进程的内存**。所以：**永远不要把 envelope 原文写进日志**，也不要放进错误信息或 Signal 回执——只记 URL 和处理结果
   - `scripts/signal_check.py`：cron 入口，结构照抄 `knowledge_mail_check.py`（同款 PID 锁 + `database.init_db()` 直连）
 - **前端：播客页 → 知识页**（#653，`static/app.js`）：🎙️/📺/📄 三个子标签，播客管理页原有的 RSS 源/详情/生词表格逻辑全部保留，只是按 `?kind=` 过滤。**旧的 `#podcast-<id>` hash 链接永久保留**——已发出去的邮件/Signal 消息里全是这种链接；播客条目仍生成旧格式 hash，只有视频/文章条目用新的 `#knowledge-<id>`
 - **独立收藏页 `/save`（#681）**：`/add` 的素材版 —— 可收藏的网址，🔗 Link / 📋 Text 两个标签，粘链接或粘正文，同样**不加载 `app.js`**（手机上从别的 App 分享文章时秒开）。入库逻辑抽到 `shared.js` 的 `ingestKnowledge()`，应用的知识页和本页共用一份；`knowledgeTitleFor()` 统一"标题留空则取首行"的规则。**两处都不许直接调 `/api/knowledge/add*`**，有测试守着

--- a/knowledge/signal_inbox.py
+++ b/knowledge/signal_inbox.py
@@ -27,6 +27,14 @@ account itself (Note to Self) are ever treated as ingest input; anything
 else is ignored. This is the same role KNOWLEDGE_MAIL_ALLOWED_SENDERS plays
 for the mailbox intake — the one gate stopping this channel from turning
 into "anyone who can message Daniel triggers a paid AI call".
+
+Privacy (measured in production, #755): `receive` doesn't hand over just
+Note-to-Self messages, it drains EVERYTHING Signal has queued for this
+linked device — message bodies from other people, attachment metadata,
+read receipts, typing indicators. The gate above keeps all of it out of the
+database, but it does pass through this process's memory. So: never log a
+raw envelope, and never put envelope contents in an error message or a
+Signal receipt. Log the URL and the outcome, nothing else.
 """
 import json
 import logging
@@ -43,10 +51,22 @@ logger = logging.getLogger(__name__)
 _RETRY_QUEUE_KEY = "signal_retry_queue"
 _MAX_ATTEMPTS = 3
 
-# signal-cli's `receive` blocks briefly waiting for the server; 120s is
-# generous headroom over its usual few-second turnaround without letting a
-# hung connection stall the cron slot indefinitely.
-_RECEIVE_TIMEOUT = 120
+# `signal-cli receive` without -t does NOT "drain the queue and exit" — it
+# keeps listening for new messages until killed, which is exactly what we
+# don't want from a cron one-shot. -t tells it to return once the queue has
+# been quiet for this many seconds (#755: the first production run hit the
+# subprocess timeout instead of ever returning).
+_RECEIVE_IDLE_SECONDS = 10
+
+# Wall-clock ceiling for the whole receive call. Generous on purpose: the
+# FIRST run after an account has only ever *sent* (this one had been sending
+# podcast notifications since #521 without ever receiving) has to chew
+# through everything Signal queued up server-side — sync copies of every
+# message from every linked device, delivery receipts, typing indicators.
+# That measured at over 2 minutes in production, which is what blew the
+# original 120s ceiling. Later runs, five minutes apart, see a handful of
+# envelopes and return in seconds.
+_RECEIVE_TIMEOUT = 300
 
 
 def _default_runner(args: list) -> str:
@@ -217,9 +237,14 @@ def check_signal_inbox(runner=None) -> dict:
             retry_items.append((url, attempts))
 
     try:
-        stdout = runner([cli_path, "-a", account, "-o", "json", "receive"])
+        stdout = runner([cli_path, "-a", account, "-o", "json", "receive",
+                         "-t", str(_RECEIVE_IDLE_SECONDS)])
     except Exception as e:
-        logger.warning("knowledge.signal_inbox: signal-cli receive 失败: %s", e)
+        # 超时不是"坏了"，通常是首轮积压还没消化完（见 _RECEIVE_TIMEOUT
+        # 的注释）。日志要说人话，否则看到一行 timeout 只会以为功能是坏的。
+        logger.warning(
+            "knowledge.signal_inbox: signal-cli receive 失败: %s"
+            "（若是超时：可能是首轮积压未消化完，下一轮 cron 会继续）", e)
         summary["reason"] = "receive_failed"
         summary["errors"].append(str(e))
         return summary

--- a/tests/test_signal_inbox.py
+++ b/tests/test_signal_inbox.py
@@ -114,6 +114,23 @@ def test_no_account_configured_skips_everything(tmp_db, monkeypatch):
     assert calls == []
 
 
+def test_receive_is_invoked_with_an_idle_timeout(tmp_db, monkeypatch):
+    """#755: without `-t`, `signal-cli receive` never returns — it keeps
+    listening for new messages until killed, so the cron one-shot always died
+    on the subprocess timeout instead of draining the queue. The flag is the
+    entire fix, so it gets a test of its own."""
+    monkeypatch.setenv("SIGNAL_ACCOUNT", ACCOUNT)
+    calls = []
+    signal_inbox.check_signal_inbox(runner=_make_runner("", calls))
+
+    assert len(calls) == 1
+    args = calls[0]
+    assert "receive" in args
+    assert "-t" in args, "receive must carry an idle timeout or it never returns"
+    # The value must follow -t, and be a positive number of seconds.
+    assert int(args[args.index("-t") + 1]) > 0
+
+
 # ---------------------------------------------------------------------------
 # Security: only Note-to-Self from the account itself is ingested
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #755

生产实测第一轮直接超时，一条消息都没收到。

## 原因（两个叠加）
1. **不带 `-t` 的 `signal-cli receive` 不会「取空就退」**——它一直监听等新消息直到被杀。cron 一次性调用因此永远等到 subprocess 超时
2. **首轮特别慢**：这个账号自 #521 起只发不收，Signal 服务端攒了大量待投递消息，实测消化超过 **2 分钟**，撑爆原来 120 秒的上限

## 修复
- `receive` 带 `-t 10`（队列静默 10 秒即返回）
- `_RECEIVE_TIMEOUT` 120 → 300，给首轮积压留余量
- 超时的日志改成说人话：指明「可能是首轮积压，下一轮会继续」——否则一行 timeout 只会让人以为功能是坏的
- 新增测试专门守着 `-t`（这个 flag 就是整个修复，值得一条自己的测试）

## 附带记录（只改文档，不改行为）
`receive` 会把 Daniel 与**所有人**的对话都同步下来——别人的消息正文、附件元数据、已读回执、正在输入指示，全在 envelope 流里。安全门挡住了它们入库，但它们经过本进程内存。所以：**永远不要把 envelope 原文写进日志**，也不要放进错误信息或 Signal 回执。已写进 `knowledge/signal_inbox.py` 模块说明和 CLAUDE.md。

## 测试
`pytest tests/` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)