### PR TITLE
生词表格紧凑化：按钮不再撑高行、Known 不再被切掉

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3619,14 +3619,14 @@ function _renderKnowledgeDetail(ep) {
   _podcastDetailWords = ep.hsk_words || [];
   _podcastDetailEpisodeId = ep.id;
   const hskRows = _podcastDetailWords.map((w, idx) => `<tr id="podcast-word-row-${idx}">
-      <td>${_escHtml(w.word || w.word_zh || '')}</td>
-      <td>${_escHtml(w.pinyin || '')}</td>
+      <td class="word-zh">${_escHtml(w.word || w.word_zh || '')}</td>
+      <td class="word-pinyin">${_escHtml(w.pinyin || '')}</td>
       <td>${_escHtml(w.definition_de || w.definition || '')}</td>
-      <td><button id="podcast-add-word-${idx}" class="btn-secondary" onclick="doPodcastAddWord(${idx})">★ List</button></td>
-      <td><button id="podcast-known-word-${idx}" class="btn-secondary" onclick="doPodcastKnownWord(${idx})" title="I already know this word — stop flagging it">✓ Known</button></td>
+      <td><button id="podcast-add-word-${idx}" class="word-table-btn" onclick="doPodcastAddWord(${idx})" title="Add to the ★ List">★ List</button></td>
+      <td><button id="podcast-known-word-${idx}" class="word-table-btn" onclick="doPodcastKnownWord(${idx})" title="I already know this word — stop flagging it">✓ Known</button></td>
     </tr>`).join('');
   const hskTable = hskRows
-    ? `<table class="cost-table"><thead><tr><th>Word</th><th>Pinyin</th><th>German</th><th>Save</th><th>Known</th></tr></thead><tbody>${hskRows}</tbody></table>`
+    ? `<div class="word-table-wrap"><table class="cost-table cost-table-compact"><thead><tr><th>Word</th><th>Pinyin</th><th>German</th><th>Save</th><th>Known</th></tr></thead><tbody>${hskRows}</tbody></table></div>`
     : '<p class="keymap-hint">No HSK vocabulary extracted.</p>';
   const links = [
     ep.youtube_url ? `<a href="${_escHtml(ep.youtube_url)}" target="_blank" rel="noopener" class="btn-secondary">${isPodcast ? 'YouTube' : 'Open'} ↗</a>` : '',

--- a/static/index.html
+++ b/static/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AnkiAdvanced</title>
-  <link rel="stylesheet" href="/static/style.css?v=15">
+  <link rel="stylesheet" href="/static/style.css?v=16">
 </head>
 <body>
 
@@ -670,7 +670,7 @@
 
 <div id="word-tip" style="display:none"></div>
 <script src="/static/shared.js?v=3"></script>
-<script src="/static/app.js?v=22"></script>
+<script src="/static/app.js?v=23"></script>
 
 <!-- Edit card modal -->
 <div id="edit-modal-overlay" onclick="closeEditCard()" style="display:none"></div>

--- a/static/style.css
+++ b/static/style.css
@@ -3723,6 +3723,34 @@ select.opt-input {
 }
 .cost-table tbody tr:last-child td { border-bottom: none; }
 .cost-table tbody tr:hover td { background: var(--bg); }
+
+/* Compact variant for the knowledge-item vocabulary table (#769). The two
+   action buttons per row used the generic .btn-secondary, which is sized for
+   modal footers (padding 11px, flex:1) — inside a <td> that pushed each row
+   to ~100px tall and wrapped "★ List" onto two lines, so a screen held about
+   eight words. */
+.word-table-wrap { overflow-x: auto; }
+.cost-table-compact td { padding: 4px 8px; }
+.cost-table-compact th { padding: 6px 8px; }
+.cost-table-compact .word-zh { font-size: 15px; white-space: nowrap; }
+.cost-table-compact .word-pinyin { color: var(--muted); white-space: nowrap; }
+/* The action column must never be what makes the table overflow: keep both
+   buttons on one line and let the German gloss column absorb the slack. */
+.cost-table-compact td:nth-child(4),
+.cost-table-compact td:nth-child(5) { width: 1%; white-space: nowrap; }
+.word-table-btn {
+  flex: none;
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: none;
+  font-size: 12px;
+  line-height: 1.4;
+  white-space: nowrap;
+  cursor: pointer;
+  color: var(--text);
+}
+.word-table-btn:hover { border-color: var(--primary); }
 .cost-model {
   font-family: monospace;
   font-size: 12px;


### PR DESCRIPTION
Closes #769

知识条目详情页底部的生词表格行高近 100px，一屏只放得下八个词，最右边的「✓ Known」还被切掉。

## 原因
两个操作按钮用的是通用 `.btn-secondary` —— 那是给模态框底部的大按钮设计的（`padding: 11px; font-size: 14px; flex: 1`）。塞进 `<td>` 之后：行被撑到近 100px 高，「★ List」宽度不够折成两行再翻倍，两个大按钮把表格撑得比容器宽，最后一列被切掉。

## 改了什么
- `.word-table-btn`：表格专用按钮，小 padding、12px 字号、`white-space: nowrap` 不折行
- `.cost-table-compact`：单元格 padding 10px → 4px
- 两个操作列 `width: 1%` + nowrap，让德语释义列吸收多余宽度 —— **溢出永远不该从操作列开始**，那正是这次「Known 被切掉」的成因
- 外套 `.word-table-wrap`（`overflow-x: auto`）：窄屏时表格自己横向滚动，而不是撑破页面
- `style.css?v=15→16`、`app.js?v=22→23`（#719：漏改则改动在浏览器里根本不出现）

按钮的 id、点击后改文字/加 class 的逻辑都没动，只换了展示样式。

## 测试
`pytest tests/` → 612 passed, 4 skipped（纯样式改动，无新测试）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)