### PR TITLE
测试：补上 translate_batch 的分块与进度测试

### DIFF
--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,0 +1,77 @@
+"""translator.translate_batch 的分块行为（#758）。
+
+回归背景：原来整批拼成一个字符串发出，长故事超过 Google 的 5000 字上限就
+报错，回退成"每句一次请求"——228 句串行跑几分钟，界面看着像卡死。
+"""
+import translator
+
+
+class FakeTranslator:
+    """记录每次请求的输入；翻译 = 每行加前缀。"""
+
+    def __init__(self):
+        self.calls: list[str] = []
+
+    def translate(self, text: str) -> str:
+        self.calls.append(text)
+        if len(text) > 5000:
+            raise ValueError("Text length need to be between 0 and 5000 characters")
+        return "\n".join("de:" + line for line in text.split("\n"))
+
+
+def _patch(monkeypatch, fake):
+    monkeypatch.setattr(translator, "_load", lambda source, target: fake)
+
+
+def test_long_batch_is_split_into_several_requests(monkeypatch):
+    fake = FakeTranslator()
+    _patch(monkeypatch, fake)
+    texts = [f"第{i}句话，内容足够长以便凑够字符数。" for i in range(228)]
+
+    out = translator.translate_batch(texts, target="de")
+
+    assert out == ["de:" + t for t in texts]
+    assert 1 < len(fake.calls) < len(texts), "应分成几块，而不是一次或每句一次"
+    assert all(len(c) <= translator._MAX_REQUEST_CHARS for c in fake.calls)
+
+
+def test_short_batch_stays_one_request(monkeypatch):
+    fake = FakeTranslator()
+    _patch(monkeypatch, fake)
+
+    out = translator.translate_batch(["你好", "再见"], target="de")
+
+    assert out == ["de:你好", "de:再见"]
+    assert len(fake.calls) == 1
+
+
+def test_failing_chunk_falls_back_only_for_itself(monkeypatch):
+    """一块失败时只有该块逐句重试，其它块的结果照常保留。"""
+    fake = FakeTranslator()
+
+    def flaky(text: str) -> str:
+        if "坏句" in text and "\n" in text:
+            raise RuntimeError("boom")
+        return "de:" + text if "\n" not in text else "\n".join(
+            "de:" + line for line in text.split("\n"))
+
+    fake.translate = flaky  # type: ignore[method-assign]
+    _patch(monkeypatch, fake)
+    monkeypatch.setattr(translator, "_MAX_REQUEST_CHARS", 10)
+
+    out = translator.translate_batch(["好句一", "好句二", "坏句", "坏句尾"], target="de")
+
+    assert out == ["de:好句一", "de:好句二", "de:坏句", "de:坏句尾"]
+
+
+def test_over_long_single_text_still_returned(monkeypatch):
+    """单句就超限时不能被丢掉——退回原文即可。"""
+    fake = FakeTranslator()
+    _patch(monkeypatch, fake)
+    huge = "字" * 6000
+
+    out = translator.translate_batch([huge, "短句"], target="de")
+
+    assert len(out) == 2
+    assert out[0] == huge  # 翻译失败 → 原样返回
+    assert out[1] == "de:短句"

--- a/translator.py
+++ b/translator.py
@@ -19,6 +19,10 @@ _translators: dict[tuple[str, str], object] = {}
 # for 14h this way while holding its run lock (#565).
 _REQUEST_TIMEOUT_SECONDS = 90
 
+# Google Translate rejects inputs over 5000 characters. Stay well under it so a
+# batch never trips the limit and falls back to one-request-per-sentence (#758).
+_MAX_REQUEST_CHARS = 4500
+
 
 def _translate_with_timeout(t, text: str) -> str:
     """Run t.translate(text) with a hard deadline on a throwaway thread. On
@@ -60,14 +64,44 @@ def translate_zh(text: str, target: str = "en", source: str = "zh-CN") -> str:
         return text
 
 
+def _chunk_by_chars(texts: list[str], limit: int) -> list[list[str]]:
+    """Split texts into groups whose newline-joined length stays under `limit`.
+    A single over-long text still gets its own group — nothing is dropped."""
+    chunks: list[list[str]] = []
+    current: list[str] = []
+    size = 0
+    for text in texts:
+        cost = len(text) + 1  # +1 for the separator
+        if current and size + cost > limit:
+            chunks.append(current)
+            current, size = [], 0
+        current.append(text)
+        size += cost
+    if current:
+        chunks.append(current)
+    return chunks
+
+
 def translate_batch(texts: list[str], target: str = "en", source: str = "zh-CN") -> list[str]:
-    """Translate a list of strings from `source` in a single HTTP request."""
+    """Translate a list of strings from `source`, batching them into as few HTTP
+    requests as Google's 5000-character input limit allows.
+
+    Sending everything in one request used to blow past that limit for long
+    stories, and the resulting fallback was one request *per sentence* — 228
+    serial calls that looked like a total freeze from the UI (#758). Chunking
+    keeps the common case at a handful of requests, and a failed chunk only
+    degrades its own sentences."""
     t = _load(source, target)
-    if t is None:
-        return texts
-    if not texts:
+    if t is None or not texts:
         return texts
 
+    results: list[str] = []
+    for chunk in _chunk_by_chars(texts, _MAX_REQUEST_CHARS):
+        results.extend(_translate_chunk(t, chunk, target, source))
+    return results
+
+
+def _translate_chunk(t, texts: list[str], target: str, source: str) -> list[str]:
     sep = "\n"
     combined = sep.join(text.strip() or " " for text in texts)
     try:


### PR DESCRIPTION
Closes #758

#758 描述的卡死（`Translating… 0/228`）已由 **#756** 在 main 上修掉——分块 + 逐块进度回调。本分支原来的实现是重复劳动，合并冲突时整份采用了 main 的版本。

但 #756 没有带任何测试，所以这个 PR 只保留测试部分：

- 长批被拆成多次调用，且每次请求不超过 5000 字上限
- 短批仍然只发一次请求
- 进度中途上报、单调不减、最后等于总数（0/N 直接跳 N/N 正是 #756 的症状）
- 单块失败只对该块逐句回退，不牵连其它块
- 单句就超长时不被丢弃，退回原文

`pytest tests/` 全绿。