### PR TITLE
fix: Browse 按语言过滤，并加上单行删除按钮

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -734,6 +734,8 @@ GET    /api/dict/history/{id} ；DELETE /api/dict/history/{id}  → 单条 / 删
 POST /api/add-word-ai                                → 界面内添加生词（#627）；body {word_zh, day?:today|tomorrow|list, lang?:zh|fr}（#636、#677；#715 起界面一律传 list，接口三值仍有效；lang 见 #726，已存在的词按 entries.lang 落点、不听该参数）；新词返回 {job_id}，已有词直接返回 {status}。**全应用唯一的加词入口**（#643）：顶栏 ＋、播客生词表格、复习界面长按菜单都走它
 GET  /api/add-word-ai/progress/{job_id}              → 轮询后台生成+导入的结果
 GET  /api/browse                                     → {deck_id?, category?, state?, q?, lang?}
+GET  /api/browse-words[?lang=] ；GET /api/search-words?q=[&lang=]  → Browse 页的词表/搜索（#815）：按 **entries.lang** 过滤（不是 decks.lang——无卡片的 reference 词条也要出现），不传则返回全部；前端还按语言过滤侧栏牌组树、非中文时隐藏 Hanzi 区
+DELETE /api/word/{id}                                → Browse 单行 🗑：硬删除词条及其全部卡片（级联，不进垃圾桶）；不存在返回 404（不假装成功）
 GET  /api/stats ；/api/retention ；/api/card-evolution（均支持 ?lang=）
 ```
 

--- a/database/browse.py
+++ b/database/browse.py
@@ -7,9 +7,16 @@ from .cards import get_card
 # Browse / search
 # ---------------------------------------------------------------------------
 
-def get_words_for_browse() -> list[dict]:
-    """Return all entries (with or without cards), with embedded card states per category."""
-    sql = """
+def get_words_for_browse(lang: str | None = None) -> list[dict]:
+    """Return all entries (with or without cards), with embedded card states per category.
+
+    `lang` filters on entries.lang (#815). It has to be the entry's own language,
+    not the deck's: a reference entry has no cards at all, so a deck-based filter
+    would drop every card-less word from Browse. Passing None keeps the old
+    "everything" behavior for callers that predate the language tabs.
+    """
+    where = "WHERE w.lang = ?" if lang else ""
+    sql = f"""
         SELECT w.id, w.word_zh, w.pinyin, w.definition, w.definition_de, w.pos, w.hsk_level, w.note_type,
                c.id as card_id, c.category, c.state, c.interval, c.ease,
                c.due, c.lapses, c.step_index, c.deck_id,
@@ -18,10 +25,11 @@ def get_words_for_browse() -> list[dict]:
         FROM entries w
         LEFT JOIN cards c ON c.word_id = w.id AND c.deleted_at IS NULL
         LEFT JOIN decks d ON d.id = c.deck_id
+        {where}
         ORDER BY w.word_zh, c.category
     """
     conn = get_db()
-    rows = conn.execute(sql).fetchall()
+    rows = conn.execute(sql, ([lang] if lang else [])).fetchall()
     conn.close()
     words: dict = {}
     for r in rows:
@@ -58,23 +66,26 @@ def get_words_for_browse() -> list[dict]:
     return list(words.values())
 
 
-def search_words(q: str) -> dict:
+def search_words(q: str, lang: str | None = None) -> dict:
     """Return word IDs split into primary (word/def match) and secondary (example/notes match).
     Includes reference entries (no cards) so Browse search works across the full knowledge base."""
     like = f"%{q}%"
+    # Same rule as get_words_for_browse: filter on the entry's own language (#815).
+    lang_clause = " AND w.lang = ?" if lang else ""
+    lang_param = [lang] if lang else []
     conn = get_db()
     primary_ids = {r["id"] for r in conn.execute(
-        """SELECT DISTINCT w.id FROM entries w
+        f"""SELECT DISTINCT w.id FROM entries w
            WHERE (w.word_zh LIKE ? OR w.pinyin LIKE ?
               OR w.definition LIKE ? OR w.definition_zh LIKE ?
-              OR w.definition_de LIKE ?)""",
-        (like, like, like, like, like),
+              OR w.definition_de LIKE ?){lang_clause}""",
+        (like, like, like, like, like, *lang_param),
     ).fetchall()}
     secondary_ids = {r["id"] for r in conn.execute(
-        """SELECT DISTINCT w.id FROM entries w
+        f"""SELECT DISTINCT w.id FROM entries w
            LEFT JOIN entry_examples we ON we.word_id = w.id
-           WHERE (we.example_zh LIKE ? OR we.example_de LIKE ? OR w.notes LIKE ?)""",
-        (like, like, like),
+           WHERE (we.example_zh LIKE ? OR we.example_de LIKE ? OR w.notes LIKE ?){lang_clause}""",
+        (like, like, like, *lang_param),
     ).fetchall()} - primary_ids
     conn.close()
     return {"primary": list(primary_ids), "secondary": list(secondary_ids)}

--- a/routes/browse.py
+++ b/routes/browse.py
@@ -26,6 +26,23 @@ def get_word_detail(word_id: int):
     return word
 
 
+@router.delete("/api/word/{word_id}")
+def delete_word_endpoint(word_id: int):
+    """Hard-delete one entry and everything hanging off it (cards, examples,
+    forms, characters — all ON DELETE CASCADE), for Browse's per-row 🗑 button
+    (#815).
+
+    Unlike a card's soft delete this does not go through the trash: the entry
+    itself is removed, which is what "delete this word" means in Browse. A
+    missing id is a 404, never a cheerful {"ok": true} for a no-op.
+    """
+    if not database.get_word(word_id):
+        raise HTTPException(status_code=404, detail="Word not found")
+    database.delete_word(word_id)
+    _queue_mgr.invalidate()
+    return {"ok": True, "deleted": word_id}
+
+
 @router.put("/api/word/{word_id}")
 def update_word(word_id: int, body: dict):
     database.update_word(word_id, body)
@@ -298,8 +315,8 @@ def ai_enrich_word(word_id: int):
 
 
 @router.get("/api/browse-words")
-def browse_words():
-    return database.get_words_for_browse()
+def browse_words(lang: str | None = None):
+    return database.get_words_for_browse(lang)
 
 
 @router.get("/api/words/random")
@@ -375,8 +392,8 @@ def update_hanzi(char_id: int, body: dict):
 
 
 @router.get("/api/search-words")
-def search_words(q: str):
-    return database.search_words(q)
+def search_words(q: str, lang: str | None = None):
+    return database.search_words(q, lang)
 
 
 @router.get("/api/words/{word_id}/cards")

--- a/static/app.js
+++ b/static/app.js
@@ -1975,9 +1975,12 @@ async function openBrowse() {
   setLoading('Loading…');
   try {
     const [words, hanzi, deckTree] = await Promise.all([
-      api('GET', '/api/browse-words'),
+      // Browse is language-scoped like every other view (#815): the word
+      // list, the deck sidebar and the search all take the active tab's lang,
+      // so French words can never show up under the Chinese tab.
+      api('GET', `/api/browse-words${_langQP('?')}`),
       api('GET', '/api/hanzi'),
-      api('GET', '/api/decks'),
+      api('GET', `/api/decks${_langQP('?')}`),
     ]);
     browseWords = words;
     _allHanzi = hanzi;
@@ -1992,6 +1995,9 @@ async function openBrowse() {
     _syncSortOptions();
     showView('browse');
     document.getElementById('browse-search').value = '';
+    // Hanzi are Chinese-only; under fr/es that section lists nothing relevant (#815).
+    const hanziSec = document.getElementById('bs-hanzi-section');
+    if (hanziSec) hanziSec.style.display = activeLang() === 'zh' ? '' : 'none';
     _renderBrowseSidebar();
     _updateBrowseActionBar();
     document.querySelectorAll('.bs-status-item').forEach(el => el.classList.remove('bs-active'));
@@ -2071,7 +2077,7 @@ function onBrowseSearch(val) {
   if (!q) { renderBrowseWords(_filteredBrowseWords()); return; }
   _browseSearchTimer = setTimeout(async () => {
     try {
-      const result = await api('GET', `/api/search-words?q=${encodeURIComponent(q)}`);
+      const result = await api('GET', `/api/search-words?q=${encodeURIComponent(q)}${_langQP('&')}`);
       const base = _filteredBrowseWords();
       const primarySet   = new Set(result.primary);
       const secondarySet = new Set(result.secondary);
@@ -2111,6 +2117,10 @@ function _wordRow(w) {
       return `<button class="${cls}" title="${tip}" onclick="toggleBrowseDotSuspend(event,${c.id},${w.id})">${letter}</button>`;
     }).join('');
   }
+  // Per-row delete (#815) — always present, whatever the status filter shows,
+  // so getting rid of one bad entry doesn't require the select-then-bulk-bar detour.
+  const delBtn = `<button class="bw-del-btn" title="Delete this word and all its cards"
+          onclick="browseDeleteWord(event,${w.id})">🗑</button>`;
   return `
     <div class="bw-row${sel}" data-word-id="${w.id}" onclick="onBrowseRowClick(event,${w.id})">
       <div class="bw-left">
