### PR TITLE
知识库按语言渲染摘要与生词（#804）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,8 @@
 ├── ai.py                  # AI 提供商调用（每种提示词类型一个函数）
 ├── news_fetcher.py        # 新闻抓取（Tagesschau API + RSS；按天缓存 data/news_cache/）
 ├── podcast.py             # 播客爬虫（#479）：播客 RSS 直链发现新单集（#497，退役 YouTube/yt-dlp）、每源 auto_process 开关+非自动源只入库元数据（#502，podcast_feeds 表）、转录链 NotebookLM 免费主力+听悟+Whisper 保底、单步异常不中止整链（#510 重排，链式降级，原 #498/#485/#486）、摘要 NotebookLM chat.ask 免费优先+DeepSeek/gpt API 链回退（api 路径内部 DeepSeek 优先省钱，#532；勾了 china-kritisch 的素材跳过 DeepSeek 直接用 OpenAI，#731）、邮件通知+Signal 通知（signal-cli 关联设备，发 Note to Self，#521，二者独立可选、互不影响；消息抬头播客名·星期·日期、链接在末尾，单集日期按 Europe/Berlin 显示，#532）、摘要 table.media 风格（`<p>` 段落+每段首句 `<b>` 加粗总结，#567）+详情页 Regenerate summary 按钮、邮件主题=`播客名 - 单集标题`（查不到播客名只用标题，不要退回死前缀）+ `summary_zh` 开头中文总结（#708 起是 `summary_de` 的**完整翻译**：同段落数、同顺序、同事实，同样 `<p>`+段首 `<b>`，HSK4-5 用词；提示词里德语先写、中文后译，JSON 里 `summary_de` 排在前面；渲染三处——邮件 `podcast._summary_zh_html`、详情页 `app.js._summaryZhHtml` 均"先全转义再放行 `<p>/<b>/<strong>/<em>/<i>/<br>`"，Signal 用 `_summary_to_plain_text` 剥标签；#708 之前的旧条目是纯文本，两处渲染都按空行补 `<p>`；**是增量不是必需**——成功判定只看 `summary_de`，模型漏掉中文总结不能让整集失败）+ 摘要里任何 HSK5+ 中文概念都标 `pinyin/汉字`（不限于提取的词表，宁多勿少，#631）；已泛化为知识库存储层，见 `knowledge/` 包
-├── knowledge/             # 知识库摄取（#650–#655，播客功能泛化，见「知识库」节）：youtube.py（字幕摄取）、article.py（正文抽取）、instagram.py（Reel/Post 摄取，yt-dlp 元数据+音频下载，#750）、ingest.py（唯一入库管线）、mailbox.py（IMAP 邮件收件）、signal_inbox.py（Signal Note to Self 分享收件，#749）
+├── annotate/              # 知识库生词标注分派（#804）：__init__.py 按 languages 的 annotator 字段分派，zh 走 zh_annotate（原样不动），romance.py 是法语/西语实现（entry_forms 精确匹配，零词干还原）+ stopwords_fr/es.txt 功能词表
+├── knowledge/             # 知识库摄取（#650–#655，播客功能泛化，见「知识库」节）：rendition.py（按语言渲染摘要，#804）、youtube.py（字幕摄取）、article.py（正文抽取）、instagram.py（Reel/Post 摄取，yt-dlp 元数据+音频下载，#750）、ingest.py（唯一入库管线）、mailbox.py（IMAP 邮件收件）、signal_inbox.py（Signal Note to Self 分享收件，#749）
 ├── zh_annotate.py         # 生词标注（#638，零 AI）：HSK 表+词库+jieba+pypinyin+谷歌翻译
 ├── translator.py          # 翻译（Google Translate，deep-translator，可选）
 ├── tts.py                 # edge-tts 封装（离线模式下只读缓存，#612）
@@ -571,6 +572,12 @@ FSRS 用毕业评分播种初始 stability/difficulty：默认权重下 **Good �
   - **免费的 NotebookLM 路径不受影响，照旧第一优先**：它是 Google 的，没理由审查这个话题，而且不花钱。勾选只改变它失败之后 API 兜底那一层选谁
   - **标记必须在粘贴那一刻打上**：摘要发生在之后独立的 `POST .../process` 调用里（甚至是 cron 里），那时已经没人在旁边说明这是什么素材
   - 三个入口（应用知识页的链接框/正文框、独立收藏页 `/save`）都有该复选框，**每次提交后自动复位**——粘性复选框会在之后所有素材上静默烧 GPT 的钱。请求字段可选且默认 false，所以不发这个字段的 iOS 快捷指令和邮件收件行为完全不变
+- **按语言渲染摘要（#804）**：知识源全语言共享，**AI 摘要只生成一次**（`summary_de` 是主版本），其它语言的阅读版本是它的谷歌翻译 + 生词标注派生物，存 `knowledge_renditions(episode_id, lang)`，第一次打开时懒生成并缓存 —— 不为每种语言再花一次 AI 的钱。中文侧**完全不走这条路**（`summary_zh` 本来就是 AI 原生的，由 `zh_annotate` 标注），零回归
+  - **翻译按 HTML 文本节点分块**（`knowledge/rendition.py._translate_html_strict`）：摘要是 `<p>`/`<b>` 标记的 HTML，整块丢给谷歌翻译会两头出错——免费端点超过约 5000 字直接拒绝，而且标签会被吃掉或挪位。所以只送文本节点、标签原样保留；行数对不上就逐节点重译
+  - **失败绝不写库**：`translator.translate_strict()` 是为此新加的（`translate_zh` 的契约是"失败返回原文"，那在这里等于把德语原文冒充成法语存进库）。失败时详情页显示原因，不静默退回德语
+  - **重新生成摘要会清空该素材的全部 rendition**，否则旧译文会留在库里和新摘要说两套话
+  - **罗曼语的生词判定不做词干还原**（`annotate/romance.py`）：靠 `database.forms_lookup()` 精确匹配 `entry_forms` 里存好的全部变位/词形 —— 这正是 #803 要求加词时把变位表生成齐全的原因。判定 = 词形表 ∪ `known_words(lang)` ∪ 功能词表；标注每篇最多 40 个词，标签内的词（`<strong>` 里的 `strong`）必须跳过，否则会毁掉标记
+  - `GET /api/podcast/episodes/{id}?lang=fr` 返回 `rendition`/`rendition_error`；`known-words` 三个接口都加了 `lang`（默认 `zh`）
 - **`GET /api/podcast/episodes` 加 `?kind=` 过滤**，`POST /api/knowledge/add` 只负责入库，**不在请求里做转录/摘要**——前端拿到 `episode_id` 后照常调用既有的 `POST /api/podcast/episodes/{id}/process`，造卡侧（`routes/story.py` 的 `knowledge` 模式，见「故事生成」）几乎零改动就能吃到播客以外的素材
 - **YouTube 字幕在服务器上必须走 NotebookLM（#681）**：YouTube 整片封锁云服务商 IP，Contabo 的服务器调字幕 API 永远得到 `RequestBlocked`。而 `RequestBlocked`/`IpBlocked`/`PoTokenRequired`/`AgeRestricted` **全是 `CouldNotRetrieveTranscript` 的子类** —— 原来只 `except` 基类，于是"被 YouTube 拒绝"被静默写成 `no_transcript`，一个有 9833 字中文字幕的视频在界面上显示"没有字幕"。现在拒绝类异常必须在基类**之前**捕获（`_blocked_error_types()`），先转 `podcast.transcribe_url_via_notebooklm()`（`sources.add_url()` 自动识别 YouTube 链接，由 Google 自己去取，绕开我们的出口 IP，免费、不下音频），兜底也空则抛 `CaptionsUnavailable` → `status='error'` + 可读原因。**真没字幕的视频不进兜底**，仍走廉价的 `no_transcript`，不浪费几分钟的 NotebookLM 轮次
   - **代价**：NotebookLM 不能指定字幕语言，返回的是视频原声轨（那条视频拿回来的是英文 32633 字，不是本地能拿到的中文翻译轨 9833 字）。摘要提示词本来就容忍任意输入语言，所以功能通；要中文轨只能给字幕 API 配付费代理（`WebshareProxyConfig`），暂不做

