### PR TITLE
词典页加 ↻ Repeat 按钮：原样重查并覆盖历史记录（#777）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -615,6 +615,7 @@ Daniel 长期把 DeepSeek 聊天当中文词典用，再手工把结果复制进
 - **提示词移植自 `de-zh-bot` 技能**（`ai.DICTIONARY_PROMPT`）：中文输入**直接给全部义项、不给选择**；德/英输入一律先分析 + `a/b/c` 选项（**不用数字**）+ 明确推荐、**倾向口语**（Daniel 反复强调的偏好）；整句先整句翻译再逐词拆解，每个成分单独可加词；解释语言德语，单词可附法语
 - **加词仍走 `/api/add-word-ai`**（`shared.js` 的 `addWordViaAi()`）：`★` 之后照常花 30 秒生成完整词条（例句/汉字分解/量词/同义反义词齐全）。词典**不得**成为第二条加词管线（#643），哪怕它手里已经有译文——省下的那一次调用换来的是内容简陋、与其它词条不一致的条目
 - **解析失败不写库**：`ai.dictionary_lookup()` 解析不出 JSON 或缺 `groups`/`zh` 就抛 `ValueError` → 500 带原始回复前 500 字。空壳词典条目比报错更糟
+- **↻ Repeat 按钮（#777）**：结果标题行右侧，用**同样的 query 原样再问一次**（AI 有随机性，多半会换个说法）。`POST /api/dict/lookup` 的可选 `replace_id` 让这次结果 **UPDATE 覆盖那一行**而不是新增 —— 重查的语义是"刚才那个答案不好"，不是"两个都留着"。三条规矩：① `replace_id` 指向不存在的行 → 404，绝不静默降级成新增；② 解析失败（`ValueError`）时什么都不写，**旧的好答案原样保留** —— 一次失败的重试不能毁掉它本想改进的东西；③ 覆盖时 `query`/`lang` 不动，只换答案，`created_at` 刷新（历史仍按"最后回答时间"排序）。从历史里点开的旧记录同样能 Repeat
 - **`dict_queries.headline` 是反范式的一列**：历史列表不该为了显示一行标题去解析 50 份 `result_json`
 - **`lang` 目前只支持 `zh`**，传别的值返回 400——拿中文提示词去答法语请求会静默生成一个**看起来合理但错误**的词条（同 #726 在加词侧的教训）
 - **页面不加载 `app.js`**（同 `/add` #668、`/save` #681）；`?q=` 打开即查询，随后 `history.replaceState` 抹掉参数——否则刷新或 iOS 恢复标签页会静默再花一次 AI 钱（#686 踩过）
@@ -701,8 +702,9 @@ GET  /save                                           → 独立素材收藏页�
 
 # AI 词典（#746，详见「AI 词典页」节）
 GET    /dict[?q=anordnen]                            → 独立词典页（不加载 app.js）；带 q 时打开即查询并抹掉参数
-POST   /api/dict/lookup                              → body {query, lang?='zh', model?} → {id, created_at, query, result}
+POST   /api/dict/lookup                              → body {query, lang?='zh', model?, replace_id?} → {id, created_at, query, result}
                                                        同步约 5–15 秒；query 空 / lang 非 zh / AI 关闭 → 400；解析失败 → 500 且**不写库**
+                                                       replace_id（#777，Repeat 按钮）→ 覆盖该行而非新增；行不存在 → 404；失败时旧答案不动
 GET    /api/dict/history[?q=&limit=]                 → 历史列表（不含 result_json；q 对 query/headline 做 LIKE）
 GET    /api/dict/history/{id} ；DELETE /api/dict/history/{id}  → 单条 / 删除；不存在均 404（不假装成功）
 POST /api/add-word-ai                                → 界面内添加生词（#627）；body {word_zh, day?:today|tomorrow|list, lang?:zh|fr}（#636、#677；#715 起界面一律传 list，接口三值仍有效；lang 见 #726，已存在的词按 entries.lang 落点、不听该参数）；新词返回 {job_id}，已有词直接返回 {status}。**全应用唯一的加词入口**（#643）：顶栏 ＋、播客生词表格、复习界面长按菜单都走它

