### PR TITLE
知识库故事：多素材改为每素材一次独立 AI 调用（#776）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -455,7 +455,7 @@ Return ONLY a numbered list of Chinese sentences, no explanation:
     照抄其中的名字和数字（用素材原文的语言写这部分），
     再用一句中文说明这句话在讲什么。面向 HSK 4-5 学习者，中文部分用词不要太难。
 21. 把事实写出来正是为了自查：任何两句的「事实：」都不许相同。
-{multi_source_block}
+
 五、输出前自检（内部进行，不要输出）
 - 句子数是否等于目标词数？
 - 每个目标词是否恰好出现一次？
@@ -486,7 +486,7 @@ PROMPT_TEMPLATE_VARIABLES: dict[str, list[str]] = {
     "story": ["words", "max_hsk", "grammar_block", "topic_block"],
     "qa": ["words", "max_hsk", "grammar_block", "topic"],
     "expository": ["words", "max_hsk", "grammar_block", "topic"],
-    "knowledge": ["words", "summary", "title", "max_hsk", "extra_hint", "multi_source_block"],
+    "knowledge": ["words", "summary", "title", "max_hsk", "extra_hint"],
 }
 
 
@@ -2689,7 +2689,7 @@ def _podcast_max_tokens(model: str, n_words: int) -> int:
 
 def generate_podcast_sentences(
     cards: list[dict],
-    sources: list[dict],      # [{"index", "title", "kind", "url", "material"}, ...] — see routes/story.py's knowledge branch; caller ensures every entry has non-empty "material"
+    source: dict,              # {"title", "kind", "url", "material"} — see routes/story.py's knowledge branch; caller ensures non-empty "material"
     model: str = DEFAULT_MODEL,     # #640: DeepSeek, same as kahneman
     max_hsk: int = 3,
     progress_key: str | None = None,
@@ -2719,19 +2719,23 @@ def generate_podcast_sentences(
     Deliberately has NO fact-check and NO whole-material validation retry —
     those are what make briefing slow and expensive, and podcast/knowledge
     content (unlike news) is not something to fact-check against an external
-    source in the same way.
+    source in the same way. `material` is normally the item's full transcript
+    (transcript_zh, truncated to 15000 chars by the caller — issue #661;
+    Daniel explicitly asked for transcript-based cards, #561 had switched to
+    summary_de purely to cut cost/latency, which stopped mattering once cost
+    was confirmed to be ~$0.003/generation) with summary_de as a fallback for
+    rows that only have a summary (old synced-down data, etc.). The prompt
+    template's {summary} placeholder is reused for whichever text is passed
+    in, so custom prompt_presets Daniel already saved keep working unchanged.
 
-    `sources` (issue #752, multi-source): one or more selected knowledge
-    items, each already carrying its own material text (the caller —
-    routes/story.py — has already resolved transcript_zh vs summary_de and
-    split the _KNOWLEDGE_MATERIAL_MAX_CHARS budget evenly across the
-    selection). With exactly one source, {title}/{summary} render as that
-    source's title/material verbatim and {multi_source_block} renders empty —
-    the single-source prompt must stay byte-for-byte identical to before this
-    was added, since Daniel is actively tuning it. With several sources,
-    {title} becomes a numbered list and {summary} a labeled concatenation of
-    every source's material, and {multi_source_block} adds the instruction to
-    spread sentences across sources and tag each with "source_index".
+    Multi-source selections (issue #752) used to be crammed into one call
+    with a "source_index" tag per sentence so the model could interleave
+    them. Daniel didn't want interleaving — he wants source A finished before
+    source B starts. Issue #776 removed that machinery: routes/story.py now
+    calls this function once per selected source, each with its own slice of
+    the due-word list, and concatenates the results in source order. This
+    function therefore only ever sees a single source again, and the prompt
+    is back to being byte-for-byte the pre-#752 single-source version.
 
     attempt_label: chunk marker like " (2/3)" appended to every progress
     message — the route batches cards by MAX_NEWS_BATCH and calls this once
@@ -2742,7 +2746,7 @@ def generate_podcast_sentences(
     an extra_hint, so a prompt rebuilt afterwards would not be the one that
     produced these sentences, which is the whole point of keeping it (#697).
     """
-    if not cards or not sources:
+    if not cards or not source:
         return [], ""
 
     # 模板可被用户自定义覆盖（issue #581）；默认渲染结果与旧内联 f-string 逐字一致。
@@ -2751,38 +2755,8 @@ def generate_podcast_sentences(
     # {summary} 占位符名字保留不变（issue #661 起实际传入的多为转录全文而非
     # 摘要）——改名会让 Daniel 已保存的自定义模板失效。
     tpl = _story_prompt_template("knowledge")
-
-    # #752: single source keeps {title}/{summary} rendering exactly as before
-    # multi-source support existed (Daniel is actively tuning this prompt, so
-    # the well-worn single-source path must not shift under him). Only with
-    # more than one source do these turn into a labeled listing, and only
-    # then does {multi_source_block} carry any text.
-    if len(sources) == 1:
-        title_block = sources[0].get("title") or ""
-        summary_block = sources[0].get("material") or ""
-        multi_source_block = ""
-    else:
-        title_block = "\n".join(
-            f"{s['index']}. 《{s.get('title') or '（无标题）'}》（{s.get('kind') or 'podcast'}）"
-            for s in sources
-        )
-        summary_block = "\n\n".join(
-            f"── 素材 {s['index']}：《{s.get('title') or '（无标题）'}》（{s.get('kind') or 'podcast'}）──\n"
-            f"{s.get('material') or ''}"
-            for s in sources
-        )
-        # 这段插在「四、reasoning_zh」与「五、输出前自检」之间，所以不另起大节号
-        # （避免出现「六」排在「五」前面），条目号顺着 21 往下接。
-        multi_source_block = (
-            "\n【本次有多份素材】\n"
-            "22. 上面的素材列表和内容各有编号，句子要分散覆盖到不同素材上，"
-            "尽量让每一份都至少被用到，不要全挤在第 1 份。\n"
-            "23. 同一句话只能依据一份素材，不许把不同素材的事实混进同一句。\n"
-            "24. 每个 JSON 元素都要多带一个整数字段 \"source_index\"，"
-            "写这句话依据的是上面第几份素材（对照素材编号）。\n"
-            "25. 输出前再自查一遍：每句都带了 source_index 吗？"
-            "是不是有素材一句都没用到？\n"
-        )
+    title_block = source.get("title") or ""
+    summary_block = source.get("material") or ""
 
     def _build_prompt(batch: list[dict], extra_hint: str = "") -> str:
         word_list = "\n".join(
@@ -2795,33 +2769,11 @@ def generate_podcast_sentences(
             "words": word_list,
             "max_hsk": str(max_hsk),
             "extra_hint": extra_hint,
-            "multi_source_block": multi_source_block,
         })
 
     sentences: list[dict] = []
     remaining = list(cards)
     prompts_sent: list[str] = []
-
-    def _source_for(item: dict, label: str) -> dict:
-        """Resolve which source a sentence is attributed to (#752).
-
-        Single-source calls always use sources[0] — no index parsing needed
-        or expected. Multi-source calls read the model's "source_index"
-        (1-based, matching the numbering shown in the prompt); a missing,
-        non-integer, or out-of-range value falls back to sources[0] rather
-        than dropping the sentence — a wrong/missing attribution is a minor
-        cosmetic issue (wrong "open article" link), not worth discarding an
-        otherwise-good sentence over."""
-        if len(sources) == 1:
-            return sources[0]
-        raw_idx = item.get("source_index")
-        idx = raw_idx if isinstance(raw_idx, int) else None
-        if idx is None and isinstance(raw_idx, str) and raw_idx.strip().lstrip("-").isdigit():
-            idx = int(raw_idx)
-        if idx is not None and 1 <= idx <= len(sources):
-            return sources[idx - 1]
-        log_progress(progress_key, f"{label}：句子缺少有效 source_index，回退到素材 1")
-        return sources[0]
 
     def _run_round(batch: list[dict], extra_hint: str, label: str) -> None:
         """One AI call for `batch`; moves every word it covered out of `remaining`."""
@@ -2854,7 +2806,6 @@ def generate_podcast_sentences(
                 continue          # no target word → drop (this mode allows no context sentences)
             remaining.remove(matched)
             got += 1
-            src = _source_for(item, label)
             sentences.append({
                 "word_ids": [matched["word_id"]],
                 "sentence_zh": s_zh,
@@ -2865,8 +2816,8 @@ def generate_podcast_sentences(
                 # reasoning_zh before writing — keep it, it shows in the card's
                 # background popup like kahneman's does.
                 "reasoning_zh": (item.get("reasoning_zh") or "").strip(),
-                "source_url": src.get("url"),
-                "source_title": src.get("title"),
+                "source_url": source.get("url"),
+                "source_title": source.get("title"),
                 "tokens": [],
             })
         log_progress(progress_key, f"{label}：拿到 {got} 句，还差 {len(remaining)} 个词")
@@ -2923,8 +2874,8 @@ def generate_podcast_sentences(
             "concept_en": "",
             "concept_zh": "",
             "reasoning_zh": "",
-            "source_url": sources[0].get("url"),
-            "source_title": sources[0].get("title"),
+            "source_url": source.get("url"),
+            "source_title": source.get("title"),
             "tokens": [],
         })
 

--- a/routes/story.py
+++ b/routes/story.py
@@ -43,26 +43,26 @@ _AGAIN_ACTION_LABELS = {
 _KNOWLEDGE_MATERIAL_MAX_CHARS = 15000
 
 
-def _knowledge_material(episode: dict, limit: int = _KNOWLEDGE_MATERIAL_MAX_CHARS) -> str:
+def _knowledge_material(episode: dict) -> str:
     """Return the text to feed knowledge-mode story generation for `episode`.
 
     issue #661: prefer the full transcript (transcript_zh, truncated to
-    `limit`) — Daniel explicitly asked for this when the feature shipped;
-    #561 switched to summary_de purely to cut cost/latency (skip fact-check +
-    fewer tokens per call), which stopped mattering once the per-generation
-    cost was confirmed to be ~$0.003. Rows synced down before this change (or
-    otherwise missing a transcript) may only have summary_de — fall back to
-    it rather than erroring, so old episodes keep working.
+    _KNOWLEDGE_MATERIAL_MAX_CHARS) — Daniel explicitly asked for this when
+    the feature shipped; #561 switched to summary_de purely to cut
+    cost/latency (skip fact-check + fewer tokens per call), which stopped
+    mattering once the per-generation cost was confirmed to be ~$0.003. Rows
+    synced down before this change (or otherwise missing a transcript) may
+    only have summary_de — fall back to it rather than erroring, so old
+    episodes keep working.
 
-    `limit` (issue #752): when generating from several sources at once, the
-    caller passes _KNOWLEDGE_MATERIAL_MAX_CHARS // len(sources) so the total
-    prompt stays within the same context-window budget as a single source —
-    each item just gets a smaller slice instead of the ceiling multiplying
-    with the number of selected items."""
+    issue #776: each selected source now gets its own AI call (see the
+    knowledge branch below), so there's no longer a shared context-window
+    budget to split across sources — every source gets the full
+    _KNOWLEDGE_MATERIAL_MAX_CHARS, same as when only one was ever selected."""
     transcript = (episode.get("transcript_zh") or "").strip()
     if transcript:
-        return transcript[:limit]
-    return (episode.get("summary_de") or "").strip()[:limit]
+        return transcript[:_KNOWLEDGE_MATERIAL_MAX_CHARS]
+    return (episode.get("summary_de") or "").strip()[:_KNOWLEDGE_MATERIAL_MAX_CHARS]
 
 
 def _parse_episode_ids(episode_ids: str | None, episode_id: int | None) -> list[int]:
@@ -402,13 +402,16 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
             # generation. See _knowledge_material()'s docstring. Rows without
             # a transcript (synced-down snapshots, etc.) fall back to
             # summary_de automatically.
-            # #752: episode_ids can now hold several source items — the words
-            # are spread across all of them in one call instead of forcing a
-            # single source. sources[] built below only includes items that
-            # actually have material; an id that resolves to nothing usable
-            # is dropped with a warning rather than failing the whole batch,
-            # since Daniel picking 3 items where 1 has no transcript yet
-            # shouldn't block the other 2.
+            # #752 let episode_ids hold several source items and crammed them
+            # into one AI call with a "source_index" tag per sentence so the
+            # model could interleave sources. Daniel didn't want interleaving
+            # — he wants source 1 finished before source 2 starts (#776). So
+            # each source now gets its own call(s), one at a time, and the
+            # results are concatenated in source order. sources[] built below
+            # only includes items that actually have material; an id that
+            # resolves to nothing usable is dropped with a warning rather than
+            # failing the whole batch, since Daniel picking 3 items where 1
+            # has no transcript yet shouldn't block the other 2.
             if not episode_ids:
                 raise ValueError("Knowledge mode requires selecting at least one source item.")
             episodes = []
@@ -417,19 +420,14 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
                 if not episode:
                     raise ValueError(f"Knowledge item {eid} not found.")
                 episodes.append(episode)
-            # Budget split evenly across sources (issue #752) so a 3-item
-            # selection stays within the same total context-window budget as
-            # a single item — see _knowledge_material()'s docstring.
-            per_source_limit = _KNOWLEDGE_MATERIAL_MAX_CHARS // len(episodes)
             sources: list[dict] = []
             for eid, episode in zip(episode_ids, episodes):
-                material = _knowledge_material(episode, limit=per_source_limit)
+                material = _knowledge_material(episode)
                 if not material:
                     logger.warning("story  knowledge item %d has no transcript/summary — skipped", eid)
                     continue
                 ep_kind = episode.get("kind") or "podcast"
                 sources.append({
-                    "index": len(sources) + 1,
                     "title": episode.get("title") or "",
                     "kind": ep_kind,
                     "url": episode.get("youtube_url") or f"/#{ep_kind}-{eid}",
@@ -444,26 +442,63 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
             model = _validated_model(model, default=ai.DEFAULT_MODEL)
             logger.info("story  knowledge model in use: %s kind=%s sources=%d batch_size=%s",
                         model, kind, len(sources), batch_size)
+
+            # Split the due-word list evenly across sources (issue #776):
+            # remainder words go to the earlier sources (16 words / 3 sources
+            # → 6/5/5). Sentences are generated and appended source by source,
+            # so the finished story reads "source 1 in full, then source 2"
+            # instead of the words being interleaved.
+            n_sources = len(sources)
+            word_groups: list[list] = []
+            start = 0
+            for i in range(n_sources):
+                size = len(cards) // n_sources + (1 if i < len(cards) % n_sources else 0)
+                word_groups.append(cards[start:start + size])
+                start += size
+
             # batch_size (issue #563): user-controlled words-per-call from the
-            # setup modal; empty/0 = one single call, capped at MAX_PODCAST_BATCH
-            # (#634). Spreading the words over the material's topics only works
-            # if one call sees them all, so one call stays the default — but
-            # past ~20 words the model starts dropping rules, hence the ceiling.
-            chunk_size = (batch_size if batch_size and batch_size > 0
-                          else min(len(cards), ai.MAX_PODCAST_BATCH))
-            chunks = [cards[i:i + chunk_size] for i in range(0, len(cards), chunk_size)]
+            # setup modal; empty/0 = one call per source, capped at
+            # MAX_PODCAST_BATCH (#634). Spreading a source's words over its
+            # own material's topics only works if one call sees them all, so
+            # one call per source stays the default — but past ~20 words the
+            # model starts dropping rules, hence the ceiling.
+            per_source_chunks: list[list[list]] = []
+            for group in word_groups:
+                if not group:
+                    per_source_chunks.append([])
+                    continue
+                chunk_size = (batch_size if batch_size and batch_size > 0
+                              else min(len(group), ai.MAX_PODCAST_BATCH))
+                per_source_chunks.append(
+                    [group[i:i + chunk_size] for i in range(0, len(group), chunk_size)])
+            total_calls = sum(len(c) for c in per_source_chunks)
+
             sentences = []
             chunk_prompts = []
-            for idx, chunk in enumerate(chunks):
-                label = f" ({idx + 1}/{len(chunks)})" if len(chunks) > 1 else ""
-                chunk_sentences, chunk_prompt = ai.generate_podcast_sentences(
-                    chunk, sources,
-                    model=model, max_hsk=max_hsk, progress_key=progress_key,
-                    attempt_label=label)
-                sentences.extend(chunk_sentences)
-                if chunk_prompt:
-                    chunk_prompts.append(
-                        f"══ chunk{label} ══\n{chunk_prompt}" if len(chunks) > 1 else chunk_prompt)
+            for s_idx, (source, chunks) in enumerate(zip(sources, per_source_chunks)):
+                for c_idx, chunk in enumerate(chunks):
+                    if n_sources > 1:
+                        label = f" (素材 {s_idx + 1}/{n_sources}"
+                        if len(chunks) > 1:
+                            label += f" · {c_idx + 1}/{len(chunks)}"
+                        label += ")"
+                    elif len(chunks) > 1:
+                        label = f" ({c_idx + 1}/{len(chunks)})"
+                    else:
+                        label = ""
+                    chunk_sentences, chunk_prompt = ai.generate_podcast_sentences(
+                        chunk, source,
+                        model=model, max_hsk=max_hsk, progress_key=progress_key,
+                        attempt_label=label)
+                    sentences.extend(chunk_sentences)
+                    if chunk_prompt and total_calls > 1:
+                        heading = f"══ 素材 {s_idx + 1}/{n_sources}《{source.get('title') or '（无标题）'}》"
+                        if len(chunks) > 1:
+                            heading += f" · {c_idx + 1}/{len(chunks)}"
+                        heading += " ══"
+                        chunk_prompts.append(f"{heading}\n{chunk_prompt}")
+                    elif chunk_prompt:
+                        chunk_prompts.append(chunk_prompt)
             # #697: this used to store a placeholder string, so knowledge stories —
             # the mode being actively tuned — were the one mode whose prompt you
             # couldn't go back and read.
@@ -634,41 +669,45 @@ def generate_sentence_for_word(card: dict, gen_params: dict | None) -> dict | No
                     sentences, _ = ai.generate_story([card], model=model, lang=lang)
             elif mode in ("knowledge", "podcast"):
                 # Knowledge Again-regen (issue #561, renamed from "podcast" in
-                # #654; multi-source since #752): same lean pipeline, one card
-                # + the selected item(s)' material, honoring the story's stored
-                # user-picked model (old stories stored gpt-5.1, which is not
-                # whitelisted, so _validated_model falls back). mode="podcast"
-                # here means a *historical* story (new stories are generated
-                # with mode="knowledge" — #654 rejects "podcast" at generation
+                # #654): same lean pipeline, one card + one source's material,
+                # honoring the story's stored user-picked model (old stories
+                # stored gpt-5.1, which is not whitelisted, so
+                # _validated_model falls back). mode="podcast" here means a
+                # *historical* story (new stories are generated with
+                # mode="knowledge" — #654 rejects "podcast" at generation
                 # time, but old stories must keep regenerating). Material is
                 # transcript_zh with a summary_de fallback (issue #661, see
                 # _knowledge_material()); no material at all → plain sentence.
                 #
                 # There is no reliable way to know which single source (of the
-                # story's several) this particular card's earlier sentence
-                # came from, so every stored source is offered again and the
-                # model picks — same as the main multi-source generation path.
+                # story's several, #752) this particular card's earlier
+                # sentence came from, and since #776 removed the mechanism
+                # that let a call juggle several sources at once, this is a
+                # deliberate simplification rather than "let the model pick":
+                # just use the first stored source that still has material.
+                # Which exact source narrates one regenerated sentence barely
+                # matters — what matters is that the style/material stays
+                # consistent with the rest of the story.
                 episode_ids = gp.get("episode_ids") or ([gp["episode_id"]] if gp.get("episode_id") else [])
-                episodes = [database.get_episode(eid) for eid in episode_ids]
-                episodes = [ep for ep in episodes if ep]
-                sources: list[dict] = []
-                if episodes:
-                    per_source_limit = _KNOWLEDGE_MATERIAL_MAX_CHARS // len(episodes)
-                    for ep in episodes:
-                        material = _knowledge_material(ep, limit=per_source_limit)
-                        if not material:
-                            continue
-                        ep_kind = ep.get("kind") or "podcast"
-                        sources.append({
-                            "index": len(sources) + 1,
-                            "title": ep.get("title") or "",
-                            "kind": ep_kind,
-                            "url": ep.get("youtube_url") or f"/#{ep_kind}-{ep['id']}",
-                            "material": material,
-                        })
-                if sources:
+                source = None
+                for eid in episode_ids:
+                    ep = database.get_episode(eid)
+                    if not ep:
+                        continue
+                    material = _knowledge_material(ep)
+                    if not material:
+                        continue
+                    ep_kind = ep.get("kind") or "podcast"
+                    source = {
+                        "title": ep.get("title") or "",
+                        "kind": ep_kind,
+                        "url": ep.get("youtube_url") or f"/#{ep_kind}-{ep['id']}",
+                        "material": material,
+                    }
+                    break
+                if source:
                     sentences, _ = ai.generate_podcast_sentences(
-                        [card], sources,
+                        [card], source,
                         model=_validated_model(gp.get("model"), default=ai.DEFAULT_MODEL),
                         max_hsk=gp.get("max_hsk", 3))
                 else:

--- a/static/index.html
+++ b/static/index.html
@@ -772,7 +772,7 @@
       </select>
       <label class="edit-label" style="margin:0">Items</label>
       <div style="font-size:12px;color:var(--muted,#888);margin:2px 0 6px">
-        Pick one or more summarized items — the sentences will be spread across them (no context sentences).
+        Pick one or more summarized items — one AI call per item, due words split evenly, item by item (no context sentences).
       </div>
       <select class="edit-input" id="setup-podcast-feed" style="margin-bottom:6px"></select>
       <!-- Selected-items chip list (issue #752 multi-select) — hidden when empty -->

--- a/tests/test_knowledge_multi_source.py
+++ b/tests/test_knowledge_multi_source.py
@@ -1,13 +1,18 @@
-"""知识库故事模式的多素材生成（issue #752）：一次生成混合多个知识库素材
-（播客/视频/文章），到期词分散到几份材料上。
+"""知识库故事模式的多素材生成（issue #776，取代 #752 的混合生成方式）：选中
+多份素材（播客/视频/文章）时，到期词表在素材之间平均切分，每份素材各自发起
+一次独立的 AI 调用，句子按素材顺序拼接——读起来是"先讲完第一份素材，
+再讲第二份"，而不是像 #752 那样在同一次调用里让模型交替引用多份素材。
 
 覆盖：
-- routes.story._parse_episode_ids 的输入解析
-- 多素材时材料预算按素材数量均分，且 ai.generate_podcast_sentences 收到的
-  sources[] 结构正确（title/kind/url/material/index）
-- ai.generate_podcast_sentences 按模型返回的 source_index 回填每句的
-  source_url/source_title，越界/缺失时回退到第一个素材
-- 单素材路径下 {multi_source_block} 渲染为空，提示词与旧版逐字一致
+- routes.story._parse_episode_ids 的输入解析（不变）
+- 词表在素材间平均切分，余数分给靠前的素材
+- 调用次数等于有材料的素材数（batch_size 未设时）；每次调用只收到一个
+  source dict，且 material 是完整的 _KNOWLEDGE_MATERIAL_MAX_CHARS 预算
+  （不再像 #752 那样按素材数量均分）
+- 返回的句子顺序：素材 1 的词全部排在素材 2 之前
+- 没有材料的素材被跳过、未知 id 报错、全部为空报错
+- 单素材路径下提示词里不能出现任何 #752 遗留的多素材痕迹
+  （source_index / multi_source_block / "素材 N" 等）
 
 AI 一律打桩在 ai._call_api 上——打在某个提供商的客户端上会随默认模型变化而
 静默失效。隔离数据库只打 database.core.DB_PATH 这个补丁。
@@ -30,6 +35,12 @@ client = TestClient(main.app)
 
 ENTRY_你好 = {"type": "vocabulary", "simplified": "你好", "pinyin": "nǐ hǎo",
                "english": "hello", "pos": "intj", "hsk": "1"}
+
+# 16 个不同的词，供"词表平均切分"测试使用。
+_MANY_WORDS = [
+    "苹果", "香蕉", "橙子", "葡萄", "西瓜", "草莓", "桃子", "梨",
+    "柠檬", "樱桃", "芒果", "菠萝", "石榴", "椰子", "木瓜", "柿子",
+]
 
 
 def write_yaml(tmp_path, name, entries):
@@ -54,15 +65,27 @@ def populated_db(tmp_db, tmp_path):
     return next(d["id"] for d in database.get_all_decks() if d["name"] == "Kouyu")
 
 
-def _fake_podcast_sentences(cards, sources, **kwargs):
+@pytest.fixture
+def many_words_db(tmp_db, tmp_path):
+    entries = [
+        {"type": "vocabulary", "simplified": w, "pinyin": w, "english": w,
+         "pos": "n", "hsk": "1"}
+        for w in _MANY_WORDS
+    ]
+    write_yaml(tmp_path, "words.yaml", entries)
+    importer.import_all(str(tmp_path))
+    return next(d["id"] for d in database.get_all_decks() if d["name"] == "Kouyu")
+
+
+def _fake_podcast_sentences(cards, source, **kwargs):
     return [
         {"word_id": c["word_id"], "sentence_zh": f"{c['word_zh']}出现在这一集里。",
          "sentence_en": "", "target_word": c["word_zh"]}
         for c in cards
-    ], "假提示词"
+    ], f"假提示词：{source.get('title') if source else ''}"
 
 
-# ── _parse_episode_ids ───────────────────────────────────────────────────────
+# ── _parse_episode_ids（不变，仍是逗号串解析）───────────────────────────────
 
 def test_parse_episode_ids_comma_separated():
     assert story_routes._parse_episode_ids("12,34,56", None) == [12, 34, 56]
@@ -92,32 +115,30 @@ def test_parse_episode_ids_episode_ids_takes_priority_over_singular():
     assert story_routes._parse_episode_ids("1,2", 999) == [1, 2]
 
 
-# ── material budget split + sources[] structure ─────────────────────────────
+# ── 词表切分 + 每次调用只带一个 source ──────────────────────────────────────
 
-def test_multi_source_budget_split_evenly(populated_db):
-    """三个素材同时选中时，每份材料的预算是总预算的三分之一——不是三份各自
-    拿到全额（那会让总提示词随选择数量线性膨胀，撑爆上下文窗口）。"""
-    deck_id = populated_db
-    long_transcript_a = "甲" * 100
-    long_transcript_b = "乙" * 100
-    long_transcript_c = "丙" * 100
-    ids = []
-    for vid, transcript, title in [
-        ("m1", long_transcript_a, "素材甲"),
-        ("m2", long_transcript_b, "素材乙"),
-        ("m3", long_transcript_c, "素材丙"),
-    ]:
-        eid = database.create_pending_episode(
-            vid, "https://example.com/feed.xml", title, None,
-            f"https://example.com/{vid}", kind="podcast")
-        database.update_episode(eid, status="summarized", transcript_zh=transcript)
-        ids.append(eid)
+def _create_episode(vid, transcript, title, kind="podcast"):
+    eid = database.create_pending_episode(
+        vid, "https://example.com/feed.xml", title, None,
+        f"https://example.com/{vid}", kind=kind)
+    database.update_episode(eid, status="summarized", transcript_zh=transcript)
+    return eid
 
-    captured = {}
 
-    def _capturing(cards, sources, **kwargs):
-        captured["sources"] = sources
-        return _fake_podcast_sentences(cards, sources, **kwargs)
+def test_word_list_split_evenly_across_three_sources(many_words_db):
+    """16 词 / 3 素材 → 6/5/5（余数分给靠前的素材）。"""
+    deck_id = many_words_db
+    ids = [
+        _create_episode("m1", "甲" * 100, "素材甲"),
+        _create_episode("m2", "乙" * 100, "素材乙"),
+        _create_episode("m3", "丙" * 100, "素材丙"),
+    ]
+
+    calls = []
+
+    def _capturing(cards, source, **kwargs):
+        calls.append((source["title"], [c["word_zh"] for c in cards]))
+        return _fake_podcast_sentences(cards, source, **kwargs)
 
     with patch("ai.generate_podcast_sentences", side_effect=_capturing) as mock_gen:
         r = client.get(f"/api/story/{deck_id}/listening",
@@ -126,34 +147,83 @@ def test_multi_source_budget_split_evenly(populated_db):
 
     assert r.status_code == 200
     assert not r.json().get("error")
-    mock_gen.assert_called_once()
-
-    sources = captured["sources"]
-    assert len(sources) == 3
-    expected_limit = story_routes._KNOWLEDGE_MATERIAL_MAX_CHARS // 3
-    for s in sources:
-        assert len(s["material"]) <= expected_limit
-    # every material distinct — budget applied per-source, not shared/truncated
-    # to a single common slice
-    assert sources[0]["material"][0] == "甲"
-    assert sources[1]["material"][0] == "乙"
-    assert sources[2]["material"][0] == "丙"
-    # index is 1-based and matches submission order
-    assert [s["index"] for s in sources] == [1, 2, 3]
-    assert [s["title"] for s in sources] == ["素材甲", "素材乙", "素材丙"]
-    assert all(s["kind"] == "podcast" for s in sources)
+    assert mock_gen.call_count == 3   # one call per source, not one call total
+    sizes = [len(words) for _, words in calls]
+    assert sizes == [6, 5, 5]
 
     story = database.get_active_story(database.anki_today().isoformat(), "listening", deck_id)
     gen_params = json.loads(story["gen_params"])
     assert gen_params["episode_ids"] == ids
-    assert gen_params["episode_id"] == ids[0]   # legacy singular key = first id
-    assert gen_params["kind"] == "mixed"        # #752: multiple sources → "mixed"
+    assert gen_params["kind"] == "mixed"   # multiple sources → "mixed"
 
 
-def test_multi_source_skips_items_without_material(populated_db):
+def test_each_call_gets_full_material_budget_not_divided(many_words_db):
+    """#752 曾把预算按素材数量均分；#776 每次调用只带一个素材，不再共享
+    上下文窗口，所以每份素材都拿到完整的 _KNOWLEDGE_MATERIAL_MAX_CHARS 预算。"""
+    deck_id = many_words_db
+    long_a = "甲" * (story_routes._KNOWLEDGE_MATERIAL_MAX_CHARS + 500)
+    long_b = "乙" * (story_routes._KNOWLEDGE_MATERIAL_MAX_CHARS + 500)
+    ids = [
+        _create_episode("m1", long_a, "素材甲"),
+        _create_episode("m2", long_b, "素材乙"),
+    ]
+
+    materials = []
+
+    def _capturing(cards, source, **kwargs):
+        materials.append(source["material"])
+        return _fake_podcast_sentences(cards, source, **kwargs)
+
+    with patch("ai.generate_podcast_sentences", side_effect=_capturing) as mock_gen:
+        r = client.get(f"/api/story/{deck_id}/listening",
+                       params={"mode": "knowledge",
+                               "episode_ids": ",".join(str(i) for i in ids)})
+
+    assert r.status_code == 200
+    assert not r.json().get("error")
+    assert mock_gen.call_count == 2
+    for m in materials:
+        assert len(m) == story_routes._KNOWLEDGE_MATERIAL_MAX_CHARS
+    assert materials[0][0] == "甲"
+    assert materials[1][0] == "乙"
+
+
+def test_sentence_order_follows_source_order(many_words_db):
+    """句子按素材顺序拼接：素材 1 的词全部排在素材 2 之前——这是本次改动
+    存在的全部理由（Daniel 不要交替讲两份素材）。不依赖词表本身的原始顺序，
+    直接记录每次 AI 调用实际收到的词，再核对最终句子顺序与之一致。"""
+    deck_id = many_words_db
+    ids = [
+        _create_episode("m1", "第一份素材正文。", "素材一"),
+        _create_episode("m2", "第二份素材正文。", "素材二"),
+    ]
+
+    calls = []
+
+    def _capturing(cards, source, **kwargs):
+        calls.append([c["word_zh"] for c in cards])
+        return _fake_podcast_sentences(cards, source, **kwargs)
+
+    with patch("ai.generate_podcast_sentences", side_effect=_capturing):
+        r = client.get(f"/api/story/{deck_id}/listening",
+                       params={"mode": "knowledge",
+                               "episode_ids": ",".join(str(i) for i in ids)})
+
+    assert r.status_code == 200
+    body = r.json()
+    assert not body.get("error")
+    assert len(calls) == 2
+    expected_order = calls[0] + calls[1]
+    actual_order = [s["sentence_zh"].split("出现在这一集里。")[0] for s in body["sentences"]]
+    assert actual_order == expected_order
+
+
+def test_multi_source_skips_items_without_material(many_words_db):
     """选了 3 个素材，其中 1 个还没有转录/摘要——生成不因此整体失败，
-    只是那一份被跳过（routes/story.py 的 knowledge 分支约定，见施工图）。"""
-    deck_id = populated_db
+    只是那一份被跳过，也就不会发起对应的 AI 调用。用多词的 fixture，
+    确保每份有材料的素材都能分到至少一个词（避免因词数太少、词表被
+    切分成空组而巧合地只调用一次）。"""
+    deck_id = many_words_db
     eid_ok1 = database.create_pending_episode(
         "s1", "https://example.com/feed.xml", "有内容 1", None,
         "https://example.com/s1", kind="podcast")
@@ -169,11 +239,11 @@ def test_multi_source_skips_items_without_material(populated_db):
         "https://example.com/s3", kind="video")
     database.update_episode(eid_ok2, status="summarized", transcript_zh="正文二。")
 
-    captured = {}
+    calls = []
 
-    def _capturing(cards, sources, **kwargs):
-        captured["sources"] = sources
-        return _fake_podcast_sentences(cards, sources, **kwargs)
+    def _capturing(cards, source, **kwargs):
+        calls.append(source["title"])
+        return _fake_podcast_sentences(cards, source, **kwargs)
 
     with patch("ai.generate_podcast_sentences", side_effect=_capturing) as mock_gen:
         r = client.get(f"/api/story/{deck_id}/listening",
@@ -182,10 +252,8 @@ def test_multi_source_skips_items_without_material(populated_db):
 
     assert r.status_code == 200
     assert not r.json().get("error")
-    mock_gen.assert_called_once()
-    sources = captured["sources"]
-    assert len(sources) == 2
-    assert [s["title"] for s in sources] == ["有内容 1", "有内容 2"]
+    assert mock_gen.call_count == 2
+    assert calls == ["有内容 1", "有内容 2"]
 
 
 def test_knowledge_mode_requires_at_least_one_item(populated_db):
@@ -207,16 +275,11 @@ def test_knowledge_mode_unknown_id_raises(populated_db):
     assert "999999" in body["reason"]
 
 
-# ── ai.generate_podcast_sentences: source_index attribution ────────────────
+# ── 单素材路径：提示词里不能有任何 #752 遗留的多素材痕迹 ─────────────────────
 
 CARDS = [
     {"word_id": 1, "word_zh": "承认", "pinyin": "chéngrèn", "definition": "admit"},
     {"word_id": 2, "word_zh": "顺便", "pinyin": "shùnbiàn", "definition": "by the way"},
-]
-
-SOURCES_2 = [
-    {"index": 1, "title": "素材一", "kind": "podcast", "url": "https://a.example/1", "material": "第一份素材正文。"},
-    {"index": 2, "title": "素材二", "kind": "video", "url": "https://b.example/2", "material": "第二份素材正文。"},
 ]
 
 
@@ -224,56 +287,8 @@ def _reply(items):
     return json.dumps(items, ensure_ascii=False)
 
 
-def test_source_index_attributes_sentence_to_right_source(monkeypatch):
-    monkeypatch.setattr(ai, "_call_api", lambda *a, **kw: _reply([
-        {"sentence_zh": "张一鸣承认公司暂时落后。", "source_index": 2},
-        {"sentence_zh": "他顺便去买了咖啡。", "source_index": 1},
-    ]))
-    sentences, _ = ai.generate_podcast_sentences(CARDS, SOURCES_2)
-
-    by_word = {s["word_ids"][0]: s for s in sentences}
-    assert by_word[1]["source_url"] == "https://b.example/2"
-    assert by_word[1]["source_title"] == "素材二"
-    assert by_word[2]["source_url"] == "https://a.example/1"
-    assert by_word[2]["source_title"] == "素材一"
-
-
-def test_source_index_out_of_range_falls_back_to_first_source(monkeypatch):
-    monkeypatch.setattr(ai, "_call_api", lambda *a, **kw: _reply([
-        {"sentence_zh": "张一鸣承认公司暂时落后。", "source_index": 99},
-        {"sentence_zh": "他顺便去买了咖啡。"},   # missing entirely
-    ]))
-    sentences, _ = ai.generate_podcast_sentences(CARDS, SOURCES_2)
-
-    for s in sentences:
-        assert s["source_url"] == "https://a.example/1"
-        assert s["source_title"] == "素材一"
-
-
-def test_multi_source_prompt_lists_sources_with_numbered_titles(monkeypatch):
-    sent = []
-
-    def fake_call(model, messages, *a, **kw):
-        sent.append(messages[0]["content"])
-        return _reply([{"sentence_zh": "张一鸣承认公司暂时落后。", "source_index": 1},
-                       {"sentence_zh": "他顺便去买了咖啡。", "source_index": 2}])
-
-    monkeypatch.setattr(ai, "_call_api", fake_call)
-    ai.generate_podcast_sentences(CARDS, SOURCES_2)
-
-    prompt = sent[0]
-    assert "1. 《素材一》（podcast）" in prompt
-    assert "2. 《素材二》（video）" in prompt
-    assert "第一份素材正文。" in prompt
-    assert "第二份素材正文。" in prompt
-    assert "source_index" in prompt   # multi_source_block instructs the model
-
-
-# ── single-source path: {multi_source_block} renders empty (逐字不变) ───────
-
-def test_single_source_prompt_has_no_multi_source_block(monkeypatch):
-    """单素材时提示词里不能出现 #752 新增的多素材说明，否则说明单素材路径
-    被这次改动动过了——Daniel 正在调这份提示词，单素材必须逐字不变。"""
+def test_single_source_prompt_has_no_multi_source_traces(monkeypatch):
+    """提示词必须逐字回到 #752 之前的样子——Daniel 正在调这份提示词。"""
     sent = []
 
     def fake_call(model, messages, *a, **kw):
@@ -282,11 +297,12 @@ def test_single_source_prompt_has_no_multi_source_block(monkeypatch):
                        {"sentence_zh": "他顺便去买了咖啡。"}])
 
     monkeypatch.setattr(ai, "_call_api", fake_call)
-    single_source = [{"index": 1, "title": "标题", "kind": "podcast",
-                       "url": None, "material": "Zusammenfassung"}]
-    ai.generate_podcast_sentences(CARDS, single_source)
+    source = {"title": "标题", "kind": "podcast", "url": None, "material": "Zusammenfassung"}
+    ai.generate_podcast_sentences(CARDS, source)
 
     prompt = sent[0]
     assert "{multi_source_block}" not in prompt
     assert "多份素材" not in prompt
     assert "source_index" not in prompt
+    assert "素材 2" not in prompt
+    assert "素材甲" not in prompt

--- a/tests/test_knowledge_story_mode.py
+++ b/tests/test_knowledge_story_mode.py
@@ -46,11 +46,10 @@ def populated_db(tmp_db, tmp_path):
     return next(d["id"] for d in database.get_all_decks() if d["name"] == "Kouyu")
 
 
-def _fake_podcast_sentences(cards, sources, **kwargs):
+def _fake_podcast_sentences(cards, source, **kwargs):
     # (sentences, prompt) since #697 — the route stores the prompt on the story.
-    # #752: signature is now (cards, sources, ...) — sources[0]["title"] stands
-    # in for the old bare `title` param since every test here uses one source.
-    title = sources[0]["title"] if sources else ""
+    # #776: signature is (cards, source, ...) — one dict, not a list.
+    title = source.get("title") if source else ""
     return [
         {"word_id": c["word_id"], "sentence_zh": f"{c['word_zh']}出现在这一集里。",
          "sentence_en": "", "target_word": c["word_zh"]}
@@ -192,9 +191,9 @@ def test_knowledge_mode_story_generation_uses_transcript(populated_db):
 
     seen_material = {}
 
-    def _capturing(cards, sources, **kwargs):
-        seen_material["value"] = sources[0]["material"] if sources else ""
-        return _fake_podcast_sentences(cards, sources, **kwargs)
+    def _capturing(cards, source, **kwargs):
+        seen_material["value"] = source.get("material") if source else ""
+        return _fake_podcast_sentences(cards, source, **kwargs)
 
     with patch("ai.generate_podcast_sentences", side_effect=_capturing) as mock_gen:
         r = client.get(f"/api/story/{deck_id}/listening",
@@ -218,9 +217,9 @@ def test_knowledge_mode_story_generation_falls_back_without_transcript(populated
 
     seen_material = {}
 
-    def _capturing(cards, sources, **kwargs):
-        seen_material["value"] = sources[0]["material"] if sources else ""
-        return _fake_podcast_sentences(cards, sources, **kwargs)
+    def _capturing(cards, source, **kwargs):
+        seen_material["value"] = source.get("material") if source else ""
+        return _fake_podcast_sentences(cards, source, **kwargs)
 
     with patch("ai.generate_podcast_sentences", side_effect=_capturing) as mock_gen:
         r = client.get(f"/api/story/{deck_id}/listening",

--- a/tests/test_podcast_sentences.py
+++ b/tests/test_podcast_sentences.py
@@ -16,10 +16,9 @@ CARDS = [
 
 
 def _sources(material, title="标题"):
-    """#752: generate_podcast_sentences now takes a list of source dicts
-    instead of a bare (material, title) pair — this builds a single-source
-    list, which is what most of these tests exercise."""
-    return [{"index": 1, "title": title, "kind": "podcast", "url": None, "material": material}]
+    """#776: generate_podcast_sentences takes a single source dict (one AI
+    call = one source; routes/story.py loops over sources itself)."""
+    return {"title": title, "kind": "podcast", "url": None, "material": material}
 
 
 def _reply(items):
@@ -135,12 +134,12 @@ def test_prompt_includes_every_retry_round(monkeypatch):
 
 
 def test_no_material_returns_empty_prompt(monkeypatch):
-    """没有素材（#752 起：没有任何可用素材源）时不调 AI，也就没有提示词可存。
+    """没有素材（没有可用的 source dict）时不调 AI，也就没有提示词可存。
     caller（routes/story.py）在真正调用前就已经把无素材的条目过滤掉了，所以
-    这里模拟"过滤后什么都不剩"的情形：sources=[]。"""
+    这里模拟"过滤后什么都不剩"的情形：source={}。"""
     monkeypatch.setattr(ai, "_call_api",
                         lambda *a, **kw: pytest.fail("素材为空时不该调 AI"))
-    sentences, prompt = ai.generate_podcast_sentences(CARDS, [])
+    sentences, prompt = ai.generate_podcast_sentences(CARDS, {})
     assert sentences == [] and prompt == ""
 
 

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -75,7 +75,6 @@ def test_knowledge_template_keeps_json_example_braces():
     rendered = ai._render_prompt(ai.DEFAULT_PROMPT_TEMPLATES["knowledge"], {
         "title": "T", "summary": "S", "words": "1. 蘑菇（mógū）— mushroom",
         "max_hsk": "3", "extra_hint": "",
-        "multi_source_block": "",  # #752: new placeholder, empty in the single-source case
     })
     # JSON 示例的花括号必须原样保留（替换只针对已知记号）。断言写在结构上而不是
     # 示例的逐字文本上——提示词本身会被反复调（#737/#741），逐字断言只会逼着


### PR DESCRIPTION
## 为什么

#752 让 knowledge 模式支持多选素材，但实现是把所有素材塞进**同一次** AI 调用，靠模型返回 `source_index` 自己分配句子来源。Daniel 用下来不满意——内容互相混杂，他要的是「先讲完第一个素材，再讲第二个」。

## 改了什么

- **词表按素材数平均切分**：余数分给靠前的素材（16 词 / 3 素材 → 6/5/5）
- **每个素材一次独立 AI 调用**，只带它自己的材料；句子按素材顺序拼接成一个故事
- **每次调用恢复完整 15000 字预算**——#752 的均分不再需要，因为一次调用只有一份材料
- `batch_size` 仍然生效，在**每份词表内部**再分块；进度标签形如 `(素材 2/3 · 1/2)`
- `prompt_text` 多次调用时按素材加抬头（`══ 素材 2/3《标题》 ══`），单次调用时和以前一样直接存原文（#697）

## 删掉的死代码

因为一次调用永远只有一个素材，#752 那套机制全部移除：`{multi_source_block}` 模板占位符与 `PROMPT_TEMPLATE_VARIABLES` 条目、`_source_for()` 与 `source_index` 解析/越界回退、`_knowledge_material()` 的 `limit` 参数。

**提示词因此逐字回到 #752 之前的版本**（脚本对比 `84f1f7f~1` 的模板确认 IDENTICAL）——Daniel 正在调这份提示词。

## Again 单句重生成

函数签名拿不到「这张卡原来出自哪份素材」，改为用第一个仍有材料的素材，注释写明这是刻意简化：哪份素材讲这一句不重要，重要的是材料/风格一致。

## 不变

前端多选与 `episode_ids` 传参格式、`gen_params` 双写 `episode_id`/`episode_ids`、`kind='mixed'`、无材料素材跳过、全空报错。只改了设置弹窗的一行说明文字。

## 测试

`pytest tests/` → **613 passed, 4 skipped**。`tests/test_knowledge_multi_source.py` 重写：验证切分比例、调用次数=有材料素材数、每次调用只收到一个 source 且拿到完整预算、句子顺序按素材、以及单素材提示词零多素材痕迹。

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)