### PR TITLE
Browse：加星句子列表和 Leech 列表支持按添加时间排序

### DIFF
--- a/database/browse.py
+++ b/database/browse.py
@@ -13,7 +13,7 @@ def get_words_for_browse() -> list[dict]:
         SELECT w.id, w.word_zh, w.pinyin, w.definition, w.definition_de, w.pos, w.hsk_level, w.note_type,
                c.id as card_id, c.category, c.state, c.interval, c.ease,
                c.due, c.lapses, c.step_index, c.deck_id,
-               c.is_leech, c.learning_again_count,
+               c.is_leech, c.leeched_at, c.learning_again_count,
                d.name as deck_name
         FROM entries w
         LEFT JOIN cards c ON c.word_id = w.id AND c.deleted_at IS NULL
@@ -51,6 +51,7 @@ def get_words_for_browse() -> list[dict]:
                 "step_index": r["step_index"],
                 "deck_id": r["deck_id"],
                 "is_leech": r["is_leech"],
+                "leeched_at": r["leeched_at"],
                 "learning_again_count": r["learning_again_count"],
                 "deck_name": r["deck_name"],
             })
@@ -115,7 +116,8 @@ def mark_leech_suspend(card_id: int) -> None:
     conn = get_db()
     conn.execute(
         """UPDATE cards
-              SET pre_suspend_state = state, state = 'suspended', is_leech = 1
+              SET pre_suspend_state = state, state = 'suspended', is_leech = 1,
+                  leeched_at = datetime('now')
             WHERE id = ? AND state != 'suspended'""",
         (card_id,),
     )
@@ -125,7 +127,7 @@ def mark_leech_suspend(card_id: int) -> None:
 
 _CLEAR_LEECH_SQL = """
     UPDATE cards
-       SET is_leech = 0, lapses = 0, learning_again_count = 0, probation = 0,
+       SET is_leech = 0, leeched_at = NULL, lapses = 0, learning_again_count = 0, probation = 0,
            state = CASE WHEN state = 'suspended' THEN COALESCE(pre_suspend_state, 'new') ELSE state END,
            pre_suspend_state = NULL
      WHERE is_leech = 1 AND deleted_at IS NULL
@@ -168,7 +170,7 @@ def toggle_card_suspension(card_id: int) -> dict:
     if cur and cur["state"] == "suspended":
         if cur["is_leech"]:
             conn.execute(
-                "UPDATE cards SET state='new', is_leech=0, lapses=0, learning_again_count=0, probation=0 WHERE id=?",
+                "UPDATE cards SET state='new', is_leech=0, leeched_at=NULL, lapses=0, learning_again_count=0, probation=0 WHERE id=?",
                 (card_id,),
             )
         else:

--- a/database/cards.py
+++ b/database/cards.py
@@ -59,7 +59,7 @@ def reset_word_to_new(word_id: int, target_deck_ids: dict, due: str,
         sql = """UPDATE cards
                  SET deck_id=?, state='new', due=?, step_index=0, interval=0,
                      ease=2.5, repetitions=0, lapses=0, stability=NULL, difficulty=NULL,
