### PR TITLE
fix: 刷新永远回到主页（#792 根治）

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -815,14 +815,6 @@ function _triggerClapAnimation() {
 
 function showView(name) {
   _currentView = name;
-  // Back on the deck list: drop any #knowledge-* deep-link hash still sitting in
-  // the address bar (#792). The boot logic reopens whatever the hash points at,
-  // so leaving it there made every later reload land on the knowledge view
-  // instead of the home screen. Direct links and staying on a knowledge tab are
-  // unaffected — this only fires once the user is back home.
-  if (name === 'decks' && location.hash) {
-    history.replaceState(null, '', location.pathname + location.search);
-  }
   if (name === 'done' && _sessionReviewedCount > 0) _triggerClapAnimation();
   // Leaving the knowledge view (#502, generalized #653): stop the episode-list
   // "processing" poll loop — it has no reason to keep firing once the view
@@ -3251,7 +3243,6 @@ async function _fetchKnowledgeList(tab) {
 
 async function openKnowledge(tab) {
   if (tab) { _knowledgeTab = tab; localStorage.setItem('knowledgeTab', tab); }
-  location.hash = `knowledge-${_knowledgeTab}`;
   _clearPodcastPoll();
   _podcastCurrentFeedId = null;
   setLoading('Loading…');
@@ -3263,7 +3254,6 @@ async function openKnowledge(tab) {
 async function switchKnowledgeTab(tab) {
   _knowledgeTab = tab;
   localStorage.setItem('knowledgeTab', tab);
-  location.hash = `knowledge-${tab}`;
   await _loadKnowledgeTab();
 }
 
@@ -3400,7 +3390,6 @@ async function _savePodcastDetailLevel(value) {
 // Layer 2 (podcast tab only): one feed's episode list ---------------------------
 
 async function openPodcastFeed(feedId) {
-  location.hash = `knowledge-feed-${feedId}`;
   _clearPodcastPoll();
   _podcastCurrentFeedId = feedId;
   _knowledgeListKind = null;
@@ -3693,10 +3682,6 @@ async function openKnowledgeItem(id) {
   setLoading('Loading…');
   try {
     const ep = await api('GET', `/api/podcast/episodes/${id}`);
-    // Old podcast notification emails/Signal messages link to #podcast-<id> —
-    // keep that hash for podcast items; video/article items (which never went
-    // out in a pre-#653 notification) get the new #knowledge-<id> form.
-    location.hash = (ep.kind && ep.kind !== 'podcast') ? `knowledge-${id}` : `podcast-${id}`;
     _clearPodcastPoll();
     showView('knowledge');
     _renderKnowledgeDetail(ep);
@@ -3916,9 +3901,8 @@ function _openKnowledgeFromHash() {
   const m = /^#(?:podcast|knowledge)-(\d+)$/.exec(location.hash);
   if (m) { openKnowledgeItem(parseInt(m[1])); return; }
   // Tab link (#704): #knowledge-video etc. — the letters-only form, which the
-  // digits-only patterns above can never match. This is what /knowledge/videos
-  // redirects to, and also what the tab bar writes into the address bar, so
-  // reloading a bookmarked tab stays on that tab.
+  // digits-only patterns above can never match. This is what the server's
+  // /knowledge/videos redirect lands on; nothing in the frontend writes it.
   const tabMatch = /^#knowledge-(podcast|video|reel|article)$/.exec(location.hash);
   if (tabMatch) openKnowledge(tabMatch[1]);
 }
@@ -11087,6 +11071,11 @@ if (/^#(?:podcast|knowledge)-feed-\d+$/.test(location.hash)
     || /^#(?:podcast|knowledge)-\d+$/.test(location.hash)
     || /^#knowledge-(?:podcast|video|reel|article)$/.test(location.hash)) {
   _openKnowledgeFromHash();
+  // Consume the hash: a direct link is a one-shot instruction to open one
+  // thing, not a sticky location. Leaving it in the address bar made every
+  // later reload land back in the knowledge base instead of the home screen
+  // (#792) — the whole reason nothing in the app writes a hash any more.
+  history.replaceState(null, '', location.pathname + location.search);
 } else {
   loadDecks();
 }

--- a/tests/test_knowledge_tab_link.py
+++ b/tests/test_knowledge_tab_link.py
@@ -81,9 +81,26 @@ def test_tab_hash_is_matched_by_exactly_one_pattern():
         assert len([p for p in HASH_PATTERNS if p.match(legacy)]) == 1, legacy
 
 
-def test_tab_switch_writes_the_tab_into_the_hash():
-    """A bare "#knowledge" is recognized by nothing, so reloading such a URL
-    used to drop back to the deck list. The tab bar must write the full form."""
-    assert "location.hash = 'knowledge';" not in APP_JS
-    assert APP_JS.count("location.hash = `knowledge-${tab}`;") == 1
-    assert APP_JS.count("location.hash = `knowledge-${_knowledgeTab}`;") == 1
+def test_nothing_in_the_app_writes_a_hash():
+    """#792 reversed the #704 contract. The tab bar used to write the tab into
+    the address bar so a reload stayed put — but that is exactly what made
+    *every* later reload land in the knowledge base instead of the home screen,
+    since the hash outlived the visit. Navigation inside the app now leaves the
+    address bar alone; the sub-tab is remembered in localStorage instead, and
+    the bookmarkable entry points (/knowledge/videos, notification links) are
+    server-generated, so they do not depend on the frontend writing anything."""
+    assert "location.hash =" not in APP_JS
+
+
+def test_boot_consumes_the_hash_so_later_reloads_go_home():
+    """A direct link is a one-shot instruction to open one item, not a sticky
+    location: after acting on it the boot code must clear it, otherwise the
+    next reload reopens the same thing instead of the deck list (#792)."""
+    boot = APP_JS[APP_JS.index("// \u2500\u2500 Boot"):]
+    boot = boot[:boot.index("_loadVersionBadge();")]
+    assert "_openKnowledgeFromHash();" in boot
+    # The clear has to sit in the branch that consumed the hash, before the
+    # else-branch that just loads the decks.
+    assert "history.replaceState(null, '', location.pathname + location.search);" in boot
+    assert boot.index("_openKnowledgeFromHash();") < boot.index("history.replaceState")
+    assert boot.index("history.replaceState") < boot.index("loadDecks();")


### PR DESCRIPTION
## 问题
今天早上的 #793 只在「回到牌组列表」时清 hash —— 但如果你**一直待在知识库页面刷新**，hash 从没被清过，启动逻辑照着它又把知识库打开了。这正是 Daniel 每次刷新遇到的情况，所以 bug 依旧。

## 根因
站内导航把当前位置写进了地址栏：`openKnowledge`、`switchKnowledgeTab`、`openPodcastFeed`、`openKnowledgeItem` 四处 `location.hash = ...`。于是 hash 的寿命超过了这次访问，变成了一条**粘性的启动指令**。

## 改动
**前端不再写任何 hash。**

- 子标签本来就存在 `localStorage('knowledgeTab')`，标签栏不写 URL 什么也没损失
- 可收藏的入口全是**服务端**生成的，不受影响：`/knowledge/videos` 由 `main.py` 303 跳到 `/#knowledge-video`，通知链接由 `podcast.py` 拼成 `{base}/#podcast-{id}`
- 启动逻辑照旧响应这些 hash，但**响应完立即清除** —— 直链是「打开某一项」的一次性指令，不是一个要反复返回的位置。所以在它之后的每一次刷新都回主页

顺带删掉 #793 那段已成死代码的兜底。

## 验证
- 全套测试 **637 passed**
- 独立端口实测四个书签入口重定向正常：`/knowledge/{videos,reels,articles,podcasts}` → 303 → 对应 hash
- `test_knowledge_tab_link.py` 里断言旧 #704 契约（标签栏必须写 hash）的那个用例，正是本 issue 要推翻的契约 —— 已替换为继任断言（前端不写 hash + 启动消费后清除），不是删掉了事

🤖 Generated with [Claude Code](https://claude.com/claude-code)