### PR TITLE
加词生成全部变位与词形、词典支持法语/西班牙语（#805）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -506,6 +506,13 @@ FSRS 用毕业评分播种初始 stability/difficulty：默认权重下 **Good �
 - **`/api/add-word-ai` 是全应用唯一的加词入口**（#643）：顶栏 ＋、播客单集的 HSK 生词表格、复习界面长按词的菜单、以及 `/add` 页面，全部共用 `shared.js` 的 `addWordViaAi()`。原来播客/长按走的 `/api/quick-add-word` 已删除 —— 它只让 AI 填四个字段（无例句/汉字分解/量词/同义反义词），而且 `added_to_deck` 分支在词已学过时被 `INSERT OR IGNORE` + `UNIQUE(word_id, category)` 全部静默丢弃，却照样返回成功。**加词只能有一条管线**，否则修好的坑会在第二条路上重新出现
 - **独立加词页 `/add`（#668）+ URL 参数（#686）**：可收藏的网址，打开就是输入框（存 iPhone 主屏当图标用）。`?word=生态`（或 `?w=`）+ 可选 `&day=today|tomorrow|list` → 打开即自动提交，供 iOS 快捷指令在任意 App 里一键加词；`day` 非法值回落 today（词才是重点，不该为此失败）。**提交后必须 `history.replaceState` 抹掉参数** —— 否则刷新或 iOS 恢复标签页会静默再花一次 AI 钱。`static/add.html` 是自包含页面，**故意不加载 `app.js`** —— 5.5 KB vs 完整应用的 77 KB + 491 KB JS，秒开就是这个功能的全部意义。为此把 `addWordViaAi()` 和 `api()` 从 `app.js` 抽到 `static/shared.js` 两页共用，**不复制第二份**（理由同上条；`tests/test_add_word.py` 有一条测试专门守着 `app.js` 里不能再出现这两个定义）
 
+**加西班牙语词与罗曼语形态（#805）**：`lang` 支持 `zh|fr|es`
+
+- **加词必须把全部变位/词形生成出来**，这不是锦上添花：知识库判定"这个词形我学过没有"靠的是 `entry_forms` 的精确匹配（`database.forms_lookup()`，零词干还原），漏掉的变位就等于这个词在阅读里永远显示为生词。提示词对法语/西语强制要求：动词给完整变位表、名词给 `gender:` + 复数、形容词给阴性/复数
+- YAML 里 `conjugations:` 进 `entry_forms(kind='conjugation')`，`forms:`（`{维度: {槽位: 形式}}`）进 `kind='inflection'`，`gender:` 进 `entries.gender`。格式见 `docs/yaml-format.md`
+- **词典 `/dict` 支持 fr/es**（`ai.DICTIONARY_PROMPT_ROMANCE`，移植自 `de-fr-bot`）：**返回的 JSON 契约与中文版完全一致**，所以前端渲染代码不分语言。★ 加词仍然走 `/api/add-word-ai`——词典不得成为第二条加词管线（#643）
+- **`GET /api/langs?available=1` 返回全部已注册语言**，`/add` 和 `/dict` 用它；主页标签栏仍用"在用语言"。区别是有意的：**一门新语言还没有牌组，按"在用"过滤就永远加不了它的第一个词**
+
 **加法语词（#726）**：`lang` 参数（`zh` 默认 / `fr`）同时决定提示词和牌组树
 
 - **每种语言一棵平行的牌组树**，根名在 `languages.py` 的 `deck_root`（zh → `Daily`，fr → `Français`）：`Français::<日期> · Listening/…` + `Français::Saved`，牌组本身 `lang='fr'`。**必须如此**——全应用的语言过滤（`_lang_subquery_clause`、`get_descendant_leaf_deck_ids`）筛的是 `decks.lang` 而不是 `entries.lang`，法语卡放进中文牌组会在 fr 标签下消失、反而混进中文复习队列（生产库里 #726 之前导入的那 7 个法语词正是这个状态）

--- a/ai.py
+++ b/ai.py
@@ -1141,6 +1141,48 @@ _ENTRY_YAML_EXAMPLE_FR = """- type: word
       vous: parlez
     participe présent: parlant
     participe passé: parlé (avoir)
+
+- type: word
+  date: "07/21"
+  word: le chat
+  pos: nom (m)
+  english: cat
+  german: die Katze, der Kater
+  level: "A1"
+  register: neutral
+  gender: m
+  note: |
+    Männliches Substantiv. Für weibliche Katzen sagt man "la chatte".
+
+    **Étymologie:** Vom lateinischen *cattus*.
+  examples:
+    - fr: Le chat dort sur le canapé.
+      english: The cat is sleeping on the couch.
+      german: Die Katze schläft auf dem Sofa.
+  forms:
+    nombre:
+      pluriel: chats
+
+- type: word
+  date: "07/21"
+  word: vert
+  pos: adjectif
+  english: green
+  german: grün
+  level: "A1"
+  register: neutral
+  note: |
+    Regelmäßiges Adjektiv, stimmt in Genus und Numerus mit dem Substantiv überein.
+  examples:
+    - fr: Le pull vert est à moi.
+      english: The green sweater is mine.
+      german: Der grüne Pullover gehört mir.
+  forms:
+    genre:
+      féminin: verte
+      féminin pluriel: vertes
+    nombre:
+      pluriel: verts
 """
 
 _ENTRY_YAML_PROMPT_FR = """You are a French dictionary expert producing an SRS flashcard entry for a
@@ -1165,6 +1207,16 @@ REQUIRED FIELDS: type, the headword key, english, german, level, date: "{today}"
   - register: one of spoken_colloquial, spoken_neutral, neutral, formal_written,
     literary, slang
   - english / german: concise glosses; separate distinct meanings with " / "
+  - gender: REQUIRED FOR EVERY NOUN, omitted for everything else. One of
+    m, f, mf (structurally both, e.g. some nouns for people). This is the
+    entry's OWN grammatical gender, separate from any inflected forms below.
+  - forms: REQUIRED FOR EVERY NOUN AND ADJECTIVE, omitted for verbs/sentences.
+    A mapping {{dimension: {{slot: form}}}} of inflected surface forms — nouns
+    need "nombre: {{pluriel: <plural form>}}"; adjectives need BOTH
+    "genre: {{féminin: <feminine>, féminin pluriel: <feminine plural>}}" AND
+    "nombre: {{pluriel: <masculine plural>}}". Only include forms that
+    genuinely differ from the headword (an invariable adjective like "rose"
+    still needs its plural "roses" if that changes).
 
 LANGUAGE RULES — these fields MUST be German:
   note, explanations, synonyms[].meaning, antonyms[].meaning, examples[].german
@@ -1201,10 +1253,225 @@ YAML SAFETY — the output is parsed by a strict loader:
   - note / explanations use block scalars (|) — colons are safe there.
   - Indent consistently with two spaces; no tab characters.
 
-EXAMPLE of the expected shape (for parler):
+EXAMPLES of the expected shape (a verb with conjugations, a noun with
+gender+forms, an adjective with forms):
 
 {example}
 """
