### PR TITLE
feat: Reel 摘要顺带生成有意义的标题，替换 "Video by 作者"（#781）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -3027,9 +3027,15 @@ Task:
 3. Extract the 20-35 most important Chinese words/phrases from the transcript that are HSK
    level 5 or above (i.e. non-basic vocabulary Daniel would benefit from pre-learning). For
    each, give pinyin and a German definition.
+4. Suggest a short German title that summarizes what this episode is actually ABOUT (the
+   people, event or argument involved) — like a real article headline, not a generic label.
+   Maximum 10 words. Do NOT write anything generic like "Video von X", "Reel von X" or
+   "Zusammenfassung" — those carry zero information about the content. No quotes, no
+   trailing period.
 
 Return ONLY a JSON object, no other text, no markdown fences:
 {{
+  "title_suggestion": "<kurzer deutscher Titel, max. 10 Wörter>",
   "summary_de": "<German HTML summary: <p> paragraphs, each starting with a <b> lead sentence, <strong> highlights>",
   "summary_zh": "<德语总结的完整中文翻译：同样的 <p> 段落，每段首句用 <b> 包住，HSK 4-5 水平的简单中文>",
   "words": [
@@ -3044,14 +3050,19 @@ def parse_podcast_summary_json(raw: str) -> dict:
     markers like "[1]" before parsing — harmless no-op for plain API
     responses, which never contain them.
 
-    Returns {"summary_zh": str, "summary_de": str, "words": [...]}; summary_de
-    is "" and words is [] on any parse failure (mirrors the previous inline
+    Returns {"summary_zh": str, "summary_de": str, "words": [...], "title_suggestion": str};
+    summary_de is "" and words is [] on any parse failure (mirrors the previous inline
     behavior in summarize_podcast_transcript).
 
     summary_zh (#631) is a bonus, not a requirement: an older model reply — or
     one that simply omitted the field — still yields a perfectly usable German
     summary, so callers gate success on summary_de alone and treat an empty
     summary_zh as "no Chinese intro this time".
+
+    title_suggestion (#781) is the same kind of bonus: NotebookLM's chat.ask path
+    and older prompt versions never produced it, so it defaults to "" on omission.
+    Callers must keep gating success on summary_de alone — a missing title
+    suggestion must never fail an otherwise-good summary.
     """
     raw = re.sub(r"\[\d+\]", "", raw)
     start, end = raw.find("{"), raw.rfind("}") + 1
@@ -3072,7 +3083,9 @@ def parse_podcast_summary_json(raw: str) -> dict:
             "definition_de": (w.get("definition_de") or "").strip(),
             "hsk": w.get("hsk") if isinstance(w.get("hsk"), int) else 5,
         })
-    return {"summary_zh": summary_zh, "summary_de": summary_de, "words": words}
+    title_suggestion = (data.get("title_suggestion") or "").strip()
+    return {"summary_zh": summary_zh, "summary_de": summary_de, "words": words,
+            "title_suggestion": title_suggestion}
 
 
 def summarize_podcast_transcript(transcript: str, title: str,

--- a/podcast.py
+++ b/podcast.py
@@ -1447,6 +1447,37 @@ def _annotate_summary(result: dict) -> dict:
     return result
 
 
+_PLACEHOLDER_TITLE_RE = re.compile(r"^(video|reel|post|photo|clip)\s+by\s+\S", re.IGNORECASE)
+_SHORTCODE_TITLE_RE = re.compile(r"^[A-Za-z0-9_-]{8,20}$")
+
+
+def _is_placeholder_title(title: str) -> bool:
+    """True if `title` looks like an auto-generated non-title rather than
+    real content (#781) — the only gate that decides whether the AI's
+    title_suggestion is allowed to overwrite an episode's stored title.
+
+    Instagram Reel/Post metadata (knowledge/instagram.py) almost always
+    yields "Video by <uploader>" as yt-dlp's `title` field — informative
+    about who posted it, not what it's about, so every Reel ends up with
+    the same handful of indistinguishable list entries. Bare Instagram
+    shortcodes show up too when even that fallback is missing.
+
+    This must be conservative: a false positive here would let an AI
+    guess silently overwrite a perfectly good real title (a podcast/
+    YouTube/article title fetched from RSS/oEmbed/trafilatura) — false
+    negatives just mean a placeholder title survives one summary cycle,
+    which is harmless (it can still be fixed via regenerate_summary).
+    """
+    title = (title or "").strip()
+    if not title or title.lower() == "(untitled)":
+        return True
+    if _PLACEHOLDER_TITLE_RE.match(title):
+        return True
+    if " " not in title and _SHORTCODE_TITLE_RE.match(title):
+        return True
+    return False
+
+
 def filter_new_words(words: list[dict]) -> list[dict]:
     """Drop words the AI picked that are already in entries.word_zh — Daniel
     already has those in his SRS deck, no need to flag them again."""
@@ -1993,9 +2024,12 @@ def _process_episode(episode_id: int, video: dict, detail_level: str, summary: d
                 return
 
             words = filter_new_words(result.get("words") or [])
+            # find_spotify_url intentionally keeps using the OLD title, even
+            # when it's about to be replaced below — Reels never need a
+            # Spotify search link, and podcasts/YouTube never have a
+            # placeholder title in the first place, so this never matters.
             spotify_url = find_spotify_url(video["title"])
-            database.update_episode(
-                episode_id,
+            update_fields = dict(
                 summary_zh=result.get("summary_zh") or "",
                 summary_de=result["summary_de"],
                 hsk_words=words,
@@ -2003,6 +2037,24 @@ def _process_episode(episode_id: int, video: dict, detail_level: str, summary: d
                 spotify_url=spotify_url,
                 status="summarized",
             )
+            title_suggestion = (result.get("title_suggestion") or "").strip()
+            if title_suggestion and _is_placeholder_title(video["title"]):
+                update_fields["title"] = title_suggestion
+                try:
+                    title_en = ai.translate_title(title_suggestion)
+                except Exception as e:
+                    # translate_title already swallows its own errors and
+                    # returns None — this is just an extra safety net so a
+                    # totally unexpected exception here can't fail the whole
+                    # episode over a nice-to-have English title.
+                    logger.warning("podcast: translate_title failed for %r: %s",
+                                    title_suggestion, e)
+                    title_en = None
+                if title_en:
+                    update_fields["title_en"] = title_en
+                logger.info("podcast: replaced placeholder title %r -> %r for %s",
+                            video["title"], title_suggestion, video["video_id"])
+            database.update_episode(episode_id, **update_fields)
             summary["summarized"] += 1
 
             episode = database.get_episode(episode_id)
@@ -2070,13 +2122,29 @@ def regenerate_summary(episode_id: int) -> dict:
         return {"regenerated": False, "error": "AI summary failed or empty"}
 
     words = filter_new_words(result.get("words") or [])
-    database.update_episode(
-        episode_id,
+    update_fields = dict(
         summary_zh=result.get("summary_zh") or "",
         summary_de=result["summary_de"],
         hsk_words=words,
         detail_level=detail_level,
     )
+    # Same placeholder-title gate as _process_episode (#781) — this is the
+    # only path that can retroactively fix the existing backlog of Reels
+    # stuck with "Video by <uploader>" titles, since it's the one Daniel can
+    # trigger by hand from the detail page's "Regenerate summary" button.
+    title_suggestion = (result.get("title_suggestion") or "").strip()
+    if title_suggestion and _is_placeholder_title(episode["title"]):
+        update_fields["title"] = title_suggestion
+        try:
+            title_en = ai.translate_title(title_suggestion)
+        except Exception as e:
+            logger.warning("podcast: translate_title failed for %r: %s", title_suggestion, e)
+            title_en = None
+        if title_en:
+            update_fields["title_en"] = title_en
+        logger.info("podcast: replaced placeholder title %r -> %r for episode %s",
+                    episode["title"], title_suggestion, episode_id)
+    database.update_episode(episode_id, **update_fields)
     logger.info("podcast: summary regenerated for episode %s (%d word(s))", episode_id, len(words))
     return {"regenerated": True, "error": None}
 

--- a/tests/test_podcast.py
+++ b/tests/test_podcast.py
@@ -255,3 +255,109 @@ def test_parse_summary_json_failure_still_has_chinese_key():
     assert out["summary_zh"] == ""
     assert out["summary_de"] == ""
     assert out["words"] == []
+
+
+# ---------------------------------------------------------------------------
+# Reel title suggestion (#781): AI-suggested titles may only overwrite a
+# placeholder title (Instagram's "Video by <uploader>" / bare shortcode),
+# never a real podcast/YouTube/article title.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_summary_json_reads_title_suggestion():
+    raw = ('{"summary_de": "<p>Text</p>", "words": [], '
+           '"title_suggestion": "Warum die Zinsen steigen"}')
+    out = ai.parse_podcast_summary_json(raw)
+    assert out["title_suggestion"] == "Warum die Zinsen steigen"
+
+
+def test_parse_summary_json_tolerates_missing_title_suggestion():
+    """title_suggestion is a bonus like summary_zh — an older model reply
+    without it must not fail the summary."""
+    out = ai.parse_podcast_summary_json('{"summary_de": "<p>Text</p>", "words": []}')
+    assert out["title_suggestion"] == ""
+
+
+import pytest
+
+
+@pytest.mark.parametrize("title,expected", [
+    ("Video by thefreepress", True),
+    ("video by thefreepress", True),
+    ("Reel by some.account", True),
+    ("Post by another_user", True),
+    ("", True),
+    ("   ", True),
+    ("(untitled)", True),
+    ("(Untitled)", True),
+    ("DM4x_kLpQ2b", True),          # bare Instagram shortcode
+    ("abcDEF123", True),           # shortcode-shaped, no spaces
+    ("Warum die Zinsen steigen", False),
+    ("第 12 集：人工智能与就业", False),
+    ("How AI Changed My Job Search", False),
+    ("Video killed the radio star", False),  # "Video" but not "Video by ..."
+])
+def test_is_placeholder_title(title, expected):
+    assert podcast._is_placeholder_title(title) is expected
+
+
+def _summary_result(title_suggestion="Warum die Zinsen steigen"):
+    return {
+        "summary_zh": "简短总结。",
+        "summary_de": "<p><b>Text</b></p>",
+        "words": [],
+        "title_suggestion": title_suggestion,
+    }
+
+
+def test_regenerate_summary_replaces_placeholder_title(monkeypatch):
+    """Reel stuck with 'Video by thefreepress' gets the AI's real title on
+    regenerate_summary — the only path Daniel can trigger by hand to fix the
+    existing backlog (#781)."""
+    episode = {
+        "id": 42,
+        "title": "Video by thefreepress",
+        "transcript_zh": "一些转录文本" * 20,
+        "china_critical": False,
+    }
+    monkeypatch.setattr(database, "get_episode", lambda eid: episode)
+    monkeypatch.setattr(database, "get_podcast_config", lambda: {"detail_level": "detailed"})
+    monkeypatch.setattr(podcast, "summarize", lambda *a, **kw: _summary_result())
+    monkeypatch.setattr(podcast, "filter_new_words", lambda words: words)
+    monkeypatch.setattr(ai, "translate_title", lambda t: "Why Interest Rates Are Rising")
+
+    captured = {}
+    def fake_update_episode(eid, **fields):
+        captured.update(fields)
+    monkeypatch.setattr(database, "update_episode", fake_update_episode)
+
+    result = podcast.regenerate_summary(42)
+    assert result["regenerated"] is True
+    assert captured["title"] == "Warum die Zinsen steigen"
+    assert captured["title_en"] == "Why Interest Rates Are Rising"
+
+
+def test_regenerate_summary_keeps_real_title(monkeypatch):
+    """A real podcast title must never be overwritten by the AI's guess,
+    even if a title_suggestion comes back (#781's whole point)."""
+    episode = {
+        "id": 7,
+        "title": "第 12 集：人工智能与就业",
+        "transcript_zh": "一些转录文本" * 20,
+        "china_critical": False,
+    }
+    monkeypatch.setattr(database, "get_episode", lambda eid: episode)
+    monkeypatch.setattr(database, "get_podcast_config", lambda: {"detail_level": "detailed"})
+    monkeypatch.setattr(podcast, "summarize", lambda *a, **kw: _summary_result())
+    monkeypatch.setattr(podcast, "filter_new_words", lambda words: words)
+    monkeypatch.setattr(ai, "translate_title", lambda t: "should not be called")
+
+    captured = {}
+    def fake_update_episode(eid, **fields):
+        captured.update(fields)
+    monkeypatch.setattr(database, "update_episode", fake_update_episode)
+
+    result = podcast.regenerate_summary(7)
+    assert result["regenerated"] is True
+    assert "title" not in captured
+    assert "title_en" not in captured


### PR DESCRIPTION
Closes #781

## 问题
Instagram Reel 的标题取自 yt-dlp 元数据，Instagram 的 `title` 字段几乎总是 `Video by <作者>`，知识页 Reels 标签下五条素材全叫这个，看不出内容。

## 改动
- `ai.build_podcast_summary_prompt`：加 Task 4，要求返回 `title_suggestion`（德语、≤10 词、像真正的文章标题，明确禁止 "Video von …"/"Zusammenfassung"）
- `ai.parse_podcast_summary_json`：解析该字段；**缺失是正常状态**（NotebookLM 路径和旧提示词都不返回），成功判定仍只看 `summary_de`
- `podcast._is_placeholder_title()`：唯一的替换闸门，判定 `Video/Reel/Post/Photo/Clip by …`、纯短码、空/`(untitled)`。刻意保守——误判会毁掉播客/文章的真标题，漏判只是占位标题多活一轮
- `_process_episode` 与 `regenerate_summary` 两处接同一道闸门；`title_en` 走 `ai.translate_title`，best-effort

已有的 5 条 Reel：详情页点 **Regenerate summary** 即可拿到新标题。

## 测试
`pytest tests/` → 634 passed, 4 skipped（新增 7 个测试：解析、占位判定参数化、以及 regenerate_summary 保留真标题 / 替换占位标题两个集成向测试）