### PR TITLE
fix: setActiveLang 里 loadDecks 参数传错，Browse 切语言会被甩回主页

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -99,9 +99,11 @@ function setActiveLang(lang) {
   // now-active tab. Only re-renders; doesn't change which view is showing.
   if (_knowledgeDetailId != null) openKnowledgeItem(_knowledgeDetailId);
   // #819: switching tabs while browsing reloads Browse in the new language
-  // instead of dropping the user back on the deck list. loadDecks(true) still
-  // runs, because Browse reads _deckLangById / _cachedDecks for its sidebar.
-  if (_currentView === 'browse') { loadDecks(true); openBrowse(); return; }
+  // instead of dropping the user back on the deck list. loadDecks still runs,
+  // because Browse reads _deckLangById / _cachedDecks for its sidebar — but it
+  // must keep the view (#822): its parameter is an object, and a bare `true`
+  // silently falls back to keepView=false, racing openBrowse() for the view.
+  if (_currentView === 'browse') { loadDecks({ keepView: true }); openBrowse(); return; }
   loadDecks();
 }
 


### PR DESCRIPTION
## 问题

`loadDecks` 的签名是对象参数：

```js
async function loadDecks({ keepView = false } = {})
```

#819 写的是 `loadDecks(true)` —— `true` 被当对象解构，`true.keepView === undefined`，`keepView` 回落成 `false`。`loadDecks` 于是照样 `setLoading()` 并在结束时 `showView('decks')`，和紧接着调用的 `openBrowse()`（结束时 `showView('browse')`）抢视图，谁的请求后回来谁说了算。表现为 Browse 里切语言有时被甩回主页。

不抛错，所以 pytest / CI 发现不了。

## 修复

改成 `loadDecks({ keepView: true })`，并在注释里写明这个坑。

Closes #822