--- a/annotate/__init__.py
+++ b/annotate/__init__.py
@@ -1,0 +1,50 @@
+"""Knowledge-base vocabulary annotation dispatch (#804).
+
+Every language the app knows about has one entry in languages.py that names
+an "annotator" implementation (a family-level field — see languages.py's
+_SINITIC_BASE/_ROMANCE_BASE). annotate_summary() is the single call site
+knowledge/rendition.py (and, for completeness, anything else that wants an
+annotated summary) goes through, so a new language only ever needs a new
+languages.py entry pointing at an existing annotator, never a new dispatch
+site.
+
+  "zh"      -> zh_annotate.py (#638): zero-AI, HSK-table + jieba + pypinyin.
+               Untouched by #804 — wrapped here, not modified.
+  "romance" -> annotate/romance.py (#804): entry_forms exact-match lookup
+               (no stemming) + a per-language stopword list + Google
+               Translate glosses for whatever's left.
+"""
+import logging
+
+import languages
+
+logger = logging.getLogger(__name__)
+
+
+def annotate_summary(text: str, lang: str) -> tuple[str, list[dict]]:
+    """(annotated_text, new_words) for `text` in `lang`. new_words is a list
+    of dicts (shape varies slightly per annotator — see the individual
+    implementations) in order of first appearance.
+
+    Never raises: an annotator failure, or an unrecognized "annotator" name
+    (should not happen — every registered language in languages.py names one
+    of the two below), degrades to the text unannotated with no new words.
+    That mirrors the "a missing gloss is a minor inconvenience" contract
+    each individual annotator already promises for its own internal
+    failures."""
+    if not text or not text.strip():
+        return text, []
+    annotator = languages.get_lang_config(lang).get("annotator")
+    try:
+        if annotator == "zh":
+            import zh_annotate
+            annotated = zh_annotate.annotate_zh_summary(text)
+            new_words = zh_annotate.extract_new_words(text)
+            return annotated, new_words
+        if annotator == "romance":
+            from . import romance
+            return romance.annotate_summary(text, lang)
+        logger.warning("annotate: unknown annotator %r for lang=%s", annotator, lang)
+    except Exception as e:
+        logger.warning("annotate: dispatch failed for lang=%s — %s", lang, e)
+    return text, []

--- a/annotate/romance.py
+++ b/annotate/romance.py
@@ -1,0 +1,180 @@
+"""Romance-language (French/Spanish) knowledge-base annotation (#804) — the
+counterpart of zh_annotate.py for languages.py's "romance" family, dispatched
+to by annotate/__init__.py.
+
+No stemming happens here — that is the entire point of #803's entry_forms
+table. Every conjugated/inflected surface form Daniel has already studied is
+stored verbatim (database.forms_lookup), so a plain exact-string lookup
+already knows "parlons" belongs to a word he knows without any linguistic
+reduction here.
+
+Best-effort throughout, like zh_annotate: any failure returns the original
+text unannotated and an empty word list. A missing gloss costs Daniel a
+lookup; losing the whole summary over it would be absurd.
+"""
+import logging
+import os
+import re
+
+import database
+import languages
+
+logger = logging.getLogger(__name__)
+
+# Inline-annotate at most this many distinct new words per summary — past
+# that the parentheses would drown the text. Every new word still lands in
+# new_words (the bottom vocabulary table), just not inline.
+_MAX_INLINE = 40
+
+# French elision prefixes ("l'économie" -> "économie"). Spanish doesn't elide
+# this way, so this list is only ever consulted for lang == "fr"; it's a
+# no-op (never matches) for "es".
+_ELISION_PREFIXES = ("l", "d", "qu", "j", "n", "s", "c", "m", "t")
+
+# A "word" is a run of Unicode letters, optionally with one internal
+# apostrophe ("l'économie", "aujourd'hui", "qu'est-ce" splits on the hyphen
+# into two words, which is fine — both get looked up independently).
+_WORD_RE = re.compile(r"[^\W\d_]+(?:['’][^\W\d_]+)?", re.UNICODE)
+
+_SENTENCE_END = (".", "!", "?", "…")
+
+# summary_de (and therefore every rendition translated from it) is HTML:
+# <p> paragraphs with a <b> lead sentence. Tag names are runs of letters too,
+# so without this the annotator would happily gloss "strong" inside a
+# <strong> tag and destroy the markup. Every match inside a tag is skipped.
+_TAG_RE = re.compile(r"<[^>]*>")
+
+_stopword_cache: dict[str, set[str]] = {}
+
+
+def _stopwords(lang: str) -> set[str]:
+    """Function-word list for `lang`, loaded once per process. An unreadable
+    file degrades to an empty set — same "worse annotation, not a crash"
+    posture as zh_annotate's HSK table."""
+    if lang in _stopword_cache:
+        return _stopword_cache[lang]
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), f"stopwords_{lang}.txt")
+    words: set[str] = set()
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    words.add(line.lower())
+    except Exception as e:
+        logger.warning("annotate.romance: cannot read %s — %s", path, e)
+    _stopword_cache[lang] = words
+    return words
+
+
+def _strip_elision(token: str) -> str:
+    """"l'économie" -> "économie". Only strips a prefix that is both
+    apostrophe-joined AND a known elision word — an apostrophe inside an
+    ordinary word ("aujourd'hui") is left whole, since "aujourd" isn't in
+    the prefix list."""
+    for sep in ("'", "’"):
+        if sep in token:
+            prefix, _, rest = token.partition(sep)
+            if rest and prefix.lower() in _ELISION_PREFIXES:
+                return rest
+    return token
+
+
+def _is_sentence_start(text: str, pos: int) -> bool:
+    before = text[:pos].rstrip()
+    if not before:
+        return True
+    return before[-1] in _SENTENCE_END
+
+
+def annotate_summary(text: str, lang: str) -> tuple[str, list[dict]]:
+    """(annotated_text, new_words); new_words is
+    [{word, lemma, definition_de}] in order of first appearance. Never
+    raises."""
+    if not text or not text.strip():
+        return text, []
+    try:
+        return _annotate(text, lang)
+    except Exception as e:
+        logger.warning("annotate.romance: failed for lang=%s — %s", lang, e)
+        return text, []
+
+
+def _annotate(text: str, lang: str) -> tuple[str, list[dict]]:
+    stopwords = _stopwords(lang)
+    tag_spans = [(m.start(), m.end()) for m in _TAG_RE.finditer(text)]
+
+    def _in_tag(pos: int) -> bool:
+        return any(start <= pos < end for start, end in tag_spans)
+
+    matches = [m for m in _WORD_RE.finditer(text) if not _in_tag(m.start())]
+    if not matches:
+        return text, []
+
+    # One pass to find every token's lookup key (lowercased, elision-
+    # stripped) and whether it looks like a proper noun (capitalized, not at
+    # a sentence start) — those are skipped entirely, never annotated and
+    # never listed as a new word.
+    tagged = []  # (match, lookup_key)
+    order: list[str] = []
+    seen: set[str] = set()
+    for m in matches:
+        raw = m.group(0)
+        core = _strip_elision(raw)
+        low = core.lower()
+        is_proper = core[:1].isupper() and not _is_sentence_start(text, m.start())
+        annotatable = len(low) >= 2 and low not in stopwords and not is_proper
+        tagged.append((m, low if annotatable else None))
+        if annotatable and low not in seen:
+            seen.add(low)
+            order.append(low)
+
+    if not order:
+        return text, []
+
+    known = database.forms_lookup(order, lang) | database.known_words_exists(order, lang)
+    new_cores = [w for w in order if w not in known]
+    if not new_cores:
+        return text, []
+
+    glosses = _glosses(new_cores, lang)
+    new_words = [
+        {"word": w, "lemma": w, "definition_de": glosses.get(w) or None}
+        for w in new_cores
+    ]
+
+    inline_set = set(new_cores[:_MAX_INLINE])
+    out: list[str] = []
+    last_end = 0
+    annotated_once: set[str] = set()
+    for m, key in tagged:
+        out.append(text[last_end:m.start()])
+        out.append(m.group(0))
+        last_end = m.end()
+        if key and key in inline_set and key not in annotated_once:
+            annotated_once.add(key)
+            gloss = glosses.get(key)
+            if gloss:
+                out.append(f" ({gloss})")
+    out.append(text[last_end:])
+    return "".join(out), new_words
+
+
+def _glosses(words: list[str], lang: str) -> dict[str, str]:
+    """German glosses for `words` via Google Translate, one batched request.
+    A failed batch degrades to no glosses at all — the words are still
+    flagged as new (no parenthetical, still listed in new_words), matching
+    zh_annotate._gloss_de's "missing gloss, not a missing word" contract."""
+    try:
+        import translator
+        source = languages.get_lang_config(lang)["translator_source"]
+        translated = translator.translate_batch(words, target="de", source=source)
+        out = {}
+        for w, t in zip(words, translated):
+            t = (t or "").strip()
+            if t and t.lower() != w.lower():
+                out[w] = t
+        return out
+    except Exception as e:
+        logger.warning("annotate.romance: gloss translation failed — %s", e)
+        return {}

