### PR TITLE
测试按 Anki 日算「今天」，不用 date.today()（#810）

### DIFF
--- a/tests/test_add_word.py
+++ b/tests/test_add_word.py
@@ -16,6 +16,13 @@ from unittest.mock import patch
 
 import ai
 import database
+
+# Anki days start at the preset's cutoff hour (4 a.m. by default), not at
+# midnight, so between 00:00 and the cutoff date.today() is one day ahead of
+# the day the app is on. Every "today"/"tomorrow" expectation in this file is
+# compared against a deck name or due date that production code derived from
+# database.anki_today(), so the tests derive theirs the same way — otherwise
+# they fail on any run started before 4 a.m. (#810).
 import main
 import routes.imports
 
@@ -86,7 +93,7 @@ def _run_add_word(word_zh, yaml_text=ENTRY_YAML, day=None, lang=None):
 
 
 def _daily_leaf_decks(day=None):
-    day = day or date.today().isoformat()
+    day = day or database.anki_today().isoformat()
     deck_id = database.get_or_create_deck_path(f"Daily::{day}")
     return database.get_or_create_category_decks(deck_id, day)
 
@@ -105,7 +112,7 @@ def test_new_word_lands_in_todays_deck_due_today(tmp_db):
     assert entry["pinyin"] == "shēngtài"
     assert entry["definition_de"] == "Ökologie / Ökosystem"
 
