### PR TITLE
顶栏显示后台正在运行的进程

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 10. [数据库模式](#数据库模式概述) · 11. [调度算法 FSRS-5](#调度算法--fsrs-5默认--sm-2-回退) · 12. [队列设计](#队列设计) · 13. [多语言支持](#多语言支持)
 
 **功能详解**
-14. [数据与导入 / 界面内加词](#数据与导入) · 15. [故事生成](#故事生成) · 16. [加星句子](#加星句子改进提示词的正例样本692) · 17. [知识库](#知识库knowledge-base650655) · 18. [生词标注](#生词标注代码做不用-aizh_annotatepy638) · 19. [复习收尾提醒](#复习收尾提醒701) · 20. [AI 词典页 /dict](#ai-词典页-dict746)
+14. [数据与导入 / 界面内加词](#数据与导入) · 15. [故事生成](#故事生成) · 16. [加星句子](#加星句子改进提示词的正例样本692) · 17. [知识库](#知识库knowledge-base650655) · 18. [生词标注](#生词标注代码做不用-aizh_annotatepy638) · 19. [复习收尾提醒](#复习收尾提醒701) · 19b. [顶栏后台任务指示器](#顶栏后台任务指示器821) · 20. [AI 词典页 /dict](#ai-词典页-dict746)
 
 **参考**
 21. [API 接口](#api-接口) · 22. [测试](#测试tests-pytest-tests-全套约-11-秒) · 23. [规范与约束](#规范与约束)
@@ -203,6 +203,7 @@
 │   └── cards.py / decks.py / entries.py / presets.py / stories.py / browse.py / stats.py / podcast.py
 ├── routes/                # FastAPI 路由模块
 │   ├── browse.py / decks.py / imports.py / review.py / story.py / podcast.py / knowledge.py（`POST /api/knowledge/add`，#651/#652）
+│   ├── tasks.py           # 顶栏后台任务指示器（#821）：`GET /api/tasks` 聚合各子系统已有的进度状态
 │   ├── sync.py            # 一键同步（#625，只在笔记本实例注册）
 │   ├── queue_manager.py   # Anki v3 风格持久会话队列
 │   └── utils.py           # 共用工具（DISABLE_AI, leaf_ids, queue_manager 单例）
@@ -616,6 +617,17 @@ FSRS 用毕业评分播种初始 stability/difficulty：默认权重下 **Good �
 
 ---
 
+## 顶栏后台任务指示器（#821）
+
+在故事加载页点「Continue in background」之后，主页看起来完全空闲，但 AI 调用、翻译、TTS 预加载还在跑一分钟；加词（约 30 秒）、知识库素材处理（可达十几分钟）同样是"提交完就没影了"。顶栏右侧的 ⚙ 徽标回答"现在服务器在干什么"，点开是明细列表。
+
+- **`routes/tasks.py` 只做聚合，绝不新建第二套记账**：每个长任务都已经把进度写在某处（`ai._story_progress`、`tts._preload_progress`、`routes/imports._import_jobs`、`routes/podcast._PROCESSING_IDS`），平行的注册表迟早和它们漂移，然后开始撒谎 —— 与 #643 坚持单一加词管线是同一条道理
+- **唯一例外是 Again 单句重生成**（`routes/review._spawn_again_regen`）：它此前没有任何记账，`tasks.register()`/`finish()` 就是补上的那个最小注册表。**别的地方不要用它** —— 除非同样确实没有自己的状态。`finish()` 必须写在 `finally:` 里，泄漏一条 = 一个永远转不完的任务
+- **终态不是任务**：`_story_progress` 里 `done`/`error`/`idle` 的条目是留给加载页最后读一次的历史，聚合时必须滤掉；TTS 同理（`done >= total`）
+- **单个采集器抛异常不许拖垮整个列表**：半份列表仍然告诉 Daniel 有东西在跑，500 什么都不告诉他。牌组/单集被删时标题回落成 id，不是报错
+- **前端轮询是自适应的**（`static/app.js`）：有任务或面板打开时 3 秒，空闲时 15 秒 —— 每个打开的标签页都在轮询，闲置装机不该被打满。**请求失败不清空指示器**：请求掉了不等于活儿停了
+- 无任务时整个按钮隐藏 —— 常驻的「0 tasks」只是噪音
+
 ## 复习收尾提醒（#701）
 
 清空队列（0 open cards）后，被评为 Again 的卡片还留在学习步骤里（`1m 10m 1d 3d`）分批回来，Daniel 离开界面就无从知道它们什么时候到期。服务器 cron 每 5 分钟跑 `scripts/due_check.py` → `POST /api/review/due-notify-check`，条件成立时发一封邮件。
@@ -657,6 +669,7 @@ GET/PUT /api/decks/{id}/preset                       → 预设（yùshè - pres
 GET/POST /api/presets ；DELETE /api/presets/{id}
 GET    /api/langs                                    → 当前使用的语言列表
 GET    /api/mode                                     → {offline, local, hard_offline}（#612/#625；offline 是实时值，本地模式下每 60 秒轮询）
+GET    /api/tasks                                    → 当前正在跑的后台任务（#821）：{tasks[{id,kind,icon,label,detail,percent,started_at}], count}
 
 # 一键同步（#625，只在 LOCAL_MODE/OFFLINE_MODE 下注册；服务器上返回 404）
 POST   /api/sync/start[?mode=sync|pull]              → 后台跑 sync_offline.sh，立即返回；重复提交 409

--- a/main.py
+++ b/main.py
@@ -199,7 +199,7 @@ try:
     import uvicorn
 
     from offline import LOCAL_MODE, OFFLINE_MODE
-    from routes import decks, review, story, browse, imports, podcast as podcast_routes, knowledge as knowledge_routes, dictionary as dictionary_routes
+    from routes import decks, review, story, browse, imports, podcast as podcast_routes, knowledge as knowledge_routes, dictionary as dictionary_routes, tasks as tasks_routes
 
     @asynccontextmanager
     async def lifespan(app):
@@ -523,6 +523,7 @@ try:
     app.include_router(podcast_routes.router)
     app.include_router(knowledge_routes.router)
     app.include_router(dictionary_routes.router)
+    app.include_router(tasks_routes.router)
     # Sync only makes sense on a laptop copy — on the server these routes must
     # not exist at all, or a stray call would overwrite production (#625).
     if LOCAL_MODE or OFFLINE_MODE:

--- a/routes/review.py
+++ b/routes/review.py
@@ -8,6 +8,7 @@ import database
 import review_notify
 import srs
 import tts
+from . import tasks
 from .utils import leaf_ids, queue_mgr as _queue_mgr, ai_disabled
 
 logger = logging.getLogger(__name__)
@@ -62,6 +63,12 @@ def _spawn_again_regen(card: dict) -> None:
     logger.info("again-regen  TRIGGER word=%s cat=%s — scheduling background regen",
                 card.get("word_zh"), card.get("category"))
 
+    # Visible in the header task indicator (#821) — this is the one background
+    # job in the app that publishes no progress state of its own.
+    task_id = f"sentence:{card['word_id']}:{card['category']}"
+    tasks.register(task_id, "sentence",
+                   f"New sentence · {card.get('word_zh') or card['word_id']}")
+
     def _run() -> None:
         try:
             from .story import generate_sentence_for_word
@@ -91,6 +98,8 @@ def _spawn_again_regen(card: dict) -> None:
                 pass
         except Exception as e:
             logger.warning("again-regen failed for word=%s: %s", card.get("word_zh"), e)
+        finally:
+            tasks.finish(task_id)
 
     threading.Thread(target=_run, daemon=True).start()
 

--- a/routes/tasks.py
+++ b/routes/tasks.py
@@ -1,0 +1,196 @@
+"""Header background-task indicator (#821).
+
+Daniel leaves the story loading screen ("continue in background") and lands on
+the deck list with no sign that anything is still running — the AI call, the
+translations and the TTS preload keep going for another minute, and adding a
+word or processing a knowledge item takes 30s to 15min with the same silence.
+
+This module answers one question: *what is running right now?*
+
+It deliberately **aggregates the progress state that already exists** instead of
+introducing a second bookkeeping layer next to it. Every long-running job in
+this app already publishes its state somewhere (`ai._story_progress`,
+`tts._preload_progress`, `routes.imports._import_jobs`,
+`routes.podcast._PROCESSING_IDS`); a parallel registry would inevitably drift
+out of sync with them and start lying about what the server is doing — the same
+reason #643 insists on a single add-word pipeline.
+
+The one exception is the Again single-sentence regeneration in
+`routes/review.py`, which had no bookkeeping at all: `register()`/`finish()`
+below are that missing minimal registry, and nothing else should use them
+unless it, too, has no state of its own.
+"""
+import logging
+import threading
+import time
+
+import ai
+import database
+import tts
+from fastapi import APIRouter
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+# ── Minimal registry for jobs that publish no progress of their own ─────────
+_ad_hoc: dict[str, dict] = {}
+_ad_hoc_lock = threading.Lock()
+
+
+def register(task_id: str, kind: str, label: str, detail: str = "") -> None:
+    """Record an ad-hoc background job as running. Callers MUST call finish()
+    in a `finally:` — a leaked entry shows as a task that never ends."""
+    with _ad_hoc_lock:
+        _ad_hoc[task_id] = {"kind": kind, "label": label, "detail": detail,
+                            "started_at": time.time()}
+
+
+def finish(task_id: str) -> None:
+    with _ad_hoc_lock:
+        _ad_hoc.pop(task_id, None)
+
+
+# ── Aggregation ─────────────────────────────────────────────────────────────
+
+# Terminal states that _story_progress keeps around for the loading screen to
+# read one last time — they are history, not work in progress.
+_STORY_DONE_PHASES = {"done", "error", "idle"}
+
+_ICONS = {"story": "📖", "audio": "🔊", "word": "＋",
+          "knowledge": "📄", "sentence": "↺", "import": "📥"}
+
+
+def _deck_label(deck_id: str | int) -> str:
+    """Deck name for a progress key, falling back to the raw id — a task list
+    that raises because a deck was deleted mid-generation is worse than one
+    that shows a number."""
+    try:
+        deck = database.get_deck(int(deck_id))
+    except Exception:
+        return str(deck_id)
+    return (deck or {}).get("name") or str(deck_id)
+
+
+def _split_progress_key(key: str) -> tuple[str, str, str]:
+    """`deck_id/category/lang` → its three parts (missing parts become '')."""
+    parts = key.split("/")
+    parts += [""] * (3 - len(parts))
+    return parts[0], parts[1], parts[2]
+
+
+def _story_tasks() -> list[dict]:
+    from . import story as story_routes
+
+    with story_routes._gen_lock:
+        generating = set(story_routes._generating)
+    out = []
+    # A key can be in _generating slightly before its progress entry exists,
+    # and a *blocking* (foreground) generation only has the progress entry —
+    # both must show up, so walk the union.
+    for key in set(ai._story_progress) | generating:
+        prog = ai._story_progress.get(key) or {}
+        phase = prog.get("phase", "starting")
+        if key not in generating and phase in _STORY_DONE_PHASES:
+            continue
+        deck_id, category, lang = _split_progress_key(key)
+        out.append({
+            "id": f"story:{key}",
+            "kind": "story",
+            "label": f"{_deck_label(deck_id)} · {category}" if category else _deck_label(deck_id),
+            "detail": prog.get("msg") or phase,
+            "percent": prog.get("percent"),
+            "lang": lang or None,
+        })
+    return out
+
+
+def _audio_tasks() -> list[dict]:
+    out = []
+    for key, prog in list(tts._preload_progress.items()):
+        total, done = prog.get("total") or 0, prog.get("done") or 0
+        if total <= 0 or done >= total:
+            continue
+        deck_id, category, lang = _split_progress_key(key)
+        out.append({
+            "id": f"audio:{key}",
+            "kind": "audio",
+            "label": f"{_deck_label(deck_id)} · {category}" if category else _deck_label(deck_id),
+            "detail": f"{done}/{total} sentences",
+            "percent": round(done * 100 / total),
+            "lang": lang or None,
+        })
+    return out
+
+
+def _import_tasks() -> list[dict]:
+    from . import imports as import_routes
+
+    out = []
+    for job_id, job in list(import_routes._import_jobs.items()):
+        if job.get("status") != "running":
+            continue
+        # Both the add-word jobs (#627) and the YAML upload jobs (#458) live in
+        # this dict; only the former carries a per-word message.
+        message = job.get("message") or "Working…"
+        kind = "word" if message.startswith("Generating entry") else "import"
+        out.append({
+            "id": f"import:{job_id}",
+            "kind": kind,
+            "label": message,
+            "detail": "",
+            "percent": None,
+            "started_at": job.get("started_at"),
+        })
+    return out
+
+
+def _knowledge_tasks() -> list[dict]:
+    from . import podcast as podcast_routes
+
+    with podcast_routes._PROCESSING_LOCK:
+        ids = list(podcast_routes._PROCESSING_IDS)
+    out = []
+    for episode_id in ids:
+        try:
+            episode = database.get_episode(episode_id) or {}
+        except Exception:
+            episode = {}
+        out.append({
+            "id": f"knowledge:{episode_id}",
+            "kind": "knowledge",
+            "label": episode.get("title") or f"Item {episode_id}",
+            "detail": "Transcribing / summarising…",
+            "percent": None,
+            "episode_id": episode_id,
+        })
+    return out
+
+
+def _ad_hoc_tasks() -> list[dict]:
+    with _ad_hoc_lock:
+        items = list(_ad_hoc.items())
+    return [{"id": task_id, "kind": t["kind"], "label": t["label"],
+             "detail": t.get("detail", ""), "percent": None,
+             "started_at": t["started_at"]} for task_id, t in items]
+
+
+@router.get("/api/tasks")
+def list_tasks():
+    """Everything the server is currently working on, for the header indicator.
+
+    Polled every few seconds by every open tab, so it must stay cheap: no AI,
+    no writes, and the only DB reads are deck/episode names for the labels.
+    A failing collector must never take the whole list down — a half-complete
+    list still tells Daniel something is running.
+    """
+    tasks: list[dict] = []
+    for collect in (_story_tasks, _audio_tasks, _import_tasks,
+                    _knowledge_tasks, _ad_hoc_tasks):
+        try:
+            tasks.extend(collect())
+        except Exception as e:
+            logger.warning("tasks: collector %s failed: %s", collect.__name__, e)
+    for task in tasks:
+        task.setdefault("started_at", None)
+        task["icon"] = _ICONS.get(task["kind"], "⚙")
+    return {"tasks": tasks, "count": len(tasks)}

--- a/static/app.js
+++ b/static/app.js
@@ -1099,6 +1099,120 @@ function _renderOfflineBanner() {
 }
 
 
+
+// ── Background-task indicator (#821) ────────────────────────────────────────
+// "Continue in background" on the story loading screen dropped Daniel on a deck
+// list that looked completely idle while the AI call, the translations and the
+// TTS preload kept running for another minute — and adding a word or processing
+// a knowledge item is just as invisible. GET /api/tasks aggregates whatever the
+// server is actually doing; this renders it in the header.
+
+let _tasksTimer = null;
+let _tasksPanelOpen = false;
+let _tasksCount = 0;
+
+// Poll fast while something runs (the detail text changes every few seconds),
+// slowly while idle — every open tab runs this poll, so an idle install must
+// not hammer the server.
+const _TASKS_POLL_BUSY = 3000;
+const _TASKS_POLL_IDLE = 15000;
+
+function _startTasksPolling() {
+  if (_tasksTimer) return;
+  const tick = async () => {
+    await _refreshTasks();
+    _tasksTimer = setTimeout(tick,
+      (_tasksCount > 0 || _tasksPanelOpen) ? _TASKS_POLL_BUSY : _TASKS_POLL_IDLE);
+  };
+  tick();
+}
+
+async function _refreshTasks() {
+  // A failed poll must not clear the indicator: a dropped request is not
+  // evidence that the work stopped. Keep showing the last known state.
+  const r = await api('GET', '/api/tasks').catch(() => null);
+  if (!r || !Array.isArray(r.tasks)) return;
+  _tasksCount = r.tasks.length;
+  _renderTasks(r.tasks);
+}
+
+function _renderTasks(tasks) {
+  const wrap = document.getElementById('tasks-wrap');
+  if (!wrap) return;
+  if (tasks.length === 0) {
+    wrap.style.display = 'none';
+    _tasksPanelOpen = false;
+    document.getElementById('tasks-panel').style.display = 'none';
+    return;
+  }
+  wrap.style.display = '';
+  document.getElementById('tasks-count').textContent = String(tasks.length);
+  document.getElementById('tasks-btn').title =
+    tasks.map(t => `${t.icon} ${t.label}`).join('\n');
+
+  const list = document.getElementById('tasks-list');
+  list.textContent = '';
+  for (const t of tasks) {
+    const row = document.createElement('div');
+    row.className = 'task-row';
+
+    const head = document.createElement('div');
+    head.className = 'task-row-head';
+    const label = document.createElement('span');
+    label.className = 'task-row-label';
+    label.textContent = `${t.icon || '⚙'} ${t.label || ''}`;
+    head.appendChild(label);
+    const age = _taskAge(t.started_at);
+    if (age) {
+      const ageEl = document.createElement('span');
+      ageEl.className = 'task-row-age';
+      ageEl.textContent = age;
+      head.appendChild(ageEl);
+    }
+    row.appendChild(head);
+
+    if (t.detail) {
+      const detail = document.createElement('div');
+      detail.className = 'task-row-detail';
+      detail.textContent = t.detail;
+      row.appendChild(detail);
+    }
+    if (typeof t.percent === 'number') {
+      const bar = document.createElement('div');
+      bar.className = 'task-bar';
+      const fill = document.createElement('div');
+      fill.style.width = Math.max(0, Math.min(100, t.percent)) + '%';
+      bar.appendChild(fill);
+      row.appendChild(bar);
+    }
+    list.appendChild(row);
+  }
+}
+
+// started_at is a server-side epoch in seconds; only the jobs that have no
+// progress bar of their own carry it.
+function _taskAge(startedAt) {
+  if (!startedAt) return '';
+  const secs = Math.max(0, Math.round(Date.now() / 1000 - startedAt));
+  if (secs < 60) return `${secs}s`;
+  return `${Math.floor(secs / 60)}m ${secs % 60}s`;
+}
+
+function toggleTasksPanel() {
+  const panel = document.getElementById('tasks-panel');
+  if (!panel) return;
+  _tasksPanelOpen = !_tasksPanelOpen;
+  panel.style.display = _tasksPanelOpen ? 'block' : 'none';
+  if (_tasksPanelOpen) _refreshTasks();
+}
+
+document.addEventListener('click', (e) => {
+  if (!_tasksPanelOpen) return;
+  const wrap = document.getElementById('tasks-wrap');
+  if (wrap && !wrap.contains(e.target)) toggleTasksPanel();
+});
+
+
 // ── Local mode + sync (#625) ────────────────────────────────────────────────
 // The laptop instance is a full copy of the app that happens to lose its AI
 // and TTS when the network goes away, so `offline` is a live value: poll it and
@@ -11238,6 +11352,7 @@ if (/^#(?:podcast|knowledge)-feed-\d+$/.test(location.hash)
   loadDecks();
 }
 _loadVersionBadge();
+_startTasksPolling();
 
 
 // ===== Home calendar heatmap (issue #307) — inlined here to dodge index.html caching =====

--- a/static/index.html
+++ b/static/index.html
@@ -59,6 +59,17 @@
     <button class="undo-btn" id="session-graph-btn" onclick="openSessionSummary()" title="Graph of cards reviewed this session">📈 Session</button>
   </div>
   <div class="header-right">
+    <!-- Background-task indicator (#821). Hidden while nothing is running;
+         _renderTasks() fills the badge and the dropdown from GET /api/tasks. -->
+    <div id="tasks-wrap" style="display:none">
+      <button id="tasks-btn" onclick="toggleTasksPanel()" title="Background tasks">
+        <span class="tasks-spinner">⚙</span><span id="tasks-count">0</span>
+      </button>
+      <div id="tasks-panel" style="display:none">
+        <div class="tasks-panel-title">Running in the background</div>
+        <div id="tasks-list"></div>
+      </div>
+    </div>
     <!-- Local instance only — injected visible by _renderOfflineBanner() (#625) -->
     <button id="sync-btn" onclick="openSyncPopup()" title="Sync with the server" style="display:none">⟳</button>
     <!-- ＋ / 📖 / 🎲 moved to the deck-list nav row (#816) so the header can

--- a/static/style.css
+++ b/static/style.css
@@ -5470,3 +5470,78 @@ table.fsrs-table td.ivl { font-weight: 700; }
   .lang-tabs-header { margin-left: 8px; }
   .lang-tabs-header .lang-tab { padding: 4px 7px 3px; font-size: 12px; }
 }
+
+/* ── Background-task indicator (#821) ───────────────────
+   Leaving the story loading screen ("continue in background") used to drop
+   Daniel on a deck list that looked completely idle while the AI call, the
+   translations and the TTS preload were still running. This is the header
+   affordance that says otherwise. Hidden entirely when nothing runs — a
+   permanently visible "0 tasks" chip is noise. */
+#tasks-wrap { position: relative; }
+#tasks-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  cursor: pointer;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1;
+  padding: 5px 10px 5px 8px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+#tasks-btn:hover { background: var(--border); }
+#tasks-btn .tasks-spinner {
+  display: inline-block;
+  font-size: 15px;
+  animation: tasks-spin 3s linear infinite;
+}
+@keyframes tasks-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  #tasks-btn .tasks-spinner { animation: none; }
+}
+#tasks-count { font-variant-numeric: tabular-nums; font-weight: 600; }
+#tasks-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 320px;
+  max-width: calc(100vw - 24px);
+  max-height: 60vh;
+  overflow-y: auto;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, .18);
+  padding: 10px 12px;
+  z-index: 40;
+  text-align: left;
+}
+.tasks-panel-title {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+.task-row { padding: 7px 0; border-top: 1px solid var(--border); }
+.task-row:first-child { border-top: none; }
+.task-row-head { display: flex; align-items: baseline; gap: 6px; }
+.task-row-label {
+  flex: 1;
+  min-width: 0;
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.task-row-age { font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; }
+.task-row-detail { font-size: 11px; color: var(--muted); margin-top: 2px; }
+.task-bar { height: 3px; border-radius: 2px; background: var(--border); margin-top: 5px; }
+.task-bar > div { height: 100%; border-radius: 2px; background: var(--primary); }
+.tasks-empty { font-size: 12px; color: var(--muted); padding: 4px 0; }
+
+@media (max-width: 560px) {
+  #tasks-btn { min-height: 40px; font-size: 15px; }
+}

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,146 @@
+"""Tests for the header background-task indicator (#821).
+
+The central claim: /api/tasks reports what is *actually* running by reading the
+progress state each subsystem already publishes. So every test here writes into
+those real dicts (ai._story_progress, tts._preload_progress, …) rather than into
+a registry of the endpoint's own — if a subsystem ever stops publishing there,
+these tests must break rather than keep reporting a comfortable lie.
+"""
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+from fastapi.testclient import TestClient
+import ai
+import database
+import main
+import tts
+from routes import imports as import_routes
+from routes import podcast as podcast_routes
+from routes import story as story_routes
+from routes import tasks as task_routes
+
+client = TestClient(main.app)
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    """Fresh temp database. Patch database.core.DB_PATH, not database.DB_PATH
+    — the latter is only a copy of the name (issue #615)."""
+    monkeypatch.setattr(database.core, "DB_PATH", str(tmp_path / "test.db"))
+    database.init_db()
+
+
+@pytest.fixture(autouse=True)
+def clean_state():
+    """The aggregated dicts are module globals shared with the running app."""
+    for d in (ai._story_progress, tts._preload_progress,
+              import_routes._import_jobs, task_routes._ad_hoc):
+        d.clear()
+    podcast_routes._PROCESSING_IDS.clear()
+    story_routes._generating.clear()
+    yield
+    for d in (ai._story_progress, tts._preload_progress,
+              import_routes._import_jobs, task_routes._ad_hoc):
+        d.clear()
+    podcast_routes._PROCESSING_IDS.clear()
+    story_routes._generating.clear()
+
+
+def get_tasks():
+    r = client.get("/api/tasks")
+    assert r.status_code == 200
+    return r.json()
+
+
+def test_idle_reports_nothing(tmp_db):
+    body = get_tasks()
+    assert body["count"] == 0 and body["tasks"] == []
+
+
+def test_story_generation_shows_up_with_phase_and_percent(tmp_db):
+    deck_id = database.get_or_create_deck("Kouyu")
+    key = f"{deck_id}/reading/zh"
+    story_routes._generating.add(key)
+    ai._story_progress[key] = {"phase": "request", "msg": "生成句子…", "percent": 40}
+
+    tasks = get_tasks()["tasks"]
+    assert len(tasks) == 1
+    assert tasks[0]["kind"] == "story"
+    assert "Kouyu" in tasks[0]["label"] and "reading" in tasks[0]["label"]
+    assert tasks[0]["detail"] == "生成句子…"
+    assert tasks[0]["percent"] == 40
+
+
+def test_blocking_generation_without_the_generating_flag_still_shows(tmp_db):
+    """A foreground (non-background) generation only writes _story_progress —
+    it must not be invisible just because it never entered _generating."""
+    deck_id = database.get_or_create_deck("Kouyu")
+    ai._story_progress[f"{deck_id}/listening/zh"] = {
+        "phase": "translating", "msg": "Translating…", "percent": 70}
+    assert [t["kind"] for t in get_tasks()["tasks"]] == ["story"]
+
+
+def test_finished_story_is_not_a_running_task(tmp_db):
+    """Terminal states linger in _story_progress for the loading screen to read
+    one last time; they are history, not work in progress."""
+    deck_id = database.get_or_create_deck("Kouyu")
+    for phase in ("done", "error", "idle"):
+        ai._story_progress[f"{deck_id}/reading/zh"] = {"phase": phase, "percent": 100}
+        assert get_tasks()["count"] == 0, phase
+
+
+def test_tts_preload_reports_a_ratio_and_disappears_when_complete(tmp_db):
+    deck_id = database.get_or_create_deck("Kouyu")
+    key = f"{deck_id}/listening/zh"
+    tts._preload_progress[key] = {"done": 3, "total": 12}
+    task = get_tasks()["tasks"][0]
+    assert task["kind"] == "audio" and task["percent"] == 25
+    assert task["detail"] == "3/12 sentences"
+
+    tts._preload_progress[key] = {"done": 12, "total": 12}
+    assert get_tasks()["count"] == 0
+
+
+def test_running_add_word_job_shows_up_but_a_finished_one_does_not(tmp_db):
+    import_routes._import_jobs["abc123"] = {
+        "status": "running", "message": "Generating entry for 生态…",
+        "started_at": 1_700_000_000.0}
+    task = get_tasks()["tasks"][0]
+    assert task["kind"] == "word"
+    assert task["started_at"] == 1_700_000_000.0
+
+    import_routes._import_jobs["abc123"]["status"] = "done"
+    assert get_tasks()["count"] == 0
+
+
+def test_knowledge_item_being_processed_shows_its_title(tmp_db):
+    episode_id = database.create_pending_episode(
+        "abc", None, "Ein Podcast", "2026-08-19", "https://example.com/x")
+    podcast_routes._PROCESSING_IDS.add(episode_id)
+    task = get_tasks()["tasks"][0]
+    assert task["kind"] == "knowledge" and task["label"] == "Ein Podcast"
+
+
+def test_ad_hoc_registry_round_trip(tmp_db):
+    """The Again single-sentence regeneration is the only job with no progress
+    state of its own, so it registers here explicitly."""
+    task_routes.register("sentence:1:reading", "sentence", "New sentence · 生态")
+    assert [t["label"] for t in get_tasks()["tasks"]] == ["New sentence · 生态"]
+    task_routes.finish("sentence:1:reading")
+    assert get_tasks()["count"] == 0
+
+
+def test_a_broken_collector_does_not_take_the_whole_list_down(tmp_db, monkeypatch):
+    """A half-complete list still tells Daniel something is running; a 500
+    tells him nothing at all."""
+    monkeypatch.setattr(task_routes, "_story_tasks",
+                        lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    task_routes.register("x", "sentence", "still here")
+    assert [t["label"] for t in get_tasks()["tasks"]] == ["still here"]
+
+
+def test_deleted_deck_falls_back_to_the_id(tmp_db):
+    ai._story_progress["99999/reading/zh"] = {"phase": "request", "percent": 10}
+    assert get_tasks()["tasks"][0]["label"] == "99999 · reading"


### PR DESCRIPTION
Closes #821

## 改了什么

顶栏右侧新增后台任务指示器：有任务在跑时显示 ⚙ + 数量，点开是明细列表（图标 / 对象 / 当前阶段 / 进度条 / 已跑时长）。无任务时整个按钮隐藏。

新增 `GET /api/tasks`，覆盖：

| 类型 | 数据来源 |
|------|----------|
| 📖 故事生成 | `ai._story_progress` + `routes/story._generating` |
| 🔊 TTS 预加载 | `tts._preload_progress` |
| ＋ 加词 / 📥 YAML 导入 | `routes/imports._import_jobs`（status=running） |
| 📄 知识库处理 / 重新摘要 | `routes/podcast._PROCESSING_IDS` |
| ↺ Again 单句重生成 | `routes/tasks` 的最小注册表 |

## 为什么这么做

**只聚合，不新建第二套记账。** 每个长任务都已经把进度写在某处；平行的注册表迟早和它们漂移，然后开始撒谎——与 #643 坚持单一加词管线同理。唯一例外是 Again 单句重生成，它此前**没有任何**记账，`register()`/`finish()` 就是补上的那个最小注册表（`finish()` 在 `finally:` 里，泄漏一条 = 一个永远转不完的任务）。

其它几条约束：

- **终态不是任务**：`_story_progress` 里 `done`/`error`/`idle` 是留给加载页最后读一次的历史，滤掉
- **单个采集器抛异常不拖垮整个列表**：半份列表仍然有用，500 没用。牌组/单集被删时标题回落成 id
- **前端轮询自适应**：有任务/面板打开 3 秒，空闲 15 秒；请求失败**不清空**指示器——请求掉了不等于活儿停了
- 文本一律 `textContent` 渲染，无 `innerHTML` 拼接

## 怎么测的

- `tests/test_tasks.py`（10 条）：写进真实的进度 dict 而不是端点自己的注册表——某个子系统哪天不再往那里写，测试必须先坏掉，而不是继续报一个舒服的假象
- `pytest tests/` 全套 695 passed / 4 skipped
- 起了一个 8002 端口的实例实测接口：空闲 `{"tasks":[],"count":0}`，写入一条故事进度后正确返回牌组名 + 阶段 + 百分比

🤖 Generated with [Claude Code](https://claude.com/claude-code)