### PR TITLE
Rebind add-word shortcut to Cmd+A

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -10413,8 +10413,10 @@ document.addEventListener('keydown', async e => {
     return;
   }
 
-  // Shift+A opens (or closes) the add-word modal (#788)
-  if (e.key === 'A' && e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
+  // Cmd+A (Ctrl+A on Windows/Linux) opens (or closes) the add-word modal (#788).
+  // Use e.code, not e.key: with Cmd held macOS may report a different e.key.
+  // Inside inputs we let the browser's select-all through untouched.
+  if (e.code === 'KeyA' && (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey) {
     if (!inInput) {
       e.preventDefault();
       const modal = document.getElementById('add-word-modal');

--- a/static/index.html
+++ b/static/index.html
@@ -57,7 +57,7 @@
   <div class="header-right">
     <!-- Local instance only — injected visible by _renderOfflineBanner() (#625) -->
     <button id="sync-btn" onclick="openSyncPopup()" title="Sync with the server" style="display:none">⟳</button>
-    <button id="add-word-btn" onclick="openAddWordModal()" title="Add a new word to today's deck (Shift+A)">＋</button>
+    <button id="add-word-btn" onclick="openAddWordModal()" title="Add a new word to today's deck (⌘A)">＋</button>
     <a id="dict-link-btn" href="/dict" title="Dictionary lookup">📖</a>
     <button id="random-words-btn" onclick="openRandomWords()" title="10 random words for today">🎲</button>
     <button id="header-regen-btn" onclick="regenerateStory()" title="Regenerate story" style="display:none">↺</button>


### PR DESCRIPTION
把「加入卡片」（header ＋ 按钮 → add-word modal）的快捷键从 `Shift+A` 改为 `Cmd+A`（Windows/Linux 为 `Ctrl+A`）。

- `static/app.js`: 用 `e.code === 'KeyA' && (e.metaKey || e.ctrlKey)` 判定；仍保留 `!inInput` 守卫，输入框内不拦截，浏览器原生「全选」照常工作。
- `static/index.html`: ＋ 按钮的 tooltip 改为 `⌘A`。

不影响故事弹窗里的 `A`（上一句）和全局的 `A`（YAML 快速建卡）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)