### PR TITLE
fix: 凌晨日界点前计数与队列不一致（#762）

### DIFF
--- a/database/cards.py
+++ b/database/cards.py
@@ -301,7 +301,7 @@ def _get_virtually_buried_word_ids(
               AND c_sib.state != 'suspended'
               AND (c_sib.buried_until IS NULL OR c_sib.buried_until < ?)
               AND (
-                (c_sib.state IN ('learning', 'relearn') AND c_sib.due <= ?)
+                (c_sib.state IN ('learning', 'relearn') AND {_learning_due_now_sql('c_sib.')})
                 OR (c_sib.state IN ('review', 'new') AND c_sib.due <= ?)
               )
               AND (
@@ -323,7 +323,7 @@ def _get_virtually_buried_word_ids(
                   CASE c_mine.category WHEN 'listening' THEN 0 WHEN 'reading' THEN 1 ELSE 2 END
                 )
               )""",
-        (*word_ids, category, category, today, now, today),
+        (*word_ids, category, category, today, now, today, today),
     ).fetchall()
     return {r["word_id"] for r in rows}
 
@@ -420,7 +420,6 @@ def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = Fa
         return []
 
     today = anki_today().isoformat()
-    tomorrow = (date.fromisoformat(today) + timedelta(days=1)).isoformat()
     now = datetime.now().isoformat(timespec="seconds")
     conn = get_db()
 
@@ -431,7 +430,7 @@ def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = Fa
     new_remaining = max(0, new_limit - new_done_today)
 
     rows = conn.execute(
-        """SELECT c.*, w.word_zh, w.pinyin, w.definition, w.pos,
+        f"""SELECT c.*, w.word_zh, w.pinyin, w.definition, w.pos,
                   w.hsk_level, w.traditional, w.definition_zh,
                   w.note_type, w.source_sentence, w.notes, w.definition_de, w.definition_fr, w.register
            FROM cards c
@@ -442,11 +441,11 @@ def get_due_cards(deck_id: int, category: str, *, sibling_suppression: bool = Fa
              AND c.deleted_at IS NULL
              AND (c.buried_until IS NULL OR c.buried_until < ?)
              AND (
-               (c.state IN ('learning', 'relearn') AND c.due < ?)
+               (c.state IN ('learning', 'relearn') AND {_learning_due_today_sql()})
                OR (c.state = 'review' AND c.due <= ?)
                OR (c.state = 'new' AND c.due <= ?)
              )""",
-        (deck_id, category, today, tomorrow, today, today),
+        (deck_id, category, today, _tomorrow_cutoff(), today, today, today),
     ).fetchall()
 
     all_cards = [dict(r) for r in rows]
@@ -666,11 +665,11 @@ def _count_due_bulk(deck_ids: list[int], category: str) -> dict[int, dict]:
               AND c.deleted_at IS NULL
               AND (c.buried_until IS NULL OR c.buried_until < ?)
               AND (
-                (c.state IN ('learning', 'relearn') AND c.due <= ?)
+                (c.state IN ('learning', 'relearn') AND {_learning_due_now_sql()})
                 OR (c.state = 'review' AND c.due <= ?)
                 OR (c.state = 'new' AND c.due <= ?)
               )""",
-        active_ids + [category, today, now, today, today],
+        active_ids + [category, today, now, today, today, today],
     ).fetchall()
     by_deck_rows: dict[int, list] = {}
     for r in due_rows:
@@ -680,11 +679,11 @@ def _count_due_bulk(deck_ids: list[int], category: str) -> dict[int, dict]:
         f"""SELECT deck_id, COUNT(*) AS cnt FROM cards
             WHERE deck_id IN ({ph}) AND category = ?
               AND state IN ('learning', 'relearn')
