### PR TITLE
fix: card header rows clipped + larger source line

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -411,6 +411,7 @@ main.browse-open {
   display: flex;
   align-items: center;
   min-height: 14px;
+  flex-shrink: 0;
 }
 .card-meta-row > #review-cat-row {
   flex: 0;
@@ -426,6 +427,11 @@ main.browse-open {
   display: flex;
   align-items: center;
   gap: 4px;
+  /* The card is a height-constrained flex column on desktop; without this the
+     row gets squeezed and its overflow:hidden clips the text (issue: clipped
+     "Sentence x / y" header). */
+  flex-shrink: 0;
+  line-height: 1.5;
   font-size: 11px;
   font-weight: 600;
   color: var(--muted);
@@ -475,6 +481,8 @@ main.browse-open {
 #card-timer.card-timer-capped { color: #b45309; opacity: 1; }
 .card-deck-path {
   width: 100%;
+  flex-shrink: 0;
+  line-height: 1.5;
   font-size: 11px;
   font-weight: 500;
   color: var(--muted);
@@ -1803,7 +1811,7 @@ main.browse-open {
   margin: 4px 12px 0;
 }
 .news-source-line {
-  font-size: 11px;
+  font-size: 14px;
   color: var(--muted);
   text-decoration: none;
   opacity: 0.85;


### PR DESCRIPTION
## 问题
1. 复习卡片顶部的牌组面包屑（`All › daily › …`）和 `Sentence x / y · …` 行文字被上下裁切。
2. 新闻/知识来源行（标题 · 来源 ↗）字号太小。

## 原因
桌面三栏布局下 `.review-center-tile .review-card` 是 `height: 100%` 的 flex 列。内容超出高度时，flex 会压缩每一个子项；这两行都设了 `overflow: hidden`，被压缩后文字就被切掉了。

## 修复
- 给 `.card-deck-path`、`#story-info-row`、`.card-meta-row` 加 `flex-shrink: 0`，并补上 `line-height: 1.5`。
- `.news-source-line` 字号 11px → 14px。

纯 CSS 改动，无逻辑变化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)