### PR TITLE
Close the add-word modal with Esc

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -10373,6 +10373,14 @@ document.addEventListener('keydown', async e => {
       closeLogsViewer();
       return;
     }
+    // Esc closes the add-word modal (its input has focus, so this must come
+    // before the blur branch below). Running jobs keep going server-side.
+    const addWordModal = document.getElementById('add-word-modal');
+    if (addWordModal && addWordModal.style.display !== 'none') {
+      e.preventDefault();
+      closeAddWordModal();
+      return;
+    }
     // Blur input fields in review view so space bar can flip the card
     if (inInput) {
       const reviewView = document.getElementById('view-review');


### PR DESCRIPTION
加词弹窗（⌘A 打开）现在可以用 Esc 关闭，和故事弹窗、日志弹窗等保持一致。

分支插在 review-view 的 blur 分支之前——弹窗打开时输入框有焦点，否则 Esc 只会失焦而不关窗。关窗不影响后台正在跑的造词任务。

🤖 Generated with [Claude Code](https://claude.com/claude-code)