### PR TITLE
加词弹窗加 Shift+A 快捷键（#788）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -10421,6 +10421,17 @@ document.addEventListener('keydown', async e => {
     return;
   }
 
+  // Shift+A opens (or closes) the add-word modal (#788)
+  if (e.key === 'A' && e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
+    if (!inInput) {
+      e.preventDefault();
+      const modal = document.getElementById('add-word-modal');
+      if (modal && modal.style.display !== 'none') closeAddWordModal();
+      else openAddWordModal();
+    }
+    return;
+  }
+
   // Shift+S toggles the FSRS scheduler inspector
   if (e.key === 'S' && e.shiftKey && !e.ctrlKey && !e.metaKey) {
     if (!inInput) { e.preventDefault(); toggleFsrsInspector(); }

--- a/static/index.html
+++ b/static/index.html
@@ -57,7 +57,7 @@
   <div class="header-right">
     <!-- Local instance only — injected visible by _renderOfflineBanner() (#625) -->
     <button id="sync-btn" onclick="openSyncPopup()" title="Sync with the server" style="display:none">⟳</button>
-    <button id="add-word-btn" onclick="openAddWordModal()" title="Add a new word to today's deck">＋</button>
+    <button id="add-word-btn" onclick="openAddWordModal()" title="Add a new word to today's deck (Shift+A)">＋</button>
     <a id="dict-link-btn" href="/dict" title="Dictionary lookup">📖</a>
     <button id="random-words-btn" onclick="openRandomWords()" title="10 random words for today">🎲</button>
     <button id="header-regen-btn" onclick="regenerateStory()" title="Regenerate story" style="display:none">↺</button>


### PR DESCRIPTION
## 改了什么
- `static/app.js`：全局 keydown 加 Shift+A 分支 → 打开/关闭加词弹窗
- `static/index.html`：顶栏 ＋ 按钮 title 标注快捷键

## 为什么
复习时加词只能用鼠标点顶栏 ＋，打断节奏。

## 怎么测试
主页按 Shift+A → 加词弹窗打开、输入框自动聚焦。在任意输入框内按 Shift+A 不触发。

Closes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)