### PR TITLE
修复：Reel 转录走成 YouTube 字幕路径（retry_episode 漏传 youtube_url）

### DIFF
--- a/podcast.py
+++ b/podcast.py
@@ -1194,6 +1194,31 @@ def _whisper_duration_allowed(duration: float, cfg: dict) -> bool:
     return duration <= max_minutes * 60
 
 
+def _episode_to_video(episode: dict) -> dict:
+    """Build the `video` dict that _process_episode/fetch_transcript expect
+    from a stored podcast_episodes row.
+
+    Exists because three call sites used to build this dict inline, and one
+    dropped field silently broke a whole ingestion path (#766): the Instagram
+    branch in fetch_transcript keys off `youtube_url`, which retry_episode's
+    hand-rolled dict never carried — so every Reel fell through to the
+    YouTube captions path and tried to look up its Instagram shortcode as a
+    YouTube video id (they're both 11 base64-ish characters, so it looks
+    plausible right up until YouTube says "no such video"). One builder, so
+    the next field added here reaches every caller.
+    """
+    return {
+        "video_id": episode["video_id"],
+        "title": episode["title"],
+        "audio_url": episode.get("audio_url"),
+        "duration_seconds": episode.get("duration_seconds"),
+        "kind": episode.get("kind") or "podcast",
+        # The Reel-vs-YouTube discriminator. Not optional despite the name:
+        # since #650 this column holds article and Instagram URLs too.
+        "youtube_url": episode.get("youtube_url"),
+    }
+
+
 def fetch_transcript(video: dict) -> tuple[str | None, dict]:
     """Get the Chinese transcript for one RSS episode. `video` needs
     video_id/title/audio_url/duration_seconds (an episode row or a
@@ -1231,6 +1256,16 @@ def fetch_transcript(video: dict) -> tuple[str | None, dict]:
     meta = {"title": title, "transcript_source": None}
 
     if video.get("kind") == "video":
+        if "youtube_url" not in video:
+            # #766: the Instagram branch below is decided purely by this
+            # field, so a caller that forgot it doesn't get a wrong answer —
+            # it gets a Reel silently routed into the YouTube captions API.
+            # Loud, because the symptom (status='no_transcript') otherwise
+            # looks exactly like "this video genuinely has no captions".
+            logger.warning(
+                "podcast: video episode %s has no 'youtube_url' key — cannot tell a "
+                "Reel from a YouTube video, assuming YouTube (see _episode_to_video)",
+                video_id)
         if _is_instagram_url(video.get("youtube_url") or ""):
             # Instagram Reel ingestion (#750): no captions API exists for
             # Instagram at all, so this never touches knowledge.youtube —
@@ -2096,12 +2131,7 @@ def retry_episode(episode_id: int) -> dict:
     database.update_episode(episode_id, status="pending", error=None)
 
     summary = {"summarized": 0, "emailed": 0, "failed": 0}
-    video = {
-        "video_id": episode["video_id"], "title": episode["title"],
-        "audio_url": episode.get("audio_url"), "duration_seconds": episode.get("duration_seconds"),
-        "kind": episode.get("kind") or "podcast",
-    }
-    _process_episode(episode_id, video, detail_level, summary)
+    _process_episode(episode_id, _episode_to_video(episode), detail_level, summary)
 
     fresh = database.get_episode(episode_id)
     return {
@@ -2214,10 +2244,6 @@ def _run_check_locked(cfg: dict) -> dict:
         logger.info("podcast: auto-retrying failed episode %s (%s)", ep["id"], ep["video_id"])
         summary["retried"] += 1
         database.update_episode(ep["id"], status="pending", error=None)
-        _process_episode(ep["id"], {
-            "video_id": ep["video_id"], "title": ep["title"],
-            "audio_url": ep.get("audio_url"), "duration_seconds": ep.get("duration_seconds"),
-            "kind": ep.get("kind") or "podcast",
-        }, detail_level, summary)
+        _process_episode(ep["id"], _episode_to_video(ep), detail_level, summary)
 
     return summary

--- a/tests/test_instagram_ingest.py
+++ b/tests/test_instagram_ingest.py
@@ -716,3 +716,58 @@ def test_ingest_url_does_not_treat_instagram_as_article(monkeypatch):
     result = ingest.ingest_url("https://www.instagram.com/reel/notanarticle/")
     episode = database.get_episode(result["episode_id"])
     assert episode["kind"] == "video"
+
+
+# ---------------------------------------------------------------------------
+# #766: the video dict handed to fetch_transcript must carry youtube_url
+# ---------------------------------------------------------------------------
+
+def test_episode_to_video_carries_youtube_url():
+    """The Instagram-vs-YouTube branch in fetch_transcript is decided purely
+    by youtube_url. retry_episode used to build its dict inline and omit the
+    field, so every Reel was routed into the YouTube captions API and came
+    back 'no_transcript' (#766)."""
+    episode = {
+        "video_id": "abc123", "title": "T", "audio_url": None,
+        "duration_seconds": 12, "kind": "video",
+        "youtube_url": "https://www.instagram.com/reel/abc123/",
+    }
+    video = podcast._episode_to_video(episode)
+    assert video["youtube_url"] == "https://www.instagram.com/reel/abc123/"
+    assert video["kind"] == "video"
+
+
+def test_retry_episode_routes_a_reel_to_instagram_transcription(monkeypatch):
+    """End-to-end for the actual caller: an Instagram row going through
+    retry_episode() must reach _transcribe_instagram, never the YouTube
+    captions path. This is the test that would have caught #766 — the
+    existing ones fed fetch_transcript a hand-built dict and so never
+    exercised how the real caller builds it."""
+    episode_id = database.create_pending_episode(
+        video_id="reelcode99", channel_id="someuser", title="Ein Reel",
+        published_at=None, youtube_url="https://www.instagram.com/reel/reelcode99/",
+        audio_url=None, duration_seconds=45, kind="video",
+    )
+
+    took = {"instagram": False, "youtube": False}
+
+    def fake_instagram(video):
+        took["instagram"] = True
+        return "Das ist ein kurzer Text aus einem Reel.", {"transcript_source": "groq_whisper"}
+
+    import knowledge.youtube
+
+    def fail_youtube(*a, **k):
+        took["youtube"] = True
+        raise AssertionError("a Reel must never reach the YouTube captions API")
+
+    monkeypatch.setattr(podcast, "_transcribe_instagram", fake_instagram)
+    monkeypatch.setattr(knowledge.youtube, "fetch_captions", fail_youtube)
+    monkeypatch.setattr(podcast, "build_transcript_de", lambda transcript: [])
+    monkeypatch.setattr(podcast, "_translate_segments",
+                        lambda segs, target, source: [f"[{target}]{s}" for s in segs])
+
+    podcast.retry_episode(episode_id)
+
+    assert took["instagram"] is True
+    assert took["youtube"] is False


### PR DESCRIPTION
Closes #766

生产实测：界面粘一条 Instagram Reel，入库正常，处理后状态 `NO TRANSCRIPT`。日志：

```
Could not retrieve a transcript for the video https://www.youtube.com/watch?v=DaveK3BxxzV!
```

它拿 Instagram 的 shortcode 当 YouTube 视频 ID 去查字幕了 —— 两者**都是 11 位 base64 字符**，看起来完全合理，直到 YouTube 说「没这个视频」。

## 根因
`fetch_transcript()` 的 Instagram 分派（#750）判据是 `video.get("youtube_url")`，但**两个真实调用方构造 `video` 字典时都没带这个键**：
- `retry_episode()` —— 界面的 `.../process`、`.../retry`、以及 #749 的 Signal 收件**全都走它**
- `run_check()` 的自动重试段

判据恒为 False，于是每条 Reel 都落进 YouTube 字幕路径。

**为什么测试没抓到**：现有测试直接把手工构造的（带 `youtube_url` 的）字典喂给 `fetch_transcript`，从没走过真实调用方。所以这次补的重点是端到端那条。

## 修复
- 抽 `_episode_to_video(episode)`，三处共用一份 —— 三份各写各的已经漏了一次，不会是最后一次
- `fetch_transcript` 里 `kind='video'` 但字典缺 `youtube_url` 时记 warning：症状（`no_transcript`）和「这视频真没字幕」长得一模一样，不吭声就永远查不出来

## 测试
新增两条，都验证过**去掉修复就变红**：
- `_episode_to_video` 带上 `youtube_url`
- 端到端：Instagram 行走 `retry_episode()` 必须进 `_transcribe_instagram`，且**绝不**碰 YouTube 字幕 API

`pytest tests/` → 612 passed, 4 skipped。

🤖 Generated with [Claude Code](https://claude.com/claude-code)