### PR TITLE
feat: 语言标签栏移进顶栏，＋/📖/🎲 移到主页按钮排

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -834,6 +834,15 @@ function showView(name) {
   document.querySelector('main').classList.toggle('review-open', name === 'review');
   const countsRow = document.getElementById('counts-row');
   if (countsRow) countsRow.style.display = name === 'review' ? 'flex' : 'none';
+  // Language tabs only on the deck list: they re-scope the home page, and the
+  // header row is taken over by the review counts anyway (#816). Re-render rather
+  // than just unhiding — some paths reach the deck list without going through
+  // renderDecks() (error fallbacks), and the tabs must still show there.
+  if (name === 'decks') _renderHeaderLangTabs();
+  else {
+    const langTabs = document.getElementById('header-lang-tabs');
+    if (langTabs) langTabs.style.display = 'none';
+  }
   document.getElementById('back-btn').style.display = name === 'decks' ? 'none' : 'block';
   document.getElementById('header-title').textContent =
     name === 'review'       ? deckName :
@@ -1225,16 +1234,21 @@ async function loadDecks({ keepView = false } = {}) {
 // Tab bar shown above the deck list — only when more than one language is in
 // use (issue #436). Selecting a tab re-scopes the whole home page: deck tree,
 // All-deck aggregation, unfinished cards, and the stats charts.
+// They live in the header (#816) rather than in the page body, because the
+// language is application-wide state — dictionary, add-word and story modes all
+// follow it — so it belongs next to the app title, above everything it scopes.
 const _LANG_TAB_LABELS = { zh: '中文', fr: 'Français' };
-function _langTabsHtml() {
-  if (_availableLangs.length <= 1) return '';
+function _renderHeaderLangTabs() {
+  const box = document.getElementById('header-lang-tabs');
+  if (!box) return;
+  if (_availableLangs.length <= 1) { box.style.display = 'none'; box.innerHTML = ''; return; }
   const cur = activeLang();
-  const tabs = _availableLangs.map(l => {
+  box.innerHTML = _availableLangs.map(l => {
     const label = _LANG_TAB_LABELS[l] || l;
     const active = l === cur ? ' lang-tab-active' : '';
     return `<button class="lang-tab${active}" onclick="setActiveLang('${l}')">${label}</button>`;
   }).join('');
-  return `<div class="lang-tabs">${tabs}</div>`;
+  box.style.display = 'flex';
 }
 
 function flatten(nodes, depth = 0) {
@@ -1452,6 +1466,9 @@ function buildCategoryButtons(deck) {
 function renderDecks(decks) {
   const navRow = `
     <div class="nav-row">
+      <button class="nav-btn" onclick="openAddWordModal()" title="Add a new word (⌘A)">＋ Add Word</button>
+      <a class="nav-btn" href="/dict" title="Dictionary lookup">📖 Dictionary</a>
+      <button class="nav-btn" onclick="openRandomWords()" title="10 random words for today">🎲 Random</button>
       <button class="nav-btn" onclick="openBrowse()" title="Shortcut: B">Browse Cards</button>
       <button class="nav-btn" onclick="openStats()">Stats</button>
       <button class="nav-btn" onclick="openKnowledge()">🧠 Knowledge</button>
@@ -1527,9 +1544,10 @@ function renderDecks(decks) {
   }
 
   document.getElementById('view-decks').innerHTML =
-    _langTabsHtml() + navRow + filteredSection +
+    navRow + filteredSection +
     '<div id="home-calendar" class="hcal-card"></div>' +
     '<div id="home-evolution" class="hcal-card"></div>' + regularSection;
+  _renderHeaderLangTabs();
   if (typeof initHomeCalendar === 'function') initHomeCalendar();
   if (typeof initHomeEvolution === 'function') initHomeEvolution();
 }

--- a/static/index.html
+++ b/static/index.html
@@ -17,6 +17,10 @@
          U+30EDE 在 Unicode 扩展 G 区，没有任何常见字体包含它。 -->
     <img id="header-logo" src="/static/logo.svg" alt="" width="32" height="32">
     <h1 id="header-title">biangbiangmian3000</h1>
+    <!-- Language tabs (#436, moved into the header #816). Filled by
+         _renderHeaderLangTabs(); only visible on the deck list, since switching
+         language re-scopes the whole home page. -->
+    <div id="header-lang-tabs" class="lang-tabs lang-tabs-header" style="display:none"></div>
   </div>
   <!-- Review counts — shown only during review, hidden otherwise -->
   <div class="counts-row" id="counts-row" style="display:none">
@@ -57,9 +61,8 @@
   <div class="header-right">
     <!-- Local instance only — injected visible by _renderOfflineBanner() (#625) -->
     <button id="sync-btn" onclick="openSyncPopup()" title="Sync with the server" style="display:none">⟳</button>
-    <button id="add-word-btn" onclick="openAddWordModal()" title="Add a new word to today's deck (⌘A)">＋</button>
-    <a id="dict-link-btn" href="/dict" title="Dictionary lookup">📖</a>
-    <button id="random-words-btn" onclick="openRandomWords()" title="10 random words for today">🎲</button>
+    <!-- ＋ / 📖 / 🎲 moved to the deck-list nav row (#816) so the header can
+         hold the language tabs. -->
     <button id="header-regen-btn" onclick="regenerateStory()" title="Regenerate story" style="display:none">↺</button>
   </div>
 </header>

--- a/static/style.css
+++ b/static/style.css
@@ -97,53 +97,7 @@ header h1 {
   margin-left: 4px;
 }
 #header-regen-btn:hover { background: var(--border); color: #6366f1; }
-#random-words-btn {
-  background: none;
-  border: none;
-  font-size: 16px;
-  cursor: pointer;
-  padding: 2px 6px;
-  border-radius: 6px;
-  line-height: 1;
-  margin-left: 4px;
-}
-#random-words-btn:hover { background: var(--border); }
-/* Dictionary page link (#746) — plain nav icon like #random-words-btn, not a
-   create action, so it doesn't get the primary-colour treatment #add-word-btn has. */
-#dict-link-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 16px;
-  cursor: pointer;
-  padding: 2px 6px;
-  border-radius: 6px;
-  line-height: 1;
-  margin-left: 4px;
-  color: var(--muted);
-  text-decoration: none;
-}
-#dict-link-btn:hover { background: var(--border); }
-/* The one action button in the header that creates something — give it the
-   primary colour and a real touch target instead of the browser default (#636) */
-#add-word-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  margin-left: 4px;
-  font-size: 20px;
-  line-height: 1;
-  background: var(--primary);
-  color: #fff;
-  border: none;
-  border-radius: 50%;
-  cursor: pointer;
-}
-#add-word-btn:hover { filter: brightness(1.1); }
-#add-word-btn:active { transform: scale(0.92); }
+/* ＋ / 📖 / 🎲 used to be header icons; they are nav-row buttons now (#816). */
 
 /* ── Layout ──────────────────────────────────────────── */
 main {
@@ -2276,6 +2230,9 @@ a.news-source-line:hover {
   transition: border-color 0.15s, color 0.15s;
 }
 .nav-btn:hover { border-color: var(--primary); color: var(--primary); }
+/* The dictionary entry is a real link (#816) — strip the anchor defaults so it
+   is indistinguishable from its neighbours. */
+a.nav-btn { text-decoration: none; }
 .nav-shortcuts-help {
   width: 100%;
   color: var(--muted);
@@ -4835,6 +4792,33 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   padding-bottom: 9px;
 }
 
+/* In-header variant (#816). The header is a white bar, so the "tab welded to the
+   panel below it" look would make the active tab the darker one — backwards.
+   Inside a toolbar the readable form is an underline tab instead. */
+.lang-tabs-header {
+  margin: 0 0 0 14px;
+  flex: 0 0 auto;
+  border-bottom: none;
+  align-self: stretch;
+  align-items: center;
+  gap: 4px;
+}
+.lang-tabs-header .lang-tab {
+  bottom: 0;
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  padding: 4px 10px 3px;
+  background: none;
+}
+.lang-tabs-header .lang-tab:hover { background: none; color: var(--text); }
+.lang-tabs-header .lang-tab.lang-tab-active {
+  background: none;
+  color: var(--primary);
+  border-bottom-color: var(--primary);
+  padding-bottom: 3px;
+}
+
 .hcal-seg { display: inline-flex; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
 .hcal-seg-btn {
   border: none;
@@ -5460,8 +5444,6 @@ table.fsrs-table td.ivl { font-weight: 700; }
   }
   /* Apple's minimum comfortable touch target is 44px; these were 32px-ish
      circles/emoji sized for a mouse. */
-  #add-word-btn { width: 40px; height: 40px; font-size: 24px; margin-left: 2px; }
-  #random-words-btn,
   #header-regen-btn,
   #sync-btn {
     min-width: 40px;
@@ -5470,4 +5452,7 @@ table.fsrs-table td.ivl { font-weight: 700; }
     padding: 0;
   }
   #back-btn { min-width: 40px; min-height: 40px; font-size: 24px; }
+  /* The title already ellipsises; keep the tabs from eating its whole width. */
+  .lang-tabs-header { margin-left: 8px; }
+  .lang-tabs-header .lang-tab { padding: 4px 7px 3px; font-size: 12px; }
 }


### PR DESCRIPTION
## 改了什么

**顶栏 = 标题 + 语言标签页**
- `static/index.html`：`header-left` 里标题右侧加 `#header-lang-tabs`
- `static/app.js`：`_langTabsHtml()` → `_renderHeaderLangTabs()`，直接写入 header 容器；`renderDecks()` 不再把标签栏拼进页面 HTML
- 标签栏只在 decks 视图显示。`showView()` 里走**重新渲染**而不是单纯 unhide —— 有些错误回退路径（`showError` 之后的 `showView('decks')`）不经过 `renderDecks()` 就回到主页，只 unhide 会让标签栏消失

**＋ / 📖 / 🎲 移到主页按钮排**
- `nav-row` 前三个：`＋ Add Word` / `📖 Dictionary` / `🎲 Random`
- `#add-word-btn` / `#dict-link-btn` / `#random-words-btn` 三段 id 专属 CSS 及响应式规则删除；新增 `a.nav-btn { text-decoration: none; }`（词典是真链接）
- ⌘A 快捷键调的是 `openAddWordModal()` 函数，不依赖被删的 id

**顶栏里的标签用下划线式，不是 #813 的连体式**
顶栏是白色 bar。连体式的前提是「激活标签与它下方的内容面板同色」，而内容区比顶栏暗，照做会让激活标签变成更暗的那一个，视觉层级正好反过来。工具栏内的标准形式是下划线标签（激活 = primary 色字 + 2px 下边框）。加词弹窗里的 `.lang-tabs` 仍用 #813 的连体样式，未受影响。

## 怎么测试

`pytest tests/` → 679 passed, 4 skipped。剩下是肉眼确认：主页顶栏、复习界面顶栏（应无标签栏）、`/add` 弹窗（连体样式不变）、窄屏。

## 备注

这个分支是从干净的 `main` 重新施加改动得来的。此前另一个会话在同一工作区提交的混合提交 `a063e20` 已保存在本地 `salvage/a063e20` 分支上，本 PR 不含其中任何属于对方的改动（Browse 语言过滤/删除按钮由 #815 单独提交）。

Closes #816