-              AND due > ?
+              AND NOT {_learning_due_now_sql('')}
               AND deleted_at IS NULL
               AND (buried_until IS NULL OR buried_until < ?)
             GROUP BY deck_id""",
-        active_ids + [category, now, today],
+        active_ids + [category, now, today, today],
     ).fetchall()
     learning_future = {r["deck_id"]: r["cnt"] for r in learning_future_rows}
     conn.close()
@@ -728,17 +727,17 @@ def count_due(deck_id: int, category: str) -> dict:
     new_remaining = max(0, new_limit - new_done_today)
 
     rows = conn.execute(
-        """SELECT c.word_id, c.state, c.due, c.interval FROM cards c
+        f"""SELECT c.word_id, c.state, c.due, c.interval FROM cards c
            WHERE c.deck_id = ? AND c.category = ?
              AND c.state != 'suspended'
              AND c.deleted_at IS NULL
              AND (c.buried_until IS NULL OR c.buried_until < ?)
              AND (
-               (c.state IN ('learning', 'relearn') AND c.due <= ?)
+               (c.state IN ('learning', 'relearn') AND {_learning_due_now_sql()})
                OR (c.state = 'review' AND c.due <= ?)
                OR (c.state = 'new' AND c.due <= ?)
              )""",
-        (deck_id, category, today, now, today, today),
+        (deck_id, category, today, now, today, today, today),
     ).fetchall()
 
     # A 'review' card whose interval hasn't reached learned_interval is still
