### PR TITLE
fix: Browse 页在手机上折叠侧栏，不再横向溢出

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2056,7 +2056,39 @@ function _filteredBrowseWords() {
   return words;
 }
 
+// ── Phone filter drawer (#827) ───────────────────────────────────────────────
+// Below 700px the sidebar is a collapsible drawer instead of a fixed column,
+// otherwise it eats half of a 390px screen and the word list gets sliced off.
+// The CSS breakpoint is the single source of truth for "is this a phone" —
+// matchMedia reads the same 700px so the two can't drift apart.
+const _BROWSE_DRAWER_MQ = '(max-width: 700px)';
+
+function _browseDrawerActive() {
+  return window.matchMedia(_BROWSE_DRAWER_MQ).matches;
+}
+
+function toggleBrowseSidebar() {
+  const bar = document.getElementById('browse-sidebar');
+  const btn = document.getElementById('browse-filter-toggle');
+  if (!bar) return;
+  const open = bar.classList.toggle('bs-open');
+  if (btn) {
+    btn.setAttribute('aria-expanded', String(open));
+    btn.textContent = open ? '✕ Filters' : '☰ Filters';
+  }
+}
+
+// Picking a filter on a phone means "show me that list" — leaving the drawer
+// open would hide the very rows the tap asked for. Expanding a deck node in
+// the tree is not a pick, so this is called from the filter setters only.
+function _closeBrowseDrawer() {
+  if (!_browseDrawerActive()) return;
+  const bar = document.getElementById('browse-sidebar');
+  if (bar && bar.classList.contains('bs-open')) toggleBrowseSidebar();
+}
+
 function setBrowseFilter(mode, filter) {
+  _closeBrowseDrawer();
   _browseMode   = mode;
   _browseFilter = filter;
   _browseDeckId = null;
@@ -2075,6 +2107,7 @@ function setBrowseFilter(mode, filter) {
 }
 
 function setBrowseStatusFilter(status) {
+  _closeBrowseDrawer();
   _browseCardStatus = status;
   _syncSortOptions();
   document.querySelectorAll('.bs-status-item').forEach(el => el.classList.remove('bs-active'));
@@ -2101,6 +2134,7 @@ function _leaveStarredView() {
 }
 
 function setBrowseDeckFilter(deckId) {
+  _closeBrowseDrawer();
   _leaveStarredView();
   if (_browseDeckId === deckId) {
     _browseDeckId = null;
@@ -2149,6 +2183,14 @@ async function openBrowse() {
     _starredSentencesCache = null;  // fresh browse open — re-fetch, don't reuse a stale list (#773)
     _syncSortOptions();
     showView('browse');
+    // Always land on the list, not on the filter drawer (#827).
+    const _sidebar = document.getElementById('browse-sidebar');
+    if (_sidebar) _sidebar.classList.remove('bs-open');
+    const _drawerBtn = document.getElementById('browse-filter-toggle');
+    if (_drawerBtn) {
+      _drawerBtn.setAttribute('aria-expanded', 'false');
+      _drawerBtn.textContent = '☰ Filters';
+    }
     document.getElementById('browse-search').value = '';
     // Hanzi are Chinese-only; under fr/es that section lists nothing relevant (#815).
     const hanziSec = document.getElementById('bs-hanzi-section');

--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,7 @@
   <title>biangbiangmian3000</title>
   <link rel="icon" href="/static/logo.svg" type="image/svg+xml">
   <link rel="apple-touch-icon" href="/static/logo.svg">
-  <link rel="stylesheet" href="/static/style.css?v=17">
+  <link rel="stylesheet" href="/static/style.css?v=18">
 </head>
 <body>
 
@@ -365,6 +365,11 @@
 
   <!-- Browse (full-width, sidebar layout) -->
   <div id="view-browse" class="browse-layout">
+    <!-- Phone only (#827): the 200px sidebar left ~190px for the list on a
+         390px screen, which the un-shrinkable row buttons blew straight
+         through. Below 700px it collapses behind this toggle instead. -->
+    <button class="browse-filter-toggle" id="browse-filter-toggle"
+            onclick="toggleBrowseSidebar()" aria-expanded="false">☰ Filters</button>
     <aside class="browse-sidebar" id="browse-sidebar">
       <div class="bs-section">
         <div class="bs-section-head">Notes</div>

--- a/static/style.css
+++ b/static/style.css
@@ -2400,6 +2400,10 @@ a.nav-btn { text-decoration: none; }
   font-weight: 600;
 }
 
+/* Phone-only drawer toggle (#827); hidden on desktop, where the sidebar is
+   a permanent column. */
+.browse-filter-toggle { display: none; }
+
 /* ── Browse main panel ───────────────────────────────── */
 .browse-main {
   flex: 1;
@@ -5561,4 +5565,51 @@ table.fsrs-table td.ivl { font-weight: 700; }
 
 @media (max-width: 560px) {
   #tasks-btn { min-height: 40px; font-size: 15px; }
+}
+
+/* ── Browse on phones (#827) ─────────────────────────────
+   Browse had no mobile breakpoint at all: a 200px fixed sidebar next to
+   flex:1 main left ~190px for the list on a 390px screen, and the row
+   internals (.bw-left min-width:80px, the nowrap category/add buttons in
+   .bw-right) cannot shrink below that — so the page overflowed sideways,
+   the sidebar covered half the screen and the word rows were sliced off.
+   Below 700px the sidebar becomes a collapsible full-width drawer.
+   Placed at the end of the file on purpose: media queries add no
+   specificity, so these have to come after the rules they override. */
+@media (max-width: 700px) {
+  #view-browse.browse-layout {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .browse-filter-toggle {
+    display: block;
+    width: 100%;
+    min-height: 44px;
+    padding: 10px 14px;
+    background: var(--card);
+    border: none;
+    border-bottom: 1.5px solid var(--border);
+    color: var(--text);
+    font-size: 14px;
+    font-weight: 600;
+    text-align: left;
+    cursor: pointer;
+  }
+  .browse-sidebar {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1.5px solid var(--border);
+    padding: 8px 0 12px;
+    /* The deck tree can be long; cap it so the list stays reachable. */
+    max-height: 55vh;
+  }
+  .browse-sidebar:not(.bs-open) { display: none; }
+  .bs-item, .bs-deck-item, .bs-status-item { padding: 10px 16px; font-size: 15px; }
+  .browse-main { padding: 12px; }
+  /* Let the action buttons drop to their own line instead of forcing the row
+     wider than the viewport. */
+  .bw-row { flex-wrap: wrap; }
+  .bw-mid { flex: 1 1 120px; }
+  .bw-right { margin-left: auto; }
+  .ss-row { flex-wrap: wrap; }
 }


### PR DESCRIPTION
Closes #827

## 问题

Browse 布局（`#view-browse.browse-layout`）是 `display:flex` 的两栏，`style.css` 里**没有任何针对它的手机断点**。390px 的 iPhone 上侧栏吃掉 200px，主栏只剩约 190px，而 `.bw-left`（`min-width:80px`）和 `.bw-right` 里 `white-space:nowrap` 的类别/加词按钮都不可压缩 → 整页横向溢出，侧栏盖住半屏，词表被切断。

## 改动

- `static/index.html`：`#view-browse` 顶部加 `#browse-filter-toggle`（桌面 `display:none`）；CSS 缓存串 `v=17` → `v=18`
- `static/style.css`：文件末尾新增 `@media (max-width: 700px)` —— 布局转纵向、侧栏变全宽抽屉（`.bs-open` 才显示、`max-height:55vh`）、触摸目标加大到 44px、`.bw-row` 允许换行。**放在文件末尾是有意的**：媒体查询不增加特异性，必须排在被覆盖的 `.bw-*` 规则之后
- `static/app.js`：`toggleBrowseSidebar()` / `_closeBrowseDrawer()`；三个过滤器设置函数（notes/status/deck）选中后自动收起抽屉，展开牌组树的箭头不收起；`openBrowse()` 每次都以收起状态进入

断点 700px 只写在 CSS 里，JS 用 `matchMedia` 读同一个值，两边不会漂移。

## 测试

- `node --check static/app.js` 通过
- `pytest tests/`：687 passed，8 个失败是本地缺 `trafilatura` 导致的既有失败（改动前后完全一致）
- 桌面（>700px）规则一条都没动