### PR TITLE
feat: 故事生成加载页加 Cancel 按钮，真正中止生成

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -537,6 +537,7 @@ FSRS 用毕业评分播种初始 stability/difficulty：默认权重下 **Good �
 - `kahneman` ——《思考，快与慢》认知偏误风格（`data/kahneman_chapters.json`）
 - `paste` ——用户在设置弹窗粘贴任意内容（#396）；自 #481 起复用 briefing 管线（`generate_briefing_sentences(generic=True)`，内容摘要框架措辞），因此同样有上下文句、Python 校验与事实核查，模型固定为服务器端 BRIEFING_MODEL；不做自动抓取回退
 - `briefing`（News flow，#399）——AI 写一篇**连贯的新闻总结**，目标词各恰好出现一次，但**不是每句都含目标词**——目标词句之间允许纯上下文句（承载数字/事实，不受 15 字限制）。含目标词的句子成为卡片；前面的上下文句用 Google Translate（非 AI）译成德语存 `story_sentences.context_de`（显示在卡片正面），中文原文存 `reasoning_zh`（背景弹窗）。briefing 卡片没有标题（concept_zh 为空）。自动抓取当日新闻（`news_fetcher.fetch_all()`：Tagesschau API + RSS，按天缓存）：两步 AI，`summarize_news_items` 挑最重要的 8 条（平衡德国/国际/中国相关）→ `generate_briefing_sentences` 生成连贯中文简报（模型固定服务器端 BRIEFING_MODEL，因 DeepSeek 会审查新闻内容）。抓取全部失败时报明确错误，不静默降级为普通故事
+- **取消生成（#828）**：加载页的 Cancel 按钮 → `POST .../cancel` 把 progress_key 记进 `ai._cancelled_keys`。**检查点挂在 `ai._set_progress()` 里，不是在 `routes/story.py` 里散布几处显式检查**：每种生成模式本来就在每个阶段（重试、翻译开始、逐句翻译进度）调它，挂在那里等于所有模式的每一步都免费获得中断能力，以后新增的模式也自动继承。另外 `_generate_and_store` 在 `database.create_story()` **之前**再查一次——上面的活儿白干无所谓，写进库的故事不是。标志必须在生成线程的 `finally:` 里 `ai.clear_cancel()`，否则下一次同一牌组的生成一启动就被旧标志掐死。`_fill_translations` 的兜底 `except Exception` 要放行 `StoryCancelled`（取消不是翻译失败）。取消后 `_story_progress` 条目被删掉，所以 #821 任务指示器和「Story ready」横幅都不会再提这次生成
 - **旧 `news` 模式已移除**（#512，界面曾叫 "News briefing"）：新故事生成拒绝 `mode='news'`（`_generate_and_store` 直接抛 `ValueError`）；但历史 `news` 故事仍能正常展示，且 Again 单句重生成仍复用 `ai.generate_news_sentences`（`generate_sentence_for_word` 保留该分支）——不影响旧数据
 - briefing/paste 共同点：每句带 `source_url`（背景弹窗"打开原文"链接），复用 kahneman 的概念框/背景弹窗 UI；文章内容存 `stories.gen_params.articles` 供 Again 重生成复现同一批内容（paste 的文章通过 regenerate 的 POST body 传输）
 - **知识模式对所有语言可用（#806）**：素材是什么语言无所谓，决定输出语言的只有提示词。所以它有独立开关 `features.knowledge_story_mode`（所有语言 True），**不和 `extended_story_modes`（kahneman/paste/briefing，仍只有中文）捆在一起**。中文走可自定义的 `DEFAULT_PROMPT_TEMPLATES["knowledge"]`，其它语言走 `ai._KNOWLEDGE_PROMPT_NON_ZH`（同样的规则，目标语言输出）。`briefing`/`paste` 仍只有中文，所以 `generate_briefing_sentences()` 没加 `lang`——加了是死代码
@@ -696,6 +697,7 @@ POST /api/decks/{id}/toggle-all-suspension
 # 故事 & 语音（均支持可选 ?lang=）
 GET  /api/story/{deck_id}/{category}                 → 今日活跃故事（如无则生成）
 POST /api/story/{deck_id}/{category}/regenerate ；GET .../history ；GET .../count
