### PR TITLE
知识页：Reel 加 📱 标识 + 粘贴框写明也收 Reel 链接

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3359,8 +3359,16 @@ function _renderKnowledgeMaterialList() {
   const el = document.getElementById('view-knowledge-content');
   if (!el) return;
   const kindLabel = _knowledgeTab === 'video' ? 'video' : 'article';
+  // The video tab also accepts Instagram Reels (#750) — same paste box, same
+  // ingest_url() dispatch. Say so, or nobody discovers it (#761).
+  const linkHint = _knowledgeTab === 'video'
+    ? 'Paste a YouTube or Instagram Reel link…'
+    : `Paste a ${kindLabel} link…`;
+  const emptyHint = _knowledgeTab === 'video'
+    ? 'No videos yet — paste a YouTube or Instagram Reel link above.'
+    : `No ${kindLabel}s yet — paste a link above.`;
   const rows = _podcastEpisodes.map(ep => _knowledgeMaterialRowHtml(ep)).join('') ||
-    `<div class="keymap-hint">No ${kindLabel}s yet — paste a link above.</div>`;
+    `<div class="keymap-hint">${emptyHint}</div>`;
   // Paste-text is an article-only escape hatch for paywalled pieces the server
   // can't fetch (#668) — video/podcast tabs only ever get a link box.
   const isArticleTab = _knowledgeTab === 'article';
@@ -3385,7 +3393,7 @@ function _renderKnowledgeMaterialList() {
     : `<div class="keymap-panel">
         <div class="keymap-row">
           <input type="text" class="opt-input" id="knowledge-add-url"
-                 placeholder="Paste a ${kindLabel} link…" style="flex:1"
+                 placeholder="${linkHint}" style="flex:1"
                  onkeydown="if(event.key==='Enter') submitKnowledgeUrl()">
           <button class="btn-secondary" onclick="submitKnowledgeUrl()">Add</button>
         </div>
@@ -3417,6 +3425,18 @@ function switchKnowledgeAddMode(mode) {
   _renderKnowledgeMaterialList();
 }
 
+// Instagram Reels ride in the video tab as kind='video' (#750 deliberately
+// did NOT add a fourth kind — a Reel is a video, and a new kind means a new
+// tab, new filters, a migration). But a list mixing YouTube and Reels reads
+// as undifferentiated mush, so mark the Reels with an icon (#761). Purely
+// presentational: derived from the stored URL, nothing stored for it.
+function _knowledgeSourceIcon(ep) {
+  const url = ep.youtube_url || '';
+  return /(^|\.)instagram\.com/.test((() => {
+    try { return new URL(url).hostname; } catch (e) { return ''; }
+  })()) ? '📱 ' : '';
+}
+
 function _knowledgeMaterialRowHtml(ep) {
   const date = _localDate(ep.published_at || ep.created_at || '');
   const status = ep.status || 'pending';
@@ -3430,7 +3450,7 @@ function _knowledgeMaterialRowHtml(ep) {
   return `<div class="podcast-row${clickable ? ' podcast-row-clickable' : ''}"
                ${clickable ? `onclick="openKnowledgeItem(${ep.id})"` : ''}>
     <span class="podcast-row-title" style="display:flex;flex-direction:column;gap:2px;overflow:hidden">
-      <span>${_escHtml(ep.title || '(untitled)')}</span>
+      <span>${_knowledgeSourceIcon(ep)}${_escHtml(ep.title || '(untitled)')}</span>
       ${ep.title_en ? `<span style="font-size:12px;color:var(--muted)">${_escHtml(ep.title_en)}</span>` : ''}
     </span>
     ${source ? `<span class="podcast-row-date">${_escHtml(source)}</span>` : ''}

--- a/static/index.html
+++ b/static/index.html
@@ -670,7 +670,7 @@
 
 <div id="word-tip" style="display:none"></div>
 <script src="/static/shared.js?v=3"></script>
-<script src="/static/app.js?v=21"></script>
+<script src="/static/app.js?v=22"></script>
 
 <!-- Edit card modal -->
 <div id="edit-modal-overlay" onclick="closeEditCard()" style="display:none"></div>

--- a/static/save.html
+++ b/static/save.html
@@ -77,7 +77,7 @@
     </div>
 
     <div id="pane-link">
-      <input type="text" id="url" placeholder="Paste an article or YouTube link…"
+      <input type="text" id="url" placeholder="Paste an article, YouTube or Instagram Reel link…"
              inputmode="url" autocomplete="off" autocapitalize="none"
              autocorrect="off" spellcheck="false" enterkeyhint="done" autofocus>
       <button class="go" id="go-link">Add</button>


### PR DESCRIPTION
Closes #761

Daniel 在知识页找不到「Reels」标签——#750 故意没做：加第四个标签就要加第四种 `kind`，前后端都要动加迁移，而 Reel 本质上就是视频。但混在一起的列表一眼分不出哪条是 Reel。

## 改了什么
- **列表行标题前加 📱**（`_knowledgeSourceIcon()`）：按存好的 URL 判断，纯展示，不存任何东西、不动数据模型
- **粘贴框写明也收 Reel**：Videos 标签的粘贴框其实一直就能吃 Instagram 链接（同一个 `ingest_url()` 分派，#750 接的），只是 placeholder 没说，所以没人发现。空列表提示和 `/save` 页同步改
- **`app.js?v=21 → 22`**（#719 的教训：漏改则改动在浏览器里根本不出现）

## 测试
`pytest tests/` → 608 passed, 4 skipped。纯前端展示改动，无新测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)