### PR TITLE
知识页：独立的 📱 Reels 标签

### DIFF
--- a/main.py
+++ b/main.py
@@ -469,6 +469,10 @@ try:
     _KNOWLEDGE_TAB_KINDS = {
         "podcast": "podcast", "podcasts": "podcast",
         "video": "video", "videos": "video",
+        # Reels are a frontend-only split of kind='video' (#764), but the
+        # bookmarkable URL has to exist all the same — /knowledge/reels is
+        # exactly the link Daniel wants on his home screen.
+        "reel": "reel", "reels": "reel", "instagram": "reel",
         "article": "article", "articles": "article",
     }
 

--- a/static/app.js
+++ b/static/app.js
@@ -3126,12 +3126,42 @@ let _podcastEpisodes = [];
 let _podcastConfig = null;
 let _podcastCurrentFeedId = null;   // layer 2/3 (podcast tab): which feed's episode list we're in
 let _podcastPollTimer = null;       // re-poll while any listed item is "processing"
-let _knowledgeTab = localStorage.getItem('knowledgeTab') || 'podcast';  // 'podcast' | 'video' | 'article'
+let _knowledgeTab = localStorage.getItem('knowledgeTab') || 'podcast';  // 'podcast' | 'video' | 'reel' | 'article'
 let _knowledgeListKind = null;      // set while a flat video/article list is showing (layer 1 for those tabs)
 let _knowledgeAddMode = 'link';     // 'link' | 'text' — article tab only (#668); paywalled articles can't be fetched, so pasting the body is the escape hatch
 
 function _clearPodcastPoll() {
   if (_podcastPollTimer) { clearTimeout(_podcastPollTimer); _podcastPollTimer = null; }
+}
+
+// 📱 Reels is a *virtual* tab (#764): Instagram Reels are stored as
+// kind='video' rows (#750 deliberately did not add a fourth kind — that
+// means a schema change, a production migration, and touching every kind
+// filter in the backend, all so a Reel can be labelled as the video it
+// already is). So both the Videos and Reels tabs fetch kind=video and get
+// split here, in the frontend, by where the URL points.
+function _knowledgeApiKind(tab) {
+  return tab === 'reel' ? 'video' : tab;
+}
+
+function _isInstagramEpisode(ep) {
+  let host = '';
+  try { host = new URL(ep.youtube_url || '').hostname; } catch (e) { return false; }
+  return /(^|\.)instagram\.com$/.test(host);
+}
+
+// The one place the video/reel split is decided. Both tabs ask the backend
+// for the same rows, so whichever filter is applied here must be the exact
+// complement of the other — otherwise a row belongs to both tabs or neither.
+function _knowledgeListFilter(tab) {
+  if (tab === 'reel') return _isInstagramEpisode;
+  if (tab === 'video') return (ep) => !_isInstagramEpisode(ep);
+  return () => true;
+}
+
+async function _fetchKnowledgeList(tab) {
+  const episodes = await api('GET', `/api/podcast/episodes?kind=${_knowledgeApiKind(tab)}&limit=1000`);
+  return (episodes || []).filter(_knowledgeListFilter(tab));
 }
 
 // Top level: sub-tab bar + per-tab list -----------------------------------------