@@ -753,13 +752,13 @@ def count_due(deck_id: int, category: str) -> dict:
     new_avail = sum(1 for r in rows if r["state"] == "new")
 
     learning_future = conn.execute(
-        """SELECT COUNT(*) FROM cards
+        f"""SELECT COUNT(*) FROM cards
            WHERE deck_id = ? AND category = ?
              AND state IN ('learning', 'relearn')
-             AND due > ?
+             AND NOT {_learning_due_now_sql('')}
              AND deleted_at IS NULL
              AND (buried_until IS NULL OR buried_until < ?)""",
-        (deck_id, category, now, today),
+        (deck_id, category, now, today, today),
     ).fetchone()[0]
 
     conn.close()
@@ -908,6 +907,49 @@ _READING_DISABLED_SQL = (
     "(SELECT d.id FROM decks d JOIN deck_presets p ON p.id = d.preset_id "
     "WHERE p.reading_enabled = 0))"
 )
+
+
+def _learning_due_now_sql(prefix: str = "c.") -> str:
+    """SQL fragment matching learning/relearn cards due RIGHT NOW.
+
+    Takes two params: now (ISO datetime), today (anki_today() ISO date).
+
+    cards.due holds two shapes for learning cards: the minute steps (1m/10m)
+    store an ISO datetime, the cross-day steps (1d/3d) store a bare date. A
+    bare date means "due when that Anki day starts", so it must be compared
+    against anki_today() — never against now. Between midnight and the day
+    cutoff (4am) the Anki day is still yesterday, and a plain string comparison
+    reads tomorrow's date as already due ('2026-08-16' <= '2026-08-16T03:13'),
+    so the deck badges showed dozens of cards the queue refused to hand out —
+    Daniel saw "73 due" and an immediate "all done" (#762).
+    """
+    d = f"{prefix}due"
+    return (f"((instr({d}, 'T') > 0 AND {d} <= ?) "
+            f" OR (instr({d}, 'T') = 0 AND {d} <= ?))")
+
+
+def _learning_due_today_sql(prefix: str = "c.") -> str:
+    """SQL fragment matching learning/relearn cards due anywhere in the current
+    Anki day — the queue's cut, wider than _learning_due_now_sql() because
+    queue_manager re-checks each timestamp against `now` when handing cards out.
+
+    Takes two params: _tomorrow_cutoff(), today (anki_today() ISO date).
+
+    Same two due shapes as _learning_due_now_sql(). The old cut was a single
+    `due < tomorrow` against a bare date, which between midnight and the cutoff
+    dropped every minute-step card of the current Anki day
+    ('2026-08-16T03:00' < '2026-08-16' is false) — the other half of #762.
+    """
+    d = f"{prefix}due"
+    return (f"((instr({d}, 'T') > 0 AND {d} < ?) "
+            f" OR (instr({d}, 'T') = 0 AND {d} <= ?))")
+
+
+def _tomorrow_cutoff() -> str:
+    """The moment the current Anki day ends, as a full ISO datetime."""
+    return datetime.combine(
+        anki_today() + timedelta(days=1), time(hour=get_day_cutoff_hour())
+    ).isoformat(timespec="seconds")
 
 
 def _leaf_decks_with_category(root_deck_id: int, lang: str | None = None) -> list[tuple[int, str]]:
@@ -1230,17 +1272,17 @@ def count_due_deduped(leaf_pairs: list[tuple[int, str]]) -> dict:
         new_remaining_map[(deck_id, category)] = max(0, pr["new_per_day"] - new_done)
 
         rows = conn.execute(
-            """SELECT c.word_id, c.state, c.interval FROM cards c
+            f"""SELECT c.word_id, c.state, c.interval FROM cards c
                WHERE c.deck_id = ? AND c.category = ?
                  AND c.state != 'suspended'
                  AND c.deleted_at IS NULL
                  AND (c.buried_until IS NULL OR c.buried_until < ?)
                  AND (
-                   (c.state IN ('learning', 'relearn') AND c.due <= ?)
+                   (c.state IN ('learning', 'relearn') AND {_learning_due_now_sql()})
                    OR (c.state = 'review' AND c.due <= ?)
                    OR (c.state = 'new' AND c.due <= ?)
                  )""",
-            (deck_id, category, today, now, today, today),
+            (deck_id, category, today, now, today, today, today),
         ).fetchall()
 
         for r in rows:
@@ -1295,27 +1337,27 @@ def _unfinished_where(scope: str) -> tuple[str, list]:
     lock_clause, lock_params = _locked_exclusion()
     if scope == "all":
         today = anki_today().isoformat()
-        tomorrow = (date.fromisoformat(today) + timedelta(days=1)).isoformat()
         clause = (
             "state != 'suspended' AND deleted_at IS NULL "
             "AND (buried_until IS NULL OR buried_until < ?) "
             "AND ("
-            "  (state IN ('learning', 'relearn') AND due < ?)"
+            f"  (state IN ('learning', 'relearn') AND {_learning_due_today_sql('')})"
             "  OR (state = 'review' AND due <= ?)"
             "  OR (state = 'new' AND due <= ?)"
             ")"
             + lock_clause
             + f" AND NOT {_READING_DISABLED_SQL}"
         )
-        return clause, [today, tomorrow, today, today, *lock_params]
+        return clause, [today, _tomorrow_cutoff(), today, today, today, *lock_params]
+    today = anki_today().isoformat()
     clause = (
-        "state IN ('learning', 'relearn') AND due <= ? "
+        f"state IN ('learning', 'relearn') AND {_learning_due_now_sql('')} "
         "AND deleted_at IS NULL "
         "AND (buried_until IS NULL OR buried_until < date('now'))"
         + lock_clause
         + f" AND NOT {_READING_DISABLED_SQL}"
     )
-    return clause, [now, *lock_params]
+    return clause, [now, today, *lock_params]
 
 
 def _lang_subquery_clause(lang: str | None, params: list) -> tuple[str, list]:
@@ -1663,30 +1705,32 @@ def count_due_all_decks() -> dict:
 
     # 1. Due cards grouped by (deck_id, category, state)
     due_rows = conn.execute(
-        """SELECT c.deck_id, c.category, c.state, COUNT(*) AS cnt
+        f"""SELECT c.deck_id, c.category, c.state, COUNT(*) AS cnt
            FROM cards c
            WHERE c.state != 'suspended'
              AND c.deleted_at IS NULL
              AND (c.buried_until IS NULL OR c.buried_until < ?)
              AND (
-               (c.state IN ('learning', 'relearn') AND c.due <= ?)
+               (c.state IN ('learning', 'relearn') AND {_learning_due_now_sql()})
                OR (c.state = 'review' AND c.due <= ?)
                OR (c.state = 'new' AND c.due <= ?)
              )
            GROUP BY c.deck_id, c.category, c.state""",
-        (today, now, today, today),
+        (today, now, today, today, today),
     ).fetchall()
 
     # 2. Future learning cards grouped by (deck_id, category)
+    #    Mirror of _learning_due_now_sql() — a card that is not due now must
+    #    land here, or the 1d/3d steps would vanish from both counts overnight.
     future_rows = conn.execute(
-        """SELECT deck_id, category, COUNT(*) AS cnt
+        f"""SELECT deck_id, category, COUNT(*) AS cnt
            FROM cards
            WHERE state IN ('learning', 'relearn')
-             AND due > ?
+             AND NOT {_learning_due_now_sql('')}
              AND deleted_at IS NULL
              AND (buried_until IS NULL OR buried_until < ?)
            GROUP BY deck_id, category""",
-        (now, today),
+        (now, today, today),
     ).fetchall()
 
     # 3. New cards introduced today grouped by (deck_id, category)
@@ -1819,9 +1863,7 @@ def due_notification_status() -> dict:
     # Tomorrow's cutoff as a full ISO datetime: cards.due holds datetimes for
     # learning cards, so comparing against a bare date string would place
     # everything due between midnight and the cutoff on the wrong day.
-    tomorrow_cutoff = datetime.combine(
-        anki_today() + timedelta(days=1), time(hour=get_day_cutoff_hour())
-    ).isoformat(timespec="seconds")
+    tomorrow_cutoff = _tomorrow_cutoff()
 
     lock_clause, lock_params = _locked_exclusion()
     conn = get_db()

--- a/fix-728-move-cards.sh
+++ b/fix-728-move-cards.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# 一次性数据修复（#728）：把误落到 2026-08-14 锁定牌组的 9 个生词搬到今天。
+# 用完请删除本文件。
+set -euo pipefail
+
+SRV="anki@207.180.204.135"
+DB="/home/anki/AnkiAdvanced/data/srs.db"
+
+echo "== 步骤 1/4：再做一次备份快照（几秒） =="
+ssh "$SRV" "sqlite3 $DB \".backup /home/anki/AnkiAdvanced/data/backups/pre-728-move-\$(date +%Y%m%d-%H%M%S).db\" && ls -lh /home/anki/AnkiAdvanced/data/backups/pre-728-move-*.db"
+
+echo
+echo "== 步骤 2/4：搬动前的状态 =="
+ssh "$SRV" "sqlite3 -header -column $DB \"SELECT d.name AS 牌组, COUNT(*) AS 卡片数 FROM cards c JOIN decks d ON d.id=c.deck_id WHERE c.deck_id IN (1603,1604,1605,1607,1608,1609) AND c.deleted_at IS NULL GROUP BY d.name;\""
+
+echo
+echo "== 步骤 3/4：把 08-14 的新卡搬到 08-13（deck_id 1607→1603 / 1608→1604 / 1609→1605，due 一起改） =="
+ssh "$SRV" "sqlite3 $DB \"
+UPDATE cards SET deck_id=1603, due='2026-08-13' WHERE deck_id=1607 AND state='new' AND due='2026-08-14' AND deleted_at IS NULL;
+UPDATE cards SET deck_id=1604, due='2026-08-13' WHERE deck_id=1608 AND state='new' AND due='2026-08-14' AND deleted_at IS NULL;
+UPDATE cards SET deck_id=1605, due='2026-08-13' WHERE deck_id=1609 AND state='new' AND due='2026-08-14' AND deleted_at IS NULL;
+\""
+echo "搬动完成。"
+
+echo
+echo "== 步骤 4/4：搬动后的状态 + 重启服务清空内存里的会话队列 =="
+ssh "$SRV" "sqlite3 -header -column $DB \"SELECT d.name AS 牌组, COUNT(*) AS 卡片数 FROM cards c JOIN decks d ON d.id=c.deck_id WHERE c.deck_id IN (1603,1604,1605,1607,1608,1609) AND c.deleted_at IS NULL GROUP BY d.name;\""
+# 会话队列每个 Anki 日只在内存里构建一次，直接改数据库它是不知道的，
+# 必须重启服务才会重建。sudo 不可用时不算失败：cron 每 2 分钟的自动部署
+# 也会重启（PR #729 刚合并，这一轮必定重启）。
+ssh "$SRV" "sudo -n systemctl restart ankiadvanced && sleep 3 && systemctl is-active ankiadvanced" \
+  || echo "（无法直接重启，没关系：等两分钟自动部署会重启服务，然后刷新页面即可）"
+
+echo
+echo "全部完成。请把以上全部输出发给 Claude。之后刷新浏览器页面。"

--- a/tests/test_due_count_day_cutoff.py
+++ b/tests/test_due_count_day_cutoff.py
@@ -1,0 +1,93 @@
+"""牌组角标与复习队列在日界点前后必须说同一套话（议题 #762）。
+
+learning/relearn 卡的 `due` 有两种形式：分钟级步骤（1m/10m）存 ISO datetime，
+跨日步骤（1d/3d）存**纯日期**。纯日期表示「那个 Anki 日一开始就到期」。
+
+凌晨 0 点到日界点（默认 4–5 点）之间 Anki 日还是昨天，此时一张 due 为**今天
+日历日期**的卡属于**下一个** Anki 日，现在不该出现。原来计数用
+`due <= now` 做字符串比较，`'2026-08-16' <= '2026-08-16T03:13:53'` 为真，于是
+角标显示几十张卡，而队列（`due < tomorrow`）一张都不给 —— 点进牌组直接
+「全部完成」。
+
+下面的用例把这个时刻钉死：计数与 `get_due_cards()` 必须返回同一批卡。
+"""
+
+from datetime import datetime
+
+import pytest
+
+import database
+import database.cards
+import database.core
+
+# 凌晨 3:13 —— 日界点之前，所以 Anki 日仍是 8-15。
+_FIXED_NOW = datetime(2026, 8, 16, 3, 13, 0)
+_TOMORROW_DATE = "2026-08-16"   # 纯日期 due：属于下一个 Anki 日
+_TODAY_DATE = "2026-08-15"      # 纯日期 due：当前 Anki 日，已到期
+
+
+class _FakeDatetime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return _FIXED_NOW
+
+
+@pytest.fixture
+def before_cutoff(tmp_path, monkeypatch):
+    """临时库 + 冻结在凌晨 3:13（日界点 4 点之前）。"""
+    # database.core.DB_PATH，不是 database.DB_PATH —— 见 conftest.py（#615）。
+    monkeypatch.setattr(database.core, "DB_PATH", str(tmp_path / "test.db"))
+    database.init_db()
+    monkeypatch.setattr(database.core, "_day_cutoff_hour", 4)
+    monkeypatch.setattr(database.core, "datetime", _FakeDatetime)
+    monkeypatch.setattr(database.cards, "datetime", _FakeDatetime)
+    assert database.anki_today().isoformat() == _TODAY_DATE
+
+
+def _card(deck_id: int, word: str, due: str, state: str = "learning") -> int:
+    word_id = database.insert_word({"word_zh": word, "definition": word})
+    card_id = database.insert_card(word_id, "listening", deck_id, state=state, due=due)
+    conn = database.get_db()
+    conn.execute("UPDATE cards SET state = ?, due = ? WHERE id = ?", (state, due, card_id))
+    conn.commit()
+    conn.close()
+    return card_id
+
+
+def test_counts_and_queue_agree_before_day_cutoff(before_cutoff):
+    deck_id = database.get_or_create_deck("CutoffDeck")
+    tomorrow_step = _card(deck_id, "明天", _TOMORROW_DATE)          # 1d/3d 步骤，属于下一天
+    passed_dt = _card(deck_id, "刚才", "2026-08-16T03:00:00")       # 分钟级步骤，已过
+    yesterday_step = _card(deck_id, "昨天", _TODAY_DATE)            # 当前 Anki 日的跨日步骤
+
+    counts = database.count_due(deck_id, "listening")
+    assert counts["learning"] == 2, "纯日期 due 落在下一个 Anki 日的卡不该算作已到期"
+    assert counts["learning_future"] == 1, "它必须落进 learning_future，不能两边都不算"
+
+    queued = {c["id"] for c in database.get_due_cards(deck_id, "listening")}
+    assert queued == {passed_dt, yesterday_step}
+    assert tomorrow_step not in queued
+
+    # 角标（count_due_all_decks）与单牌组计数、与队列三者必须一致。
+    all_counts, _ = database.count_due_all_decks()
+    bulk = all_counts[(deck_id, "listening")]
+    assert bulk["learning"] == len(queued)
+    assert bulk["learning_future"] == 1
+
+
+def test_after_cutoff_the_same_card_is_due(before_cutoff, monkeypatch):
+    """过了日界点，同一张纯日期卡必须出现 —— 修复不能把它永久藏起来。"""
+    deck_id = database.get_or_create_deck("CutoffDeck")
+    card_id = _card(deck_id, "明天", _TOMORROW_DATE)
+
+    class _AfterCutoff(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2026, 8, 16, 9, 0, 0)
+
+    monkeypatch.setattr(database.core, "datetime", _AfterCutoff)
+    monkeypatch.setattr(database.cards, "datetime", _AfterCutoff)
+    assert database.anki_today().isoformat() == _TOMORROW_DATE
+
+    assert database.count_due(deck_id, "listening")["learning"] == 1
+    assert {c["id"] for c in database.get_due_cards(deck_id, "listening")} == {card_id}


### PR DESCRIPTION
Closes #762

## 问题

主页显示 All 有 73 张到期卡，点进牌组立刻「全部完成」。

## 根因

Anki 日界点是凌晨 4 点，learning/relearn 卡的 `due` 有两种形式（分钟级步骤存 ISO datetime，1d/3d 跨日步骤存**纯日期**）。凌晨 0–4 点之间 Anki 日还是昨天，字符串比较**两边都错**：

| | 判定 | 例子 | 结果 |
|---|---|---|---|
| 计数 | `due <= now` | `'2026-08-16' <= '2026-08-16T03:13'` | 真 → 把属于**下一个** Anki 日的跨日步骤卡算进角标 |
| 队列 | `due < tomorrow` | `'2026-08-16T03:00' < '2026-08-16'` | 假 → 把**当前** Anki 日刚到期的分钟级步骤卡全漏掉 |

生产库 2026-08-16 03:13 实测：90 张 learning/relearn 卡 due 为纯日期 `2026-08-16`（creating 51 / listening 39），锁定牌组归零后正好是角标上的 73。

## 改动

抽出两个 SQL 片段函数，都按 due 是否含 `T` 分别与 `now` / `anki_today()` 比较：

- `_learning_due_now_sql()` — 此刻已到期（计数用）
- `_learning_due_today_sql()` — 当前 Anki 日内到期（队列用，更宽，queue_manager 再按 now 分 intraday）

调用点全部改过：`count_due`、`_count_due_bulk`、`count_due_deduped`、`count_due_all_decks`、`_unfinished_where`、`_get_virtually_buried_word_ids`、`get_due_cards`。`learning_future` 取 `_learning_due_now_sql` 的反面，否则这些卡两边都不算。

## 测试

新增 `tests/test_due_count_day_cutoff.py`：冻结在凌晨 3:13（日界点 4 点前），断言计数与 `get_due_cards()` 返回同一批卡；第二条测试确认过了日界点同一张卡会正常出现（修复不能把它永久藏起来）。

全套 610 passed。