+POST /api/story/{deck_id}/{category}/cancel          → 中止正在跑的生成（#828）；没有在跑返回 {cancelled:false}（不假装取消过）
 POST /api/speak ；POST /api/speak-multi ；GET /api/speak-status ；POST /api/speak-stop
 GET  /api/tts-file ；POST /api/preload ；POST /api/preload-session/{deck_id}/{category}
 GET  /api/tts-progress/{deck_id}/{category} ；GET /api/story-progress/{deck_id}/{category}

--- a/ai.py
+++ b/ai.py
@@ -44,8 +44,42 @@ _QUOTA_FALLBACK_PURPOSES = {"briefing", "briefing_fact_check"}
 _story_progress: dict[str, dict] = {}
 
 
+class StoryCancelled(Exception):
+    """The user pressed Cancel on the generation loading screen (#828)."""
+
+
+# Progress keys the user asked to abandon. Checked from _set_progress() rather
+# than from a handful of explicit checkpoints in routes/story.py: every
+# generation mode already reports each phase (retry attempt, translation start,
+# per-sentence translation progress) through _set_progress, so hanging the
+# check there interrupts all of them at every step for free — and a mode added
+# later inherits it without anyone remembering to wire a checkpoint in.
+_cancelled_keys: set[str] = set()
+
+
+def request_cancel(key: str | None) -> None:
+    if key:
+        _cancelled_keys.add(key)
+
+
+def clear_cancel(key: str | None) -> None:
+    """Must run in the generation thread's finally: a leftover flag would kill
+    the next run for the same deck the instant it starts."""
+    _cancelled_keys.discard(key)
+
+
+def is_cancelled(key: str | None) -> bool:
+    return bool(key) and key in _cancelled_keys
+
+
+def raise_if_cancelled(key: str | None) -> None:
+    if is_cancelled(key):
+        raise StoryCancelled("Story generation cancelled")
+
+
 def _set_progress(key: str | None, **kwargs) -> None:
     if key:
+        raise_if_cancelled(key)
         _story_progress[key] = kwargs
 
 
