### PR TITLE
style: 语言标签栏改成浏览器风格标签页

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -4805,23 +4805,35 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   margin-bottom: 12px;
 }
 /* ── Main-page language tab bar (issue #436) — only rendered when >1 lang is in use ── */
+/* Browser-style tabs: the active tab sits on the baseline and covers it, so it
+   reads as one surface with the content below instead of as a row of buttons. */
 .lang-tabs {
   display: flex;
-  gap: 6px;
-  margin-bottom: 12px;
+  align-items: flex-end;
+  gap: 2px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--border);
 }
 .lang-tab {
-  border: 1px solid var(--border);
-  background: var(--card);
+  position: relative;
+  bottom: -1px;
+  border: 1px solid transparent;
+  border-bottom: none;
+  background: transparent;
   color: var(--muted);
-  padding: 6px 16px;
+  padding: 7px 16px 8px;
   font-size: 13px;
   font-weight: 600;
-  border-radius: 8px;
+  border-radius: 8px 8px 0 0;
   cursor: pointer;
 }
-.lang-tab:hover { background: var(--bg); }
-.lang-tab.lang-tab-active { background: #6366f1; color: #fff; border-color: #6366f1; }
+.lang-tab:hover { color: var(--text); background: var(--bg); }
+.lang-tab.lang-tab-active {
+  background: var(--card);
+  color: var(--text);
+  border-color: var(--border);
+  padding-bottom: 9px;
+}
 
 .hcal-seg { display: inline-flex; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
 .hcal-seg-btn {


### PR DESCRIPTION
## 改了什么

`static/style.css` 的 `.lang-tabs` / `.lang-tab`：

- 标签栏加 `border-bottom` 基线，`align-items: flex-end`
- 激活标签 `bottom: -1px` + 无下边框 + 背景 `var(--card)` → 盖住基线，和内容面板连成一个面
- 非激活标签透明背景、`var(--muted)` 字色，hover 才轻微高亮
- 圆角改为只有上方 `8px 8px 0 0`

## 为什么

原样式是两个独立圆角按钮（激活的是紫色实心块），读起来像按钮组而不是标签页。

## 怎么测试

打开主页（有多于一种语言时才显示标签栏）和 `/add` 页，肉眼确认。纯 CSS 改动，不涉及 `app.js` 的类名和渲染逻辑。

Closes #813