### PR TITLE
feat: 每种语言一个主题色，标签坐在横跨整页的线上

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -92,6 +92,7 @@ function _langQP(sep) { const q = _langQ(); return q ? `${sep}${q}` : ''; }
 function setActiveLang(lang) {
   if (lang === activeLang()) return;
   localStorage.setItem('activeLang', lang);
+  _applyLangTheme();  // recolour immediately, don't wait for the reload (#824)
   invalidateHomeEvolution();
   // #804: a knowledge-base item detail view open at the moment of the switch
   // shows a per-language rendition of the summary — re-fetch it in the new
@@ -1247,7 +1248,20 @@ async function loadDecks({ keepView = false } = {}) {
 // language is application-wide state — dictionary, add-word and story modes all
 // follow it — so it belongs next to the app title, above everything it scopes.
 const _LANG_TAB_LABELS = { zh: '中文', fr: 'Français' };
+
+// Each language gets its own accent colour (#824), carried by body[data-lang] so
+// the header's bottom rule is tinted in *every* view — the tab bar itself only
+// shows on two of them, but "which language am I in" matters during review too.
+// Single-language users get no attribute at all, and so the original grey rule.
+function _applyLangTheme() {
+  const body = document.body;
+  if (!body) return;
+  if (_availableLangs.length <= 1) delete body.dataset.lang;
+  else body.dataset.lang = activeLang();
+}
+
 function _renderHeaderLangTabs() {
+  _applyLangTheme();
   const box = document.getElementById('header-lang-tabs');
   if (!box) return;
   if (_availableLangs.length <= 1) { box.style.display = 'none'; box.innerHTML = ''; return; }

--- a/static/style.css
+++ b/static/style.css
@@ -4806,32 +4806,44 @@ details[open] .cat-override-summary::before { content: '▼ '; }
   padding-bottom: 9px;
 }
 
-/* In-header variant (#816). The header is a white bar, so the "tab welded to the
-   panel below it" look would make the active tab the darker one — backwards.
-   Inside a toolbar the readable form is an underline tab instead. */
+/* In-header variant (#816, recoloured #824). The active tab is a tinted block
+   running the full height of the header down to the header's own bottom rule —
+   which is itself tinted, so the "underline" spans the whole page width. */
 .lang-tabs-header {
   margin: 0 0 0 14px;
   flex: 0 0 auto;
   border-bottom: none;
   align-self: stretch;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
 }
 .lang-tabs-header .lang-tab {
   bottom: 0;
-  border: none;
-  border-bottom: 2px solid transparent;
-  border-radius: 0;
-  padding: 4px 10px 3px;
+  /* Cancel the header's vertical padding (10px) and its 1px rule, so the tab is
+     full-height and the active one can sit on top of the rule. */
+  margin: -10px 0 -11px;
+  padding: 10px 16px 11px;
+  border: 1px solid transparent;
+  border-bottom: none;
+  border-radius: 8px 8px 0 0;
   background: none;
 }
-.lang-tabs-header .lang-tab:hover { background: none; color: var(--text); }
+.lang-tabs-header .lang-tab:hover { background: var(--bg); color: var(--text); }
 .lang-tabs-header .lang-tab.lang-tab-active {
-  background: none;
-  color: var(--primary);
-  border-bottom-color: var(--primary);
-  padding-bottom: 3px;
+  background: var(--card);
+  border-color: var(--lang-accent, var(--border));
+  color: var(--lang-accent, var(--text));
 }
+
+/* ── Per-language accent (#824) ──────────────────────────────────────────────
+   Set as body[data-lang] by _applyLangTheme(); absent for single-language users,
+   who keep the plain grey header rule below. */
+body[data-lang="zh"] { --lang-accent: #dc2626; }
+body[data-lang="fr"] { --lang-accent: #0891b2; }
+body[data-lang="es"] { --lang-accent: #ca8a04; }
+/* The rule the tabs sit on — it runs the full page width, and the active tab
+   covers the 1px of it that it stands on. */
+body[data-lang] header { border-bottom-color: var(--lang-accent, var(--border)); }
 
 .hcal-seg { display: inline-flex; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
 .hcal-seg-btn {
@@ -5468,5 +5480,10 @@ table.fsrs-table td.ivl { font-weight: 700; }
   #back-btn { min-width: 40px; min-height: 40px; font-size: 24px; }
   /* The title already ellipsises; keep the tabs from eating its whole width. */
   .lang-tabs-header { margin-left: 8px; }
-  .lang-tabs-header .lang-tab { padding: 4px 7px 3px; font-size: 12px; }
+  /* Header padding drops to 8px here, so the full-height tab has to match (#824). */
+  .lang-tabs-header .lang-tab {
+    margin: -8px 0 -9px;
+    padding: 8px 10px 9px;
+    font-size: 12px;
+  }
 }


### PR DESCRIPTION
## 改了什么

按 Daniel 给的加词弹窗截图，把顶栏标签改成**连体样式**：

- 激活标签 = 白色块（`var(--card)`），上圆角 + 主题色 1px 边框、无下边框，用负 margin 撑满 header 全高并向下多出 1px **盖住 header 的下边框**
- header 的下边框染成当前语言的主题色 → 那条线横跨整个页面宽度，激活标签在它上面开一个缺口
- 非激活标签透明、灰字，hover 才轻微高亮

**每种语言一个主题色**（`body[data-lang]` + CSS 变量，由 `_applyLangTheme()` 写）：

| 语言 | 色值 |
|---|---|
| 中文 | `#dc2626`（红） |
| 法语 | `#0891b2`（青蓝） |
| 西语 | `#ca8a04`（土黄，为 #803 预留） |

放在 `body` 上而不是标签栏内部，是为了让**所有视图**的顶栏那条线都跟着当前语言 —— 标签栏只在主页/Browse 显示，但「我现在在哪个模式」在复习时同样要看得出来。

单语言用户不写 `data-lang`，顶栏仍是原来的灰色 1px 边框，零变化。加词弹窗里的 `.lang-tabs`（#813）不受影响。

## 怎么测试

`pytest tests/` → 685 passed, 4 skipped。肉眼：切到法语顶栏整条线变青蓝、中文变红；进复习界面线仍在；窄屏下标签仍与线严丝合缝（移动端 header padding 是 8px，负 margin 已跟着改）。

## 备注

本分支在独立 worktree 里从干净的 `origin/main` 开出，没有碰共享工作区（那里有其它会话未提交的 #821 改动）。

Closes #824