--- a/database/dictionary.py
+++ b/database/dictionary.py
@@ -28,6 +28,33 @@ def save_dict_query(
     return new_id
 
 
+def update_dict_query(
+    qid: int,
+    input_lang: str | None,
+    kind: str | None,
+    headline: str | None,
+    result_json: str,
+    model: str | None,
+) -> bool:
+    """Overwrite one stored lookup in place (#777's Repeat button) and return
+    whether the row existed. `query`/`lang` are deliberately not touched — a
+    repeat re-asks the *same* question, so only the answer may change.
+    created_at is refreshed so the history list still sorts by "last answered".
+    """
+    conn = get_db()
+    cur = conn.execute(
+        """UPDATE dict_queries
+           SET input_lang = ?, kind = ?, headline = ?, result_json = ?, model = ?,
+               created_at = datetime('now','localtime')
+           WHERE id = ?""",
+        (input_lang, kind, headline, result_json, model, qid),
+    )
+    conn.commit()
+    updated = cur.rowcount > 0
+    conn.close()
+    return updated
+
+
 def get_dict_query(qid: int) -> dict | None:
     """Full row for one lookup, including the raw result_json string — the
     caller (routes/dictionary.py) is responsible for json.loads-ing it."""

--- a/routes/dictionary.py
+++ b/routes/dictionary.py
@@ -23,6 +23,10 @@ class DictLookupRequest(BaseModel):
     query: str
     lang: str = "zh"
     model: str | None = None
+    # Repeat button (#777): ask the same question again and overwrite this
+    # stored row instead of adding a second one. Daniel wants only the latest
+    # answer in the history — a repeat means "that one was bad", not "keep both".
+    replace_id: int | None = None
 
 
 def _row_to_result(row: dict) -> dict:
@@ -48,24 +52,34 @@ def lookup(body: DictLookupRequest):
     if body.lang != "zh":
         raise HTTPException(400, f"language {body.lang!r} is not supported yet (only 'zh')")
 
+    # Check the target exists *before* spending 5–15s and a paid AI call on a
+    # repeat that could never be stored.
+    if body.replace_id is not None and database.get_dict_query(body.replace_id) is None:
+        raise HTTPException(404, "not found")
+
     try:
         result, model_used = ai.dictionary_lookup(query, lang=body.lang, model=body.model)
     except ValueError as e:
+        # Nothing is written on a parse failure — for a repeat that also means
+        # the previous (good) answer stays untouched: a bad retry must never
+        # destroy what it was meant to improve.
         logger.error("dict lookup failed for %r: %s", query, e)
         raise HTTPException(500, str(e))
 
-    headline = result.get("headline") or None
-    new_id = database.save_dict_query(
-        query=query,
-        lang=body.lang,
+    fields = dict(
         input_lang=result.get("input_lang"),
         kind=result.get("kind"),
-        headline=headline,
+        headline=result.get("headline") or None,
         result_json=json.dumps(result, ensure_ascii=False),
         model=model_used,
     )
-    row = database.get_dict_query(new_id)
-    return _row_to_result(row)
+    if body.replace_id is not None:
+        if not database.update_dict_query(body.replace_id, **fields):
+            raise HTTPException(404, "not found")
+        row_id = body.replace_id
+    else:
+        row_id = database.save_dict_query(query=query, lang=body.lang, **fields)
+    return _row_to_result(database.get_dict_query(row_id))
 
 
 @router.get("/api/dict/history")

--- a/static/dict.html
+++ b/static/dict.html
@@ -52,6 +52,14 @@
   #result { margin-top: 1.1rem; }
   #result:empty { display: none; }
   .headline-row { display: flex; align-items: baseline; gap: .6rem; flex-wrap: wrap; }
+  button.repeat {
+    margin-left: auto; align-self: center; flex-shrink: 0;
+    padding: .3rem .6rem; font: inherit; font-size: .82rem;
+    color: var(--muted); background: var(--card);
+    border: 1px solid var(--line); border-radius: 8px; cursor: pointer;
+  }
+  button.repeat:hover:not(:disabled) { background: var(--line); color: var(--fg); }
+  button.repeat:disabled { opacity: .5; cursor: default; }
   .headline { font-size: 1.6rem; font-weight: 700; }
   .headline-pinyin { color: var(--muted); font-size: 1rem; }
   .headline-de { color: var(--fg); opacity: .8; margin-top: .15rem; }
@@ -254,6 +262,16 @@
     const hrow = textEl('div', 'headline-row');
     hrow.append(textEl('span', 'headline', r.headline || record.query));
     if (r.headline_pinyin) hrow.append(textEl('span', 'headline-pinyin', r.headline_pinyin));
+    // Repeat (#777): ask the exact same question again when the answer was
+    // poor. The query box is empty by now (cleared on success) and a pasted
+    // German sentence is painful to retype — the record still knows it.
+    const repeat = document.createElement('button');
+    repeat.className = 'repeat';
+    repeat.type = 'button';
+    repeat.textContent = '↻ Repeat';
+    repeat.title = 'Ask again — this stored answer is replaced';
+    repeat.onclick = () => lookup(record.query, record.id);
+    hrow.append(repeat);
     head.append(hrow);
     if (r.headline_de) head.append(textEl('div', 'headline-de', r.headline_de));
     if (r.notes) head.append(textEl('div', 'notes', r.notes));
@@ -326,13 +344,19 @@
   }
 
   // ---- Lookup ----
-  async function lookup(q) {
+  // replaceId (#777, optional): overwrite that stored lookup instead of adding
+  // a new history row — a repeat means "that answer was bad", not "keep both".
+  async function lookup(q, replaceId) {
     if (!q) return;
     goBtn.disabled = true;
     queryEl.disabled = true;
-    setStatus('Looking up… (5–15s)');
+    const repeatBtns = resultEl.querySelectorAll('button.repeat');
+    repeatBtns.forEach(b => { b.disabled = true; });
+    setStatus(replaceId ? 'Asking again… (5–15s)' : 'Looking up… (5–15s)');
     try {
-      const record = await api('POST', '/api/dict/lookup', { query: q, lang: 'zh' });
+      const body = { query: q, lang: 'zh' };
+      if (replaceId) body.replace_id = replaceId;
+      const record = await api('POST', '/api/dict/lookup', body);
       setStatus('');
       // Cleared only on success: a failed lookup (AI hiccup, bad JSON) is worth
       // retrying verbatim, and retyping a pasted German sentence is painful.
@@ -341,6 +365,9 @@
       loadHistory(histSearch.value.trim());
     } catch (e) {
       setStatus(e.message || 'Lookup failed', true);
+      // The old result is still on screen and still stored — a failed repeat
+      // must leave its Repeat button usable rather than stranding the answer.
+      repeatBtns.forEach(b => { b.disabled = false; });
     } finally {
       goBtn.disabled = false;
       queryEl.disabled = false;

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -129,6 +129,52 @@ def test_delete_missing_history_item_is_404(tmp_db):
     assert client.delete("/api/dict/history/999").status_code == 404
 
 
+# ---------------------------------------------------------------------------
+# Repeat button (#777): replace_id
+# ---------------------------------------------------------------------------
+
+def test_repeat_overwrites_the_same_row(tmp_db):
+    with patch.object(ai, "_call_api", return_value=_stub_response()):
+        first = client.post("/api/dict/lookup", json={"query": "anordnen"}).json()
+
+    better = dict(GOOD_RESULT, headline="安排")
+    with patch.object(ai, "_call_api", return_value=_stub_response(better)):
+        again = client.post(
+            "/api/dict/lookup", json={"query": "anordnen", "replace_id": first["id"]}
+        )
+    assert again.status_code == 200, again.text
+    assert again.json()["id"] == first["id"]
+    assert again.json()["result"]["headline"] == "安排"
+
+    # One row, not two — the history keeps only the latest answer.
+    items = client.get("/api/dict/history").json()["items"]
+    assert len(items) == 1
+    assert items[0]["headline"] == "安排"
+
+
+def test_repeat_on_missing_row_is_404_and_creates_nothing(tmp_db):
+    """A stale id must not silently degrade into a fresh lookup."""
+    with patch.object(ai, "_call_api", return_value=_stub_response()):
+        r = client.post("/api/dict/lookup", json={"query": "test", "replace_id": 999})
+    assert r.status_code == 404
+    assert client.get("/api/dict/history").json()["items"] == []
+
+
+def test_failed_repeat_leaves_the_previous_answer_intact(tmp_db):
+    """A bad retry must never destroy the answer it was meant to improve."""
+    with patch.object(ai, "_call_api", return_value=_stub_response()):
+        first = client.post("/api/dict/lookup", json={"query": "anordnen"}).json()
+
+    with patch.object(ai, "_call_api", return_value="Sorry, I cannot help with that."):
+        r = client.post(
+            "/api/dict/lookup", json={"query": "anordnen", "replace_id": first["id"]}
+        )
+    assert r.status_code == 500
+
+    stored = client.get(f"/api/dict/history/{first['id']}").json()
+    assert stored["result"] == GOOD_RESULT
+
+
 def test_empty_query_is_rejected(tmp_db):
     assert client.post("/api/dict/lookup", json={"query": "   "}).status_code == 400
 


### PR DESCRIPTION
Closes #777

## 改了什么

`/dict` 结果标题行右侧加 **↻ Repeat**：用**同样的 query** 再问一次 AI，结果替换当前显示。AI 有随机性，多半会给出不同版本。

## 为什么

现在答得不好的唯一补救是把原词重新打进输入框——而输入框成功后已被清空，粘贴过的德语长句要重打。

## 关键决定

- **覆盖，不新增**（Daniel 2026-08-16 决定）：`replace_id` → UPDATE 那一行，历史里只留最新答案。重查的语义是「刚才那个不好」，不是「两个都留着」
- **`replace_id` 无效 → 404**，绝不静默降级成新增；而且**在调 AI 之前**就检查，免得为一次注定存不下的重查白花 5–15 秒 + 一次付费调用
- **解析失败什么都不写**（沿用 #746 的规矩），对覆盖同样成立：**旧的好答案原样保留**——一次失败的重试不能毁掉它本想改进的东西
- 覆盖只换答案，`query`/`lang` 不动；`created_at` 刷新，历史仍按「最后回答时间」排序
- 从历史里点开的旧记录同样能 Repeat

## 测试

`pytest tests/test_dictionary.py` → 17 passed（新增 3 条：覆盖同一行、无效 id 404 且不建行、失败重查不动旧答案）

🤖 Generated with [Claude Code](https://claude.com/claude-code)