-    today = date.today().isoformat()
+    today = database.anki_today().isoformat()
     leaf_ids = set(_today_leaf_decks().values())
     conn = database.get_db()
     cards = conn.execute(
@@ -153,7 +160,7 @@ def test_known_word_is_reset_into_todays_deck_without_calling_the_ai(tmp_db):
     # INSERT OR IGNORE silently dropped every card, so nothing reached the daily
     # deck. Prove the cards really moved — a success report is only worth
     # something if it matches reality.
-    today = date.today().isoformat()
+    today = database.anki_today().isoformat()
     leaf_ids = set(_today_leaf_decks().values())
     conn = database.get_db()
     rows = conn.execute(
@@ -217,7 +224,7 @@ def test_saved_word_is_promoted_into_todays_deck(tmp_db):
         r = client.post("/api/add-word-ai", json={"word_zh": "生态"})
     assert r.json()["status"] == "promoted"
 
-    today = date.today().isoformat()
+    today = database.anki_today().isoformat()
     leaf_ids = set(_today_leaf_decks().values())
     conn = database.get_db()
     rows = conn.execute(
@@ -236,7 +243,7 @@ def test_tomorrow_lands_in_tomorrows_deck_due_tomorrow(tmp_db):
     result = _run_add_word("生态", day="tomorrow")
     assert result["job"]["status"] == "done", result["job"]
 
-    tomorrow = (date.today() + timedelta(days=1)).isoformat()
+    tomorrow = (database.anki_today() + timedelta(days=1)).isoformat()
     assert result["deck_path"] == f"Daily::{tomorrow}"
 
     entry = database.get_word_by_zh("生态")
@@ -260,7 +267,7 @@ def test_saved_word_promoted_to_tomorrow(tmp_db):
         r = client.post("/api/add-word-ai", json={"word_zh": "生态", "day": "tomorrow"})
     assert r.json()["status"] == "promoted"
 
-    tomorrow = (date.today() + timedelta(days=1)).isoformat()
+    tomorrow = (database.anki_today() + timedelta(days=1)).isoformat()
     conn = database.get_db()
     rows = conn.execute(
         "SELECT deck_id, due FROM cards WHERE word_id=? AND deleted_at IS NULL",
@@ -395,7 +402,7 @@ def test_list_generates_the_full_entry_but_parks_it_suspended(tmp_db):
 def test_listed_word_is_invisible_to_the_review_queue(tmp_db):
     """The whole point: a listed word must not turn up for review anywhere."""
     _run_add_word("生态", day="list")
-    today_deck = database.get_or_create_deck_path(f"Daily::{date.today().isoformat()}")
+    today_deck = database.get_or_create_deck_path(f"Daily::{database.anki_today().isoformat()}")
     for category in ("reading", "listening", "creating"):
         r = client.get(f"/api/today/{today_deck}/{category}")
         assert r.status_code == 200
@@ -508,7 +515,7 @@ def test_listed_word_can_be_promoted_into_a_daily_deck(tmp_db):
     assert r.status_code == 200, r.text
     # Today, not tomorrow (#728): a future daily deck is locked, so the word
     # would be invisible for the rest of the day Daniel asked for it.
-    today = date.today().isoformat()
+    today = database.anki_today().isoformat()
     assert r.json()["deck_path"] == f"Daily::{today}"
 
     conn = database.get_db()
@@ -528,7 +535,7 @@ def test_listed_word_can_still_be_promoted_to_tomorrow(tmp_db):
 
     r = client.post(f"/api/saved/{entry_id}/promote?day=tomorrow")
     assert r.status_code == 200, r.text
-    tomorrow = (date.today() + timedelta(days=1)).isoformat()
+    tomorrow = (database.anki_today() + timedelta(days=1)).isoformat()
     assert r.json()["deck_path"] == f"Daily::{tomorrow}"
 
     conn = database.get_db()
@@ -645,7 +652,7 @@ ENTRY_YAML_FR_VERB = """- type: word
 
 
 def _fr_leaf_decks(day=None):
-    day = day or date.today().isoformat()
+    day = day or database.anki_today().isoformat()
     deck_id, _ = database.get_or_create_daily_deck(day, "fr")
     return database.get_or_create_category_decks(deck_id, day)
 
@@ -654,7 +661,7 @@ def test_french_word_lands_in_the_french_deck_tree(tmp_db):
     result = _run_add_word("séjour", yaml_text=ENTRY_YAML_FR, lang="fr")
     assert result["job"]["status"] == "done", result["job"]
     assert result["job"]["summary"]["imported"] == 1
-    assert result["deck_path"] == f"Français::{date.today().isoformat()}"
+    assert result["deck_path"] == f"Français::{database.anki_today().isoformat()}"
 
     entry = database.get_word_by_zh("séjour")
     assert entry["lang"] == "fr"
@@ -713,7 +720,7 @@ def test_listed_french_word_is_promoted_inside_its_own_tree(tmp_db):
 
     r = client.post(f"/api/saved/{entry_id}/promote")
     assert r.status_code == 200, r.text
-    today = date.today().isoformat()
+    today = database.anki_today().isoformat()
     assert r.json()["deck_path"] == f"Français::{today}"
 
     conn = database.get_db()

--- a/tests/test_anki_day_semantics.py
+++ b/tests/test_anki_day_semantics.py
@@ -1,0 +1,70 @@
+"""Guard for #810: tests must express "today" the way the app does.
+
+Anki days start at the preset's cutoff hour (4 a.m. by default), not at
+midnight. Production code derives every deck name and due date from
+database.anki_today(); a test that builds its expectation from
+datetime.date.today() therefore disagrees with the app for four hours every
+night, and five tests really did fail on any local run started before 4 a.m.
+
+Two guards here: the real behavioral one (anki_today respects the cutoff),
+and a cheap grep-style one so the pattern doesn't creep back in — the same
+approach tests/test_add_word.py uses to keep addWordViaAi from being copied
+into app.js a second time.
+"""
+import os
+import re
+import sys
+from datetime import date, datetime, timedelta
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import database
+
+_TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_anki_today_respects_the_cutoff_hour(monkeypatch):
+    """Before the cutoff, the Anki day is still yesterday's."""
+    monkeypatch.setattr(database.core, "_DAY_CUTOFF_HOUR", 4, raising=False)
+    monkeypatch.setattr(database.core, "get_day_cutoff_hour", lambda: 4)
+
+    real = datetime(2026, 8, 19, 1, 30)  # 01:30 — before the cutoff
+
+    class _FakeDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return real
+
+    monkeypatch.setattr(database.core, "datetime", _FakeDateTime)
+
+    assert database.core.anki_today() == date(2026, 8, 18)
+    assert database.core.anki_today() != real.date()
+
+    after = real.replace(hour=9)
+    monkeypatch.setattr(_FakeDateTime, "now", classmethod(lambda cls, tz=None: after))
+    assert database.core.anki_today() == date(2026, 8, 19)
+
+
+def test_no_test_builds_a_day_expectation_from_date_today():
+    """date.today() in a test is almost always the #810 bug.
+
+    If a future test genuinely needs the wall-clock date (something unrelated
+    to Anki days), give it a different spelling — datetime.now().date() — and
+    say why in a comment, rather than weakening this guard.
+    """
+    offenders = []
+    for name in sorted(os.listdir(_TESTS_DIR)):
+        if not name.startswith("test_") or not name.endswith(".py"):
+            continue
+        if name == os.path.basename(__file__):
+            continue
+        text = open(os.path.join(_TESTS_DIR, name), encoding="utf-8").read()
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if line.lstrip().startswith("#"):
+                continue          # the explanatory comments name it on purpose
+            if re.search(r"\bdate\.today\(\)", line):
+                offenders.append(f"{name}:{lineno}: {line.strip()}")
+    assert not offenders, (
+        "use database.anki_today() instead of date.today() (#810):\n"
+        + "\n".join(offenders)
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,13 +11,19 @@ Strategy:
 
 import pytest
 from unittest.mock import patch, call
-from datetime import date
 
 # If fastapi is not installed the whole file is skipped cleanly.
 pytest.importorskip("fastapi", reason="fastapi not installed")
 
 from fastapi.testclient import TestClient
 import database
+
+# Anki days start at the preset's cutoff hour (4 a.m. by default), not at
+# midnight, so between 00:00 and the cutoff date.today() is one day ahead of
+# the day the app is on. Every "today"/"tomorrow" expectation in this file is
+# compared against a deck name or due date that production code derived from
+# database.anki_today(), so the tests derive theirs the same way — otherwise
+# they fail on any run started before 4 a.m. (#810).
 import importer
 import main
 
@@ -152,7 +158,7 @@ class TestGetStory:
         without re-calling AI.
         """
         deck_id = populated_db
-        today = date.today().isoformat()
+        today = database.anki_today().isoformat()
 
         with patch("ai.generate_story", side_effect=fake_generate_story):
             client.get(f"/api/story/{deck_id}/listening")
@@ -179,7 +185,7 @@ class TestRegenerateStory:
         so it becomes the active story. Old stories are kept forever.
         """
         deck_id = populated_db
-        today = date.today().isoformat()
+        today = database.anki_today().isoformat()
 
         with patch("ai.generate_story", side_effect=fake_generate_story):
             client.get(f"/api/story/{deck_id}/listening")           # story 1

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -16,6 +16,13 @@ import yaml
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import database
+
+# Anki days start at the preset's cutoff hour (4 a.m. by default), not at
+# midnight, so between 00:00 and the cutoff date.today() is one day ahead of
+# the day the app is on. Every "today"/"tomorrow" expectation in this file is
+# compared against a deck name or due date that production code derived from
+# database.anki_today(), so the tests derive theirs the same way — otherwise
+# they fail on any run started before 4 a.m. (#810).
 import importer
 
 
@@ -265,7 +272,7 @@ class TestQueuePriority:
         deck_id = self._setup_three_words(tmp_path)
 
         card_id = _get_listening_card_id("你好")
-        today = date.today().isoformat()
+        today = database.anki_today().isoformat()
         _force_card_state(card_id, state="review", due=today, interval=1)
 
         next_card = database.get_next_card(deck_id, "listening")
@@ -296,7 +303,7 @@ class TestQueuePriority:
         # otherwise the card counts as still-learning and never reaches the
         # review group at all.
         review_id = _get_listening_card_id("再见")
-        today = date.today().isoformat()
+        today = database.anki_today().isoformat()
         _force_card_state(review_id, state="review", due=today, interval=10)
 
         # 老师 stays new


### PR DESCRIPTION
## 问题

Anki 日以预设的日界小时（默认凌晨 4 点）为界，不是午夜。生产代码全部用 `database.anki_today()`，这几个测试却用 `date.today()` 拼期望值——每天 0–4 点之间两者差一天，5 条测试在任何凌晨启动的运行里必挂：

```
anki_today: 2026-08-18    date.today: 2026-08-19
```

CI 在 UTC 跑，德国凌晨 0–4 点只有一小段落在 UTC 00–02，所以一直没暴露。

## 改了什么

- `test_add_word.py` / `test_api.py` / `test_importer.py` 共 16 处 `date.today()` → `database.anki_today()`，各文件顶部写清原因
- 新增 `tests/test_anki_day_semantics.py`：① 验证 `anki_today()` 确实尊重日界（01:30 时返回前一天，09:00 时返回当天）；② 守卫测试禁止测试里再出现 `date.today()`——思路同现有那条防止 `addWordViaAi` 被复制进 `app.js` 的守卫

## 怎么测的

在本地 **01:15**（正是原来必挂的时段）跑 `pytest tests/`：**679 passed, 4 skipped**。

Closes #810