### PR TITLE
修复：Saved 牌组进垃圾桶后所有加词返回 500 (#801)

### DIFF
--- a/database/decks.py
+++ b/database/decks.py
@@ -223,13 +223,27 @@ def purge_old_trash(days: int = 30) -> int:
 
 def get_or_create_deck(name: str, parent_id: int | None = None,
                        category: str | None = None, lang: str | None = None) -> int:
-    """Get deck id by (name, parent_id), creating it if it doesn't exist."""
+    """Get deck id by (name, parent_id), creating it if it doesn't exist.
+
+    A soft-deleted deck with the same (name, parent_id) is revived rather than
+    duplicated (issue #801): UNIQUE(name, parent_id) does not include
+    `deleted_at`, so inserting alongside a trashed twin raises IntegrityError.
+    That is how trashing the 'Saved' deck made every add-word request return
+    500. Only the deck row comes back — its cards keep whatever `deleted_at`
+    they have, since trashing a deck and emptying it are separate actions.
+    """
     conn = get_db()
     row = conn.execute(
-        "SELECT id FROM decks WHERE name = ? AND parent_id IS ? AND deleted_at IS NULL",
+        "SELECT id, deleted_at FROM decks WHERE name = ? AND parent_id IS ?",
         (name, parent_id),
     ).fetchone()
     if row:
+        if row["deleted_at"] is not None:
+            conn.execute("UPDATE decks SET deleted_at = NULL WHERE id = ?", (row["id"],))
+            conn.commit()
+            conn.close()
+            _invalidate_locked_deck_cache()
+            return row["id"]
         conn.close()
         return row["id"]
     preset_id = _ensure_default_preset(conn)

--- a/tests/test_add_word.py
+++ b/tests/test_add_word.py
@@ -442,6 +442,62 @@ def test_listing_an_already_listed_word_is_reported_as_such(tmp_db):
     assert body["status"] == "already_listed"
 
 
+def test_trashed_saved_deck_is_revived_instead_of_breaking_add_word(tmp_db):
+    """Trashing the 'Saved' deck used to 500 every add-word request (#801).
+
+    UNIQUE(name, parent_id) ignores `deleted_at`, so get_or_create_deck found no
+    live deck, inserted, and hit an IntegrityError. Reviving is the only sane
+    answer: the user asked for the word to be parked in ★ List, so ★ List has
+    to exist.
+    """
+    saved_id = database.get_or_create_saved_deck("zh")
+    database.delete_deck(saved_id)
+
+    body = _run_add_word("生态", day="list")
+    assert body["job"]["status"] == "done", body["job"]
+
+    conn = database.get_db()
+    row = conn.execute("SELECT deleted_at FROM decks WHERE id=?", (saved_id,)).fetchone()
+    dupes = conn.execute(
+        "SELECT COUNT(*) c FROM decks WHERE name='Saved' AND parent_id IS ?",
+        (database.get_all_deck_id(),),
+    ).fetchone()["c"]
+    conn.close()
+    assert row["deleted_at"] is None
+    assert dupes == 1
+    # The word really landed in the revived deck, not somewhere improvised.
+    entry_id = database.get_word_by_zh("生态")["id"]
+    conn = database.get_db()
+    decks = {r["deck_id"] for r in conn.execute(
+        "SELECT deck_id FROM cards WHERE word_id=? AND deleted_at IS NULL", (entry_id,))}
+    conn.close()
+    assert decks == {saved_id}
+
+
+def test_reviving_a_deck_leaves_its_cards_alone(tmp_db):
+    """Trashing a deck and emptying it are separate actions (#801): a deck that
+    comes back must not drag deleted cards back with it."""
+    deck_id = database.get_or_create_deck("Reviveme")
+    database.delete_deck(deck_id)
+    conn = database.get_db()
+    conn.execute(
+        "INSERT INTO entries (word_zh, pinyin) VALUES ('测试词', 'cèshìcí')")
+    entry_id = conn.execute("SELECT id FROM entries WHERE word_zh='测试词'").fetchone()["id"]
+    conn.execute(
+        "INSERT INTO cards (word_id, deck_id, category, due, deleted_at)"
+        " VALUES (?, ?, 'reading', date('now'), datetime('now'))",
+        (entry_id, deck_id),
+    )
+    conn.commit()
+    conn.close()
+
+    assert database.get_or_create_deck("Reviveme") == deck_id
+    conn = database.get_db()
+    card = conn.execute("SELECT deleted_at FROM cards WHERE word_id=?", (entry_id,)).fetchone()
+    conn.close()
+    assert card["deleted_at"] is not None
+
+
 def test_listed_word_can_be_promoted_into_a_daily_deck(tmp_db):
     """Browse's '→ Add to Daily' button must work on words added via ★ List —
     that round trip is the reason the feature exists."""


### PR DESCRIPTION
## 问题

顶栏 ＋ 加任何中文词 → `POST /api/add-word-ai → 500`。

服务器日志（2026-08-19 04:16:31）：

```
sqlite3.IntegrityError: UNIQUE constraint failed: decks.name, decks.parent_id
  add_word_ai → get_or_create_saved_deck → get_or_create_deck_path → get_or_create_deck
```

生产库里 `Saved`（id=1581）在 2026-08-18 19:30 被软删进了垃圾桶，它下面 159 张卡一张都没删。`get_or_create_deck` 的 SELECT 带 `deleted_at IS NULL`，查不到 → INSERT → 撞上唯一约束（约束不含 `deleted_at`）。

不是 Saved 独有：任何被丢进垃圾桶的牌组（某天的 Daily、某个类别叶子）再被需要时都会同样崩。

## 改动

`database.get_or_create_deck()`：查到同名同父的已软删牌组时把它复活（`deleted_at = NULL`）并返回原 id，而不是插入重复行。卡片的 `deleted_at` 不动——删牌组和清空牌组是两个独立动作。

## 测试

新增两条（`tests/test_add_word.py`）：
- 软删 Saved 后加词仍成功，牌组复活、无重复行，卡片确实落在复活的那个牌组里
- 复活牌组不会把它里面已软删的卡片一起带回来

`pytest tests/` 全套 639 passed。

## 上线后

代码上线后第一次加词会自动复活生产库里的 Saved（159 张 ★ List 卡片随之回到界面）。

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)