### PR TITLE
feat: Browse 里显示语言标签栏，切换后留在 Browse

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -98,6 +98,10 @@ function setActiveLang(lang) {
   // language instead of leaving the old language's text on screen under the
   // now-active tab. Only re-renders; doesn't change which view is showing.
   if (_knowledgeDetailId != null) openKnowledgeItem(_knowledgeDetailId);
+  // #819: switching tabs while browsing reloads Browse in the new language
+  // instead of dropping the user back on the deck list. loadDecks(true) still
+  // runs, because Browse reads _deckLangById / _cachedDecks for its sidebar.
+  if (_currentView === 'browse') { loadDecks(true); openBrowse(); return; }
   loadDecks();
 }
 
@@ -834,11 +838,14 @@ function showView(name) {
   document.querySelector('main').classList.toggle('review-open', name === 'review');
   const countsRow = document.getElementById('counts-row');
   if (countsRow) countsRow.style.display = name === 'review' ? 'flex' : 'none';
-  // Language tabs only on the deck list: they re-scope the home page, and the
-  // header row is taken over by the review counts anyway (#816). Re-render rather
-  // than just unhiding — some paths reach the deck list without going through
-  // renderDecks() (error fallbacks), and the tabs must still show there.
-  if (name === 'decks') _renderHeaderLangTabs();
+  // Language tabs on the deck list and in Browse — the two views that list cards
+  // across a whole language. Browse is language-scoped too (#815), and switching
+  // tabs is the only way to change language (#819), so the tabs have to be
+  // reachable from there. Everywhere else the header row is needed for something
+  // else (review counts) or the language is fixed by what's on screen.
+  // Re-render rather than just unhiding — some paths reach these views without
+  // going through renderDecks() (error fallbacks), and the tabs must still show.
+  if (name === 'decks' || name === 'browse') _renderHeaderLangTabs();
   else {
     const langTabs = document.getElementById('header-lang-tabs');
     if (langTabs) langTabs.style.display = 'none';


### PR DESCRIPTION
## 改了什么

`static/app.js` 两处：

- `showView()`：标签栏在 `decks` **和 `browse`** 下渲染。这两个视图都在列举整门语言的卡片；其余视图要么顶栏被复习计数占满，要么语言已由屏幕上的内容固定
- `setActiveLang()`：在 Browse 里切标签 → `loadDecks(true)` + `openBrowse()`，按新语言重新拉词表/侧栏/搜索并**留在 Browse**。此前走 `loadDecks()`（默认 `keepView=false`）会把人踢回主页

## 为什么

#815 已经让 Browse 的数据按语言隔离，#816 把标签栏挪进顶栏时限制成只在主页显示 —— 于是 Browse 里既隔离了语言又没有切换入口。Daniel 的要求是「Browse 里各语言完全隔离，切换语言的唯一途径就是切标签页」，那标签页就必须在 Browse 里可见。

## 不做

词条详情页不显示标签栏：在一个具体词条上切语言没有意义，返回 Browse 时标签栏自然回来。

## 怎么测试

`pytest tests/` → 685 passed, 4 skipped。肉眼：Browse 里点另一种语言 → 词表、侧栏牌组树、搜索全换语言且仍停在 Browse；非中文下 Hanzi 区仍隐藏（#815）。

Closes #819