@@ -3155,7 +3185,8 @@ async function switchKnowledgeTab(tab) {
 }
 
 function _knowledgeTabBarHtml() {
-  const tabs = [['podcast', '🎙️ Podcasts'], ['video', '📺 Videos'], ['article', '📄 Articles']];
+  const tabs = [['podcast', '🎙️ Podcasts'], ['video', '📺 Videos'],
+                ['reel', '📱 Reels'], ['article', '📄 Articles']];
   const btns = tabs.map(([id, label]) =>
     `<button class="hcal-seg-btn ${_knowledgeTab === id ? 'active' : ''}" onclick="switchKnowledgeTab('${id}')">${label}</button>`
   ).join('');
@@ -3177,8 +3208,7 @@ async function _loadKnowledgeTab() {
       _renderPodcastFeedList();
     } else {
       _knowledgeListKind = _knowledgeTab;
-      const episodes = await api('GET', `/api/podcast/episodes?kind=${_knowledgeTab}&limit=1000`);
-      _podcastEpisodes = episodes || [];
+      _podcastEpisodes = await _fetchKnowledgeList(_knowledgeTab);
       _renderKnowledgeMaterialList();
       _schedulePodcastPollIfNeeded();
     }
@@ -3358,15 +3388,15 @@ function _renderPodcastEpisodeList() {
 function _renderKnowledgeMaterialList() {
   const el = document.getElementById('view-knowledge-content');
   if (!el) return;
-  const kindLabel = _knowledgeTab === 'video' ? 'video' : 'article';
-  // The video tab also accepts Instagram Reels (#750) — same paste box, same
-  // ingest_url() dispatch. Say so, or nobody discovers it (#761).
-  const linkHint = _knowledgeTab === 'video'
-    ? 'Paste a YouTube or Instagram Reel link…'
-    : `Paste a ${kindLabel} link…`;
-  const emptyHint = _knowledgeTab === 'video'
-    ? 'No videos yet — paste a YouTube or Instagram Reel link above.'
-    : `No ${kindLabel}s yet — paste a link above.`;
+  // Each tab says what it actually takes — the paste box is the same
+  // ingest_url() dispatch for all of them, so the only thing that tells
+  // Daniel a Reel link is welcome here is this text (#761/#764).
+  const HINTS = {
+    video: ['Paste a YouTube link…', 'No videos yet — paste a YouTube link above.'],
+    reel: ['Paste an Instagram Reel link…', 'No Reels yet — paste an Instagram link above.'],
+    article: ['Paste an article link…', 'No articles yet — paste a link above.'],
+  };
+  const [linkHint, emptyHint] = HINTS[_knowledgeTab] || HINTS.article;
   const rows = _podcastEpisodes.map(ep => _knowledgeMaterialRowHtml(ep)).join('') ||
     `<div class="keymap-hint">${emptyHint}</div>`;
   // Paste-text is an article-only escape hatch for paywalled pieces the server
@@ -3425,16 +3455,12 @@ function switchKnowledgeAddMode(mode) {
   _renderKnowledgeMaterialList();
 }
 
-// Instagram Reels ride in the video tab as kind='video' (#750 deliberately
-// did NOT add a fourth kind — a Reel is a video, and a new kind means a new
-// tab, new filters, a migration). But a list mixing YouTube and Reels reads
-// as undifferentiated mush, so mark the Reels with an icon (#761). Purely
-// presentational: derived from the stored URL, nothing stored for it.
+// Reels get an icon even inside their own tab (#761), so a row stays
+// self-describing wherever it's rendered. Same predicate the tab split uses
+// (#764) — two independent "is this Instagram?" checks would eventually
+// disagree, and then a row shows the phone icon in the Videos tab.
 function _knowledgeSourceIcon(ep) {
-  const url = ep.youtube_url || '';
-  return /(^|\.)instagram\.com/.test((() => {
-    try { return new URL(url).hostname; } catch (e) { return ''; }
-  })()) ? '📱 ' : '';
+  return _isInstagramEpisode(ep) ? '📱 ' : '';
 }
 
 function _knowledgeMaterialRowHtml(ep) {
@@ -3513,8 +3539,7 @@ async function _submitKnowledgeAdd(payload, msg) {
       if (msg) msg.textContent = 'Already in your library.';
     }
     if (_knowledgeListKind === _knowledgeTab) {
-      const episodes = await api('GET', `/api/podcast/episodes?kind=${_knowledgeTab}&limit=1000`);
-      _podcastEpisodes = episodes || [];
+      _podcastEpisodes = await _fetchKnowledgeList(_knowledgeTab);
       _renderKnowledgeMaterialList();
       _schedulePodcastPollIfNeeded();
     }
@@ -3811,7 +3836,7 @@ function _openKnowledgeFromHash() {
   // digits-only patterns above can never match. This is what /knowledge/videos
   // redirects to, and also what the tab bar writes into the address bar, so
   // reloading a bookmarked tab stays on that tab.
-  const tabMatch = /^#knowledge-(podcast|video|article)$/.exec(location.hash);
+  const tabMatch = /^#knowledge-(podcast|video|reel|article)$/.exec(location.hash);
   if (tabMatch) openKnowledge(tabMatch[1]);
 }
 
@@ -10966,7 +10991,7 @@ async function _loadVersionBadge() {
 // are recognized (see _openKnowledgeFromHash).
 if (/^#(?:podcast|knowledge)-feed-\d+$/.test(location.hash)
     || /^#(?:podcast|knowledge)-\d+$/.test(location.hash)
-    || /^#knowledge-(?:podcast|video|article)$/.test(location.hash)) {
+    || /^#knowledge-(?:podcast|video|reel|article)$/.test(location.hash)) {
   _openKnowledgeFromHash();
 } else {
   loadDecks();

--- a/static/index.html
+++ b/static/index.html
@@ -670,7 +670,7 @@
 
 <div id="word-tip" style="display:none"></div>
 <script src="/static/shared.js?v=3"></script>
-<script src="/static/app.js?v=23"></script>
+<script src="/static/app.js?v=24"></script>
 
 <!-- Edit card modal -->
 <div id="edit-modal-overlay" onclick="closeEditCard()" style="display:none"></div>

--- a/tests/test_knowledge_tab_link.py
+++ b/tests/test_knowledge_tab_link.py
@@ -28,6 +28,11 @@ def client():
     ("/knowledge/podcasts", "podcast"),
     ("/knowledge/podcast", "podcast"),
     ("/knowledge/VIDEOS", "video"),
+    # Reels (#764) are a frontend-only split of kind='video', but the URL
+    # has to work like any other tab.
+    ("/knowledge/reels", "reel"),
+    ("/knowledge/reel", "reel"),
+    ("/knowledge/instagram", "reel"),
 ])
 def test_tab_link_redirects_to_the_matching_hash(client, path, tab):
     resp = client.get(path, follow_redirects=False)
@@ -53,7 +58,7 @@ APP_JS = pathlib.Path("static/app.js").read_text(encoding="utf-8")
 HASH_PATTERNS = [
     re.compile(r"^#(?:podcast|knowledge)-feed-\d+$"),
     re.compile(r"^#(?:podcast|knowledge)-\d+$"),
-    re.compile(r"^#knowledge-(?:podcast|video|article)$"),
+    re.compile(r"^#knowledge-(?:podcast|video|reel|article)$"),
 ]
 
 
@@ -61,14 +66,14 @@ def test_app_js_declares_the_tab_hash_pattern():
     """The boot branch decides between "open the knowledge view" and "load the
     deck list"; if it doesn't know the tab form, a bookmarked tab link opens
     the deck list instead."""
-    assert APP_JS.count("#knowledge-(?:podcast|video|article)$") == 1
-    assert "/^#knowledge-(podcast|video|article)$/" in APP_JS
+    assert APP_JS.count("#knowledge-(?:podcast|video|reel|article)$") == 1
+    assert "/^#knowledge-(podcast|video|reel|article)$/" in APP_JS
 
 
 def test_tab_hash_is_matched_by_exactly_one_pattern():
     """The tab form is letters-only and the item/feed forms are digits-only,
     so an item link can never be mistaken for a tab link or vice versa."""
-    for tab in ("podcast", "video", "article"):
+    for tab in ("podcast", "video", "reel", "article"):
         matched = [p for p in HASH_PATTERNS if p.match(f"#knowledge-{tab}")]
         assert len(matched) == 1, tab
     # The legacy links that already went out in podcast emails/Signal messages.


### PR DESCRIPTION
Closes #764

Daniel 要求独立的 Instagram 标签，#761 的 📱 图标不够。

## 做法：前端虚拟标签
Reel 仍然是 `kind='video'` 的行 —— #750 的决定不变：加第四种 `kind` 意味着改 schema、迁移生产库、动后端每一处 kind 过滤和造卡侧，全都只为了给一个本来就是视频的东西换个标签。

所以 Videos 和 Reels 两个标签请求同一批 `kind=video`，在**前端**按 URL 主机名拆开。界面上是四个完全独立的标签。

## 关键设计
- **`_isInstagramEpisode()` 是唯一判据**，`_knowledgeSourceIcon()`（#761）改成复用它 —— 两份独立的「是不是 Instagram」判断迟早会打架，那时 Videos 标签里就会冒出带手机图标的行
- **两个过滤分支互为补集**，否则一行会同时属于两个标签、或者哪个都不属于
- `_fetchKnowledgeList()` 统一了原来两处各自写的「取数据 + 过滤」
- 每个标签的粘贴框提示说清自己收什么 —— 粘贴框对所有标签都是同一个 `ingest_url()`，提示文字是唯一的区分
- `#knowledge-reel` 和 `/knowledge/reels|reel|instagram` 都能用，刷新后回到该标签

**app.js 里有两处标签正则**（`_openKnowledgeFromHash` 和启动分支），我第一次只改了一处 —— `test_app_js_declares_the_tab_hash_pattern` 当场抓住了。那条测试值回票价。

## 测试
`pytest tests/` → 615 passed, 4 skipped。新增 `/knowledge/reels|reel|instagram` 的重定向断言，标签正则的同步测试也扩到了 reel。

🤖 Generated with [Claude Code](https://claude.com/claude-code)