+
+
+# ---------------------------------------------------------------------------
+# The Spanish twin (issue #805) — same Romance-family contract as French
+# (docs/yaml-format.md "西班牙语格式"), just different vocabulary: gender,
+# forms (plural/feminine), and a fuller conjugation table (Spanish distinguishes
+# more tenses in everyday speech than the French set already covers).
+# importer._normalize_romance_entry(entry, "es") maps word/level/examples[].es
+# onto the internal keys the same way it does for French.
+# ---------------------------------------------------------------------------
+
+_ENTRY_YAML_EXAMPLE_ES = """- type: word
+  date: "07/21"
+  word: hablar
+  pos: verbo
+  english: to speak, to talk
+  german: sprechen, reden
+  level: "A1"
+  register: neutral
+  note: |
+    Regelmäßiges Verb auf -ar. Grundverb für „sprechen" — mit Sprache direkt
+    danach (hablar español), mit „de" für „über etwas sprechen" (hablar de algo),
+    mit „con" für den Gesprächspartner (hablar con alguien).
+
+    **Etimología:** Vom lateinischen *fabulari* („erzählen, plaudern").
+  examples:
+    - es: Hablo un poco de español.
+      english: I speak a little Spanish.
+      german: Ich spreche ein wenig Spanisch.
+    - es: Hablamos de ti ayer.
+      english: We talked about you yesterday.
+      german: Wir haben gestern über dich gesprochen.
+  synonyms:
+    - word: charlar
+      meaning: plaudern, sich unterhalten
+  antonyms:
+    - word: callarse
+      meaning: schweigen
+  conjugations:
+    presente:
+      yo: hablo
+      tú: hablas
+      él/ella: habla
+      nosotros: hablamos
+      vosotros: habláis
+      ellos/ellas: hablan
+    pretérito perfecto:
+      yo: he hablado
+      tú: has hablado
+      él/ella: ha hablado
+      nosotros: hemos hablado
+      vosotros: habéis hablado
+      ellos/ellas: han hablado
+    pretérito indefinido:
+      yo: hablé
+      tú: hablaste
+      él/ella: habló
+      nosotros: hablamos
+      vosotros: hablasteis
+      ellos/ellas: hablaron
+    imperfecto:
+      yo: hablaba
+      tú: hablabas
+      él/ella: hablaba
+      nosotros: hablábamos
+      vosotros: hablabais
+      ellos/ellas: hablaban
+    futuro:
+      yo: hablaré
+      tú: hablarás
+      él/ella: hablará
+      nosotros: hablaremos
+      vosotros: hablaréis
+      ellos/ellas: hablarán
+    condicional:
+      yo: hablaría
+      tú: hablarías
+      él/ella: hablaría
+      nosotros: hablaríamos
+      vosotros: hablaríais
+      ellos/ellas: hablarían
+    presente de subjuntivo:
+      yo: hable
+      tú: hables
+      él/ella: hable
+      nosotros: hablemos
+      vosotros: habléis
+      ellos/ellas: hablen
+    participio: hablado
+    gerundio: hablando
+
+- type: word
+  date: "07/21"
+  word: el gato
+  pos: sustantivo (m)
+  english: cat
+  german: die Katze, der Kater
+  level: "A1"
+  register: neutral
+  gender: m
+  note: |
+    Männliches Substantiv. Für weibliche Katzen sagt man "la gata".
+
+    **Etimología:** Vom lateinischen *cattus*.
+  examples:
+    - es: El gato duerme en el sofá.
+      english: The cat is sleeping on the couch.
+      german: Die Katze schläft auf dem Sofa.
+  forms:
+    numero:
+      plural: gatos
+
+- type: word
+  date: "07/21"
+  word: verde
+  pos: adjetivo
+  english: green
+  german: grün
+  level: "A1"
+  register: neutral
+  note: |
+    Regelmäßiges Adjektiv. Endet auf -e, deshalb gleiche Form für Maskulin
+    und Femininum — nur die Pluralform ändert sich.
+  examples:
+    - es: El jersey verde es mío.
+      english: The green sweater is mine.
+      german: Der grüne Pullover gehört mir.
+  forms:
+    numero:
+      plural: verdes
+"""
+
+_ENTRY_YAML_PROMPT_ES = """You are a Spanish dictionary expert producing an SRS flashcard entry for a
+German-speaking learner (CEFR A2, everyday spoken Spanish). Generate a complete
+YAML entry for: {word}
+
+Return ONLY the YAML — a single list item starting with "- type:". No markdown
+fences, no commentary before or after.
+
+TYPE — pick exactly one:
+  word        a single word (verb, noun, adjective, adverb)
+  expression  a multi-word phrase acting as a unit (idiom, collocation)
+  sentence    a full sentence
+
+The headword key is named after the type: `word:`, `expression:` or `sentence:`.
+There is no `simplified` field and no Chinese in the output.
+
+REQUIRED FIELDS: type, the headword key, english, german, level, date: "{today}".
+  - pos: Spanish part of speech — verbo, sustantivo (m), sustantivo (f),
+    adjetivo, adverbio, locución … NOUNS ALWAYS CARRY THEIR GENDER. Omit pos
+    for `sentence`.
+  - level: a quoted CEFR string "A1"…"C2"
+  - register: one of spoken_colloquial, spoken_neutral, neutral, formal_written,
+    literary, slang
+  - english / german: concise glosses; separate distinct meanings with " / "
+  - gender: REQUIRED FOR EVERY NOUN, omitted for everything else. One of
+    m, f, mf (structurally both, e.g. some nouns for people). This is the
+    entry's OWN grammatical gender, separate from any inflected forms below.
+  - forms: REQUIRED FOR EVERY NOUN AND ADJECTIVE, omitted for verbs/sentences.
+    A mapping {{dimension: {{slot: form}}}} of inflected surface forms — nouns
+    need "numero: {{plural: <plural form>}}"; adjectives need "numero:
+    {{plural: <plural form>}}" and, when the adjective actually varies by
+    gender (most -o/-a adjectives do, -e ones usually don't), also "genero:
+    {{femenino: <feminine>, femenino plural: <feminine plural>}}". Only include
+    forms that genuinely differ from the headword.
+
+LANGUAGE RULES — these fields MUST be German:
+  note, explanations, synonyms[].meaning, antonyms[].meaning, examples[].german
+  examples[].english is English; the headword and examples[].es are Spanish.
+
+CONTENT:
+  - note (word/expression): German prose block scalar (|) covering usage,
+    common collocations, false-friend warnings, and a short
+    "**Etimología:** …" line (1-2 sentences) — Spanish has no separate
+    etymology column, so it belongs in the note.
+  - examples: 2-4 sentences, EACH with all three keys es, english, german
+  - synonyms / antonyms: {{word, meaning}} items; include when they add real value
+  - conjugations: REQUIRED FOR EVERY VERB, omitted for everything else.
+    All of: presente, pretérito perfecto, pretérito indefinido, imperfecto,
+    futuro, condicional, presente de subjuntivo, participio, gerundio.
+    Person keys are exactly yo, tú, él/ella, nosotros, vosotros, ellos/ellas
+    (omit vosotros only if you are certain the learner only needs Latin
+    American Spanish — default to including it). participio/gerundio are
+    plain strings (no person). Never guess irregular forms (ser, estar, ir,
+    tener, hacer, poder, querer, decir, poner, saber, venir … are all
+    irregular — get them right).
+  - sentence type: use `explanations` (German block scalar) instead of note,
+    add `source_de` with the German original, and optionally
+    similar_sentences: [{{es, german}}].
+
+YAML SAFETY — the output is parsed by a strict loader:
+  - Never use double quotes for meaning/english/german fields. If a colon is
+    unavoidable inside an inline string, wrap it in single quotes; better yet,
+    rephrase to avoid the colon.
+  - A Spanish apostrophe (rare, but e.g. in loanwords) inside a single-quoted
+    string must be doubled. Prefer leaving such values unquoted.
+  - note / explanations use block scalars (|) — colons are safe there.
+  - Indent consistently with two spaces; no tab characters.
+
+EXAMPLES of the expected shape (a verb with conjugations, a noun with
+gender+forms, an adjective with forms):
+
+{example}
+"""
+
+
+# lang -> (prompt template, example block). Every Romance language shares the
+# same contract (docs/multilang.md); adding a new one is one more entry here
+# plus its own prompt/example pair, no other code path changes (issue #805).
+_ENTRY_YAML_TEMPLATES = {
+    "zh": (_ENTRY_YAML_PROMPT, _ENTRY_YAML_EXAMPLE),
+    "fr": (_ENTRY_YAML_PROMPT_FR, _ENTRY_YAML_EXAMPLE_FR),
+    "es": (_ENTRY_YAML_PROMPT_ES, _ENTRY_YAML_EXAMPLE_ES),
+}
 
 
 def generate_word_entry_yaml(word_zh: str, model: str = DEFAULT_MODEL,
@@ -1212,10 +1479,10 @@ def generate_word_entry_yaml(word_zh: str, model: str = DEFAULT_MODEL,
     """Generate a complete dictionary YAML entry for one word.
 
     `lang` picks the prompt and the output format: 'zh' produces a de-zh-bot
-    entry, 'fr' the de-fr-bot French format (issue #726). Returns YAML ready
-    for importer.import_yaml_content(). Raises ValueError if the model returns
-    something that isn't a YAML list item — callers surface that to the user
-    rather than importing garbage.
+    entry, 'fr'/'es' the de-fr-bot-style Romance format (issues #726, #805).
+    Returns YAML ready for importer.import_yaml_content(). Raises ValueError
+    if the model returns something that isn't a YAML list item — callers
+    surface that to the user rather than importing garbage.
 
     Non-Chinese output is wrapped in a `lang:` header rather than relying on
     the target deck's language: the entry format and the lang have to agree, so
@@ -1224,8 +1491,7 @@ def generate_word_entry_yaml(word_zh: str, model: str = DEFAULT_MODEL,
     """
     from datetime import date as _date
 
-    template = _ENTRY_YAML_PROMPT if lang == "zh" else _ENTRY_YAML_PROMPT_FR
-    example = _ENTRY_YAML_EXAMPLE if lang == "zh" else _ENTRY_YAML_EXAMPLE_FR
+    template, example = _ENTRY_YAML_TEMPLATES.get(lang, (_ENTRY_YAML_PROMPT, _ENTRY_YAML_EXAMPLE))
     prompt = template.format(
         word=word_zh,
         today=_date.today().strftime("%m/%d"),
@@ -1338,6 +1604,99 @@ a/b/c... never digits):
 Input to look up: {query}"""
 
 
+# ---------------------------------------------------------------------------
+# Romance-language dictionary (issue #805) — ported from the de-fr-bot skill,
+# generalized to fr/es via {lang_name}/{level}. The JSON CONTRACT IS IDENTICAL
+# to DICTIONARY_PROMPT above (same "headline"/"kind"/"sentence"/"groups[].
+# options[]" shape, same field names, "zh"/"pinyin" included) so the /dict
+# frontend never has to branch on language — the target-language word/pinyin
+# just goes in the "zh"/"pinyin" slots regardless of what language they
+# actually hold (pinyin is simply omitted for Romance languages, which have
+# no tone-mark transcription need).
+# ---------------------------------------------------------------------------
+
+DICTIONARY_PROMPT_ROMANCE = """You are a {lang_name} dictionary for a German-speaking learner (Daniel, {level}).
+He types a word, phrase, or sentence in {lang_name}, German, or English and wants
+a structured lookup, not a chat reply. Never use Japanese or Chinese.
+
+Behavior rules:
+- {lang_name} input -> give the FULL dictionary entry directly. List EVERY sense
+  (meaning) of the word/phrase, each as its own group. Do not ask him to
+  choose anything and do not present alternative translations to pick from
+  — there is nothing to choose, he already has the {lang_name} word.
+- German or English input (word, phrase, or a full sentence) -> always give an
+  ANALYSIS: an overall translation plus one or more groups of candidate
+  {lang_name} translations, each option labeled a/b/c... (NEVER use 1/2/3).
+  Exactly one option per group may be "recommended": true, and the
+  recommendation should lean toward everyday spoken {lang_name} (langage
+  courant) — this is Daniel's strongest, most repeated preference.
+- A full German sentence as input -> first give the whole-sentence {lang_name}
+  translation (the "sentence" field, no pinyin — leave "pinyin" out), THEN
+  break the sentence into its components (each a candidate group of its own)
+  so every component is individually addable as a word.
+- Explanations, usage notes, and example sentence translations are always in
+  GERMAN.
+
+Quality rules (these decide whether the entry is useful at all):
+- At most 3-5 options per group, and only GENUINELY DIFFERENT translations —
+  different register, connotation, or part of speech. Do not pad a group with
+  near-synonyms; two options that a learner would use interchangeably are one
+  option.
+- EVERY option must carry example_zh (the {lang_name} example sentence) +
+  example_de. An option without an example is unusable: register claims are
+  only believable when the sentence shows them. Omit example_pinyin entirely
+  — {lang_name} uses the Latin alphabet, there is no separate transcription.
+- "usage" must say WHEN to use it (register, context, connotation), not repeat
+  the translation.
+- Do not fill in "pinyin" or "headline_pinyin" for {lang_name} — leave them out.
+- "register" must be one of: spoken_colloquial, spoken_neutral, neutral,
+  formal_written, literary, slang.
+- For {lang_name} input, "headline" is the input word itself and each group's
+  "label" names one sense in German (e.g. "1. Ökologie (Biologie)").
+- "kind" is exactly one of: "chinese" (reused here to mean "target-language
+  input", i.e. any {lang_name} input), "word", "phrase", "sentence"
+  (German/English input, by length). Only "sentence" makes the "sentence"
+  field appear.
+
+Output ONLY raw JSON — no markdown code fence, no prose before or after it.
+Match this shape exactly (omit "sentence" unless kind == "sentence"; omit
+"pinyin"/"headline_pinyin" always; every group needs at least one option;
+option "key" values are a/b/c... never digits). Note: the JSON field is
+literally named "zh" for historical reasons (this contract is shared with the
+Chinese dictionary) — put the {lang_name} word/sentence there:
+
+{{
+  "input_lang": "de",
+  "kind": "phrase",
+  "headline": "assigner une tâche",
+  "headline_de": "jemandem eine Aufgabe geben",
+  "notes": "kurze deutsche Anmerkung, optional",
+  "sentence": {{
+    "zh": "Tu es libre quand la semaine prochaine ?",
+    "de": "Wann hast du nächste Woche Zeit?"
+  }},
+  "groups": [
+    {{
+      "label": "assigner / donner une tâche (Verb)",
+      "options": [
+        {{
+          "key": "a",
+          "zh": "confier une tâche",
+          "de": "jdm. eine Aufgabe anvertrauen",
+          "usage": "neutral, im Alltag üblich.",
+          "register": "spoken_neutral",
+          "recommended": true,
+          "example_zh": "Le prof m'a encore confié une tâche.",
+          "example_de": "Der Lehrer hat mir schon wieder eine Aufgabe gegeben."
+        }}
+      ]
+    }}
+  ]
+}}
+
+Input to look up: {query}"""
+
+
 def _strip_code_fence(raw: str) -> str:
     """Some models wrap JSON in ```json ... ``` despite being told not to."""
     fenced = re.search(r"```(?:json)?\s*\n(.*?)```", raw, re.DOTALL)
@@ -1352,16 +1711,22 @@ def dictionary_lookup(query: str, lang: str = "zh", model: str | None = None) ->
     not store or return a placeholder, since a blank dictionary entry is worse
     than an error (routes/dictionary.py turns this into a 500).
 
-    lang is the target vocabulary language. Only Chinese is implemented — a
-    French dictionary needs its own prompt (see the de-fr-bot skill), and
-    silently answering a French request with the Chinese prompt would produce
-    a plausible-looking but wrong entry, exactly the failure #726 guarded
-    against on the add-word side.
+    lang is the target vocabulary language: 'zh', 'fr' or 'es' (#805).
+    Silently answering a French/Spanish request with the Chinese prompt (or
+    vice versa) would produce a plausible-looking but wrong entry, exactly the
+    failure #726 guarded against on the add-word side — so an unsupported lang
+    raises rather than falling back.
     """
-    if lang != "zh":
-        raise ValueError(f"dictionary_lookup: language {lang!r} is not supported yet (only 'zh')")
     use_model = model or DEFAULT_MODEL
-    prompt = DICTIONARY_PROMPT.format(query=query)
+    if lang == "zh":
+        prompt = DICTIONARY_PROMPT.format(query=query)
+    elif lang in ("fr", "es"):
+        cfg = languages.get_lang_config(lang)
+        prompt = DICTIONARY_PROMPT_ROMANCE.format(
+            query=query, lang_name=cfg["name_en"], level=cfg["learner_level"],
+        )
+    else:
+        raise ValueError(f"dictionary_lookup: language {lang!r} is not supported yet (zh/fr/es only)")
 
     logger.info("[%s] dictionary_lookup: %s", use_model, query)
     raw = _call_api(use_model, [{"role": "user", "content": prompt}], max_tokens=4000,

--- a/database/entries.py
+++ b/database/entries.py
@@ -14,10 +14,12 @@ def insert_word(word: dict) -> int:
         """INSERT OR IGNORE INTO entries
            (word_zh, lang, pinyin, definition, pos, hsk_level,
             traditional, definition_zh, source, note_type,
-            notes, date_yaml, source_sentence, grammar_notes, register, definition_de, definition_fr)
+            notes, date_yaml, source_sentence, grammar_notes, register, definition_de, definition_fr,
+            gender)
            VALUES (:word_zh, :lang, :pinyin, :definition, :pos, :hsk_level,
                    :traditional, :definition_zh, :source, :note_type,
-                   :notes, :date_yaml, :source_sentence, :grammar_notes, :register, :definition_de, :definition_fr)""",
+                   :notes, :date_yaml, :source_sentence, :grammar_notes, :register, :definition_de, :definition_fr,
+                   :gender)""",
         {
             **word,
             "lang":            word.get("lang") or "zh",
@@ -36,6 +38,8 @@ def insert_word(word: dict) -> int:
             "register":        word.get("register"),
             "definition_de":   word.get("definition_de"),
             "definition_fr":   word.get("definition_fr"),
+            # Noun grammatical gender (French/Spanish; #803/#805) — 'm'|'f'|'mf'|None
+            "gender":          word.get("gender"),
         },
     )
     # Backfill notes / date_yaml for entries that existed before these fields were added
@@ -97,6 +101,7 @@ def get_word_full(word_id: int) -> dict | None:
     word["relations"] = get_word_relations(word_id)
     word["components"] = get_note_components(word_id)
     word["conjugations"] = get_word_conjugations(word_id)
+    word["inflections"] = get_word_inflections(word_id)
     return word
 
 
@@ -202,6 +207,25 @@ def insert_word_relation(word_id: int, related_zh: str,
     conn.close()
 
 
+def insert_word_form(word_id: int, kind: str, paradigm: str, slot: str,
+                     form: str, position: int) -> None:
+    """Generic single-row writer for entry_forms (#805). `kind` is
+    'conjugation' (paradigm=tense, slot=person) or 'inflection'
+    (paradigm=dimension e.g. 'nombre'/'genre', slot=value e.g.
+    'pluriel'/'féminin'). insert_word_conjugation is a thin wrapper over this
+    kept for its established call sites/signature.
+    """
+    conn = get_db()
+    conn.execute(
+        """INSERT OR IGNORE INTO entry_forms
+           (word_id, kind, paradigm, slot, form, position)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (word_id, kind, paradigm, slot, form, position),
+    )
+    conn.commit()
+    conn.close()
+
+
 def insert_word_conjugation(word_id: int, tense: str, person: str,
                             form: str, position: int) -> None:
     """person is '' for impersonal forms (participles, infinitive).
@@ -210,15 +234,7 @@ def insert_word_conjugation(word_id: int, tense: str, person: str,
     entry_forms is the single source of truth going forward — see
     docs/multilang.md). tense -> paradigm, person -> slot.
     """
-    conn = get_db()
-    conn.execute(
-        """INSERT OR IGNORE INTO entry_forms
-           (word_id, kind, paradigm, slot, form, position)
-           VALUES (?, 'conjugation', ?, ?, ?, ?)""",
-        (word_id, tense, person, form, position),
-    )
-    conn.commit()
-    conn.close()
+    insert_word_form(word_id, "conjugation", tense, person, form, position)
 
 
 def get_word_conjugations(word_id: int) -> list[dict]:
@@ -229,6 +245,21 @@ def get_word_conjugations(word_id: int) -> list[dict]:
     rows = conn.execute(
         """SELECT paradigm AS tense, slot AS person, form, position
            FROM entry_forms WHERE word_id = ? AND kind = 'conjugation'
+           ORDER BY position, id""",
+        (word_id,),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def get_word_inflections(word_id: int) -> list[dict]:
+    """Inflection rows for a word (noun/adjective forms — plural, gender
+    agreement; #805), shaped like get_word_conjugations for the frontend's
+    'inflection' collapsible section: [{paradigm, slot, form, position}]."""
+    conn = get_db()
+    rows = conn.execute(
+        """SELECT paradigm, slot, form, position
+           FROM entry_forms WHERE word_id = ? AND kind = 'inflection'
            ORDER BY position, id""",
         (word_id,),
     ).fetchall()

--- a/docs/multilang.md
+++ b/docs/multilang.md
@@ -305,8 +305,89 @@ CREATE TABLE knowledge_renditions (
 `sentence_limit`）已经是从 `languages.py` 取的，新语言不需要新的生成逻辑，
 只需要语言族的 `features.extended_story_modes` 等标志位控制哪些模式可用。
 
-### AI 词典多语言（本 Issue 仍不实现，只占位）
+## 加词与词典：fr/es 的完整形态生成（#805，已实现）
 
-`/api/dict/lookup` 目前 `lang` 硬编码只接受 `'zh'`（见 CLAUDE.md「AI 词典页」
-一节）——扩展到 fr/es 时提示词要按 `family` 分支，不是按具体语言分支（法语
-和西班牙语的提示词结构应该几乎一样）。
+依赖上面的语言族 + `entry_forms`。目标：法语/西班牙语加词生成的词条要和中文
+一样完整——动词全部变位、名词/形容词全部词形变化——因为 `database.forms_lookup()`
+是知识库判定"这个词形学过没有"的唯一办法，**不做词干还原**，所以形态表不全
+就等于知识库标注对罗曼语永远漏词。
+
+### 加词：`ai.generate_word_entry_yaml`
+
+`_ENTRY_YAML_TEMPLATES = {"zh": ..., "fr": ..., "es": ...}` 按 `lang` 选提示词
++ 示例块，新增语言只是往这个字典里加一对，不改函数本身。法语/西班牙语提示词
+要求：
+
+- **名词**：`gender: m|f|mf` 字段 + `forms:` 里的复数（`nombre`/`numero`
+  维度）。
+- **形容词**：`forms:` 里的阴性、复数、阴性复数（`genre`/`genero` +
+  `nombre`/`numero`）。
+- **动词**：`conjugations:`——法语沿用 #726 已有的 7 个时态；西班牙语额外要求
+  `presente`、`pretérito perfecto`、`pretérito indefinido`、`imperfecto`、
+  `futuro`、`condicional`、`presente de subjuntivo` + `participio`/`gerundio`
+  （西班牙语日常口语区分的过去时比法语这套多，少一个时态就是一整类"这句话
+  哪个时态"的生词标注漏判）。
+
+`forms:` 的 YAML 结构与 `conjugations:` 完全同构（`{维度: {槽位: 形式}}`），
+这不是巧合——两者最终都写进同一张 `entry_forms` 表，只是 `kind` 不同
+（见下）。完整字段规则和示例见 `docs/yaml-format.md` 的"法语格式"/"西班牙语
+格式"两节，那里是唯一详细文档，这里不重复。
+
+### 导入器：`_normalize_romance_entry` 泛化，`_process_forms` 新增
+
+`importer._normalize_fr_entry` 改名（旧名保留为别名）为
+`_normalize_romance_entry(entry, lang)`，用 `lang` 参数决定例句/相似句读
+`fr:` 还是 `es:` 键，其余归一化逻辑（headword、CEFR 等级映射、丢弃中文专属
+字段）两种语言完全共享。`gender:` 字段做一次合法性校验（`m`/`f`/`mf`，非法
+值静默丢弃为 `None`，不因为一个可选字段拒绝整条词条——同 `register` 字段的
+处理姿态）。
+
+`_process_forms(entry, word_id)` 与既有的 `_process_conjugations` 是姊妹函数
+（结构几乎一样，`kind='inflection'` 而不是 `'conjugation'`），把 `forms:`
+映射逐槽位写进 `entry_forms`。`database/entries.py` 新增
+`insert_word_form(word_id, kind, paradigm, slot, form, position)` 作为通用的
+单行写入函数，`insert_word_conjugation` 现在是它的薄封装——两个写入路径共享
+同一段 SQL，不是各写一份。`get_word_full()` 新增 `word["inflections"]`（形状
+同 `word["conjugations"]`：`[{paradigm, slot, form, position}]`）。
+
+### `POST /api/add-word-ai` 的 `lang` 参数
+
+`is_valid_lang()` 已经认得 `es`（#803 把它注册成真语言），`_validate_word_for_lang`
+的拉丁字母校验对 fr/es 天然通用（判断逻辑不认字母表具体是哪种，只认"不是
+汉字且含拉丁字母"），所以这条路径**不需要改代码**——#805 在这里唯一动的是
+错误提示信息，从硬编码"in French"改成按 `languages.get_lang_config(lang)["name_en"]`
+取语言名。
+
+### 词典：`DICTIONARY_PROMPT_ROMANCE`
+
+`ai.py` 新增一份罗曼语版提示词（移植自 `de-fr-bot` 技能），用
+`{lang_name}`/`{level}` 参数化，法语和西班牙语共用同一份模板——正是语言族存在
+的意义：两种语言的词典分析结构应该几乎一样，不需要各写一份。**JSON 契约与
+中文版完全一致**（`headline`/`kind`/`sentence`/`groups[].options[]`，字段名
+不变）：目标语言的词/例句仍然写进名叫 `"zh"`/`"example_zh"` 的字段（历史命名，
+`/dict` 前端不分语言渲染，字段名换了前端就要按语言分支，反而制造出#805明确
+要避免的那类耦合）；`pinyin`/`headline_pinyin` 对 fr/es 留空——拉丁字母没有
+单独的注音需要。
+
+`ai.dictionary_lookup(query, lang, model)` 按 `lang in {"zh","fr","es"}` 选
+`DICTIONARY_PROMPT` 或 `DICTIONARY_PROMPT_ROMANCE`；其他值抛 `ValueError`
+（路由层转 400，不是让模型硬答一个错误语言的词典条目——同 #726 加词侧的姿态）。
+`routes/dictionary.py` 的 400 校验、`dict_queries.lang` 列同步放开到三个值。
+
+### 前端：`/dict` 语言切换
+
+`static/dict.html` 加了和 `/add`（#726）完全一样的语言选择器模式：拉一次
+`/api/langs`，只有多于一种语言在用时才显示切换钮；`?lang=` URL 参数打开即
+选定语言。★ 按钮和 Repeat 按钮都要带上"这条历史记录当初是用哪种语言查的"
+（`record.lang`，由 `_row_to_result` 新增的 `lang` 字段带出），而不是"选择器
+现在显示的语言"——否则切标签页再点旧结果的 Repeat/★，会用错误的语言重新生成。
+`/dict` 页面**仍然不加载 `app.js`**（保持原则不变）。
+
+### 浏览与词条详情：`entry_forms` → 词形变化折叠区
+
+`renderConjugationSection` 早已经从 `entry_forms`（经 `get_word_conjugations`
+读回旧形状）读数据，这次不用改。新增 `renderInflectionSection`——同样的分组
+渲染逻辑，读 `word.inflections` + `word.gender`，中文词条两者都是空/None，
+折叠区直接不渲染（`el.innerHTML = ''`），零 UI 差异。挂载点：`wd-inflection-section`
+（词条详情弹窗）+ `inflection-section`（复习卡背面），紧跟在各自的
+conjugation 挂载点后面。

--- a/docs/yaml-format.md
+++ b/docs/yaml-format.md
@@ -15,6 +15,7 @@
 6. [嵌套结构：`word_analyses`](#嵌套结构-word_analyses)
 7. [向后兼容性](#向后兼容性)
 8. [法语格式（`lang: fr`）](#法语格式lang-fr)
+9. [西班牙语格式（`lang: es`）](#西班牙语格式lang-es)
 
 ---
 
@@ -323,7 +324,9 @@ word_analyses:
 ## 法语格式（`lang: fr`）
 
 文件顶层必须声明 `lang: fr`（或粘贴导入到法语牌组——此时可省略）。法语条目经
-`importer._normalize_fr_entry` 归一化后复用全部下游逻辑；中文专属模块（汉字分解、
+`importer._normalize_romance_entry(entry, "fr")` 归一化后复用全部下游逻辑
+（`_normalize_fr_entry` 仍作为别名保留，向后兼容）；同一函数按 `lang` 参数
+也服务西班牙语（见下方「西班牙语格式」一节）。中文专属模块（汉字分解、
 量词、拼音、`word_analyses`）不适用。
 
 ### 与中文格式的字段差异
@@ -337,7 +340,9 @@ word_analyses:
 | `examples[]` | 每项 `{fr, german, english}`（`fr` 代替 `zh`，`german` 代替 `de`） |
 | `similar_sentences[]` | 同上，`{fr, german}`，仅 sentence 类型 |
 | `synonyms` / `antonyms` | 同中文格式：`{word, meaning}`（meaning 用德语） |
-| `conjugations` | 动词专用，见下——存入 `entry_conjugations` 表（议题 #596） |
+| `conjugations` | 动词专用，见下——存入 `entry_forms` 表，`kind='conjugation'`（议题 #596/#803） |
+| `gender` | 名词专用，`m`\|`f`\|`mf`——存入 `entries.gender`（议题 #805） |
+| `forms` | 名词/形容词专用，见下——存入 `entry_forms` 表，`kind='inflection'`（议题 #805） |
 | `register` | 同中文格式的取值集合 |
 
 ### `conjugations` 结构（仅动词）
@@ -386,6 +391,64 @@ entries:
       participe passé: parlé (avoir)
 ```
 
+### `gender` + `forms`（名词/形容词，罗曼语通用，议题 #805）
+
+`gender` 是词条本身固定的语法性别（`entries.gender` 列）：**每个名词必须写**，
+形容词/动词/句子不写。`forms` 是词形变化表——存入 `entry_forms`
+（`kind='inflection'`），与 `conjugations` 用**同一套 `{维度: {槽位: 形式}}`
+映射结构**，只是维度/槽位的名字换成"数""性"而不是"时态""人称"：
+
+```yaml
+lang: fr
+entries:
+  - type: word
+    date: "07/21"
+    word: le chat
+    pos: nom (m)
+    english: cat
+    german: die Katze
+    level: "A1"
+    register: neutral
+    gender: m
+    note: |
+      Männliches Substantiv. Für weibliche Katzen sagt man "la chatte".
+    examples:
+      - fr: Le chat dort sur le canapé.
+        english: The cat is sleeping on the couch.
+        german: Die Katze schläft auf dem Sofa.
+    forms:
+      nombre:
+        pluriel: chats
+
+  - type: word
+    date: "07/21"
+    word: vert
+    pos: adjectif
+    english: green
+    german: grün
+    level: "A1"
+    register: neutral
+    note: |
+      Regelmäßiges Adjektiv, stimmt in Genus und Numerus überein.
+    examples:
+      - fr: Le pull vert est à moi.
+        english: The green sweater is mine.
+        german: Der grüne Pullover gehört mir.
+    forms:
+      genre:
+        féminin: verte
+        féminin pluriel: vertes
+      nombre:
+        pluriel: verts
+```
+
+**名词**只需要 `nombre: {pluriel: ...}`（复数）。**形容词**通常两个维度都要：
+`genre`（阴性、阴性复数）+ `nombre`（阳性复数——阳性单数就是词条本身，不重复
+写）。省音/单复数不变的词形不必写。维度名/槽位名不是强制枚举——代码只按 YAML
+里写的原样存入 `paradigm`/`slot` 两列并原样展示，但为了和西班牙语/未来语言
+的标注实现（`forms_lookup`）保持词面一致，建议只用上面示例里出现的这几个：
+`nombre`（`pluriel`）、`genre`（`féminin`、`féminin pluriel`）。
+
 ### sentence 类型（法语）
 
 ```yaml
@@ -409,4 +472,82 @@ entries:
 |-----------|--------------|
 | `word` / `sentence` / `expression` | `entries.word_zh`（列名是历史遗留，存目标语言词形） |
 | `level`（CEFR） | `entries.hsk_level`（A1=1 … C2=6） |
-| `conjugations` | `entry_conjugations`（word_id, tense, person, form, position；无人称形式 person=''） |
+| `gender` | `entries.gender`（#805） |
+| `conjugations` | `entry_forms`，`kind='conjugation'`（word_id, paradigm=tense, slot=person, form, position；无人称形式 slot=''；#803 起不再写旧的 `entry_conjugations` 表） |
+| `forms` | `entry_forms`，`kind='inflection'`（word_id, paradigm=维度, slot=槽位, form, position；#805） |
+
+---
+
+## 西班牙语格式（`lang: es`）
+
+文件顶层必须声明 `lang: es`（或粘贴导入到西班牙语牌组——此时可省略）。与法语
+共享同一套罗曼语归一化逻辑（`importer._normalize_romance_entry(entry, "es")`），
+唯一区别是例句用 `es:` 键代替 `fr:` 键；字段规则、`forms`/`gender` 结构、
+数据库映射与上面的法语格式完全一致，只是动词变位的时态集合更大（西班牙语
+日常口语区分的时态比法语这套多）。
+
+### 与法语格式的字段差异
+
+| 字段 | 说明 |
+|------|------|
+| `examples[].es` / `similar_sentences[].es` | 代替 `fr`，西班牙语原文 |
+| `pos` | `verbo`、`sustantivo (m)`、`sustantivo (f)`、`adjetivo`、`adverbio`、`locución` … |
+| `conjugations` | 时态键：`presente`、`pretérito perfecto`、`pretérito indefinido`、`imperfecto`、`futuro`、`condicional`、`presente de subjuntivo` + `participio`/`gerundio`（无人称，纯字符串）。人称键固定 `yo`、`tú`、`él/ella`、`nosotros`、`vosotros`、`ellos/ellas` |
+| `forms` | 维度命名习惯用 `numero`（`plural`）+ `genero`（`femenino`、`femenino plural`）—— 与法语的 `nombre`/`genre` 同构，只是西班牙语拼写不带重音（数据库不关心具体拼法，`paradigm`/`slot` 原样存储） |
+| `note` | 词源行写 `**Etimología:** …`（法语是 `**Étymologie:**`） |
+
+### 完整示例
+
+```yaml
+lang: es
+entries:
+  - type: word
+    date: "08/18"
+    word: hablar
+    pos: verbo
+    english: to speak
+    german: sprechen
+    level: "A1"
+    register: neutral
+    note: |
+      Regelmäßiges Verb auf -ar.
+
+      **Etimología:** Vom lateinischen *fabulari*.
+    examples:
+      - es: Hablo un poco de español.
+        english: I speak a little Spanish.
+        german: Ich spreche ein wenig Spanisch.
+    conjugations:
+      presente:
+        yo: hablo
+        tú: hablas
+        él/ella: habla
+        nosotros: hablamos
+        vosotros: habláis
+        ellos/ellas: hablan
+      participio: hablado
+      gerundio: hablando
+
+  - type: word
+    date: "08/18"
+    word: el gato
+    pos: sustantivo (m)
+    english: cat
+    german: die Katze
+    level: "A1"
+    register: neutral
+    gender: m
+    note: |
+      Männliches Substantiv. Für weibliche Katzen sagt man "la gata".
+    examples:
+      - es: El gato duerme en el sofá.
+        english: The cat is sleeping on the couch.
+        german: Die Katze schläft auf dem Sofa.
+    forms:
+      numero:
+        plural: gatos
+```
+
+### 西班牙语专属数据库映射
+
+与法语一致（同一套 `entry_forms`/`entries.gender` 映射），见上表。

--- a/importer.py
+++ b/importer.py
@@ -197,7 +197,7 @@ def preview_yaml_content(content: str) -> dict:
 
     for entry in entries:
         if preview_lang and preview_lang != "zh":
-            entry = _normalize_fr_entry(entry)
+            entry = _normalize_romance_entry(entry, preview_lang)
 
         yaml_type = entry.get("type", "")
         note_type = NOTE_TYPE_MAP.get(yaml_type)
@@ -346,11 +346,23 @@ def _cefr_to_int(level) -> int | None:
     return _CEFR_TO_INT.get(str(level or "").strip().upper())
 
 
-def _normalize_fr_entry(entry: dict) -> dict:
-    """Reshape a French-format YAML entry into the internal (Chinese-era) key
-    layout so all downstream processing (_build_word_dict, examples, etc.)
-    stays untouched. Chinese-only modules (characters, measure words,
-    word_analyses) are simply absent from the French format.
+_VALID_GENDERS = {"m", "f", "mf"}
+
+
+def _normalize_gender(raw) -> str | None:
+    g = str(raw or "").strip().lower()
+    return g if g in _VALID_GENDERS else None
+
+
+def _normalize_romance_entry(entry: dict, lang: str = "fr") -> dict:
+    """Reshape a Romance-language (fr/es) YAML entry into the internal
+    (Chinese-era) key layout so all downstream processing (_build_word_dict,
+    examples, etc.) stays untouched. Chinese-only modules (characters,
+    measure words, word_analyses) are simply absent from this format.
+
+    `lang` picks which example/similar_sentence key holds the target-language
+    text ('fr' or 'es') — everything else about the format is shared between
+    Romance languages (issue #805).
     """
     normalized = dict(entry)
     normalized["simplified"] = (
@@ -359,7 +371,7 @@ def _normalize_fr_entry(entry: dict) -> dict:
     )
     normalized["examples"] = [
         {
-            "zh":     ex.get("fr", ""),
+            "zh":     ex.get(lang) or ex.get("fr", ""),
             "english": ex.get("english"),
             "de":     ex.get("german") or ex.get("de"),
             "pinyin": None,
@@ -368,21 +380,29 @@ def _normalize_fr_entry(entry: dict) -> dict:
     ]
     # `level: B1` (CEFR string) → shared 1-6 integer level (issue #596)
     normalized["cefr_level"] = _cefr_to_int(entry.get("level"))
-    # similar_sentences {fr, german} → internal {zh, de} keys (sentence entries)
+    # similar_sentences {fr/es, german} → internal {zh, de} keys (sentence entries)
     normalized["similar_sentences"] = [
         {
-            "zh":      ss.get("fr", ""),
+            "zh":      ss.get(lang) or ss.get("fr", ""),
             "english": ss.get("english"),
             "de":      ss.get("german") or ss.get("de"),
             "pinyin":  None,
         }
         for ss in (entry.get("similar_sentences") or [])
     ]
-    # French format doesn't define these Chinese-only fields
+    # gender: m|f|mf (#805) — invalid/missing values fall back to None rather
+    # than raising, same "don't fail the whole entry over an optional field"
+    # posture as register in _build_word_dict.
+    normalized["gender"] = _normalize_gender(entry.get("gender"))
+    # Romance format doesn't define these Chinese-only fields
     for key in ("hsk", "traditional", "pinyin", "word_analyses",
                 "characters", "measure_words"):
         normalized.pop(key, None)
     return normalized
+
+
+# Backward-compatible alias — existing callers/tests import this name.
+_normalize_fr_entry = _normalize_romance_entry
 
 
 def _build_word_dict(entry: dict, source: str, note_type: str = "vocabulary",
@@ -414,6 +434,9 @@ def _build_word_dict(entry: dict, source: str, note_type: str = "vocabulary",
         "source_sentence": entry.get("source_de"),
         "grammar_notes":   None,
         "register":        register,
+        # Noun grammatical gender (French/Spanish; #803/#805) — normalized to
+        # m|f|mf|None in _normalize_romance_entry; absent (zh) stays None.
+        "gender":          entry.get("gender"),
     }
 
 
@@ -520,6 +543,38 @@ def _process_conjugations(entry: dict, word_id: int) -> None:
             database.insert_word_conjugation(
                 word_id=word_id, tense=tense, person=person,
                 form=form, position=position,
+            )
+            position += 1
+
+
+def _process_forms(entry: dict, word_id: int) -> None:
+    """Insert noun/adjective inflected forms (issue #805) from an entry's
+    `forms` mapping into entry_forms with kind='inflection'.
+
+    YAML shape mirrors `conjugations`: {dimension: {slot: form, ...}}, e.g.
+    {"nombre": {"pluriel": "chats"}, "genre": {"féminin": "verte"}} — dimension
+    -> entry_forms.paradigm, slot -> entry_forms.slot (see docs/multilang.md).
+    A bare {dimension: "form"} value (single slot, no sub-mapping) is also
+    accepted, stored with slot=''.
+    """
+    forms = entry.get("forms")
+    if not isinstance(forms, dict):
+        return
+    position = 0
+    for dimension, slots in forms.items():
+        dimension = str(dimension).strip()
+        if not dimension:
+            continue
+        if isinstance(slots, dict):
+            pairs = [(str(s).strip(), str(f).strip()) for s, f in slots.items()]
+        else:
+            pairs = [("", str(slots).strip())]
+        for slot, form in pairs:
+            if not form:
+                continue
+            database.insert_word_form(
+                word_id=word_id, kind="inflection", paradigm=dimension,
+                slot=slot, form=form, position=position,
             )
             position += 1
 
@@ -664,7 +719,7 @@ def _import_entries(entries: list, deck_ids: dict, source: str, label: str,
     for entry in entries:
       try:
         if lang != "zh":
-            entry = _normalize_fr_entry(entry)
+            entry = _normalize_romance_entry(entry, lang)
 
         yaml_type = entry.get("type", "")
         note_type = NOTE_TYPE_MAP.get(yaml_type)
@@ -806,8 +861,11 @@ def _import_entries(entries: list, deck_ids: dict, source: str, label: str,
         # word/meaning keys, issue #596)
         _process_word_relations(entry, word_id)
 
-        # Verb conjugations (fr and future conjugating languages, issue #596)
+        # Verb conjugations (fr/es and future conjugating languages, issue #596)
         _process_conjugations(entry, word_id)
+
+        # Noun/adjective inflected forms — plural, gender agreement (issue #805)
+        _process_forms(entry, word_id)
 
         # The following processors handle Chinese-only YAML fields (characters,
         # measure words, grammar structures, word_analyses components).

--- a/routes/decks.py
+++ b/routes/decks.py
@@ -110,9 +110,19 @@ def get_mode():
 
 
 @router.get("/api/langs")
-def get_langs():
+def get_langs(available: bool = False):
     """Distinct languages currently in use across decks. Frontend shows the
-    tab bar only when more than one language is returned."""
+    tab bar only when more than one language is returned.
+
+    available=1 returns every language registered in languages.py instead
+    (#805). The home tab bar wants "in use" — showing a tab for a language
+    with no cards would be noise. The /add and /dict pages want "registered":
+    they are where a language *starts*, and a brand-new language has no decks
+    yet, so filtering by usage there would make it impossible to add its very
+    first word.
+    """
+    if available:
+        return list(languages.LANGUAGES.keys())
     return database.get_available_langs()
 
 

--- a/routes/dictionary.py
+++ b/routes/dictionary.py
@@ -36,6 +36,7 @@ def _row_to_result(row: dict) -> dict:
         "id": row["id"],
         "created_at": row["created_at"],
         "query": row["query"],
+        "lang": row["lang"],
         "result": json.loads(row["result_json"]),
     }
 
@@ -49,8 +50,8 @@ def lookup(body: DictLookupRequest):
         raise HTTPException(400, "AI is disabled")
     # A bad language is the caller's mistake, not a model failure — 400, not
     # the 500 the ValueError below would otherwise produce.
-    if body.lang != "zh":
-        raise HTTPException(400, f"language {body.lang!r} is not supported yet (only 'zh')")
+    if body.lang not in ("zh", "fr", "es"):
+        raise HTTPException(400, f"language {body.lang!r} is not supported yet (zh/fr/es only)")
 
     # Check the target exists *before* spending 5–15s and a paid AI call on a
     # repeat that could never be stored.

--- a/routes/imports.py
+++ b/routes/imports.py
@@ -11,7 +11,7 @@ import ai
 import database
 import importer
 from fastapi import APIRouter, Form, HTTPException, UploadFile
-from languages import DEFAULT_LANG, is_valid_lang
+from languages import DEFAULT_LANG, get_lang_config, is_valid_lang
 
 from .utils import ai_disabled, queue_mgr
 
@@ -292,7 +292,8 @@ def _validate_word_for_lang(word: str, lang: str) -> None:
         raise HTTPException(status_code=400,
                             detail="That looks like Chinese — switch the language first")
     if not _LATIN_RE.search(word):
-        raise HTTPException(status_code=400, detail="Please enter the word in French")
+        lang_name = get_lang_config(lang)["name_en"]
+        raise HTTPException(status_code=400, detail=f"Please enter the word in {lang_name}")
 
 
 @router.post("/api/add-word-ai")

--- a/static/add.html
+++ b/static/add.html
@@ -107,8 +107,8 @@
   // otherwise; the backend rejects the wrong script, so the placeholder has to
   // say which language the box currently expects.
   let lang = 'zh';
-  const LANG_LABELS = { zh: '中文', fr: 'Français' };
-  const PLACEHOLDERS = { zh: '中文生词', fr: 'nouveau mot' };
+  const LANG_LABELS = { zh: '中文', fr: 'Français', es: 'Español' };
+  const PLACEHOLDERS = { zh: '中文生词', fr: 'nouveau mot', es: 'palabra nueva' };
 
   function setLang(l) {
     lang = l;
@@ -126,7 +126,7 @@
   async function loadLangs() {
     let langs;
     try {
-      langs = await api('GET', '/api/langs');
+      langs = await api('GET', '/api/langs?available=1');
     } catch { return; }
     if (!langs || !langs.length) return;
     // A ?lang= naming a language this install doesn't use falls back to zh

--- a/static/app.js
+++ b/static/app.js
@@ -2577,6 +2577,7 @@ function renderWordDetail(word) {
 
   // Shared sections (notes, conjugation, word analysis, examples)
   renderConjugationSection(document.getElementById('wd-conjugation-section'), word);
+  renderInflectionSection(document.getElementById('wd-inflection-section'), word);
   renderNotesSection(document.getElementById('wd-notes-section'), word.notes, word.id);
   renderWordAnalysis(document.getElementById('wd-word-analysis-section'), word, word.id);
   renderVocabDetail(document.getElementById('wd-examples-section'), word.examples, word.id);
@@ -5488,6 +5489,7 @@ function loadCard(c, counts) {
         renderVocabDetail();
         renderNotesSection();
         renderConjugationSection();
+        renderInflectionSection();
         _callRenderWordAnalysis();
         // MOST IMPORTANT: Re-render category row with actual card data
         renderReviewCatRow();
@@ -5880,6 +5882,7 @@ function revealAnswer() {
   // Populate character breakdown, examples, notes, conjugation, and word analysis
   renderNotesSection();
   renderConjugationSection();
+  renderInflectionSection();
   _callRenderWordAnalysis();
   renderVocabDetail();
   renderReviewCatRow();
@@ -6409,6 +6412,50 @@ function renderConjugationSection(container, wordData) {
     `<div class="section-label section-toggle" onclick="toggleSection('${bodyId}')">` +
       `<span id="${bodyId}-arrow">▶</span> Conjugation</div>` +
     `<div id="${bodyId}" style="display:none"><div class="conj-grid">${cards}</div></div>`;
+}
+
+// Noun/adjective inflection section (issue #805) — plural, gender agreement.
+// Chinese entries never have wordData.gender or .inflections, so this section
+// is simply absent for them. wordData.inflections rows come pre-ordered by
+// position, shaped like conjugations ({paradigm, slot, form}); group them
+// back into per-dimension cards (e.g. paradigm='nombre'/'genre').
+const GENDER_LABELS = { m: 'masculine', f: 'feminine', mf: 'masculine/feminine' };
+
+function renderInflectionSection(container, wordData) {
+  const el = container ?? document.getElementById('inflection-section');
+  if (!el) return;
+  const wd = wordData ?? wordDetails;
+  const inflections = wd?.inflections || [];
+  const gender = wd?.gender;
+  if (!inflections.length && !gender) { el.innerHTML = ''; return; }
+
+  let genderRow = '';
+  if (gender) {
+    genderRow = `<div class="conj-row"><span class="conj-person">Gender</span>` +
+      `<span class="conj-form">${GENDER_LABELS[gender] || gender}</span></div>`;
+  }
+
+  const paradigms = [];
+  const byParadigm = new Map();
+  inflections.forEach(f => {
+    if (!byParadigm.has(f.paradigm)) { byParadigm.set(f.paradigm, []); paradigms.push(f.paradigm); }
+    byParadigm.get(f.paradigm).push(f);
+  });
+  const cards = paradigms.map(p => {
+    const rows = byParadigm.get(p).map(f =>
+      f.slot
+        ? `<div class="conj-row"><span class="conj-person">${f.slot}</span><span class="conj-form">${f.form}</span></div>`
+        : `<div class="conj-row"><span class="conj-form">${f.form}</span></div>`
+    ).join('');
+    return `<div class="conj-tense-card"><div class="conj-tense-name">${p}</div>${rows}</div>`;
+  }).join('');
+
+  const bodyId = el.id + '-body';
+  const genderCard = genderRow ? `<div class="conj-tense-card">${genderRow}</div>` : '';
+  el.innerHTML =
+    `<div class="section-label section-toggle" onclick="toggleSection('${bodyId}')">` +
+      `<span id="${bodyId}-arrow">▶</span> Inflection</div>` +
+    `<div id="${bodyId}" style="display:none"><div class="conj-grid">${genderCard}${cards}</div></div>`;
 }
 
 function renderWordAnalysis(container, wordData, wordId) {

--- a/static/dict.html
+++ b/static/dict.html
@@ -62,6 +62,16 @@
   }
   button.repeat:hover:not(:disabled) { background: var(--line); color: var(--fg); }
   button.repeat:disabled { opacity: .5; cursor: default; }
+  /* Language picker (#805) — same pattern as /add (#726): hidden until
+     /api/langs says more than one language is in use. */
+  .langs { display: none; gap: .4rem; margin-bottom: .9rem; }
+  .langs button {
+    padding: .35rem .9rem; font: inherit; font-size: .85rem; font-weight: 600;
+    color: var(--muted); background: var(--bg);
+    border: 1px solid var(--line); border-radius: 8px; cursor: pointer;
+  }
+  .langs button.active { background: var(--accent); border-color: var(--accent); color: #fff; }
+
   .headline { font-size: 1.6rem; font-weight: 700; }
   .headline-pinyin { color: var(--muted); font-size: 1rem; }
   .headline-de { color: var(--fg); opacity: .8; margin-top: .15rem; }
@@ -150,6 +160,7 @@
   </header>
 
   <div class="card">
+    <div class="langs" id="langs"></div>
     <textarea id="query" placeholder="German / English / Chinese word, phrase or sentence…"
               autocapitalize="none" autocorrect="off" spellcheck="false" autofocus></textarea>
     <button class="go" id="go">Look up</button>
@@ -183,6 +194,45 @@
   const histList = document.getElementById('hist-list');
   const histEmpty = document.getElementById('hist-empty');
 
+  // Language of the lookup (#805) — same picker pattern as /add (#726).
+  // Chinese unless ?lang= or the picker says otherwise.
+  let lang = 'zh';
+  const LANG_LABELS = { zh: '中文', fr: 'Français', es: 'Español' };
+  const PLACEHOLDERS = {
+    zh: 'German / English / Chinese word, phrase or sentence…',
+    fr: 'German / English / French word, phrase or sentence…',
+    es: 'German / English / Spanish word, phrase or sentence…',
+  };
+
+  function setLang(l) {
+    lang = l;
+    queryEl.placeholder = PLACEHOLDERS[l] || l;
+    for (const b of document.getElementById('langs').children) {
+      b.classList.toggle('active', b.dataset.lang === l);
+    }
+  }
+
+  async function loadLangs() {
+    let langs;
+    try {
+      langs = await api('GET', '/api/langs?available=1');
+    } catch { return; }
+    if (!langs || !langs.length) return;
+    if (!langs.includes(lang)) setLang('zh');
+    if (langs.length <= 1) return;
+    const el = document.getElementById('langs');
+    el.replaceChildren(...langs.map(l => {
+      const b = document.createElement('button');
+      b.type = 'button';
+      b.dataset.lang = l;
+      b.textContent = LANG_LABELS[l] || l;
+      b.onclick = () => setLang(l);
+      return b;
+    }));
+    el.style.display = 'flex';
+    setLang(langs.includes(lang) ? lang : 'zh');
+  }
+
   function setStatus(text, isError) {
     statusEl.textContent = text || '';
     statusEl.classList.toggle('error', !!isError);
@@ -205,7 +255,7 @@
   // add-word pipeline (#643). Each button tracks its own state so several
   // can be "running" (~30s each) at once without blocking one another —
   // addWordViaAi already polls its own job, we just need to not share state.
-  function makeStarButton(zh) {
+  function makeStarButton(zh, wordLang) {
     const btn = document.createElement('button');
     btn.className = 'star';
     btn.type = 'button';
@@ -237,7 +287,7 @@
           errMsg.textContent = text || 'Failed to add';
           errMsg.style.display = '';
         }
-      }, 'zh');
+      }, wordLang || lang);
     };
 
     const wrap = document.createElement('div');
@@ -272,7 +322,7 @@
     repeat.type = 'button';
     repeat.textContent = '↻ Repeat';
     repeat.title = 'Ask again — this stored answer is replaced';
-    repeat.onclick = () => lookup(record.query, record.id);
+    repeat.onclick = () => lookup(record.query, record.id, record.lang);
     hrow.append(repeat);
     head.append(hrow);
     if (r.headline_de) head.append(textEl('div', 'headline-de', r.headline_de));
@@ -288,7 +338,7 @@
       if (r.sentence.pinyin) text.append(textEl('div', 'pinyin', r.sentence.pinyin));
       if (r.sentence.de) text.append(textEl('div', 'de', r.sentence.de));
       card.append(text);
-      if (r.sentence.zh) card.append(makeStarButton(r.sentence.zh));
+      if (r.sentence.zh) card.append(makeStarButton(r.sentence.zh, record.lang));
       resultEl.append(card);
     }
 
@@ -297,13 +347,13 @@
       g.className = 'group';
       if (group.label) g.append(textEl('div', 'group-label', group.label));
       for (const opt of (group.options || [])) {
-        g.append(renderOption(opt));
+        g.append(renderOption(opt, record.lang));
       }
       resultEl.append(g);
     }
   }
 
-  function renderOption(opt) {
+  function renderOption(opt, wordLang) {
     const row = document.createElement('div');
     row.className = 'option' + (opt.recommended ? ' recommended' : '');
 
@@ -341,14 +391,17 @@
     }
 
     row.append(body);
-    if (opt.zh) row.append(makeStarButton(opt.zh));
+    if (opt.zh) row.append(makeStarButton(opt.zh, wordLang));
     return row;
   }
 
   // ---- Lookup ----
   // replaceId (#777, optional): overwrite that stored lookup instead of adding
   // a new history row — a repeat means "that answer was bad", not "keep both".
-  async function lookup(q, replaceId) {
+  // queryLang (#805, optional): Repeat re-asks in the language the stored
+  // record was originally answered in, not whatever the picker currently
+  // shows — switching tabs must not silently change a repeat's language.
+  async function lookup(q, replaceId, queryLang) {
     if (!q) return;
     goBtn.disabled = true;
     queryEl.disabled = true;
@@ -356,7 +409,7 @@
     repeatBtns.forEach(b => { b.disabled = true; });
     setStatus(replaceId ? 'Asking again… (5–15s)' : 'Looking up… (5–15s)');
     try {
-      const body = { query: q, lang: 'zh' };
+      const body = { query: q, lang: queryLang || lang };
       if (replaceId) body.replace_id = replaceId;
       const record = await api('POST', '/api/dict/lookup', body);
       setStatus('');
@@ -456,8 +509,12 @@
   // straight into a lookup. Accepts ?query= as an alias. Must strip the param
   // afterwards (history.replaceState): a reload or an iOS "restore tabs" would
   // otherwise silently spend another AI call, the same trap #686 hit on /add.
+  // ?lang=fr (#805) picks the language, same convention as /add (#726).
   const params = new URLSearchParams(location.search);
   const preset = (params.get('q') || params.get('query') || '').trim();
+  const langParam = (params.get('lang') || '').trim();
+  if (langParam) setLang(langParam);
+  loadLangs();
   if (preset) {
     history.replaceState(null, '', location.pathname);
     queryEl.value = preset;

--- a/static/index.html
+++ b/static/index.html
@@ -305,6 +305,7 @@
         <div id="vocab-content" style="display:none">
           <div id="notes-section"></div>
           <div id="conjugation-section"></div>
+          <div id="inflection-section"></div>
           <div id="word-analysis-section"></div>
           <div id="examples-section"></div>
           <div style="display:flex;gap:8px;justify-content:center">
@@ -439,6 +440,7 @@
     <div class="wd-body">
       <div id="wd-relations-section"></div>
       <div id="wd-conjugation-section"></div>
+      <div id="wd-inflection-section"></div>
       <div id="wd-notes-section"></div>
       <div id="wd-word-analysis-section"></div>
       <div id="wd-examples-section"></div>

--- a/tests/test_multilang_805.py
+++ b/tests/test_multilang_805.py
@@ -1,0 +1,293 @@
+"""Tests for issue #805: French/Spanish add-word full morphology (conjugations
++ inflected forms + gender), and the AI dictionary's fr/es support.
+
+Isolation follows tests/test_entry_forms.py / tests/test_importer_fr.py:
+monkeypatch database.core.DB_PATH directly (the package-level DB_PATH is only
+a name copy — issue #615). The AI is stubbed at ai._call_api, never at a
+provider client (issue #615's other half).
+"""
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+import ai
+import database
+import importer
+import main
+import routes.dictionary
+
+client = TestClient(main.app)
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    db_file = str(tmp_path / "test_srs.db")
+    monkeypatch.setattr(database.core, "DB_PATH", db_file)
+    database.init_db()
+    monkeypatch.setattr(routes.dictionary, "ai_disabled", lambda: False)
+    return db_file
+
+
+# ---------------------------------------------------------------------------
+# Importer: Spanish entries — gender + forms (inflection) + conjugations
+# ---------------------------------------------------------------------------
+
+ENTRY_YAML_ES_NOUN = """lang: es
+entries:
+  - type: word
+    date: "08/18"
+    word: el gato
+    pos: sustantivo (m)
+    english: cat
+    german: die Katze
+    level: "A1"
+    register: neutral
+    gender: m
+    note: |
+      Männliches Substantiv.
+    examples:
+      - es: El gato duerme.
+        english: The cat is sleeping.
+        german: Die Katze schläft.
+    forms:
+      numero:
+        plural: gatos
+"""
+
+ENTRY_YAML_ES_ADJ = """lang: es
+entries:
+  - type: word
+    date: "08/18"
+    word: verde
+    pos: adjetivo
+    english: green
+    german: grün
+    level: "A1"
+    register: neutral
+    note: |
+      Regelmäßiges Adjektiv.
+    examples:
+      - es: El jersey verde es mío.
+        english: The green sweater is mine.
+        german: Der grüne Pullover gehört mir.
+    forms:
+      numero:
+        plural: verdes
+      genero:
+        femenino: verde
+"""
+
+ENTRY_YAML_ES_VERB = """lang: es
+entries:
+  - type: word
+    date: "08/18"
+    word: hablar
+    pos: verbo
+    english: to speak
+    german: sprechen
+    level: "A1"
+    register: neutral
+    note: |
+      Regelmäßiges Verb auf -ar.
+    examples:
+      - es: Hablo español.
+        english: I speak Spanish.
+        german: Ich spreche Spanisch.
+    conjugations:
+      presente:
+        yo: hablo
+        tú: hablas
+      participio: hablado
+"""
+
+
+def _import(yaml_text):
+    deck_id = database.get_or_create_deck_path("Español::Test")
+    return importer.import_yaml_content(yaml_text, deck_id)
+
+
+def test_spanish_noun_imports_gender_and_plural_inflection(tmp_db):
+    result = _import(ENTRY_YAML_ES_NOUN)
+    assert result["imported"] == 1, result
+
+    entry = database.get_word_by_zh("el gato")
+    assert entry is not None
+    assert entry["lang"] == "es"
+    assert entry["gender"] == "m"
+
+    full = database.get_word_full(entry["id"])
+    assert full["inflections"] == [
+        {"paradigm": "numero", "slot": "plural", "form": "gatos", "position": 0}
+    ]
+    # forms_lookup must find the inflected form for known-word annotation (#803).
+    assert database.forms_lookup(["gatos"], "es") == {"gatos"}
+
+
+def test_spanish_adjective_imports_multiple_inflection_dimensions(tmp_db):
+    result = _import(ENTRY_YAML_ES_ADJ)
+    assert result["imported"] == 1, result
+
+    entry = database.get_word_by_zh("verde")
+    assert entry["gender"] is None  # adjectives don't carry entries.gender
+    full = database.get_word_full(entry["id"])
+    paradigms = {(f["paradigm"], f["slot"]): f["form"] for f in full["inflections"]}
+    assert paradigms[("numero", "plural")] == "verdes"
+    assert paradigms[("genero", "femenino")] == "verde"
+
+
+def test_spanish_verb_conjugations_still_work_via_shared_pipeline(tmp_db):
+    result = _import(ENTRY_YAML_ES_VERB)
+    assert result["imported"] == 1, result
+
+    entry = database.get_word_by_zh("hablar")
+    conj = database.get_word_conjugations(entry["id"])
+    by_tense_person = {(c["tense"], c["person"]): c["form"] for c in conj}
+    assert by_tense_person[("presente", "yo")] == "hablo"
+    assert by_tense_person[("presente", "tú")] == "hablas"
+    assert by_tense_person[("participio", "")] == "hablado"
+
+
+def test_reimporting_es_entry_is_idempotent(tmp_db):
+    first = _import(ENTRY_YAML_ES_NOUN)
+    assert first["imported"] == 1
+    second = _import(ENTRY_YAML_ES_NOUN)
+    assert second["imported"] == 0
+    assert second["skipped_duplicate"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Importer: invalid gender value falls back to None rather than raising
+# ---------------------------------------------------------------------------
+
+def test_invalid_gender_value_is_dropped_not_stored(tmp_db):
+    bad = ENTRY_YAML_ES_NOUN.replace("gender: m", "gender: neuter")
+    _import(bad)
+    entry = database.get_word_by_zh("el gato")
+    assert entry["gender"] is None
+
+
+# ---------------------------------------------------------------------------
+# ai.generate_word_entry_yaml routes to the Spanish prompt
+# ---------------------------------------------------------------------------
+
+def test_spanish_prompt_is_used_for_es():
+    with patch.object(ai, "_call_api", return_value=ENTRY_YAML_ES_NOUN.split("entries:\n")[1]) as call:
+        ai.generate_word_entry_yaml("el gato", lang="es")
+    prompt = call.call_args[0][1][0]["content"]
+    assert "Spanish dictionary expert" in prompt
+    assert "gender" in prompt and "forms" in prompt
+
+
+def test_french_prompt_now_requires_gender_and_forms():
+    """#805 extends the existing French prompt to also require gender/forms
+    for nouns and adjectives, not just conjugations for verbs."""
+    with patch.object(ai, "_call_api", return_value="- type: word\n  word: x\n") as call:
+        ai.generate_word_entry_yaml("chat", lang="fr")
+    prompt = call.call_args[0][1][0]["content"]
+    assert "gender" in prompt and "forms" in prompt
+
+
+# ---------------------------------------------------------------------------
+# AI dictionary: fr/es lookups
+# ---------------------------------------------------------------------------
+
+ROMANCE_DICT_RESULT = {
+    "input_lang": "de",
+    "kind": "phrase",
+    "headline": "confier une tâche",
+    "headline_de": "jemandem eine Aufgabe geben",
+    "groups": [
+        {
+            "label": "assigner (Verb)",
+            "options": [
+                {
+                    "key": "a",
+                    "zh": "confier une tâche",
+                    "de": "jdm. eine Aufgabe anvertrauen",
+                    "usage": "neutral, im Alltag üblich.",
+                    "register": "spoken_neutral",
+                    "recommended": True,
+                    "example_zh": "Le prof m'a confié une tâche.",
+                    "example_de": "Der Lehrer hat mir eine Aufgabe gegeben.",
+                }
+            ],
+        }
+    ],
+}
+
+
+def test_dictionary_lookup_uses_romance_prompt_for_fr():
+    with patch.object(ai, "_call_api", return_value=json.dumps(ROMANCE_DICT_RESULT)) as call:
+        result, model = ai.dictionary_lookup("eine Aufgabe geben", lang="fr")
+    assert result["headline"] == "confier une tâche"
+    prompt = call.call_args[0][1][0]["content"]
+    assert "French dictionary" in prompt
+
+
+def test_dictionary_lookup_uses_romance_prompt_for_es():
+    with patch.object(ai, "_call_api", return_value=json.dumps(ROMANCE_DICT_RESULT)):
+        result, model = ai.dictionary_lookup("eine Aufgabe geben", lang="es")
+    assert result["headline"] == "confier une tâche"
+
+
+def test_dictionary_lookup_rejects_unsupported_lang():
+    with pytest.raises(ValueError):
+        ai.dictionary_lookup("test", lang="de")
+
+
+def test_dict_lookup_api_accepts_fr(tmp_db):
+    with patch.object(ai, "_call_api", return_value=json.dumps(ROMANCE_DICT_RESULT)):
+        r = client.post("/api/dict/lookup", json={"query": "eine Aufgabe geben", "lang": "fr"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["lang"] == "fr"
+    assert body["result"]["headline"] == "confier une tâche"
+
+
+def test_dict_lookup_api_accepts_es(tmp_db):
+    with patch.object(ai, "_call_api", return_value=json.dumps(ROMANCE_DICT_RESULT)):
+        r = client.post("/api/dict/lookup", json={"query": "eine Aufgabe geben", "lang": "es"})
+    assert r.status_code == 200, r.text
+    assert r.json()["lang"] == "es"
+
+
+def test_dict_lookup_api_rejects_unsupported_lang(tmp_db):
+    r = client.post("/api/dict/lookup", json={"query": "test", "lang": "de"})
+    assert r.status_code == 400
+
+
+def test_dict_page_served_with_lang_picker_markup():
+    r = client.get("/dict")
+    assert r.status_code == 200
+    assert 'id="langs"' in r.text
+
+
+def test_langs_endpoint_available_lists_registered_languages(tmp_db):
+    """/api/langs?available=1 must list every registered language (#805).
+
+    The home tab bar wants "languages in use" — a tab for a language with no
+    cards would be noise. But /add and /dict are where a language *starts*:
+    a brand-new language has no decks yet, so filtering by usage there would
+    make its very first word impossible to add.
+    """
+    from fastapi.testclient import TestClient
+    import main
+    import languages as languages_mod
+
+    client = TestClient(main.app)
+
+    in_use = client.get("/api/langs").json()
+    assert "es" not in in_use  # no Spanish decks in a fresh DB
+
+    available = client.get("/api/langs?available=1").json()
+    assert set(available) == set(languages_mod.LANGUAGES)
+    assert available[0] == "zh"  # default language stays first


### PR DESCRIPTION
## 改了什么

法语/西班牙语模式第三步。

- **加词生成完整形态**：`fr`/`es` 的提示词强制要求动词完整变位表、名词 `gender:` + 复数、形容词阴性/复数。**这是整条链的前提**——知识库判断"这个词形我学过没有"靠 `entry_forms` 精确匹配（零词干还原），漏掉的变位等于该词在阅读里永远被当生词
- **导入器**：`forms:` → `entry_forms(kind='inflection')`，`gender:` → `entries.gender`；`_normalize_fr_entry` 泛化为 `_normalize_romance_entry(entry, lang)`
- **词典 `/dict` 支持 fr/es**：提示词移植自 `de-fr-bot`（先分析 + a/b/c 选项 + 明确推荐、倾向口语），**返回 JSON 契约与中文版完全一致**，前端渲染代码不分语言。★ 加词仍走 `/api/add-word-ai`（#643 的唯一管线）
- 词条详情页/复习卡背面新增 Inflection 折叠区；中文不显示
- **`GET /api/langs?available=1`**：`/add` 和 `/dict` 用它列出全部已注册语言。主页标签栏仍按"在用语言"——区别是有意的：一门新语言还没有牌组，按"在用"过滤就永远加不了它的第一个词

## 怎么测的

`pytest tests/`：670 passed, 4 skipped。新增 `tests/test_multilang_805.py` 15 条：西语名词/形容词/动词导入后 `entry_forms` 与 `gender` 落库正确、非法 gender 回落、`forms_lookup` 集成、提示词按语言路由、词典接口接受 fr/es 拒绝其它、`/api/langs?available=1` 的语义。

Closes #805