@@ -2120,7 +2130,7 @@ function _wordRow(w) {
       <div class="bw-mid">
         <span class="bw-def">${def}</span>
       </div>
-      <div class="bw-right">${rightHtml}</div>
+      <div class="bw-right">${rightHtml}${delBtn}</div>
     </div>`;
 }
 
@@ -2264,7 +2274,7 @@ async function browseActionMove() {
 
 async function _browseReload() {
   const q = document.getElementById('browse-search').value.trim();
-  browseWords = await api('GET', '/api/browse-words');
+  browseWords = await api('GET', `/api/browse-words${_langQP('?')}`);
   _browseSelected.clear();
   _updateBrowseActionBar();
   _renderBrowseSidebar();
@@ -2309,6 +2319,25 @@ function renderBrowseWords(words) {
     return;
   }
   list.innerHTML = `<div class="bw-list">${_sortWords(words).map(_wordRow).join('')}</div>`;
+}
+
+// Hard-deletes the entry itself, not just its cards — the entry is what a
+// Browse row *is*. Irreversible (no trash), hence the confirm; the row is
+// removed from the local list rather than re-fetching the whole page.
+async function browseDeleteWord(e, wordId) {
+  e.stopPropagation();
+  const word = browseWords.find(w => w.id === wordId);
+  const ok = await showConfirm(
+    `Delete "${word ? word.word_zh : wordId}" and all its cards? This cannot be undone.`);
+  if (!ok) return;
+  try {
+    await api('DELETE', `/api/word/${wordId}`);
+    browseWords = browseWords.filter(w => w.id !== wordId);
+    _browseSelected.delete(wordId);
+    _updateBrowseActionBar();
+    const q = document.getElementById('browse-search').value.trim();
+    if (q) onBrowseSearch(q); else renderBrowseWords(_filteredBrowseWords());
+  } catch (err) { showError('Delete failed: ' + err.message); }
 }
 
 // ── Starred sentences view (#692) ────────────────────────────────────────────
@@ -2480,7 +2509,7 @@ async function openWordByZh(zh) {
   let word = browseWords.find(w => w.word_zh === zh);
   if (word) { openWordDetail(word.id); return; }
   try {
-    const all = await api('GET', '/api/browse-words');
+    const all = await api('GET', `/api/browse-words${_langQP('?')}`);
     browseWords = all;
     const found = all.find(w => w.word_zh === zh);
     if (found) openWordDetail(found.id);

--- a/static/index.html
+++ b/static/index.html
@@ -370,7 +370,8 @@
         <button class="bs-status-item" id="bss-starred"   onclick="setBrowseStatusFilter('starred')"
                 title="Sentences you starred while reviewing — good examples for prompt tuning">⭐ Sentences</button>
       </div>
-      <div class="bs-section">
+      <!-- Chinese-only: hidden under a non-zh language tab (#815) -->
+      <div class="bs-section" id="bs-hanzi-section">
         <div class="bs-section-head">Hanzi</div>
         <button class="bs-item" id="bsf-hanzi" onclick="setBrowseFilter('hanzi','all')">All Hanzi</button>
       </div>

--- a/static/style.css
+++ b/static/style.css
@@ -2695,6 +2695,20 @@ a.news-source-line:hover {
 }
 .bw-add-btn:hover { background: #dbeafe; }
 
+/* Per-row delete (#815). Deliberately quiet until hovered — it sits on every
+   row and must not compete with the category buttons next to it. */
+.bw-del-btn {
+  font-size: 12px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 2px 6px;
+  margin-left: 6px;
+  cursor: pointer;
+  opacity: 0.35;
+}
+.bw-del-btn:hover { opacity: 1; border-color: #ef4444; background: #fee2e2; }
+
 /* Leeched-list per-row action: clear the leech flag */
 .bw-unleech-btn {
   font-size: 11px;

--- a/tests/test_browse_lang.py
+++ b/tests/test_browse_lang.py
@@ -1,0 +1,102 @@
+"""Tests for issue #815: Browse is language-scoped, and rows can be deleted.
+
+Before this, /api/browse-words and /api/search-words had no lang parameter at
+all, so French words (boire, dossier, ...) were listed and pinyin-sorted right
+next to Chinese ones under the Chinese tab.
+
+The filter deliberately keys off entries.lang, not decks.lang: Browse also
+lists reference entries that have no card in any deck, and a deck-based filter
+would silently drop every one of them.
+"""
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import database
+import main
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    # database.core.DB_PATH, never database.DB_PATH — the latter is only a
+    # wildcard-import copy and patching it writes to the real DB (#615).
+    monkeypatch.setattr(database.core, "DB_PATH", str(tmp_path / "test.db"))
+    database.init_db()
+
+
+def _entry(word: str, lang: str, definition: str = "") -> int:
+    return database.insert_word({
+        "word_zh": word, "lang": lang, "pinyin": None, "definition": definition,
+        "pos": None, "hsk_level": None, "traditional": None, "definition_zh": None,
+        "source": "test", "note_type": "vocabulary", "notes": None, "date_yaml": None,
+        "source_sentence": None, "grammar_notes": None, "register": None,
+        "definition_de": None, "definition_fr": None,
+    })
+
+
+@pytest.fixture
+def client(tmp_db):
+    _entry("生态", "zh", "ecology")
+    _entry("boire", "fr", "to drink")
+    _entry("dossier", "fr", "file")
+    return TestClient(main.app)
+
+
+def test_browse_words_filters_by_lang(client):
+    zh = client.get("/api/browse-words?lang=zh").json()
+    assert {w["word_zh"] for w in zh} == {"生态"}
+
+    fr = client.get("/api/browse-words?lang=fr").json()
+    assert {w["word_zh"] for w in fr} == {"boire", "dossier"}
+
+
+def test_browse_words_without_lang_returns_everything(client):
+    """Back-compat: callers that predate the language tabs see no change."""
+    words = client.get("/api/browse-words").json()
+    assert {w["word_zh"] for w in words} == {"生态", "boire", "dossier"}
+
+
+def test_browse_lists_cardless_reference_entries(client):
+    """The lang filter must not turn into a deck filter: an entry with no card
+    at all still belongs to Browse."""
+    fr = client.get("/api/browse-words?lang=fr").json()
+    assert all(w["cards"] == [] for w in fr)
+    assert len(fr) == 2
+
+
+def test_search_filters_by_lang(client):
+    """"o" matches all three entries (the Chinese one through its English
+    definition "ecology"), so it isolates the lang filter itself."""
+    words = {w["id"]: w["word_zh"] for w in client.get("/api/browse-words").json()}
+
+    def _hits(lang):
+        r = client.get(f"/api/search-words?q=o&lang={lang}").json()
+        return {words[i] for i in set(r["primary"]) | set(r["secondary"])}
+
+    assert _hits("fr") == {"boire", "dossier"}
+    assert _hits("zh") == {"生态"}
+
+
+def test_delete_word_removes_entry_and_cards(tmp_db):
+    word_id = _entry("dossier", "fr", "file")
+    deck_id = database.get_or_create_deck("Français", lang="fr")
+    database.insert_card(word_id, "listening", deck_id)
+    assert database.get_cards_for_word(word_id)
+
+    client = TestClient(main.app)
+    resp = client.delete(f"/api/word/{word_id}")
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] == word_id
+
+    assert database.get_word(word_id) is None
+    assert database.get_cards_for_word(word_id) == []
+
+
+def test_delete_missing_word_is_404(tmp_db):
+    """A no-op delete must not report success (nothing was deleted)."""
+    client = TestClient(main.app)
+    assert client.delete("/api/word/999999").status_code == 404


### PR DESCRIPTION
## 改了什么

**1. Browse 按语言过滤**

`/api/browse-words`、`/api/search-words` 加可选 `?lang=`，按 **`entries.lang`** 过滤。
不用 `decks.lang` 是有意的：Browse 也列出没有任何卡片的 reference 词条，按牌组过滤会把它们整类丢掉。不传 `lang` 时行为与从前完全一致。

前端（`static/app.js`）：`openBrowse()`、`_browseReload()`、搜索、`openWordByZh()` 四处请求都带上当前语言；`/api/decks` 同样传 lang，所以侧栏不再同时显示 `Daily` 和 `Français`；非中文标签下隐藏 Hanzi 区（对法语/西语没有意义）。

**2. 单行删除按钮**

每行右侧加 🗑（平时半透明，悬停变红），二次确认后调用新的 `DELETE /api/word/{id}`：硬删除词条，卡片/例句/形态表/汉字关联靠外键级联一起走。不进垃圾桶——删的是词条本身，这正是 Browse 一行的含义。id 不存在返回 404，不返回一个空欢喜的 `{"ok": true}`。

## 怎么测试

- `tests/test_browse_lang.py`（6 条）：按语言过滤、不传 lang 的向后兼容、reference 词条不被丢掉、搜索过滤、删除后词条与卡片都没了、删不存在的 id 返回 404
- 全套 `pytest tests/`：**685 passed, 4 skipped**
- 真实启动应用（端口 8011，不占 8000）实测：`/api/browse-words?lang=zh` 只返回中文词，`?lang=fr` 只返回法语词，`DELETE /api/word/2` → 200 且该词从列表消失

Closes #815