--- a/database/podcast.py
+++ b/database/podcast.py
@@ -382,3 +382,58 @@ def list_known_words(lang: str | None = None) -> list[dict]:
         ).fetchall()
     conn.close()
     return [dict(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Per-language knowledge-base renditions (#804)
+# ---------------------------------------------------------------------------
+# One episode, one AI-generated summary_de — every other language's reading
+# view is a translated-and-annotated derivative, generated lazily and cached
+# here so repeat views don't re-translate. Chinese has no rendition row: its
+# summary_zh is AI-native and annotated by zh_annotate.py already.
+
+def get_knowledge_rendition(episode_id: int, lang: str) -> dict | None:
+    """The cached rendition for (episode_id, lang), or None if it hasn't been
+    generated yet."""
+    conn = get_db()
+    row = conn.execute(
+        "SELECT * FROM knowledge_renditions WHERE episode_id = ? AND lang = ?",
+        (episode_id, lang),
+    ).fetchone()
+    conn.close()
+    if not row:
+        return None
+    d = dict(row)
+    d["new_words"] = json.loads(d["new_words"]) if d.get("new_words") else []
+    return d
+
+
+def save_knowledge_rendition(episode_id: int, lang: str, summary: str,
+                             new_words: list[dict] | None = None) -> None:
+    """Store (or overwrite) the rendition for (episode_id, lang). Only ever
+    called after a translation succeeds — see knowledge/rendition.py; a
+    failed translation must never reach here (#804: no half-finished or
+    untranslated text may be stored pretending to be a lang's summary)."""
+    conn = get_db()
+    conn.execute(
+        """INSERT INTO knowledge_renditions (episode_id, lang, summary, new_words)
+           VALUES (?, ?, ?, ?)
+           ON CONFLICT(episode_id, lang) DO UPDATE SET
+               summary = excluded.summary,
+               new_words = excluded.new_words,
+               created_at = datetime('now')""",
+        (episode_id, lang, summary, json.dumps(new_words or [], ensure_ascii=False)),
+    )
+    conn.commit()
+    conn.close()
+
+
+def delete_knowledge_renditions(episode_id: int) -> None:
+    """Wipe every cached rendition for an episode (#804) — called whenever
+    summary_de is regenerated, so a stale French/Spanish translation of the
+    OLD summary can't keep being served next to a freshly regenerated German
+    one. The next detail-page view for that language regenerates it lazily."""
+    conn = get_db()
+    conn.execute("DELETE FROM knowledge_renditions WHERE episode_id = ?", (episode_id,))
+    conn.commit()
+    conn.close()

--- a/docs/multilang.md
+++ b/docs/multilang.md
@@ -201,15 +201,112 @@ def get_word_conjugations(word_id: int) -> list[dict]: ...   # [{tense, person, 
 
 ---
 
-## 后续阶段的接口约定（本 Issue 不实现，只占位）
+## 知识库按语言渲染摘要与生词（#804，已实现）
 
-- **知识库多语言标注**：`annotator` 字段决定走哪套实现；罗曼语实现要用
-  `forms_lookup()` 而不是简单的字符串包含判断——"reconnaître 出现在文章里"
-  不代表"reconnaissons"这个变位形式也该被认成已学。
-- **AI 词典多语言**：`/api/dict/lookup` 目前 `lang` 硬编码只接受 `'zh'`
-  （见 CLAUDE.md「AI 词典页」一节）——扩展到 fr/es 时提示词要按 `family`
-  分支，不是按具体语言分支（法语和西班牙语的提示词结构应该几乎一样）。
-- **造句（story generation）多语言**：`ai.py` 的提示词片段（`learner_level`
-  / `background_vocab` / `sentence_limit`）已经是从 `languages.py` 取的，
-  新语言不需要新的生成逻辑，只需要语言族的 `features.extended_story_modes`
-  等标志位控制哪些模式可用。
+依赖上面的语言族 + `forms_lookup` + 按语言 `known_words`。目标：知识库素材
+（播客/视频/文章）只存一份摘要，但每种学习语言看到的"哪些词带翻译"必须不同
+——中文模式和法语模式下的生词集合天然不重合，因为两边"已学词"是两套完全不同
+的表。
+
+### 设计取舍：翻译一次，不重新调用 AI
+
+`podcast_episodes.summary_de`（德语）是唯一的 AI 生成版本。其他语言的阅读版
+是它的**翻译+标注**衍生品，不是第二次 AI 摘要——多语言不该让每篇素材的摘要
+成本乘以语言数。中文是例外：`summary_zh` 本来就是 AI 原生生成、由
+`zh_annotate.py` 标注的，不走这条派生路径，行为一字不改。
+
+### 新表 `knowledge_renditions`
+
+```sql
+CREATE TABLE knowledge_renditions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    episode_id INTEGER NOT NULL REFERENCES podcast_episodes(id) ON DELETE CASCADE,
+    lang TEXT NOT NULL,
+    summary TEXT NOT NULL,     -- 目标语言摘要，生词已内联标注
+    new_words TEXT,            -- JSON [{word, lemma, definition_de}]
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(episode_id, lang)
+);
+```
+
+懒生成：`GET /api/podcast/episodes/{id}?lang=fr` 第一次访问时才翻译+标注并
+写入这张表；之后同一 (episode, lang) 直接读缓存，不重复调用 Google 翻译。
+`podcast.regenerate_summary()` 重新生成 `summary_de` 成功后立即
+`database.delete_knowledge_renditions(episode_id)` 清空全部旧翻译（否则旧
+法语翻译会和新德语摘要说两套话）——这一步是 best-effort（try/except 包裹），
+失败只记日志，不会把已经成功的摘要重生成打回失败状态。
+
+`translator.py` 新增 `translate_strict(text, target, source)`：和已有的
+`translate_zh` 行为相反——失败时**抛异常**而不是静默返回原文。渲染路径必须
+能区分"翻译成功"和"翻译失败"，才能决定要不要写库；`translate_zh`
+"失败就返回原文"的契约对已有调用方是对的（少一个词的德语注释不该毁掉整篇
+故事），但这里如果吞掉失败，会把德语原文当成"法语摘要"存进库。
+
+`knowledge/rendition.py` 的 `get_or_create_rendition(episode_id, lang)` 是唯一
+入口：查缓存 → 没有则取 `summary_de` → `translate_strict` → 失败就抛
+`RenditionError`（**不写库**）→ 成功则 `annotate.annotate_summary()` 标注 →
+`database.save_knowledge_rendition()` 落盘。`routes/podcast.py` 的
+`get_episode()` 接住 `RenditionError`，返回 `rendition: null` +
+`rendition_error` 说明原因，绝不用未翻译的德语文本冒充目标语言摘要。
+
+### 标注分派：`annotate/` 包
+
+`annotate/__init__.py` 的 `annotate_summary(text, lang)` 按
+`languages.get_lang_config(lang)["annotator"]` 分派：
+
+- `"zh"` → 包一层 `zh_annotate.py`（#638），**逻辑一字不改**，中文路径不存在
+  回归的可能——甚至不产生 rendition 行，中文永远读 `summary_zh`。
+- `"romance"` → `annotate/romance.py`（#804 新增），法语/西班牙语共用同一套
+  实现（这正是语言族存在的意义：两种语言的形态学处理方式相同）。
+
+`annotate/romance.py` 的判定逻辑：
+
+1. 分词：按 Unicode 字母切分，剥离省音前缀（`l'économie` → `économie`）——
+   但省音前缀单字母本身（`l`/`d`/`c`/`j`/`m`/`t`/`s`/`qu`/`n`）也在停用词表
+   里，双重保险。
+2. 跳过：停用词表（`annotate/stopwords_fr.txt` / `stopwords_es.txt`，各
+   200+ 条常见虚词）、单字符、句中大写的专有名词。
+3. **已学判定 = `database.forms_lookup(tokens, lang) | database.known_words_exists(tokens, lang)`**
+   ——**不做词干还原**。`forms_lookup` 精确匹配 `entry_forms.form`：一个词的
+   任何存过的变位/词形都算已学，`parlons` 因为在表里所以直接命中，不需要
+   还原成 `parler` 再判断。这正是 #803 把所有变位存进 `entry_forms` 的
+   原因。
+4. 剩下的未知词：`translator.translate_batch()` 批量取德语释义（source=该
+   语言的 `translator_source`，target=`de`），行内标成 `mot (gloss)`，每词
+   只标首次；每篇最多内联标注 40 个（超出的仍进 `new_words`，只是不内联）。
+5. 全程 `try/except` 兜底，任何一步失败都返回原文 + 空生词列表——同
+   `zh_annotate` 的"少个释义是小事，丢整篇摘要才是荒唐"原则。
+
+### 前端
+
+`static/app.js`：`openKnowledgeItem` 请求 `?lang=<activeLang()>`；
+`_renderKnowledgeDetail` 按 `activeLang()` 分支——`zh` 路径字节不变，其它
+语言读 `ep.rendition.summary` / `ep.rendition.new_words`（渲染失败时显示
+`ep.rendition_error`）。语言标签切换（`setActiveLang`）时，如果知识库详情页
+正开着，自动重新拉取当前素材（`_knowledgeDetailId`）。生词表格的"★ List"
+和"✓ Known"按钮沿用已有的 `addWordViaAi()` / `markWordKnown()`（`shared.js`），
+两者都已支持可选 `lang` 参数（分别是 #726、#804 加的），按钮点击时传入
+`_podcastDetailLang`。
+
+### 未覆盖 / 已知限制
+
+- `summary_de` 是 HTML（`<p>`/`<b>` 标签），`translate_strict` 把整段 HTML
+  当纯文本整体丢给 Google 翻译——没有单独验证标签在翻译后是否完整保留；
+  如果翻译引擎重排或吞掉标签，渲染出来的法语/西班牙语摘要可能丢失加粗/分段
+  样式（内容本身不会丢，是纯 HTML 结构风险）。
+- 罗曼语分词是简单的 Unicode 字母正则，不处理连字符复合词（`qu'est-ce` 之类
+  会被拆成多个词单独判断）——精度足以标注生词，但不是完整的形态学分析器。
+- 播客/邮件/Signal 通知（`podcast.send_mail` / `send_signal_text`）仍然只发
+  德语+中文版本，本 Issue 明确不动通知路径。
+
+### 造句（story generation）多语言（本 Issue 仍不实现，只占位）
+
+`ai.py` 的提示词片段（`learner_level` / `background_vocab` /
+`sentence_limit`）已经是从 `languages.py` 取的，新语言不需要新的生成逻辑，
+只需要语言族的 `features.extended_story_modes` 等标志位控制哪些模式可用。
+
+### AI 词典多语言（本 Issue 仍不实现，只占位）
+
+`/api/dict/lookup` 目前 `lang` 硬编码只接受 `'zh'`（见 CLAUDE.md「AI 词典页」
+一节）——扩展到 fr/es 时提示词要按 `family` 分支，不是按具体语言分支（法语
+和西班牙语的提示词结构应该几乎一样）。

--- a/knowledge/rendition.py
+++ b/knowledge/rendition.py
@@ -1,0 +1,133 @@
+"""Per-language reading renditions of a knowledge-base episode's summary
+(#804). The AI writes summary_de exactly once, no matter how many languages
+Daniel is studying; every other language's detail-page view is a lazily
+generated, cached translate-then-annotate derivative of that one German
+text. Chinese is not a "rendition" — summary_zh is already AI-native and
+annotated by zh_annotate.py, so routes/podcast.py's get_episode() never
+calls into this module for lang == 'zh'.
+
+See docs/multilang.md ("Knowledge base") for the full design and
+schema.sql's knowledge_renditions table for storage.
+"""
+import logging
+import re
+
+import annotate
+import database
+import languages
+import translator
+
+logger = logging.getLogger(__name__)
+
+
+# summary_de is HTML (<p> paragraphs, <b> lead sentences). Sending that whole
+# blob to Google Translate is wrong twice over: the free endpoint rejects
+# anything past ~5000 characters, and it reorders/eats tags. So we split the
+# markup into tag and text nodes here, translate only the text, and put the
+# tags back untouched — the rendition keeps exactly the markup the summary
+# had, which is what podcast._summary_zh_html / app.js._summaryZhHtml expect.
+_TAG_RE = re.compile(r"(<[^>]*>)")
+# The free Google endpoint's limit is ~5000 chars; translator.py uses the same
+# 4500 budget for its own batching.
+_CHUNK_CHAR_BUDGET = 4500
+_SEP = "\n"
+
+
+def _translate_html_strict(html: str, target: str, source: str = "de") -> str:
+    """Translate the text nodes of `html`, leaving every tag byte-identical.
+
+    Strict on purpose (#804): any failure raises so the caller can report it
+    instead of storing German text under a French label. Text nodes are sent
+    in newline-joined chunks under the endpoint's size limit; if a chunk comes
+    back with a different number of lines than it went out with (Google
+    occasionally merges or splits lines) that chunk's nodes are retried one at
+    a time, which is slower but keeps every node aligned with its position in
+    the document.
+    """
+    parts = _TAG_RE.split(html)
+    text_idx = [i for i, part in enumerate(parts)
+                if not part.startswith("<") and part.strip()]
+    if not text_idx:
+        return html
+
+    chunks: list[list[int]] = []
+    budget = 0
+    for i in text_idx:
+        if chunks and budget + len(parts[i]) > _CHUNK_CHAR_BUDGET:
+            chunks.append([])
+            budget = 0
+        elif not chunks:
+            chunks.append([])
+        chunks[-1].append(i)
+        budget += len(parts[i]) + 1
+
+    for chunk in chunks:
+        originals = [parts[i].strip() for i in chunk]
+        translated = translator.translate_strict(
+            _SEP.join(originals), target=target, source=source)
+        lines = (translated or "").split(_SEP)
+        if len(lines) != len(originals):
+            logger.info(
+                "knowledge.rendition: line-count mismatch (%d vs %d), retrying node by node",
+                len(lines), len(originals))
+            lines = [translator.translate_strict(o, target=target, source=source)
+                     for o in originals]
+        for i, orig, line in zip(chunk, originals, lines):
+            line = (line or "").strip()
+            if not line:
+                raise RuntimeError("translator returned an empty segment")
+            # Keep the original node's surrounding whitespace so words don't
+            # get glued to an adjacent tag.
+            lead = parts[i][:len(parts[i]) - len(parts[i].lstrip())]
+            trail = parts[i][len(parts[i].rstrip()):]
+            parts[i] = f"{lead}{line}{trail}"
+    return "".join(parts)
+
+
+class RenditionError(Exception):
+    """No rendition could be produced. Callers must report the reason
+    instead of writing (or returning) anything — #804 is explicit that a
+    half-translated or untranslated summary must never be stored or served
+    as if it were a real rendition."""
+
+
+def get_or_create_rendition(episode_id: int, lang: str) -> dict:
+    """{"lang", "summary", "new_words"} for episode_id in `lang`. Cached in
+    knowledge_renditions after the first successful generation — repeat
+    detail-page views (and repeat requests before a language switch) don't
+    re-translate. Raises RenditionError on any failure; nothing is written
+    to the database in that case."""
+    if lang == languages.DEFAULT_LANG:
+        raise RenditionError("zh has no rendition — read summary_zh directly")
+    if not languages.is_valid_lang(lang):
+        raise RenditionError(f"unknown language: {lang!r}")
+
+    cached = database.get_knowledge_rendition(episode_id, lang)
+    if cached:
+        return {"lang": lang, "summary": cached["summary"], "new_words": cached["new_words"]}
+
+    episode = database.get_episode(episode_id)
+    if not episode:
+        raise RenditionError(f"episode {episode_id} not found")
+    summary_de = (episode.get("summary_de") or "").strip()
+    if not summary_de:
+        raise RenditionError("episode has no German summary yet")
+
+    target = languages.get_lang_config(lang)["translator_source"]
+    try:
+        translated = _translate_html_strict(summary_de, target=target, source="de")
+    except Exception as e:
+        logger.warning(
+            "knowledge.rendition: translation failed for episode %s lang=%s — %s",
+            episode_id, lang, e,
+        )
+        raise RenditionError(f"translation failed: {e}") from e
+    translated = (translated or "").strip()
+    if not translated:
+        raise RenditionError("translation returned empty text")
+
+    annotated, new_words = annotate.annotate_summary(translated, lang)
+    database.save_knowledge_rendition(episode_id, lang, annotated, new_words)
+    logger.info("knowledge.rendition: generated episode %s lang=%s (%d new word(s))",
+               episode_id, lang, len(new_words))
+    return {"lang": lang, "summary": annotated, "new_words": new_words}

--- a/podcast.py
+++ b/podcast.py
@@ -2145,6 +2145,16 @@ def regenerate_summary(episode_id: int) -> dict:
         logger.info("podcast: replaced placeholder title %r -> %r for episode %s",
                     episode["title"], title_suggestion, episode_id)
     database.update_episode(episode_id, **update_fields)
+    # #804: the German summary just changed, so any cached French/Spanish/etc.
+    # rendition was translated from the OLD text and is now stale — drop them
+    # all, the next per-language detail view regenerates lazily. Best-effort:
+    # the summary itself already saved successfully above, so a hiccup
+    # invalidating a secondary cache must not turn that into a failure.
+    try:
+        database.delete_knowledge_renditions(episode_id)
+    except Exception as e:
+        logger.warning("podcast: failed to invalidate renditions for episode %s — %s",
+                       episode_id, e)
     logger.info("podcast: summary regenerated for episode %s (%d word(s))", episode_id, len(words))
     return {"regenerated": True, "error": None}
 

--- a/routes/knowledge.py
+++ b/routes/knowledge.py
@@ -68,11 +68,16 @@ def add_knowledge_text(body: AddKnowledgeTextRequest):
 
 class KnownWordRequest(BaseModel):
     word: str
+    # #804: known_words is keyed per language (see #803's known_words.lang) —
+    # a known French word and a known Chinese word that happen to share a
+    # surface form must not silently mark each other known. Defaults to 'zh'
+    # so pre-#804 callers (no lang field sent) keep their existing behavior.
+    lang: str = "zh"
 
 
 @router.get("/api/known-words")
-def get_known_words():
-    return {"words": database.list_known_words()}
+def get_known_words(lang: str | None = None):
+    return {"words": database.list_known_words(lang)}
 
 
 @router.post("/api/known-words")
@@ -80,14 +85,14 @@ def add_known_word(body: KnownWordRequest):
     word = (body.word or "").strip()
     if not word:
         raise HTTPException(400, "word required")
-    database.add_known_word(word)
-    return {"status": "ok", "word": word}
+    database.add_known_word(word, body.lang)
+    return {"status": "ok", "word": word, "lang": body.lang}
 
 
 @router.delete("/api/known-words/{word}")
-def delete_known_word(word: str):
+def delete_known_word(word: str, lang: str = "zh"):
     """Undo. Reports a miss instead of pretending — a 404 here means the
     frontend and the database disagree about what is on the list."""
-    if not database.remove_known_word(word.strip()):
+    if not database.remove_known_word(word.strip(), lang):
         raise HTTPException(404, "word not on the known list")
-    return {"status": "ok", "word": word}
+    return {"status": "ok", "word": word, "lang": lang}

--- a/routes/podcast.py
+++ b/routes/podcast.py
@@ -7,6 +7,7 @@ import threading
 from xml.etree import ElementTree
 
 import database
+import knowledge.rendition
 import podcast
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
@@ -56,7 +57,7 @@ def list_episodes(limit: int = 100, feed_id: int | None = None, kind: str | None
 
 
 @router.get("/api/podcast/episodes/{episode_id}")
-def get_episode(episode_id: int):
+def get_episode(episode_id: int, lang: str = "zh"):
     episode = database.get_episode(episode_id)
     if not episode:
         raise HTTPException(404, "Episode not found")
@@ -72,6 +73,21 @@ def get_episode(episode_id: int):
         except Exception:
             logger.warning("podcast: lazy transcript_de backfill failed for episode %s",
                            episode_id, exc_info=True)
+    # Per-language reading rendition (#804): zh reads summary_zh/hsk_words
+    # directly (unchanged, see docstring on knowledge/rendition.py), every
+    # other language gets a lazily generated + cached translated summary.
+    # Never lets a translation failure turn the whole detail view into a
+    # 500 — the frontend gets rendition=None + rendition_error and falls
+    # back to showing the German summary.
+    if lang != "zh":
+        episode = dict(episode)
+        try:
+            rendition = knowledge.rendition.get_or_create_rendition(episode_id, lang)
+            episode["rendition"] = rendition
+            episode["rendition_error"] = None
+        except knowledge.rendition.RenditionError as e:
+            episode["rendition"] = None
+            episode["rendition_error"] = str(e)
     return _overlay_processing_status(episode)
 
 

--- a/schema.sql
+++ b/schema.sql
@@ -715,6 +715,24 @@ CREATE TABLE IF NOT EXISTS podcast_episodes (
     created_at       TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+-- ---------------------------------------------------------------------------
+-- Per-language reading renditions of a knowledge-base episode's summary
+-- (#804). The AI writes summary_de exactly once; every other language's
+-- reading view is a Google-translated-then-annotated derivative of it,
+-- generated lazily on first request and cached here so it isn't re-translated
+-- on every page view. Chinese is NOT stored here — summary_zh is already
+-- AI-native and annotated by zh_annotate.py, so it has no rendition row.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS knowledge_renditions (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    episode_id INTEGER NOT NULL REFERENCES podcast_episodes(id) ON DELETE CASCADE,
+    lang       TEXT NOT NULL,
+    summary    TEXT NOT NULL,   -- target-language summary, new words already annotated inline
+    new_words  TEXT,            -- JSON array of {word, lemma, definition_de}
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(episode_id, lang)
+);
+
 CREATE TABLE IF NOT EXISTS podcast_config (
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL

--- a/static/app.js
+++ b/static/app.js
@@ -93,6 +93,11 @@ function setActiveLang(lang) {
   if (lang === activeLang()) return;
   localStorage.setItem('activeLang', lang);
   invalidateHomeEvolution();
+  // #804: a knowledge-base item detail view open at the moment of the switch
+  // shows a per-language rendition of the summary — re-fetch it in the new
+  // language instead of leaving the old language's text on screen under the
+  // now-active tab. Only re-renders; doesn't change which view is showing.
+  if (_knowledgeDetailId != null) openKnowledgeItem(_knowledgeDetailId);
   loadDecks();
 }
 
@@ -3678,11 +3683,21 @@ function _schedulePodcastPollIfNeeded() {
 
 // Layer 3: item detail — shared by all three kinds -------------------------------
 
+// _knowledgeDetailId (#804) tracks which episode is currently open so a
+// language-tab switch (setActiveLang) can silently re-fetch it in the new
+// language — see the hook at the bottom of setActiveLang. null when no
+// detail view is open (the podcast list, or any other view).
+let _knowledgeDetailId = null;
+
 async function openKnowledgeItem(id) {
   setLoading('Loading…');
   try {
-    const ep = await api('GET', `/api/podcast/episodes/${id}`);
+    // lang (#804): the detail endpoint returns a translated+annotated
+    // rendition of the summary for non-Chinese tabs; zh's response is
+    // byte-identical to before #804 either way (see routes/podcast.py).
+    const ep = await api('GET', `/api/podcast/episodes/${id}?lang=${activeLang()}`);
     _clearPodcastPoll();
+    _knowledgeDetailId = id;
     showView('knowledge');
     _renderKnowledgeDetail(ep);
   } catch (e) {
@@ -3692,6 +3707,7 @@ async function openKnowledgeItem(id) {
 }
 
 function closeKnowledgeDetail() {
+  _knowledgeDetailId = null;
   if (_podcastCurrentFeedId != null) {
     openPodcastFeed(_podcastCurrentFeedId);
   } else {
@@ -3706,11 +3722,18 @@ function _renderKnowledgeDetail(ep) {
   const isPodcast = kind === 'podcast';
   const contentLabel = kind === 'video' ? 'Subtitles' : kind === 'article' ? 'Article text' : 'Transcript';
   const date = _localDate(ep.published_at || ep.created_at || '');
+  // lang (#804): zh reads hsk_words/summary_zh/summary_de exactly as before
+  // #804 — not one byte of that path changes. Every other language reads
+  // its lazily-generated rendition instead (routes/podcast.py attaches it
+  // to the response as ep.rendition / ep.rendition_error).
+  const lang = activeLang();
+  const isZh = lang === 'zh';
   // Keep the raw word objects around so click handlers can look them up by
   // index instead of serializing them into onclick attributes (avoids
   // quote/apostrophe escaping issues in word_zh/definition_de text).
-  _podcastDetailWords = ep.hsk_words || [];
+  _podcastDetailWords = isZh ? (ep.hsk_words || []) : ((ep.rendition && ep.rendition.new_words) || []);
   _podcastDetailEpisodeId = ep.id;
+  _podcastDetailLang = lang;
   const hskRows = _podcastDetailWords.map((w, idx) => `<tr id="podcast-word-row-${idx}">
       <td class="word-zh">${_escHtml(w.word || w.word_zh || '')}</td>
       <td class="word-pinyin">${_escHtml(w.pinyin || '')}</td>
@@ -3742,6 +3765,19 @@ function _renderKnowledgeDetail(ep) {
          <div id="podcast-transcript-body" class="podcast-transcript" style="display:none">${trBody}</div>
        </div>`
     : '';
+  // #804: zh's summary block is untouched. Every other language shows its
+  // rendition (translated from summary_de, new words annotated inline); a
+  // failed/not-yet-generated rendition shows the reason rather than silently
+  // falling back to a German block Daniel didn't ask to read.
+  const summaryBlock = isZh
+    ? `${ep.summary_zh ? `<div id="podcast-summary-zh">${_summaryZhHtml(ep.summary_zh)}</div>` : ''}
+       <div id="podcast-summary-de">${ep.summary_de || ''}</div>`
+    : (ep.rendition
+        // Same whitelist sanitizer the zh summary uses: the rendition text
+        // passed through Google Translate and the annotator, so it gets
+        // escaped and only <p>/<b>/<em>/<i>/<br> are let back through.
+        ? `<div id="podcast-summary-rendition">${_summaryZhHtml(ep.rendition.summary || '')}</div>`
+        : `<p class="keymap-hint">${_escHtml(ep.rendition_error || 'Rendition unavailable.')}</p>`);
 
   el.innerHTML = `
     <button class="keymap-reset-all" onclick="closeKnowledgeDetail()">← Back</button>
@@ -3749,11 +3785,10 @@ function _renderKnowledgeDetail(ep) {
       <h2 class="keymap-heading">${_escHtml(ep.title || '(untitled)')}</h2>
       <p class="keymap-hint">${date}</p>
       <div style="margin:4px 0 10px">${links}</div>
-      ${ep.summary_zh ? `<div id="podcast-summary-zh">${_summaryZhHtml(ep.summary_zh)}</div>` : ''}
-      <div id="podcast-summary-de">${ep.summary_de || ''}</div>
+      ${summaryBlock}
     </div>
     <div class="keymap-panel">
-      <h2 class="keymap-heading">HSK vocabulary</h2>
+      <h2 class="keymap-heading">${isZh ? 'HSK vocabulary' : 'New words'}</h2>
       ${hskTable}
     </div>
     <div class="keymap-panel">
@@ -3778,6 +3813,11 @@ let _podcastDetailWords = [];
 // doPodcastNotify (#530) so the Send to Signal/Email buttons don't need to
 // embed the id in their onclick attribute.
 let _podcastDetailEpisodeId = null;
+
+// Language the currently rendered podcast detail was fetched/rendered in
+// (#804) — doPodcastAddWord/doPodcastKnownWord need it to file the word (or
+// known-word mark) under the right language tree.
+let _podcastDetailLang = 'zh';
 
 // Regenerate the summary of the currently shown episode (#567): POST kicks
 // off a background thread on the server, then poll the detail endpoint until
@@ -3852,12 +3892,15 @@ function doPodcastAddWord(idx) {
   // Always the ★ List (#715): a word met while reading goes to the staging
   // area, never straight into today's or tomorrow's review queue. Activating
   // it is a separate, deliberate step in Browse's saved view.
+  //
+  // lang (#804): file the word under the language it was actually read in,
+  // not always Chinese — same reasoning as #726's addWordViaAi lang param.
   addWordViaAi(wordZh, 'list', (state, text) => {
     btn.textContent = text;
     btn.classList.toggle('podcast-add-error', state === 'error');
     // Only a failure is worth retrying; a finished add is not repeatable.
     if (state === 'error') btn.disabled = false;
-  });
+  }, _podcastDetailLang);
 }
 
 // "✓ Known" in the HSK word table (#710): Daniel already knows this word, it
@@ -3877,7 +3920,8 @@ function doPodcastKnownWord(idx) {
 
   btn.disabled = true;
   btn.textContent = '…';
-  markWordKnown(wordZh).then(() => {
+  // lang (#804): known_words is per-language — see markWordKnown's docstring.
+  markWordKnown(wordZh, _podcastDetailLang).then(() => {
     btn.textContent = '✓ known';
     document.getElementById(`podcast-word-row-${idx}`)?.classList.add('podcast-word-known');
   }).catch(e => {

--- a/static/shared.js
+++ b/static/shared.js
@@ -133,6 +133,9 @@ function knowledgeTitleFor(title, text) {
 // action, the opposite of adding it to a deck. Fire-and-await — the caller
 // updates its own UI optimistically and reports a rejected promise as an
 // error rather than silently leaving a wrong ✓ on screen.
-async function markWordKnown(word) {
-  return api('POST', '/api/known-words', { word });
+//
+// lang (#804) keys known_words per language, same reasoning as addWordViaAi's
+// lang param — omitted means Chinese, so every pre-#804 call site is unaffected.
+async function markWordKnown(word, lang) {
+  return api('POST', '/api/known-words', lang ? { word, lang } : { word });
 }

--- a/tests/test_knowledge_rendition.py
+++ b/tests/test_knowledge_rendition.py
@@ -1,0 +1,275 @@
+"""Tests for issue #804: per-language knowledge-base renditions.
+
+The knowledge base (#650-#655) stores one AI summary (summary_de) per
+episode; every other language's reading view is a lazily generated,
+cached translate-then-annotate derivative of it (knowledge/rendition.py +
+annotate/romance.py). Covers the four acceptance criteria from the issue:
+
+  1. A rendition is generated once and reused on a second request (no
+     re-translation).
+  2. Already-known French words (including forms that only exist in
+     entry_forms, e.g. a conjugated verb form) are not annotated; unknown
+     words are.
+  3. Regenerating an episode's summary clears its cached renditions.
+  4. A translation failure writes nothing to the database.
+
+Each test gets its own isolated temp DB by monkeypatching
+database.core.DB_PATH (same pattern as tests/test_entry_forms.py) — never
+database.DB_PATH, which is only a wildcard-import copy (#615).
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import annotate
+import database
+import knowledge.rendition
+import podcast
+import translator
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(database.core, "DB_PATH", str(tmp_path / "test.db"))
+    database.init_db()
+
+
+def _minimal_word(word_zh: str, lang: str = "zh") -> dict:
+    return {
+        "word_zh": word_zh,
+        "lang": lang,
+        "pinyin": None,
+        "definition": None,
+        "pos": None,
+        "hsk_level": None,
+        "traditional": None,
+        "definition_zh": None,
+        "source": "test",
+        "note_type": "vocabulary",
+        "notes": None,
+        "date_yaml": None,
+        "source_sentence": None,
+        "grammar_notes": None,
+        "register": None,
+        "definition_de": None,
+        "definition_fr": None,
+    }
+
+
+def _make_summarized_episode(summary_de: str = "<p>Bonjour le monde.</p>") -> int:
+    episode_id = database.create_pending_episode(
+        video_id="vid-1", channel_id=None, title="Test episode",
+        published_at=None, youtube_url="https://example.com/1",
+    )
+    database.update_episode(episode_id, status="summarized", summary_de=summary_de,
+                            transcript_zh="一些转录文本" * 5)
+    return episode_id
+
+
+# ---------------------------------------------------------------------------
+# 1. Rendition generated once, reused on the second request
+# ---------------------------------------------------------------------------
+
+def test_rendition_generated_and_cached(tmp_db, monkeypatch):
+    episode_id = _make_summarized_episode()
+
+    calls = {"n": 0}
+
+    def fake_translate_strict(text, target="en", source="zh-CN"):
+        calls["n"] += 1
+        return "Bonjour le monde."
+
+    monkeypatch.setattr(translator, "translate_strict", fake_translate_strict)
+    monkeypatch.setattr(translator, "translate_batch", lambda words, **kw: words)
+
+    first = knowledge.rendition.get_or_create_rendition(episode_id, "fr")
+    assert calls["n"] == 1
+    assert "Bonjour" in first["summary"]
+
+    second = knowledge.rendition.get_or_create_rendition(episode_id, "fr")
+    assert calls["n"] == 1  # not re-translated
+    assert second["summary"] == first["summary"]
+
+    # And it's actually persisted, not just process-memoized.
+    cached = database.get_knowledge_rendition(episode_id, "fr")
+    assert cached is not None
+    assert cached["summary"] == first["summary"]
+
+
+# ---------------------------------------------------------------------------
+# 2. Known words (incl. entry_forms-only conjugations) skipped; unknown flagged
+# ---------------------------------------------------------------------------
+
+def test_known_words_not_annotated_unknown_words_are(tmp_db):
+    # "parler" is studied; "parlons" only exists as its entry_forms
+    # conjugation, never as its own entries row (#803's whole point).
+    fr_word_id = database.insert_word(_minimal_word("parler", lang="fr"))
+    database.set_entry_forms(fr_word_id, [
+        {"kind": "conjugation", "paradigm": "présent", "slot": "nous",
+         "form": "parlons", "position": 0},
+    ])
+    # "bonjour" was never studied but Daniel marked it known (#710/#803).
+    database.add_known_word("bonjour", "fr")
+
+    text = "Nous parlons de bonjour et de mystère."
+    annotated, new_words = annotate.annotate_summary(text, "fr")
+
+    new_word_surfaces = {w["word"] for w in new_words}
+    assert "parlons" not in new_word_surfaces
+    assert "bonjour" not in new_word_surfaces
+    assert "mystère" in new_word_surfaces
+
+    assert "parlons (" not in annotated
+    assert "bonjour (" not in annotated
+    assert "mystère" in annotated
+
+
+def test_zh_annotation_dispatch_untouched(tmp_db):
+    """annotate.annotate_summary('zh') must produce the same result as
+    calling zh_annotate directly — the dispatch wraps it, it doesn't change
+    its behavior."""
+    import zh_annotate
+    text = "对就业的影响很大。"
+    annotated, new_words = annotate.annotate_summary(text, "zh")
+    assert annotated == zh_annotate.annotate_zh_summary(text)
+    assert new_words == zh_annotate.extract_new_words(text)
+
+
+# ---------------------------------------------------------------------------
+# 3. regenerate-summary clears cached renditions
+# ---------------------------------------------------------------------------
+
+def test_regenerate_summary_clears_renditions(tmp_db, monkeypatch):
+    episode_id = _make_summarized_episode()
+    database.save_knowledge_rendition(episode_id, "fr", "Ancien résumé.", [])
+    assert database.get_knowledge_rendition(episode_id, "fr") is not None
+
+    def fake_summarize(*a, **kw):
+        return {"summary_zh": "新总结。", "summary_de": "<p>Neuer Text.</p>", "words": []}
+
+    monkeypatch.setattr(podcast, "summarize", fake_summarize)
+    monkeypatch.setattr(podcast, "filter_new_words", lambda words: words)
+
+    result = podcast.regenerate_summary(episode_id)
+    assert result["regenerated"] is True
+    assert database.get_knowledge_rendition(episode_id, "fr") is None
+
+
+# ---------------------------------------------------------------------------
+# 4. Translation failure writes nothing
+# ---------------------------------------------------------------------------
+
+def test_translation_failure_does_not_write(tmp_db, monkeypatch):
+    episode_id = _make_summarized_episode()
+
+    def fake_translate_strict(text, target="en", source="zh-CN"):
+        raise RuntimeError("translator unavailable")
+
+    monkeypatch.setattr(translator, "translate_strict", fake_translate_strict)
+
+    with pytest.raises(knowledge.rendition.RenditionError):
+        knowledge.rendition.get_or_create_rendition(episode_id, "fr")
+
+    assert database.get_knowledge_rendition(episode_id, "fr") is None
+
+
+def test_missing_summary_de_does_not_write(tmp_db):
+    """An episode with no German summary yet (still pending/transcribing)
+    raises rather than translating an empty string into a fake rendition."""
+    episode_id = database.create_pending_episode(
+        video_id="vid-2", channel_id=None, title="Not summarized yet",
+        published_at=None, youtube_url="https://example.com/2",
+    )
+    with pytest.raises(knowledge.rendition.RenditionError):
+        knowledge.rendition.get_or_create_rendition(episode_id, "fr")
+    assert database.get_knowledge_rendition(episode_id, "fr") is None
+
+
+def test_zh_has_no_rendition():
+    with pytest.raises(knowledge.rendition.RenditionError):
+        knowledge.rendition.get_or_create_rendition(1, "zh")
+
+
+# ---------------------------------------------------------------------------
+# 5. HTML survives the round trip, and the HTTP wiring actually works
+# ---------------------------------------------------------------------------
+
+def test_html_tags_are_preserved_and_never_annotated(tmp_db, monkeypatch):
+    """summary_de is HTML (<p> paragraphs, <b> lead sentences).
+
+    Two things must hold: the tags come back byte-identical (they are never
+    sent to Google Translate — only the text nodes are, which also keeps
+    every request under the endpoint's ~5000-character limit), and the
+    annotator never treats a tag name as a word ("<strong>" must not turn
+    into "<strong (stark)>", which would destroy the markup).
+    """
+    html = ("<p><b>Ein Satz.</b> Noch ein Satz.</p>"
+            "<p><strong>Zweiter Absatz.</strong> Letzter Satz.</p>")
+    episode_id = _make_summarized_episode(summary_de=html)
+
+    sent = []
+
+    def fake_translate_strict(text, target="en", source="zh-CN"):
+        sent.append(text)
+        return "\n".join("mot " + line for line in text.split("\n"))
+
+    monkeypatch.setattr(translator, "translate_strict", fake_translate_strict)
+    monkeypatch.setattr(translator, "translate_batch",
+                        lambda words, **kw: ["gloss" for _ in words])
+
+    out = knowledge.rendition.get_or_create_rendition(episode_id, "fr")["summary"]
+
+    assert out.count("<p>") == 2 and out.count("</p>") == 2
+    assert "<b>" in out and "<strong>" in out
+    # No tag name ever got a gloss appended inside the tag itself.
+    assert "<strong (" not in out and "<b (" not in out
+    # Tags were never handed to the translator.
+    assert all("<" not in chunk for chunk in sent)
+
+
+def test_detail_endpoint_serves_rendition(tmp_db, monkeypatch):
+    """End-to-end through FastAPI: ?lang=fr attaches a rendition, zh doesn't."""
+    from fastapi.testclient import TestClient
+    import main
+
+    episode_id = _make_summarized_episode(summary_de="<p>Ein deutscher Satz.</p>")
+    monkeypatch.setattr(translator, "translate_strict",
+                        lambda text, target="en", source="zh-CN": "Une phrase française.")
+    monkeypatch.setattr(translator, "translate_batch",
+                        lambda words, **kw: ["gloss" for _ in words])
+
+    client = TestClient(main.app)
+
+    fr = client.get(f"/api/podcast/episodes/{episode_id}?lang=fr").json()
+    assert fr["rendition"] is not None
+    assert "phrase" in fr["rendition"]["summary"]
+    assert fr["rendition_error"] is None
+
+    zh = client.get(f"/api/podcast/episodes/{episode_id}").json()
+    assert "rendition" not in zh  # zh path untouched (#804)
+    assert zh["summary_de"] == "<p>Ein deutscher Satz.</p>"
+
+
+def test_detail_endpoint_reports_translation_failure(tmp_db, monkeypatch):
+    """A failed translation must not 500 the detail view, and must not store
+    the German text as if it were French."""
+    from fastapi.testclient import TestClient
+    import main
+
+    episode_id = _make_summarized_episode(summary_de="<p>Ein deutscher Satz.</p>")
+
+    def boom(text, target="en", source="zh-CN"):
+        raise RuntimeError("translator unavailable")
+
+    monkeypatch.setattr(translator, "translate_strict", boom)
+
+    client = TestClient(main.app)
+    resp = client.get(f"/api/podcast/episodes/{episode_id}?lang=fr")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["rendition"] is None
+    assert "translation failed" in body["rendition_error"]
+    assert database.get_knowledge_rendition(episode_id, "fr") is None

--- a/translator.py
+++ b/translator.py
@@ -48,6 +48,22 @@ def _load(source: str, target: str) -> object | None:
         return None
 
 
+def translate_strict(text: str, target: str = "en", source: str = "zh-CN") -> str:
+    """Like translate_zh, but raises instead of silently returning the
+    original text on failure (#804). translate_zh's swallow-everything
+    contract is right for its existing callers (a missing gloss shouldn't
+    sink a whole story/episode), but knowledge-base language renditions need
+    to tell "translated" apart from "translation failed" so a failure can be
+    reported to the frontend instead of being stored as if it were a real
+    translation into that language."""
+    t = _load(source, target)
+    if t is None:
+        raise RuntimeError(f"translator unavailable (source={source}, target={target})")
+    if not text.strip():
+        return text
+    return _translate_with_timeout(t, text)
+
+
 def translate_zh(text: str, target: str = "en", source: str = "zh-CN") -> str:
     """Translate a string from `source` to the target language. Returns original on failure."""
     t = _load(source, target)


### PR DESCRIPTION
## 改了什么

法语/西班牙语模式第二步。知识源全语言共享，阅读体验按语言个性化。

- **AI 摘要只生成一次**（`summary_de` 是主版本）；其它语言的版本 = 谷歌翻译 + 生词标注，存 `knowledge_renditions`，懒生成并缓存。**中文路径一个字节都没改**
- **`annotate/` 包**按 `languages` 的 `annotator` 字段分派：zh → 原有 `zh_annotate`；romance → 新实现，靠 #803 的 `entry_forms` **精确匹配**判定已学词（零词干还原），配法语/西语功能词表
- `GET /api/podcast/episodes/{id}?lang=fr` 返回 `rendition` / `rendition_error`；`known-words` 三个接口加 `lang`

## 两个自己修掉的坑

- **整块 HTML 丢给谷歌翻译是错的**：免费端点超 5000 字直接拒绝，而且标签会被吃掉。改成只送文本节点、标签原样拼回
- **标注器会把标签名当单词**：`<strong>` 会被标成 `<strong (stark)>`，直接毁掉标记。现在跳过标签内的所有匹配

## 失败时的行为

翻译失败 → 不写库、详情页显示原因，**不静默退回德语摘要**冒充法语。为此新加 `translator.translate_strict()`（`translate_zh` 的"失败返回原文"契约在这里是有害的）。

## 怎么测的

`pytest tests/`：655 passed, 4 skipped。新增 `tests/test_knowledge_rendition.py` 10 条，含：缓存只翻译一次、只存在于 `entry_forms` 的变位形不被当生词、重新生成摘要清空缓存、翻译失败不写库、HTML 标签零损伤、以及走 FastAPI 的端到端请求。

Closes #804