### PR TITLE
修复：刷新回到主页而不是知识库页面（#792）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -815,6 +815,14 @@ function _triggerClapAnimation() {
 
 function showView(name) {
   _currentView = name;
+  // Back on the deck list: drop any #knowledge-* deep-link hash still sitting in
+  // the address bar (#792). The boot logic reopens whatever the hash points at,
+  // so leaving it there made every later reload land on the knowledge view
+  // instead of the home screen. Direct links and staying on a knowledge tab are
+  // unaffected — this only fires once the user is back home.
+  if (name === 'decks' && location.hash) {
+    history.replaceState(null, '', location.pathname + location.search);
+  }
   if (name === 'done' && _sessionReviewedCount > 0) _triggerClapAnimation();
   // Leaving the knowledge view (#502, generalized #653): stop the episode-list
   // "processing" poll loop — it has no reason to keep firing once the view


### PR DESCRIPTION
## 改了什么

`static/app.js` 的 `showView()`：当切回 `decks`（主页牌组列表）且地址栏还有 hash 时，用 `history.replaceState` 把 hash 去掉。

## 为什么

知识库的条目页和标签页会把 `#knowledge-…` 写进地址栏（#480/#704），但没有任何代码清除它。返回主页后 hash 仍在，于是启动逻辑（app.js 约 11078 行）在每次刷新时都重新打开知识库页面——Daniel 报告"每次刷新都跳到那个页面，我想到主页"。

## 怎么测试

1. 进知识库 → 点某条目 → 返回主页 → 地址栏无 `#knowledge-…`，刷新停在主页 ✅
2. 直接打开 `…/#knowledge-123` → 仍直接进该条目 ✅
3. 停在知识库标签页刷新 → 仍留在该标签页（#704 不变）✅
4. `node --check static/app.js` 通过

Closes #792