### PR TITLE
fix: 故事生成的翻译进度改为按批实时上报（#756）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -1518,8 +1518,16 @@ def _fill_translations(sentences: list[dict], progress_key: str | None = None,
             _set_progress(progress_key, phase="translating",
                           msg=f"Translating… 0/{total}", percent=88)
 
+        # Real per-chunk progress (#756): the loading screen used to sit at
+        # 0/N for the whole translation and then jump straight to N/N.
+        def _on_progress(done: int, n: int) -> None:
+            _set_progress(progress_key, phase="translating",
+                          msg=f"Translating… {done}/{n}",
+                          percent=88 + 4 * done / n)
+
         t0 = time.time()
-        de_results = _t.translate_batch(texts, target="de", source=source)
+        de_results = _t.translate_batch(texts, target="de", source=source,
+                                        on_progress=_on_progress if progress_key else None)
         logger.info("translate DE done in %.1fs (%d sentences)", time.time() - t0, total)
 
         if progress_key and total > 0:

--- a/podcast.py
+++ b/podcast.py
@@ -1513,26 +1513,13 @@ def _split_segments_any(text: str) -> list[str]:
 
 
 def _translate_segments(segs: list[str], target: str, source: str) -> list[str]:
-    """Translate `segs` to `target` from `source`, batching under Google
-    Translate's ~5000-char free-endpoint request limit (translate_batch joins
-    a batch with newlines into one request). Returns a list aligned 1:1 with
-    segs (translate_batch already falls back to the source text for any
-    segment it can't translate). Generalized (#750) from the zh->de-only
-    original (_translate_segments_de, kept below as a thin wrapper) so
-    _zero_cost_summary can reuse the exact same batching logic for any
-    direction instead of a second copy."""
-    out: list[str] = []
-    batch: list[str] = []
-    size = 0
-    for seg in segs:
-        if batch and size + len(seg) > 4500:
-            out.extend(translator.translate_batch(batch, target=target, source=source))
-            batch, size = [], 0
-        batch.append(seg)
-        size += len(seg) + 1
-    if batch:
-        out.extend(translator.translate_batch(batch, target=target, source=source))
-    return out
+    """Translate `segs` to `target` from `source`. Returns a list aligned 1:1
+    with segs (translate_batch falls back to the source text for any segment it
+    can't translate, and since #756 does the chunking under Google Translate's
+    ~5000-char free-endpoint request limit itself — this function used to carry
+    that batching loop). Generalized (#750) from the zh->de-only original
+    (_translate_segments_de, kept below as a thin wrapper)."""
+    return translator.translate_batch(segs, target=target, source=source)
 
 
 def _translate_segments_de(zh_segments: list[str]) -> list[str]:

--- a/translator.py
+++ b/translator.py
@@ -60,14 +60,17 @@ def translate_zh(text: str, target: str = "en", source: str = "zh-CN") -> str:
         return text
 
 
-def translate_batch(texts: list[str], target: str = "en", source: str = "zh-CN") -> list[str]:
-    """Translate a list of strings from `source` in a single HTTP request."""
-    t = _load(source, target)
-    if t is None:
-        return texts
-    if not texts:
-        return texts
+# The free Google endpoint rejects requests beyond ~5000 characters, so a batch
+# is split into chunks below that limit (podcast.py did this at its own call
+# site; #756 moved it in here so every caller gets it).
+_CHUNK_CHAR_BUDGET = 4500
 
+
+def _translate_chunk(t, texts: list[str], target: str, source: str,
+                     on_item=None) -> list[str]:
+    """One HTTP request for the whole chunk; per-sentence retry on failure.
+    on_item() is called once per sentence in the slow retry path only — the
+    joined request has no interior progress to report."""
     sep = "\n"
     combined = sep.join(text.strip() or " " for text in texts)
     try:
@@ -79,7 +82,65 @@ def translate_batch(texts: list[str], target: str = "en", source: str = "zh-CN")
     except Exception as e:
         logger.warning("translator: batch error (source=%s, target=%s) — %s", source, target, e)
 
-    return [translate_zh(text, target, source) for text in texts]
+    out = []
+    for text in texts:
+        out.append(translate_zh(text, target, source))
+        if on_item:
+            on_item()
+    return out
+
+
+def translate_batch(texts: list[str], target: str = "en", source: str = "zh-CN",
+                    on_progress=None) -> list[str]:
+    """Translate a list of strings from `source`, chunked under the endpoint's
+    request-size limit. on_progress(done, total) is called after each chunk (and
+    after each sentence of a chunk that had to fall back to one request per
+    sentence) so callers can show real progress instead of 0/N → N/N (#756)."""
+    t = _load(source, target)
+    if t is None:
+        return texts
+    if not texts:
+        return texts
+
+    total = len(texts)
+    out: list[str] = []
+    done = 0
+
+    def _report(extra: int = 0) -> None:
+        """Report progress as `len(out) + extra` — out is the single source of
+        truth for how many sentences are finished, so the fast path (whole chunk
+        at once) and the per-sentence retry path can share one counter."""
+        nonlocal done
+        n = len(out) + extra
+        if n != done:
+            done = n
+            if on_progress:
+                on_progress(done, total)
+
+    def _translate_and_report(chunk: list[str]) -> None:
+        # In the retry path the chunk's own results aren't in `out` yet, so the
+        # callback counts them via `extra`.
+        pending = {"n": 0}
+
+        def _on_item() -> None:
+            pending["n"] += 1
+            _report(pending["n"])
+
+        out.extend(_translate_chunk(t, chunk, target, source, on_item=_on_item))
+        _report()
+
+    chunk: list[str] = []
+    size = 0
+    for text in texts:
+        if chunk and size + len(text) > _CHUNK_CHAR_BUDGET:
+            _translate_and_report(chunk)
+            chunk, size = [], 0
+        chunk.append(text)
+        size += len(text) + 1
+    if chunk:
+        _translate_and_report(chunk)
+
+    return out
 
 
 # Legacy aliases kept for any callers that used the old API


### PR DESCRIPTION
Closes #756

## 问题

生成故事时加载界面长时间停在 `Translating… 0/228`，然后一下跳到完成。

`ai._fill_translations()` 只在 `translator.translate_batch()` 前后各写一次进度，而 `translate_batch()` 把**全部**句子用 `\n` 拼成一个字符串发一次请求——228 句远超 Google 免费端点约 5000 字符的上限，请求失败后退化成逐句翻译（228 次串行 HTTP）。这既是"卡很久"的真正原因，进度也只有 0/N 和 N/N 两个值。

## 改动

- `translator.translate_batch()` 内部按 4500 字符分批（原来这个分批逻辑在 `podcast._translate_segments` 的调用侧，现在收进来，那边的循环删掉）
- 新增可选 `on_progress(done, total)`：每批完成上报一次；某批失败退化成逐句时，逐句上报
- `ai._fill_translations()` 传入回调，实时写 `Translating… {done}/{total}`，percent 88→92 线性
- 前端 `_startStoryProgressPoll` 本来就显示 `p.msg`，**零改动**

## 测试

- `pytest tests/` — 602 passed, 4 skipped
- 手写脚本验证：228 句 → 5 次请求（每次 ≤5000 字符），进度回调 `[58, 110, 154, 198, 228]`；模拟批量请求失败时逐句回退且逐句上报 `[1, 2, 3]`