-                     last_review=NULL, learning_again_count=0, is_leech=0,
+                     last_review=NULL, learning_again_count=0, is_leech=0, leeched_at=NULL,
                      probation=0, buried_until=NULL, pre_suspend_state=NULL
                  WHERE word_id=? AND category=? AND deleted_at IS NULL"""
         params = [target_deck_id, due, word_id, category]

--- a/database/core.py
+++ b/database/core.py
@@ -285,6 +285,8 @@ def init_db() -> None:
         conn.execute("ALTER TABLE cards ADD COLUMN learning_again_count INTEGER NOT NULL DEFAULT 0")
     if "is_leech" not in card_cols:
         conn.execute("ALTER TABLE cards ADD COLUMN is_leech INTEGER NOT NULL DEFAULT 0")
+    if "leeched_at" not in card_cols:
+        conn.execute("ALTER TABLE cards ADD COLUMN leeched_at TEXT")
 
     # FSRS memory state. Absence of `stability` signals a pre-FSRS database →
     # seed existing review/relearn cards from their SM-2 interval/ease below.
@@ -699,6 +701,28 @@ def init_db() -> None:
                 "DELETE FROM podcast_episodes WHERE id = ?", [(i,) for i in stale_ids])
         conn.execute(
             "INSERT OR REPLACE INTO app_settings (key, value) VALUES ('purged_legacy_youtube_rows', '1')")
+        conn.commit()
+
+    # One-time backfill of cards.leeched_at (#773): the column is new, so
+    # existing leech cards have no timestamp to sort the Leeched browse view
+    # by. Approximate it with last_review — mark_leech_suspend() is always
+    # called right after the review that tripped the threshold, so the two
+    # are effectively the same moment. Marker-guarded like
+    # purged_legacy_youtube_rows above (same reasoning: production redeploys
+    # and re-runs init_db every 2 minutes, so an unguarded UPDATE would
+    # re-stamp leeched_at on every startup, clobbering the real value written
+    # later by mark_leech_suspend()). Deliberately outside the "table already
+    # existed" migration block above so a brand-new database sets the marker
+    # too and the backfill can never fire on rows created later in its life.
+    already_backfilled_leeched_at = conn.execute(
+        "SELECT value FROM app_settings WHERE key = 'backfilled_leeched_at'"
+    ).fetchone()
+    if not already_backfilled_leeched_at:
+        conn.execute(
+            "UPDATE cards SET leeched_at = COALESCE(last_review, date('now')) "
+            "WHERE is_leech = 1 AND leeched_at IS NULL")
+        conn.execute(
+            "INSERT OR REPLACE INTO app_settings (key, value) VALUES ('backfilled_leeched_at', '1')")
         conn.commit()
 
     # One-time transcript normalization (#500): NotebookLM ASR output stored

--- a/schema.sql
+++ b/schema.sql
@@ -327,6 +327,10 @@ CREATE TABLE IF NOT EXISTS cards (
     -- set to 1 when the card was suspended by leech detection (vs. manual suspend)
     is_leech    INTEGER NOT NULL DEFAULT 0,
 
+    -- when the leech flag was set (NULL when not a leech); drives the Leeched
+    -- browse sort. Cleared back to NULL whenever the leech flag is cleared.
+    leeched_at  TEXT,
+
     -- Temporary burial: card is hidden until this date (resets automatically next day)
     buried_until TEXT,
 

--- a/scripts/offline_sync_server.py
+++ b/scripts/offline_sync_server.py
@@ -43,7 +43,7 @@ WATERMARK_KEY = "offline_sync_review_log_max"
 CARD_FIELDS = [
     "state", "due", "step_index", "interval", "ease", "repetitions", "lapses",
     "stability", "difficulty", "last_review", "learning_again_count",
-    "is_leech", "buried_until", "pre_suspend_state", "next_note", "probation",
+    "is_leech", "leeched_at", "buried_until", "pre_suspend_state", "next_note", "probation",
 ]
 
 REVIEW_FIELDS = [

--- a/static/app.js
+++ b/static/app.js
@@ -1815,16 +1815,56 @@ function _sortWords(words) {
     case 'hanzi-asc':   sorted.sort((a, b) => (a.word_zh || '').localeCompare(b.word_zh || '', 'zh')); break;
     case 'hanzi-desc':  sorted.sort((a, b) => (b.word_zh || '').localeCompare(a.word_zh || '', 'zh')); break;
     case 'newest':      sorted.sort((a, b) => b.id - a.id); break;
+    case 'leeched-desc': case 'leeched-asc': {
+      // Sort key = the latest leeched_at across a word's cards (a word has up
+      // to three cards, only some of which may be leeches). Words with no
+      // leeched_at at all sort last regardless of direction — they don't
+      // belong on this axis, so burying them mid-list would look broken (#773).
+      const asc = _browseSort === 'leeched-asc';
+      const key = w => (w.cards || []).reduce((max, c) => c.leeched_at && c.leeched_at > max ? c.leeched_at : max, '');
+      sorted.sort((a, b) => {
+        const ka = key(a), kb = key(b);
+        if (!ka && !kb) return 0;
+        if (!ka) return 1;   // no leeched_at → always last
+        if (!kb) return -1;
+        if (ka === kb) return 0;
+        return (ka < kb) === asc ? -1 : 1;
+      });
+      break;
+    }
   }
   return sorted;
 }
 
 function onBrowseSort(val) {
   _browseSort = val;
+  // Picking a starred-* option re-sorts the sentence list in place — it must
+  // NOT leave the starred view, unlike every other sort option (#773).
+  if (val.startsWith('starred-') && _browseCardStatus === 'starred') { renderStarredSentences(); return; }
   _leaveStarredView();  // the sort options are word fields (pinyin/hanzi), #692
   const q = document.getElementById('browse-search').value.trim();
   if (_browseMode === 'hanzi') renderHanziList(_allHanzi, q);
   else if (q) onBrowseSearch(q); else renderBrowseWords(_filteredBrowseWords());
+}
+
+// The Leeched and ⭐ Sentences views sort by a timestamp the other views
+// don't have (leeched_at / starred_at), so their options only appear while
+// that view is active, and switching away falls back to the default word
+// sort (#773). Must run BEFORE the list is (re)rendered so _browseSort is
+// already correct.
+function _syncSortOptions() {
+  const showLeeched = _browseCardStatus === 'leech';
+  const showStarred = _browseCardStatus === 'starred';
+  document.querySelectorAll('#browse-sort option[value^="leeched-"]').forEach(o => o.hidden = !showLeeched);
+  document.querySelectorAll('#browse-sort option[value^="starred-"]').forEach(o => o.hidden = !showStarred);
+  if (showLeeched && !_browseSort.startsWith('leeched-')) _browseSort = 'leeched-desc';
+  else if (showStarred && !_browseSort.startsWith('starred-')) _browseSort = 'starred-desc';
+  else if (!showLeeched && !showStarred &&
+           (_browseSort.startsWith('leeched-') || _browseSort.startsWith('starred-'))) {
+    _browseSort = 'pinyin-asc';
+  }
+  const sel = document.getElementById('browse-sort');
+  if (sel) sel.value = _browseSort;
 }
 
 function _leafDeckIds(deckId) {
@@ -1861,6 +1901,7 @@ function setBrowseFilter(mode, filter) {
   _browseFilter = filter;
   _browseDeckId = null;
   _leaveStarredView();
+  _syncSortOptions();
   // Update sidebar active state
   document.querySelectorAll('.bs-item').forEach(el => el.classList.remove('bs-active'));
   const btnId = mode === 'hanzi' ? 'bsf-hanzi' : `bsf-${filter}`;
@@ -1875,6 +1916,7 @@ function setBrowseFilter(mode, filter) {
 
 function setBrowseStatusFilter(status) {
   _browseCardStatus = status;
+  _syncSortOptions();
   document.querySelectorAll('.bs-status-item').forEach(el => el.classList.remove('bs-active'));
   const btn = document.getElementById(`bss-${status}`);
   if (btn) btn.classList.add('bs-active');
@@ -1892,6 +1934,8 @@ function setBrowseStatusFilter(status) {
 function _leaveStarredView() {
   if (_browseCardStatus !== 'starred') return;
   _browseCardStatus = 'all';
+  _starredSentencesCache = null;  // stale on next entry — re-fetch (#773)
+  _syncSortOptions();
   document.querySelectorAll('.bs-status-item').forEach(el => el.classList.remove('bs-active'));
   document.getElementById('bss-all')?.classList.add('bs-active');
 }
@@ -1939,9 +1983,10 @@ async function openBrowse() {
     _browseDeckExpanded = new Set();
     _browseSelected.clear();
     _browseCardStatus = 'all';
+    _starredSentencesCache = null;  // fresh browse open — re-fetch, don't reuse a stale list (#773)
+    _syncSortOptions();
     showView('browse');
     document.getElementById('browse-search').value = '';
-    document.getElementById('browse-sort').value = _browseSort;
     _renderBrowseSidebar();
     _updateBrowseActionBar();
     document.querySelectorAll('.bs-status-item').forEach(el => el.classList.remove('bs-active'));
@@ -2266,8 +2311,41 @@ function renderBrowseWords(words) {
 // context that makes it useful: which mode/model produced it and from which
 // source material. That's what you read when deciding how to change a prompt.
 
+let _starredSentencesCache = null;  // avoids a refetch when only the sort changes (#773)
+
+// starred-asc = oldest first; anything else (including the default) = newest
+// first. Sentences without a starred_at (shouldn't happen, but defensive)
+// sort last regardless of direction, same rule as the leeched sort.
+function _sortStarredSentences(sentences) {
+  const asc = _browseSort === 'starred-asc';
+  const sorted = [...sentences];
+  sorted.sort((a, b) => {
+    const ka = a.starred_at || '', kb = b.starred_at || '';
+    if (!ka && !kb) return 0;
+    if (!ka) return 1;
+    if (!kb) return -1;
+    if (ka === kb) return 0;
+    return (ka < kb) === asc ? -1 : 1;
+  });
+  return sorted;
+}
+
+// Single paint path for both the fetched and the cached list, so the empty
+// state can't go missing on one of them (unstarring the last sentence goes
+// through the cached branch).
+function _paintStarredList(sentences) {
+  const list = document.getElementById('browse-list');
+  if (!sentences.length) {
+    list.innerHTML = '<div class="browse-empty">No starred sentences yet — press Shift+F ' +
+                     'or tap ☆ while reviewing to keep a good one.</div>';
+    return;
+  }
+  list.innerHTML = `<div class="bw-list">${_sortStarredSentences(sentences).map(_starredSentenceRow).join('')}</div>`;
+}
+
 async function renderStarredSentences() {
   const list = document.getElementById('browse-list');
+  if (_starredSentencesCache) { _paintStarredList(_starredSentencesCache); return; }
   list.innerHTML = '<div class="browse-empty">Loading…</div>';
   let sentences;
   try {
@@ -2278,12 +2356,8 @@ async function renderStarredSentences() {
     return;
   }
   if (_browseCardStatus !== 'starred') return;  // user switched tabs while loading
-  if (!sentences.length) {
-    list.innerHTML = '<div class="browse-empty">No starred sentences yet — press Shift+F ' +
-                     'or tap ☆ while reviewing to keep a good one.</div>';
-    return;
-  }
-  list.innerHTML = `<div class="bw-list">${sentences.map(_starredSentenceRow).join('')}</div>`;
+  _starredSentencesCache = sentences;
+  _paintStarredList(sentences);
 }
 
 function _starredSentenceRow(s) {
@@ -2327,6 +2401,7 @@ async function unstarSentence(sentenceId, btn) {
   btn.disabled = true;
   try {
     await api('POST', `/api/story-sentence/${sentenceId}/star`, { starred: false });
+    if (_starredSentencesCache) _starredSentencesCache = _starredSentencesCache.filter(s => s.id !== sentenceId);
     btn.closest('.ss-row')?.remove();
     if (!document.querySelector('.ss-row')) renderStarredSentences();  // back to empty state
   } catch (e) {

--- a/static/index.html
+++ b/static/index.html
@@ -384,6 +384,10 @@
           <option value="hanzi-asc">Hanzi A→Z</option>
           <option value="hanzi-desc">Hanzi Z→A</option>
           <option value="newest">Newest first</option>
+          <option value="leeched-desc" hidden>Leeched: newest first</option>
+          <option value="leeched-asc" hidden>Leeched: oldest first</option>
+          <option value="starred-desc" hidden>Starred: newest first</option>
+          <option value="starred-asc" hidden>Starred: oldest first</option>
         </select>
       </div>
       <div id="browse-action-bar">


### PR DESCRIPTION
Closes #773

## 改了什么

**后端：新增 `cards.leeched_at`**
- `schema.sql` + `database/core.py` 迁移；一次性回填现有 leech 卡用 `COALESCE(last_review, date('now'))` 近似（标 leech 后立刻暂停，最后一次复习基本就是标记时刻），带 `app_settings.backfilled_leeched_at` 标记守住只跑一次（#688 的教训：生产每 2 分钟重启一次 `init_db()`）
- 写入点只有 `mark_leech_suspend()` 一处；清除 leech 的三处（`_CLEAR_LEECH_SQL`、`toggle_card_suspension()`、`reset_word_to_new()`）都置回 NULL
- `get_words_for_browse()` 带出该字段；`scripts/offline_sync_server.py` 的 `CARD_FIELDS` 白名单同步加上，否则离线同步会丢这一列

**前端**
- `#browse-sort` 加四个平时 `hidden` 的选项，`_syncSortOptions()` 按当前视图显示/隐藏并在切走时回落 `pinyin-asc`
- `_sortWords()` 的 leech 分支按该词所有卡里最大的 `leeched_at` 排；无值的词正序倒序都排最后
- `onBrowseSort()` 选 starred 排序时不再离开加星视图，就地重排
- 加星列表只换排序时复用缓存，不重新请求接口

## 怎么测试

- `pytest tests/` → 615 passed, 4 skipped
- 临时库验证迁移：全新库首次 `init_db()` 即写标记；重复启动不再回填；旧安装（标记缺失+已有 leech 行）能正确回填成 `last_review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)