### PR TITLE
feat: 复习界面顶栏加回 ＋ 加词按钮

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -863,6 +863,11 @@ function showView(name) {
     name === 'settings'     ? 'Settings' :
     name === 'knowledge'    ? 'Knowledge' : 'biangbiangmian3000';
   if (name === 'decks') quickMode = false;
+  // ＋ during review (#829). Hidden offline for the same reason as ↺: the whole
+  // entry generation is an AI call, so it can only fail there (#612).
+  const headerAddBtn = document.getElementById('header-add-btn');
+  if (headerAddBtn) headerAddBtn.style.display =
+    (name === 'review' && !_offlineMode) ? '' : 'none';
   const headerRegenBtn = document.getElementById('header-regen-btn');
   // Offline mode hides both regenerate affordances — they can only fail (#612).
   if (headerRegenBtn) headerRegenBtn.style.display =
@@ -6926,7 +6931,10 @@ function _renderAddWordLangs() {
   }).join('');
 }
 
-function openAddWordModal() {
+// preferredLang: the review header's ＋ passes the current card's language
+// (#829) — the word was picked out of that card, so the home page's tab is
+// irrelevant there. Everywhere else it's omitted and the tab decides.
+function openAddWordModal(preferredLang) {
   document.getElementById('add-word-overlay').style.display = 'block';
   document.getElementById('add-word-modal').style.display = 'block';
   const input = document.getElementById('add-word-input');
@@ -6935,7 +6943,8 @@ function openAddWordModal() {
   document.getElementById('add-word-status').textContent = '';
   // Follow the home page's language tab, but only for languages that exist —
   // a stale localStorage value must not send words into an unknown tree.
-  setAddWordLang(_availableLangs.includes(activeLang()) ? activeLang() : 'zh');
+  const wanted = preferredLang || activeLang();
+  setAddWordLang(_availableLangs.includes(wanted) ? wanted : 'zh');
   // Jobs that finished while the modal was closed already reported via banner.
   _addWordQueue = _addWordQueue.filter(item => item.state === 'running');
   _renderAddWordQueue();

--- a/static/index.html
+++ b/static/index.html
@@ -74,6 +74,11 @@
     <button id="sync-btn" onclick="openSyncPopup()" title="Sync with the server" style="display:none">⟳</button>
     <!-- ＋ / 📖 / 🎲 moved to the deck-list nav row (#816) so the header can
          hold the language tabs. -->
+    <!-- #816 moved ＋ to the deck-list nav row, which left review with no
+         add-word entry point at all on a phone (⌘A only helps on a desktop) —
+         and reading a sentence is exactly when a new word turns up (#829). -->
+    <button id="header-add-btn" onclick="openAddWordModal(currentCardLang())"
+            title="Add a new word (⌘A)" style="display:none">＋</button>
     <button id="header-regen-btn" onclick="regenerateStory()" title="Regenerate story" style="display:none">↺</button>
   </div>
 </header>

--- a/static/style.css
+++ b/static/style.css
@@ -85,6 +85,7 @@ header h1 {
   header h1 { font-size: 15px; }
   #header-logo { width: 26px; height: 26px; }
 }
+#header-add-btn,
 #header-regen-btn {
   background: none;
   border: none;
@@ -96,8 +97,11 @@ header h1 {
   line-height: 1;
   margin-left: 4px;
 }
+#header-add-btn:hover,
 #header-regen-btn:hover { background: var(--border); color: #6366f1; }
-/* ＋ / 📖 / 🎲 used to be header icons; they are nav-row buttons now (#816). */
+/* ＋ is a header icon again during review only (#829); on the deck list it
+   stays in the nav row where #816 put it. */
+#header-add-btn { font-size: 20px; font-weight: 600; }
 
 /* ── Layout ──────────────────────────────────────────── */
 main {
@@ -5470,6 +5474,7 @@ table.fsrs-table td.ivl { font-weight: 700; }
   }
   /* Apple's minimum comfortable touch target is 44px; these were 32px-ish
      circles/emoji sized for a mouse. */
+  #header-add-btn,
   #header-regen-btn,
   #sync-btn {
     min-width: 40px;


### PR DESCRIPTION
Closes #829

## 问题

#816 把 `＋ Add Word` 挪到牌组列表页的 `.nav-row`，好给顶栏腾出语言标签。代价是复习途中没有加词入口了——电脑上还剩 ⌘A，手机上没有键盘，等于这个功能在复习时彻底消失。而读到句子里的生词正是最想加词的时刻。

## 改动

- `static/index.html`：`.header-right` 里加 `#header-add-btn`，默认隐藏
- `static/app.js`：`showView()` 里按 `name === 'review' && !_offlineMode` 显示；`openAddWordModal(preferredLang)` 加可选参数
- `static/style.css`：与 `#header-regen-btn` 共用样式；手机断点里一起加到 40px 触摸目标

两个决定：

1. **离线时隐藏**，理由同 ↺（#612）：整个词条生成就是一次 AI 调用，离线只会失败
2. **语言按当前卡片走**（`currentCardLang()`），不跟主页标签——词是从这张卡里挑出来的，和复习界面长按菜单的处理一致（#726）

加词仍然只走 `openAddWordModal()` → `/api/add-word-ai`，没有第二条管线（#643）。牌组页 nav-row 的 ＋ 不变。

**CSS 缓存串故意没动**（还是 `v=17`）：#830 已经把它改成 `v=18`，两个分支都改同一行必然冲突。两个 PR 合并后 `v=18` 会一次性带上两边的样式。

## 测试

- `node --check static/app.js` 通过
- `pytest tests/test_add_word.py`：41 passed（含守着 `app.js` 里不能重复定义 `addWordViaAi`/`api` 的那条）