### PR TITLE
fix: Reel 自动标题改用中文（#786）

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -3027,15 +3027,16 @@ Task:
 3. Extract the 20-35 most important Chinese words/phrases from the transcript that are HSK
    level 5 or above (i.e. non-basic vocabulary Daniel would benefit from pre-learning). For
    each, give pinyin and a German definition.
-4. Suggest a short German title that summarizes what this episode is actually ABOUT (the
+4. Suggest a short CHINESE title that summarizes what this episode is actually ABOUT (the
    people, event or argument involved) — like a real article headline, not a generic label.
-   Maximum 10 words. Do NOT write anything generic like "Video von X", "Reel von X" or
-   "Zusammenfassung" — those carry zero information about the content. No quotes, no
-   trailing period.
+   Maximum 15 characters, written at HSK 4-5 level like summary_zh, since this is the title
+   Daniel reads in the list. Do NOT write anything generic like "某人的视频", "Reel 总结" or
+   "内容总结" — those carry zero information about the content. No quotes, no punctuation
+   at the end.
 
 Return ONLY a JSON object, no other text, no markdown fences:
 {{
-  "title_suggestion": "<kurzer deutscher Titel, max. 10 Wörter>",
+  "title_suggestion": "<简短中文标题，最多 15 字，HSK 4-5 水平>",
   "summary_de": "<German HTML summary: <p> paragraphs, each starting with a <b> lead sentence, <strong> highlights>",
   "summary_zh": "<德语总结的完整中文翻译：同样的 <p> 段落，每段首句用 <b> 包住，HSK 4-5 水平的简单中文>",
   "words": [

--- a/tests/test_podcast.py
+++ b/tests/test_podcast.py
@@ -266,9 +266,9 @@ def test_parse_summary_json_failure_still_has_chinese_key():
 
 def test_parse_summary_json_reads_title_suggestion():
     raw = ('{"summary_de": "<p>Text</p>", "words": [], '
-           '"title_suggestion": "Warum die Zinsen steigen"}')
+           '"title_suggestion": "为什么利率会上升"}')
     out = ai.parse_podcast_summary_json(raw)
-    assert out["title_suggestion"] == "Warum die Zinsen steigen"
+    assert out["title_suggestion"] == "为什么利率会上升"
 
 
 def test_parse_summary_json_tolerates_missing_title_suggestion():
@@ -292,7 +292,7 @@ import pytest
     ("(Untitled)", True),
     ("DM4x_kLpQ2b", True),          # bare Instagram shortcode
     ("abcDEF123", True),           # shortcode-shaped, no spaces
-    ("Warum die Zinsen steigen", False),
+    ("为什么利率会上升", False),
     ("第 12 集：人工智能与就业", False),
     ("How AI Changed My Job Search", False),
     ("Video killed the radio star", False),  # "Video" but not "Video by ..."
@@ -301,7 +301,7 @@ def test_is_placeholder_title(title, expected):
     assert podcast._is_placeholder_title(title) is expected
 
 
-def _summary_result(title_suggestion="Warum die Zinsen steigen"):
+def _summary_result(title_suggestion="为什么利率会上升"):
     return {
         "summary_zh": "简短总结。",
         "summary_de": "<p><b>Text</b></p>",
@@ -333,7 +333,7 @@ def test_regenerate_summary_replaces_placeholder_title(monkeypatch):
 
     result = podcast.regenerate_summary(42)
     assert result["regenerated"] is True
-    assert captured["title"] == "Warum die Zinsen steigen"
+    assert captured["title"] == "为什么利率会上升"
     assert captured["title_en"] == "Why Interest Rates Are Rising"
 
 


### PR DESCRIPTION
Closes #786

#781 把 `title_suggestion` 定成了德语，Daniel 要中文。

- `ai.build_podcast_summary_prompt` 的 Task 4：改为中文标题，≤15 字、HSK 4-5 水平（这是他在列表上读的东西，和 `summary_zh` 同性质），禁止 "某人的视频"/"内容总结" 这类无信息标题
- JSON 契约示例同步
- `_is_placeholder_title` 闸门、`title_en` 的 `translate_title` 调用均不变
- 测试桩数据改成中文标题

`pytest tests/test_podcast.py` → 38 passed