@@ -1903,6 +1937,8 @@ def _fill_translations(sentences: list[dict], progress_key: str | None = None,
             s["sentence_de"] = de
             s.setdefault("sentence_en", "")
             s.setdefault("sentence_fr", "")
+    except StoryCancelled:
+        raise  # a cancel is not a translation failure — let it out (#828)
     except Exception as e:
         err = str(e)
         vpn_hint = " (VPN issue?)" if any(k in err.lower() for k in ("eof", "connect", "timeout", "proxy", "ssl")) else ""

--- a/routes/story.py
+++ b/routes/story.py
@@ -308,7 +308,8 @@ def _generate_and_store(deck_id: int, category: str, today: str, cards: list, *,
     # the queue on its pre-story learning-first order and the session started at a
     # sentence in the middle of the story (issue #783).
     # Full invalidation is coarse but cheap: queues are rebuilt lazily.
-    if result and not (isinstance(result, dict) and result.get("error")):
+    if result and not (isinstance(result, dict)
+                       and (result.get("error") or result.get("cancelled"))):
         queue_mgr.invalidate()
     return result
 
@@ -544,8 +545,15 @@ def _generate_and_store_body(deck_id: int, category: str, today: str, cards: lis
             grammar_focus=grammar_focus, grammar_pct=grammar_pct,
             mode=mode, chapter_ids=chapter_ids, articles=articles, lang=lang,
             origin=origin, episode_ids=episode_ids, batch_size=batch_size, kind=kind)
+        # Last checkpoint before the write (#828): everything above is throwaway
+        # work, a stored story is not — cancelling and then finding a story you
+        # did not want waiting for you is worse than no cancel button at all.
+        ai.raise_if_cancelled(progress_key)
         database.create_story(today, category, deck_id, sentences, prompt_text, topic, gen_params, lang=lang)
         story = database.get_active_story(today, category, deck_id, lang=lang)
+    except ai.StoryCancelled:
+        logger.info("story  CANCELLED deck=%d cat=%s", deck_id, category)
+        return {"cancelled": True}
     except Exception as e:
         logger.error("story  generation error: %s", e)
         return {
@@ -578,7 +586,14 @@ def _start_background_generation(deck_id: int, category: str, today: str, cards:
                 grammar_focus=grammar_focus, grammar_pct=grammar_pct,
                 mode=mode, chapter_ids=chapter_ids, articles=articles, progress_key=progress_key,
                 lang=lang, episode_ids=episode_ids, batch_size=batch_size)
-            if isinstance(result, dict) and result.get("error"):
+            if isinstance(result, dict) and result.get("cancelled"):
+                # Leave no terminal state behind: the user is already gone, and
+                # a sticky done/error entry would keep the #821 task indicator
+                # and the "Story ready" banner talking about a run nobody
+                # wanted finished.
+                ai._story_progress.pop(progress_key, None)
+                logger.info("story  BG-CANCEL deck=%d cat=%s", deck_id, category)
+            elif isinstance(result, dict) and result.get("error"):
                 ai._story_progress[progress_key] = {
                     "phase": "error", "percent": 0, "msg": result.get("reason", "Generation failed")}
                 logger.warning("story  BG-ERROR deck=%d cat=%s: %s",
@@ -593,6 +608,9 @@ def _start_background_generation(deck_id: int, category: str, today: str, cards:
         finally:
             with _gen_lock:
                 _generating.discard(progress_key)
+            # A leftover cancel flag would kill the next run for this deck the
+            # instant it starts, so it is cleared with the same guarantee.
+            ai.clear_cancel(progress_key)
 
     threading.Thread(target=_run, daemon=True).start()
 
@@ -1455,6 +1473,8 @@ async def pregen_today():
                 mode=mode, chapter_ids=gp.get("chapter_ids"), articles=None,
                 progress_key=progress_key, lang=lang, origin="pregen")
             ai._story_progress.pop(progress_key, None)
+            if isinstance(result, dict) and result.get("cancelled"):
+                raise RuntimeError("cancelled")
             if isinstance(result, dict) and result.get("error"):
                 raise RuntimeError(result.get("reason", "generation failed"))
             n_sentences = len((result or {}).get("sentences", []))
@@ -1547,6 +1567,37 @@ def put_pregen_config(body: dict):
     logger.info("pregen-config  deck=%s set to %s", deck_id,
                 [(e["category"], e["mode"]) for e in entries])
     return {"ok": True, "entries": database.get_pregen_config()}
+
+
+@router.post("/api/story/{deck_id}/{category}/cancel")
+def cancel_story_generation(deck_id: int, category: str, lang: str | None = None):
+    """Abandon an in-flight generation (#828).
+
+    "Continue in background" was the only way off the loading screen, so a run
+    started by mistake kept spending AI money and ended in a banner nobody
+    wanted. This sets a flag the generation thread checks at every progress
+    step; the HTTP request already in flight can't be interrupted, but nothing
+    after it runs — no repair round, no translation, no TTS, no story written.
+
+    Returns {"cancelled": false} when nothing was running: the caller asked for
+    a state that already holds, and reporting a cancel that never happened
+    would be a lie.
+    """
+    lang = lang or database.get_deck_lang(deck_id)
+    key = f"{deck_id}/{category}/{lang}"
+    with _gen_lock:
+        running = key in _generating
+        if running:
+            ai.request_cancel(key)
+    if not running:
+        # Also drop any sticky terminal state so the loading screen isn't
+        # re-shown an old error for a run the user just walked away from.
+        ai._story_progress.pop(key, None)
+        logger.info("story  CANCEL no-op deck=%d cat=%s lang=%s — nothing running",
+                    deck_id, category, lang)
+        return {"cancelled": False}
+    logger.info("story  CANCEL requested deck=%d cat=%s lang=%s", deck_id, category, lang)
+    return {"cancelled": True}
 
 
 @router.get("/api/story-progress/{deck_id}/{category}")

--- a/static/app.js
+++ b/static/app.js
@@ -5044,10 +5044,41 @@ let _bgLeaveRequested = false;  // set when the user clicks "Continue in backgro
 function _showLoadingBgButton() {
   const b = document.getElementById('loading-bg-btn');
   if (b) b.style.display = 'block';
+  const c = document.getElementById('loading-cancel-btn');
+  if (c) { c.style.display = 'block'; c.disabled = false; c.textContent = 'Cancel ✕'; }
 }
 function _hideLoadingBgButton() {
   const b = document.getElementById('loading-bg-btn');
   if (b) b.style.display = 'none';
+  const c = document.getElementById('loading-cancel-btn');
+  if (c) c.style.display = 'none';
+}
+
+// User clicked "Cancel" (#828): tell the server to stop and go back to the deck
+// list WITHOUT registering the run in _bgStories. The difference from
+// "Continue in background" is the whole point — that one keeps spending money
+// and ends in a "Story ready" banner for a story nobody wants.
+async function _cancelStoryGeneration() {
+  if (!_bgActiveResume) return;
+  const ctx = _bgActiveResume;
+  const btn = document.getElementById('loading-cancel-btn');
+  if (btn) { btn.disabled = true; btn.textContent = 'Cancelling…'; }
+  // Stop our own polling first so the in-flight _pollBackgroundStory resolves
+  // to _BG_LEFT and its caller returns instead of racing us to showView().
+  _bgLeaveRequested = true;
+  _bgActiveResume = null;
+  _stopFakeProgress();
+  _stopStoryProgressPoll();
+  try {
+    await api('POST', `/api/story/${ctx.storyDeckId}/${ctx.storyCategory}/cancel${_langQP('?')}`);
+  } catch (e) {
+    // The generation may well have finished a second ago — either way the user
+    // asked to leave, so leaving is the honest response. Say what happened
+    // rather than pretending the cancel went through.
+    showNotice('Could not reach the server to cancel — generation may still be running.');
+  }
+  _hideLoadingBgButton();
+  loadDecks();
 }
 
 // Poll the background story endpoint until it returns a story (or an error dict),

--- a/static/index.html
+++ b/static/index.html
@@ -96,9 +96,16 @@
     <!-- Generation log (issue #642): cumulative step-by-step lines from the
          backend, so a long run shows what it already did and where it is now -->
     <div id="loading-log" style="display:none"></div>
-    <button id="loading-bg-btn" style="display:none" onclick="_continueStoryInBackground()">
-      Continue in background ⏎
-    </button>
+    <div id="loading-actions">
+      <button id="loading-bg-btn" style="display:none" onclick="_continueStoryInBackground()">
+        Continue in background ⏎
+      </button>
+      <!-- #828: leaving in the background still spends the AI money and ends in
+           a "Story ready" banner nobody asked for. This one actually stops. -->
+      <button id="loading-cancel-btn" style="display:none" onclick="_cancelStoryGeneration()">
+        Cancel ✕
+      </button>
+    </div>
   </div>
 
   <!-- Deck list -->

--- a/static/style.css
+++ b/static/style.css
@@ -180,10 +180,18 @@ main.browse-open {
 
 .spinner.hidden { display: none; }
 
-/* "Continue in background" button on the story-generation loading screen */
-#loading-bg-btn {
-  margin: 20px auto 0;
-  display: block;
+/* Story-generation loading screen: "Continue in background" and Cancel (#828).
+   Side by side on a desktop, stacked on a phone so neither shrinks below a
+   comfortable touch target. */
+#loading-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 20px;
+}
+#loading-bg-btn,
+#loading-cancel-btn {
   background: transparent;
   color: var(--muted);
   border: 1px solid var(--border);
@@ -193,6 +201,13 @@ main.browse-open {
   cursor: pointer;
 }
 #loading-bg-btn:hover { color: var(--text); border-color: var(--muted); }
+#loading-cancel-btn:hover { color: #dc2626; border-color: #dc2626; }
+#loading-cancel-btn:disabled { opacity: 0.5; cursor: default; }
+@media (max-width: 560px) {
+  #loading-actions { flex-direction: column; align-items: stretch; }
+  #loading-bg-btn,
+  #loading-cancel-btn { min-height: 44px; font-size: 15px; }
+}
 
 /* ── Error banner ────────────────────────────────────── */
 #error-banner {

--- a/tests/test_story_cancel.py
+++ b/tests/test_story_cancel.py
@@ -1,0 +1,148 @@
+"""Cancelling an in-flight story generation (#828).
+
+The point of the Cancel button is that it is *not* "Continue in background":
+nothing may be written, and the flag must not survive into the next run.
+"""
+
+import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
+
+from fastapi.testclient import TestClient
+
+import ai
+import database
+import importer
+import main
+from routes import story as story_routes
+
+from tests.test_api import (  # noqa: F401  (fixtures come along by reference)
+    ENTRY_你好,
+    ENTRY_谢谢,
+    fake_generate_story,
+    populated_db,
+    tmp_db,
+    write_yaml,
+)
+
+client = TestClient(main.app)
+
+
+@pytest.fixture(autouse=True)
+def _clean_generation_state():
+    """These are module-level singletons; a leak here poisons other tests."""
+    yield
+    ai._cancelled_keys.clear()
+    ai._story_progress.clear()
+    story_routes._generating.clear()
+
+
+# ---------------------------------------------------------------------------
+# The flag itself
+# ---------------------------------------------------------------------------
+
+def test_set_progress_raises_once_cancelled():
+    key = "1/listening/zh"
+    ai._set_progress(key, phase="request", percent=10)   # fine before cancel
+    ai.request_cancel(key)
+    with pytest.raises(ai.StoryCancelled):
+        ai._set_progress(key, phase="translating", percent=88)
+
+
+def test_clear_cancel_releases_the_key():
+    """A leftover flag would kill the next run for this deck the moment it
+    starts, which is why clear_cancel() lives in the thread's finally."""
+    key = "1/listening/zh"
+    ai.request_cancel(key)
+    ai.clear_cancel(key)
+    ai._set_progress(key, phase="request", percent=10)   # must not raise
+    assert not ai.is_cancelled(key)
+
+
+def test_cancel_does_not_leak_to_other_keys():
+    ai.request_cancel("1/listening/zh")
+    ai._set_progress("1/reading/zh", phase="request", percent=10)
+    ai._set_progress("2/listening/zh", phase="request", percent=10)
+
+
+# ---------------------------------------------------------------------------
+# POST /api/story/{deck_id}/{category}/cancel
+# ---------------------------------------------------------------------------
+
+def test_cancel_reports_false_when_nothing_is_running(populated_db):
+    deck_id = populated_db
+    r = client.post(f"/api/story/{deck_id}/listening/cancel")
+    assert r.status_code == 200
+    # Reporting a cancel that never happened would be a lie.
+    assert r.json() == {"cancelled": False}
+
+
+def test_cancel_sets_the_flag_for_a_running_generation(populated_db):
+    deck_id = populated_db
+    lang = database.get_deck_lang(deck_id)
+    key = f"{deck_id}/listening/{lang}"
+    story_routes._generating.add(key)
+
+    r = client.post(f"/api/story/{deck_id}/listening/cancel")
+
+    assert r.json() == {"cancelled": True}
+    assert ai.is_cancelled(key)
+
+
+def test_cancel_clears_a_sticky_error_state(populated_db):
+    """A background run that ended in an error leaves a sticky progress entry so
+    polling stops. Walking away from it must not leave that error waiting to be
+    re-shown on the next visit."""
+    deck_id = populated_db
+    lang = database.get_deck_lang(deck_id)
+    key = f"{deck_id}/listening/{lang}"
+    ai._story_progress[key] = {"phase": "error", "percent": 0, "msg": "boom"}
+
+    client.post(f"/api/story/{deck_id}/listening/cancel")
+
+    assert key not in ai._story_progress
+
+
+# ---------------------------------------------------------------------------
+# Nothing gets written
+# ---------------------------------------------------------------------------
+
+def test_cancelled_generation_stores_no_story(populated_db, monkeypatch):
+    """The checkpoint right before create_story is the one that matters: every
+    step above it is throwaway work, a stored story is not."""
+    deck_id = populated_db
+    lang = database.get_deck_lang(deck_id)
+    key = f"{deck_id}/listening/{lang}"
+    today = database.anki_today().isoformat()
+    cards = story_routes._get_cards_for_story(deck_id, "listening", lang=lang)
+    assert cards, "fixture must have due cards, otherwise this proves nothing"
+
+    monkeypatch.setattr(ai, "generate_story", fake_generate_story)
+    # Cancel pressed while the AI call was already in flight.
+    ai.request_cancel(key)
+
+    result = story_routes._generate_and_store(
+        deck_id, "listening", today, cards,
+        topic=None, max_hsk=3, model=None, grammar_focus=None, grammar_pct=75,
+        mode="story", chapter_ids=None, progress_key=key, lang=lang)
+
+    assert result == {"cancelled": True}
+    assert database.get_active_story(today, "listening", deck_id, lang=lang) is None
+
+
+def test_uncancelled_generation_still_stores_a_story(populated_db, monkeypatch):
+    """Guard against the checkpoint being wired in a way that always fires."""
+    deck_id = populated_db
+    lang = database.get_deck_lang(deck_id)
+    key = f"{deck_id}/listening/{lang}"
+    today = database.anki_today().isoformat()
+    cards = story_routes._get_cards_for_story(deck_id, "listening", lang=lang)
+
+    monkeypatch.setattr(ai, "generate_story", fake_generate_story)
+    result = story_routes._generate_and_store(
+        deck_id, "listening", today, cards,
+        topic=None, max_hsk=3, model=None, grammar_focus=None, grammar_pct=75,
+        mode="story", chapter_ids=None, progress_key=key, lang=lang)
+
+    assert not result.get("cancelled")
+    assert database.get_active_story(today, "listening", deck_id, lang=lang) is not None


### PR DESCRIPTION
Closes #828

## 问题

加载页只有「Continue in background ⏎」：它把生成登记进 `_bgStories` 继续跑。选错模式、选错素材、或者纯粹不想等的时候没有出路——AI 的钱照花，TTS 照样预加载，最后还弹一个没人要的横幅。

## 后端

- `ai.py`：`StoryCancelled` + `_cancelled_keys` + `request_cancel/clear_cancel/is_cancelled/raise_if_cancelled`
- **检查点挂在 `ai._set_progress()` 里**，不是在 `routes/story.py` 里散布几处显式检查。每种生成模式本来就在每个阶段调它（重试之间、翻译开始前、逐句翻译进度），挂在那里等于所有模式的每一步都免费获得中断能力，而且以后新增的模式自动继承，不用有人记得去接线
- `_generate_and_store` 在 `database.create_story()` **之前**再查一次：上面的活儿白干无所谓，写进库的故事不是——取消完再发现一个不想要的故事在等你，比没有取消按钮更糟
- 标志在生成线程的 `finally:` 里 `ai.clear_cancel()`，与 `_generating.discard()` 同一个保证。留一个陈旧标志 = 下次同一牌组的生成一启动就被掐死
- `_fill_translations` 的兜底 `except Exception` 放行 `StoryCancelled`——取消不是翻译失败
- 取消后 `_story_progress` 条目被删掉 → #821 任务指示器不再显示它，「Story ready」横幅也不会弹
- 没有在跑的生成时返回 `{"cancelled": false}`，并顺手清掉可能残留的 error 终态。**不假装取消过**

已经发出去的那一次 HTTP 请求打不断，这是可以接受的；关键是它之后的补漏轮、翻译、写库、TTS 全都不再发生。

## 前端

- `#loading-actions` 容器装两个按钮，手机上纵向堆叠、44px 触摸目标
- `_cancelStoryGeneration()`：先置 `_bgLeaveRequested`（让在飞的 `_pollBackgroundStory` 解析成 `_BG_LEFT`，调用方直接 return，不和我们抢 `showView`），**不**把这次生成登记进 `_bgStories`，然后 POST 取消、回牌组页
- 取消请求本身失败时如实说「可能还在跑」，不谎报成功

## 测试

`tests/test_story_cancel.py`（8 条）：标志的置位/清除/不串键、`_set_progress` 取消后抛异常、端点在没跑时返回 false、在跑时置标志、清掉 sticky error、**取消后库里没有故事**、以及反向的「没取消照样写进库」（防止检查点写成永远触发）。

`pytest tests/`：695 passed（新增 8 条），8 个失败是本地缺 `trafilatura` 的既有失败，改动前后完全一致。