### PR TITLE
fix: 知识库卡片来源链接指向站内摘要页（#790）

### DIFF
--- a/routes/story.py
+++ b/routes/story.py
@@ -442,7 +442,14 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
                 sources.append({
                     "title": episode.get("title") or "",
                     "kind": ep_kind,
-                    "url": episode.get("youtube_url") or f"/#{ep_kind}-{eid}",
+                    # #790: always the in-app knowledge detail page, never the
+                    # external video/article URL — the detail page carries the
+                    # summary, bilingual transcript and new-word table, and has
+                    # its own "Open ↗" button to the original. Hash shape must
+                    # match the frontend router (app.js): podcasts keep the
+                    # legacy #podcast-<id>, everything else is #knowledge-<id>
+                    # (the old f"/#{ep_kind}-…" produced dead #video-<id> links).
+                    "url": f"/#{'podcast' if ep_kind == 'podcast' else 'knowledge'}-{eid}",
                     "material": material,
                 })
             if not sources:


### PR DESCRIPTION
Closes #790

## 改了什么

`routes/story.py` 里 knowledge 模式 source dict 的 `url`：

```diff
-"url": episode.get("youtube_url") or f"/#{ep_kind}-{eid}",
+"url": f"/#{'podcast' if ep_kind == 'podcast' else 'knowledge'}-{eid}",
```

## 为什么

1. 复习卡片上的来源行（`Video by explained.by.vara ↗`）直接跳外部视频，绕过了我们自己的详情页——那一页有摘要、双语对照转录、生词表格，而且已经有 `Open ↗` 按钮再跳原视频
2. 兜底分支的 hash 格式是错的：`kind='video'` 生成 `/#video-<id>`，前端路由（`app.js:3691`）认的是 `#knowledge-<id>`，只有 podcast 保留旧的 `#podcast-<id>`

历史故事已存的 `story_sentences.source_url` 不迁移。

## 测试

`pytest tests/` → 636 passed, 4 skipped